### PR TITLE
Implement hero powers and 5 cards in CORE cardset

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -12,7 +12,7 @@ CORE | CS1_042 | Goldshire Footman | O
 CORE | CS1_112 | Holy Nova | O
 CORE | CS1_113 | Mind Control | O
 CORE | CS1_130 | Holy Smite | O
-CORE | CS2_003 | Mind Vision |  
+CORE | CS2_003 | Mind Vision | O
 CORE | CS2_004 | Power Word: Shield | O
 CORE | CS2_005 | Claw | O
 CORE | CS2_007 | Healing Touch | O
@@ -43,7 +43,7 @@ CORE | CS2_063 | Corruption | O
 CORE | CS2_064 | Dread Infernal | O
 CORE | CS2_065 | Voidwalker | O
 CORE | CS2_072 | Backstab | O
-CORE | CS2_074 | Deadly Poison |  
+CORE | CS2_074 | Deadly Poison | O
 CORE | CS2_075 | Sinister Strike | O
 CORE | CS2_076 | Assassinate | O
 CORE | CS2_077 | Sprint | O
@@ -56,8 +56,8 @@ CORE | CS2_091 | Light's Justice | O
 CORE | CS2_092 | Blessing of Kings | O
 CORE | CS2_093 | Consecration | O
 CORE | CS2_094 | Hammer of Wrath | O
-CORE | CS2_097 | Truesilver Champion |  
-CORE | CS2_103 | Charge |  
+CORE | CS2_097 | Truesilver Champion | O
+CORE | CS2_103 | Charge | O
 CORE | CS2_105 | Heroic Strike | O
 CORE | CS2_106 | Fiery War Axe | O
 CORE | CS2_108 | Execute | O
@@ -93,7 +93,7 @@ CORE | CS2_200 | Boulderfist Ogre | O
 CORE | CS2_201 | Core Hound | O
 CORE | CS2_213 | Reckless Rocketeer | O
 CORE | CS2_222 | Stormwind Champion | O
-CORE | CS2_226 | Frostwolf Warlord |  
+CORE | CS2_226 | Frostwolf Warlord | O
 CORE | CS2_232 | Ironbark Protector | O
 CORE | CS2_234 | Shadow Word: Pain | O
 CORE | CS2_235 | Northshire Cleric | O
@@ -142,7 +142,7 @@ CORE | NEW1_004 | Vanish | O
 CORE | NEW1_011 | Kor'kron Elite | O
 CORE | NEW1_031 | Animal Companion |  
 
-- Progress: 85% (114 of 133 Cards)
+- Progress: 89% (119 of 133 Cards)
 
 ## Classic
 

--- a/Documents/TaskList.md
+++ b/Documents/TaskList.md
@@ -13,9 +13,12 @@
 ## Basic tasks
 
 * AddEnchantmentTask
+* AddStackToTask
 * ArmorTask
 * ConditionTask
 * ControlTask
+* CopyTask
+* CountTask
 * DamageTask
 * DestroyTask
 * DiscardTask
@@ -23,8 +26,10 @@
 * DrawTask
 * EnqueueTask
 * FlagTask
+* FuncNumberTask
 * HealFullTask
 * HealTask
+* HeroPowerTask
 * IncludeTask
 * ManaCrystalTask
 * RandomTask
@@ -33,3 +38,4 @@
 * SummonTask
 * TempManaTask
 * TransformTask
+* WeaponTask

--- a/Includes/Rosetta/Actions/Targeting.hpp
+++ b/Includes/Rosetta/Actions/Targeting.hpp
@@ -6,6 +6,7 @@
 #ifndef ROSETTASTONE_TARGETING_HPP
 #define ROSETTASTONE_TARGETING_HPP
 
+#include <Rosetta/Models/Character.hpp>
 #include <Rosetta/Models/Entity.hpp>
 
 namespace RosettaStone::Generic

--- a/Includes/Rosetta/Enchants/Effect.hpp
+++ b/Includes/Rosetta/Enchants/Effect.hpp
@@ -10,7 +10,7 @@
 
 namespace RosettaStone
 {
-class Character;
+class Entity;
 class AuraEffects;
 
 //! Effect operator to change card value such as attack and health.
@@ -52,17 +52,17 @@ class Effect
     Effect& operator=(Effect&& effect) = default;
 
     //! Applies this effect to the target entity.
-    //! \param character The character to which effect is applied.
+    //! \param entity An entity to which effect is applied.
     //! \param isOneTurnEffect Whether effect lasts only one turn.
-    void Apply(Character* character, bool isOneTurnEffect = false) const;
+    void Apply(Entity* entity, bool isOneTurnEffect = false) const;
 
     //! Applies this effect to the target as an aura effect.
     //! \param auraEffects The aura effect.
     void Apply(AuraEffects& auraEffects) const;
 
     //! Removes this aura effect from the target entity.
-    //! \param character The character to which effect is removed.
-    void Remove(Character* character) const;
+    //! \param entity An entity to which effect is removed.
+    void Remove(Entity* entity) const;
 
     //! Removes this aura effect from the target entity.
     //! \param auraEffects The aura effect.

--- a/Includes/Rosetta/Enchants/Effect.hpp
+++ b/Includes/Rosetta/Enchants/Effect.hpp
@@ -68,6 +68,11 @@ class Effect
     //! \param auraEffects The aura effect.
     void Remove(AuraEffects& auraEffects) const;
 
+    //! Creates a new Effect having changed amount of \p newValue.
+    //! \param newValue A value to change.
+    //! \return A new Effect having changed amount.
+    Effect ChangeValue(int newValue) const;
+
  private:
     GameTag m_gameTag = GameTag::INVALID;
     EffectOperator m_effectOperator = EffectOperator::SET;

--- a/Includes/Rosetta/Enchants/Effects.hpp
+++ b/Includes/Rosetta/Enchants/Effects.hpp
@@ -46,6 +46,11 @@ class Effects
     inline static Effect Windfury =
         Effect(GameTag::WINDFURY, EffectOperator::SET, 1);
 
+    //! An ability allowing a minion to attack the same turn it is summoned or
+    //! brought under a new player's control.
+    inline static Effect Charge =
+        Effect(GameTag::CHARGE, EffectOperator::SET, 1);
+
     //! A minion ability which prevents that minion from being the target of
     //! enemy attacks, spells and effects until they attack.
     inline static Effect Stealth =

--- a/Includes/Rosetta/Enchants/Effects.hpp
+++ b/Includes/Rosetta/Enchants/Effects.hpp
@@ -30,8 +30,14 @@ class Effects
         return Effect(GameTag::HEALTH, EffectOperator::ADD, n);
     }
 
-    //! A minion ability which forces the opposing player to direct any melee
-    //! attacks toward enemy targets with this ability.
+    //! Creates effect that increases attack and health by \p n.
+    static std::vector<Effect> AttackHealthN(int n)
+    {
+        return { AttackN(n), HealthN(n) };
+    }
+
+    //! A minion ability which forces the opposing player to direct any
+    //! melee attacks toward enemy targets with this ability.
     inline static Effect Taunt = Effect(GameTag::TAUNT, EffectOperator::SET, 1);
 
     //! A minion ability that causes any minion damaged by them to be destroyed.

--- a/Includes/Rosetta/Enchants/Enchant.hpp
+++ b/Includes/Rosetta/Enchants/Enchant.hpp
@@ -37,6 +37,10 @@ class Enchant
     //! \param effect The effect of the card.
     Enchant(Effect& effect);
 
+    //! Constructs enchant with given \p _effects.
+    //! \param _effects A list of effect.
+	Enchant(std::initializer_list<Effect> _effects);
+
     //! Constructs enchant with given \p effects.
     //! \param effects A list of effect.
     //! \param isOneTurnEffect A flag that sets whether this is one-turn effect.

--- a/Includes/Rosetta/Enchants/Enchant.hpp
+++ b/Includes/Rosetta/Enchants/Enchant.hpp
@@ -13,7 +13,7 @@
 
 namespace RosettaStone
 {
-class Character;
+class Entity;
 
 //!
 //! \brief Enchant class.
@@ -42,9 +42,9 @@ class Enchant
     //! \param isOneTurnEffect A flag that sets whether this is one-turn effect.
     Enchant(std::vector<Effect>& effects, bool isOneTurnEffect);
 
-    //! Activates enchant to \p character.
-    //! \param character The character to which enchant is activated.
-    void ActivateTo(Character* character);
+    //! Activates enchant to \p entity.
+    //! \param entity An entity to which enchant is activated.
+    void ActivateTo(Entity* entity);
 
     std::vector<Effect> effects;
     bool isOneTurnEffect = false;

--- a/Includes/Rosetta/Enchants/Enchant.hpp
+++ b/Includes/Rosetta/Enchants/Enchant.hpp
@@ -27,7 +27,8 @@ class Enchant
     //! Default constructor.
     Enchant() = default;
 
-    //! Constructs enchant with given \p gameTag, \p effectOperator and \p value.
+    //! Constructs enchant with given \p gameTag, \p effectOperator and
+    //! \p value.
     //! \param gameTag The game tag of the card.
     //! \param effectOperator The effect operator to change card value.
     //! \param value The value to change.
@@ -37,20 +38,23 @@ class Enchant
     //! \param effect The effect of the card.
     Enchant(Effect& effect);
 
-    //! Constructs enchant with given \p _effects.
+    //! Constructs enchant with given \p _effects, \p _useScriptTag and
+    //! \p _isOneTurnEffect.
     //! \param _effects A list of effect.
-	Enchant(std::initializer_list<Effect> _effects);
-
-    //! Constructs enchant with given \p effects.
-    //! \param effects A list of effect.
-    //! \param isOneTurnEffect A flag that sets whether this is one-turn effect.
-    Enchant(std::vector<Effect>& effects, bool isOneTurnEffect);
+    //! \param _useScriptTag A flag to use script tag.
+    //! \param _isOneTurnEffect A flag whether this is one-turn effect.
+    Enchant(std::vector<Effect> _effects, bool _useScriptTag = false,
+            bool _isOneTurnEffect = false);
 
     //! Activates enchant to \p entity.
     //! \param entity An entity to which enchant is activated.
-    void ActivateTo(Entity* entity);
+    //! \param num1 The number of GameTag::TAG_SCRIPT_DATA_NUM_1.
+    //! \param num2 The number of GameTag::TAG_SCRIPT_DATA_NUM_2.
+    void ActivateTo(Entity* entity, int num1, int num2);
 
     std::vector<Effect> effects;
+
+    bool useScriptTag = false;
     bool isOneTurnEffect = false;
 };
 }  // namespace RosettaStone

--- a/Includes/Rosetta/Enchants/Enchants.hpp
+++ b/Includes/Rosetta/Enchants/Enchants.hpp
@@ -6,6 +6,7 @@
 #ifndef ROSETTASTONE_ENCHANTS_HPP
 #define ROSETTASTONE_ENCHANTS_HPP
 
+#include <Rosetta/Enchants/Effects.hpp>
 #include <Rosetta/Enchants/Enchant.hpp>
 
 #include <string>
@@ -20,6 +21,10 @@ namespace RosettaStone
 class Enchants
 {
  public:
+    //! Enchant that adds attack/health and uses script tag.
+    inline static Enchant AddAttackHealthScriptTag =
+        Enchant(Effects::AttackHealthN(0), true);
+
     //! Creates enchant from card's text.
     //! \param cardID A card's ID.
     //! \return A newly created enchant from card's text.

--- a/Includes/Rosetta/Enchants/Trigger.hpp
+++ b/Includes/Rosetta/Enchants/Trigger.hpp
@@ -43,6 +43,8 @@ class Trigger
 
     ITask* singleTask = nullptr;
 
+    bool fastExecution = false;
+
  private:
     //! Processes trigger to apply the effect.
     //! \param player A pointer to player.

--- a/Includes/Rosetta/Enchants/Trigger.hpp
+++ b/Includes/Rosetta/Enchants/Trigger.hpp
@@ -44,6 +44,7 @@ class Trigger
     ITask* singleTask = nullptr;
 
     bool fastExecution = false;
+    bool removeAfterTriggered = false;
 
  private:
     //! Processes trigger to apply the effect.

--- a/Includes/Rosetta/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Enums/TaskEnums.hpp
@@ -46,6 +46,7 @@ enum class TaskID
     FUNC_NUMBER,
     HERO_POWER,
     COPY,
+    ADD_STACK_TO,
 
     NUM_TASK_ID
 };

--- a/Includes/Rosetta/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Enums/TaskEnums.hpp
@@ -45,6 +45,7 @@ enum class TaskID
     WEAPON,
     FUNC_NUMBER,
     HERO_POWER,
+    COPY,
 
     NUM_TASK_ID
 };

--- a/Includes/Rosetta/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Enums/TaskEnums.hpp
@@ -42,6 +42,7 @@ enum class TaskID
     ARMOR,
     RETURN_HAND,
     TEMP_MANA,
+    WEAPON,
 
     NUM_TASK_ID
 };

--- a/Includes/Rosetta/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Enums/TaskEnums.hpp
@@ -44,6 +44,7 @@ enum class TaskID
     TEMP_MANA,
     WEAPON,
     FUNC_NUMBER,
+    HERO_POWER,
 
     NUM_TASK_ID
 };

--- a/Includes/Rosetta/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Enums/TaskEnums.hpp
@@ -70,6 +70,7 @@ enum class EntityType
     ENEMY_HAND,
     ALL_MINIONS,
     MINIONS,
+    MINIONS_NOSOURCE,
     ENEMY_MINIONS,
     STACK
 };

--- a/Includes/Rosetta/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Enums/TaskEnums.hpp
@@ -43,6 +43,7 @@ enum class TaskID
     RETURN_HAND,
     TEMP_MANA,
     WEAPON,
+    FUNC_NUMBER,
 
     NUM_TASK_ID
 };

--- a/Includes/Rosetta/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Enums/TaskEnums.hpp
@@ -47,6 +47,7 @@ enum class TaskID
     HERO_POWER,
     COPY,
     ADD_STACK_TO,
+    COUNT,
 
     NUM_TASK_ID
 };

--- a/Includes/Rosetta/Enums/TriggerEnums.hpp
+++ b/Includes/Rosetta/Enums/TriggerEnums.hpp
@@ -14,6 +14,7 @@ enum class TriggerType
 {
     NONE,        //!< The effect has nothing.
     TURN_START,  //!< The effect will be triggered at the start of turn.
+    TURN_END,    //!< The effect will be triggered at the end of turn.
     HEAL,        //!< The effect will be triggered when characters are healed.
 };
 

--- a/Includes/Rosetta/Enums/TriggerEnums.hpp
+++ b/Includes/Rosetta/Enums/TriggerEnums.hpp
@@ -16,12 +16,14 @@ enum class TriggerType
     TURN_START,  //!< The effect will be triggered at the start of turn.
     TURN_END,    //!< The effect will be triggered at the end of turn.
     HEAL,        //!< The effect will be triggered when characters are healed.
+    ATTACK,      //!< The effect will be triggered when characters attack.
 };
 
 //! \brief An enumerator for identifying trigger source.
 enum class TriggerSource
 {
     NONE,
+    HERO,
     ALL_MINIONS,
 };
 

--- a/Includes/Rosetta/Games/Game.hpp
+++ b/Includes/Rosetta/Games/Game.hpp
@@ -145,7 +145,7 @@ class Game
     std::deque<ITask*> taskQueue;
 
     std::vector<Aura*> auras;
-    std::vector<std::pair<Character*, Effect*>> oneTurnEffects;
+    std::vector<std::pair<Entity*, Effect*>> oneTurnEffects;
     std::map<std::size_t, Minion*> deadMinions;
 
  private:

--- a/Includes/Rosetta/Games/TriggerManager.hpp
+++ b/Includes/Rosetta/Games/TriggerManager.hpp
@@ -28,9 +28,12 @@ class TriggerManager
 
     void OnHealTrigger(Player* player, Entity* sender);
 
+    void OnAttackTrigger(Player* player, Entity* sender);
+
     std::function<void(Player*, Entity*)> startTurnTrigger;
     std::function<void(Player*, Entity*)> endTurnTrigger;
     std::function<void(Player*, Entity*)> healTrigger;
+    std::function<void(Player*, Entity*)> attackTrigger;
 };
 }  // namespace RosettaStone
 

--- a/Includes/Rosetta/Games/TriggerManager.hpp
+++ b/Includes/Rosetta/Games/TriggerManager.hpp
@@ -24,9 +24,12 @@ class TriggerManager
  public:
     void OnStartTurnTrigger(Player* player, Entity* sender);
 
+    void OnEndTurnTrigger(Player* player, Entity* sender);
+
     void OnHealTrigger(Player* player, Entity* sender);
 
     std::function<void(Player*, Entity*)> startTurnTrigger;
+    std::function<void(Player*, Entity*)> endTurnTrigger;
     std::function<void(Player*, Entity*)> healTrigger;
 };
 }  // namespace RosettaStone

--- a/Includes/Rosetta/Models/Character.hpp
+++ b/Includes/Rosetta/Models/Character.hpp
@@ -84,6 +84,14 @@ class Character : public Entity
     //! \param spellPower The value of spell power.
     void SetSpellPower(int spellPower);
 
+    //! Returns the number of attacks at this turn.
+    //! \return The number of attacks at this turn.
+    int GetNumAttacksThisTurn() const;
+
+    //! Gets the number of attacks at this turn.
+    //! \param amount The number of attacks at this turn.
+    void SetNumAttacksThisTurn(int amount);
+
     //! Returns whether attack is possible.
     //! \return Whether attack is possible.
     bool CanAttack();
@@ -113,8 +121,6 @@ class Character : public Entity
     //! \param source An entity to give heal.
     //! \param heal The value of heal.
     void TakeHeal(Entity& source, int heal);
-
-    std::size_t numAttacked = 0;
 };
 }  // namespace RosettaStone
 

--- a/Includes/Rosetta/Models/Character.hpp
+++ b/Includes/Rosetta/Models/Character.hpp
@@ -105,7 +105,7 @@ class Character : public Entity
     //! Returns a list of valid target in combat.
     //! \param opponent The opponent player.
     //! \return A list of pointer to valid target.
-    static std::vector<Character*> GetValidCombatTargets(Player& opponent);
+    std::vector<Character*> GetValidCombatTargets(Player& opponent) const;
 
     //! Takes damage from a certain other entity.
     //! \param source An entity to give damage.

--- a/Includes/Rosetta/Models/Entity.hpp
+++ b/Includes/Rosetta/Models/Entity.hpp
@@ -74,6 +74,14 @@ class Entity
     //! \param cost The value of cost.
     void SetCost(int cost);
 
+    //! Returns the value of exhausted.
+    //! \return The value of exhausted.
+    bool GetExhausted() const;
+
+    //! Sets the value of exhausted.
+    //! \param exhausted The value of exhausted.
+    void SetExhausted(bool exhausted);
+
     //! Destroys character.
     virtual void Destroy();
 

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -67,6 +67,7 @@
 #include <Rosetta/Tasks/PlayerTasks/AttackTask.hpp>
 #include <Rosetta/Tasks/PlayerTasks/ChooseTask.hpp>
 #include <Rosetta/Tasks/PlayerTasks/EndTurnTask.hpp>
+#include <Rosetta/Tasks/PlayerTasks/HeroPowerTask.hpp>
 #include <Rosetta/Tasks/PlayerTasks/PlayCardTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ArmorTask.hpp>

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -89,6 +89,7 @@
 #include <Rosetta/Tasks/SimpleTasks/SummonTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/TempManaTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/TransformTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/WeaponTask.hpp>
 #include <Rosetta/Tasks/TaskMeta.hpp>
 #include <Rosetta/Tasks/TaskStack.hpp>
 #include <Rosetta/Tasks/TaskStatus.hpp>

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -70,6 +70,7 @@
 #include <Rosetta/Tasks/PlayerTasks/HeroPowerTask.hpp>
 #include <Rosetta/Tasks/PlayerTasks/PlayCardTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ControlTask.hpp>

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -75,6 +75,7 @@
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ControlTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/CopyTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/CountTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DestroyTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DiscardTask.hpp>

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -79,6 +79,7 @@
 #include <Rosetta/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FlagTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/FuncNumberTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/HealFullTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/HealTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/IncludeTask.hpp>

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -73,6 +73,7 @@
 #include <Rosetta/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ControlTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/CopyTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DestroyTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DiscardTask.hpp>

--- a/Includes/Rosetta/Tasks/PlayerTasks/HeroPowerTask.hpp
+++ b/Includes/Rosetta/Tasks/PlayerTasks/HeroPowerTask.hpp
@@ -1,0 +1,39 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_HERO_POWER_TASK_HPP
+#define ROSETTASTONE_HERO_POWER_TASK_HPP
+
+#include <Rosetta/Tasks/Tasks.hpp>
+
+namespace RosettaStone::SimpleTasks
+{
+//!
+//! \brief WeaponTask class.
+//!
+//! This class represents the task for equipping weapon.
+//!
+class HeroPowerTask : public ITask
+{
+ public:
+    //! Constructs task with given \p cardID.
+    //! \param target A pointer to target entity to receive power.
+    explicit HeroPowerTask(Entity* target = nullptr);
+
+    //! Returns task ID.
+    //! \return Task ID.
+    TaskID GetTaskID() const override;
+
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player& player) override;
+
+    std::string m_cardID;
+};
+}  // namespace RosettaStone::SimpleTasks
+
+#endif  // ROSETTASTONE_HERO_POWER_TASK_HPP

--- a/Includes/Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp
@@ -20,7 +20,7 @@ class AddStackToTask : public ITask
  public:
     //! Constructs task with given \p entityType and \p amount.
     //! \param entityType The type of entity to add.
-    AddStackToTask(EntityType entityType);
+    explicit AddStackToTask(EntityType entityType);
 
     //! Returns task ID.
     //! \return Task ID.

--- a/Includes/Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp
@@ -1,0 +1,37 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_ADD_STACK_TO_TASK_HPP
+#define ROSETTASTONE_ADD_STACK_TO_TASK_HPP
+
+#include <Rosetta/Tasks/Tasks.hpp>
+
+namespace RosettaStone::SimpleTasks
+{
+//!
+//! \brief AddStackToTask class.
+//!
+//! This class represents the task for adding stack to something.
+//!
+class AddStackToTask : public ITask
+{
+ public:
+    //! Constructs task with given \p entityType and \p amount.
+    //! \param entityType The type of entity to add.
+    AddStackToTask(EntityType entityType);
+
+    //! Returns task ID.
+    //! \return Task ID.
+    TaskID GetTaskID() const override;
+
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player& player) override;
+};
+}  // namespace RosettaStone::SimpleTasks
+
+#endif  // ROSETTASTONE_ADD_STACK_TO_TASK_HPP

--- a/Includes/Rosetta/Tasks/SimpleTasks/CopyTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/CopyTask.hpp
@@ -1,0 +1,40 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_COPY_TASK_HPP
+#define ROSETTASTONE_COPY_TASK_HPP
+
+#include <Rosetta/Tasks/Tasks.hpp>
+
+namespace RosettaStone::SimpleTasks
+{
+//!
+//! \brief CopyTask class.
+//!
+//! This class represents the task for copying entities.
+//!
+class CopyTask : public ITask
+{
+ public:
+    //! Constructs task with given \p entityType and \p amount.
+    //! \param entityType The type of entity.
+    //! \param amount The number of entities to copy.
+    CopyTask(EntityType entityType, int amount);
+
+    //! Returns task ID.
+    //! \return Task ID.
+    TaskID GetTaskID() const override;
+
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player& player) override;
+
+    int m_amount = 0;
+};
+}  // namespace RosettaStone::SimpleTasks
+
+#endif  // ROSETTASTONE_COPY_TASK_HPP

--- a/Includes/Rosetta/Tasks/SimpleTasks/CountTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/CountTask.hpp
@@ -1,0 +1,40 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_COUNT_TASK_HPP
+#define ROSETTASTONE_COUNT_TASK_HPP
+
+#include <Rosetta/Tasks/Tasks.hpp>
+
+namespace RosettaStone::SimpleTasks
+{
+//!
+//! \brief CountTask class.
+//!
+//! This class represents the task for counting entities.
+//!
+class CountTask : public ITask
+{
+ public:
+    //! Constructs task with given \p entityType and \p numIndex.
+    //! \param entityType The type of entity.
+    //! \param numIndex An index of number.
+    CountTask(EntityType entityType, int numIndex = 0);
+
+    //! Returns task ID.
+    //! \return Task ID.
+    TaskID GetTaskID() const override;
+
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player& player) override;
+
+    int m_numIndex = 0;
+};
+}  // namespace RosettaStone::SimpleTasks
+
+#endif  // ROSETTASTONE_COUNT_TASK_HPP

--- a/Includes/Rosetta/Tasks/SimpleTasks/FuncNumberTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/FuncNumberTask.hpp
@@ -22,7 +22,7 @@ class FuncNumberTask : public ITask
  public:
     //! Constructs task with given \p cardID.
     //! \param func A function to execute.
-    explicit FuncNumberTask(std::function<void(Player&)> func);
+    explicit FuncNumberTask(std::function<void(Entity*)> func);
 
     //! Returns task ID.
     //! \return Task ID.
@@ -34,7 +34,7 @@ class FuncNumberTask : public ITask
     //! \return The result of task processing.
     TaskStatus Impl(Player& player) override;
 
-    std::function<void(Player&)> m_func;
+    std::function<void(Entity*)> m_func;
 };
 }  // namespace RosettaStone::SimpleTasks
 

--- a/Includes/Rosetta/Tasks/SimpleTasks/FuncNumberTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/FuncNumberTask.hpp
@@ -1,0 +1,41 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_FUNC_NUMBER_TASK_HPP
+#define ROSETTASTONE_FUNC_NUMBER_TASK_HPP
+
+#include <Rosetta/Tasks/Tasks.hpp>
+
+#include <functional>
+
+namespace RosettaStone::SimpleTasks
+{
+//!
+//! \brief WeaponTask class.
+//!
+//! This class represents the task for executing specific function.
+//!
+class FuncNumberTask : public ITask
+{
+ public:
+    //! Constructs task with given \p cardID.
+    //! \param func A function to execute.
+    explicit FuncNumberTask(std::function<void(Player&)> func);
+
+    //! Returns task ID.
+    //! \return Task ID.
+    TaskID GetTaskID() const override;
+
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player& player) override;
+
+    std::function<void(Player&)> m_func;
+};
+}  // namespace RosettaStone::SimpleTasks
+
+#endif  // ROSETTASTONE_FUNC_NUMBER_TASK_HPP

--- a/Includes/Rosetta/Tasks/SimpleTasks/RandomTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/RandomTask.hpp
@@ -18,7 +18,7 @@ namespace RosettaStone::SimpleTasks
 class RandomTask : public ITask
 {
  public:
-    //! Constructs task with given \p tasks and \p num.
+    //! Constructs task with given \p entityType and \p num.
     //! \param entityType The type of entity.
     //! \param num The number of entities to pick.
     RandomTask(EntityType entityType, int num);

--- a/Includes/Rosetta/Tasks/SimpleTasks/WeaponTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/WeaponTask.hpp
@@ -1,0 +1,39 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_WEAPON_TASK_HPP
+#define ROSETTASTONE_WEAPON_TASK_HPP
+
+#include <Rosetta/Tasks/Tasks.hpp>
+
+namespace RosettaStone::SimpleTasks
+{
+//!
+//! \brief WeaponTask class.
+//!
+//! This class represents the task for equipping weapon.
+//!
+class WeaponTask : public ITask
+{
+ public:
+    //! Constructs task with given \p cardID.
+    //! \param cardID The card ID of weapon to equip.
+    explicit WeaponTask(std::string&& cardID);
+
+    //! Returns task ID.
+    //! \return Task ID.
+    TaskID GetTaskID() const override;
+
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player& player) override;
+
+    std::string m_cardID;
+};
+}  // namespace RosettaStone::SimpleTasks
+
+#endif  // ROSETTASTONE_WEAPON_TASK_HPP

--- a/Includes/Rosetta/Tasks/TaskStack.hpp
+++ b/Includes/Rosetta/Tasks/TaskStack.hpp
@@ -19,9 +19,6 @@ struct TaskStack
 
     int num = 0;
     int num1 = 0;
-    int num2 = 0;
-    int num3 = 0;
-    int num4 = 0;
 
     bool flag = true;
 };

--- a/Includes/Rosetta/Tasks/TaskStack.hpp
+++ b/Includes/Rosetta/Tasks/TaskStack.hpp
@@ -16,6 +16,13 @@ struct TaskStack
 
     Entity* source = nullptr;
     Entity* target = nullptr;
+
+    int num = 0;
+    int num1 = 0;
+    int num2 = 0;
+    int num3 = 0;
+    int num4 = 0;
+
     bool flag = true;
 };
 }  // namespace RosettaStone

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Basic & Classic
 
-- 85% Basic (114 of 133 Cards)
+- 89% Basic (119 of 133 Cards)
 - 9% Classic (23 of 237 Cards)
 - 9% Hall of Fame (2 of 22 Cards)
 

--- a/Sources/Rosetta/Actions/Attack.cpp
+++ b/Sources/Rosetta/Actions/Attack.cpp
@@ -18,6 +18,10 @@ void Attack(Player& player, Character* source, Character* target)
         return;
     }
 
+    // Activate attack trigger
+    player.GetGame()->triggerManager.OnAttackTrigger(&player, source);
+    player.GetGame()->ProcessTasks();
+
     // Set game step to MAIN_COMBAT
     player.GetGame()->step = Step::MAIN_COMBAT;
 

--- a/Sources/Rosetta/Actions/Attack.cpp
+++ b/Sources/Rosetta/Actions/Attack.cpp
@@ -91,7 +91,7 @@ void Attack(Player& player, Character* source, Character* target)
         (source->numAttacked >= 2 &&
          source->GetGameTag(GameTag::WINDFURY) == 1))
     {
-        source->SetGameTag(GameTag::EXHAUSTED, 1);
+        source->SetExhausted(true);
     }
 
     // Process destroy and update aura

--- a/Sources/Rosetta/Actions/Attack.cpp
+++ b/Sources/Rosetta/Actions/Attack.cpp
@@ -87,12 +87,12 @@ void Attack(Player& player, Character* source, Character* target)
     }
 
     // Increase the number of attacked
-    source->numAttacked++;
+    source->SetNumAttacksThisTurn(source->GetNumAttacksThisTurn() + 1);
 
     // Check source is exhausted
-    if ((source->numAttacked >= 1 &&
+    if ((source->GetNumAttacksThisTurn() >= 1 &&
          source->GetGameTag(GameTag::WINDFURY) == 0) ||
-        (source->numAttacked >= 2 &&
+        (source->GetNumAttacksThisTurn() >= 2 &&
          source->GetGameTag(GameTag::WINDFURY) == 1))
     {
         source->SetExhausted(true);

--- a/Sources/Rosetta/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/Actions/PlayCard.cpp
@@ -100,6 +100,11 @@ void PlaySpell(Player& player, Spell* spell, Character* target)
     // Process power tasks
     for (auto& powerTask : spell->card.power.GetPowerTask())
     {
+        if (powerTask == nullptr)
+        {
+            continue;
+        }
+
         powerTask->SetSource(spell);
         powerTask->SetTarget(target);
         powerTask->Run(player);
@@ -112,7 +117,30 @@ void PlaySpell(Player& player, Spell* spell, Character* target)
 
 void PlayWeapon(Player& player, Weapon* weapon, Character* target)
 {
-    (void)target;
+    // Process trigger
+    if (weapon->card.power.GetTrigger().has_value())
+    {
+        weapon->card.power.GetTrigger().value().Activate(*weapon);
+    }
+
+    // Process aura
+    if (weapon->card.power.GetAura().has_value())
+    {
+        weapon->card.power.GetAura().value().Activate(*weapon);
+    }
+
+    // Process power tasks
+    for (auto& powerTask : weapon->card.power.GetPowerTask())
+    {
+        if (powerTask == nullptr)
+        {
+            continue;
+        }
+
+        powerTask->SetSource(weapon);
+        powerTask->SetTarget(target);
+        powerTask->Run(player);
+    }
 
     player.GetHero()->AddWeapon(*weapon);
 }

--- a/Sources/Rosetta/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/Actions/PlayCard.cpp
@@ -147,6 +147,12 @@ bool IsPlayableByCardReq(Entity* source)
     {
         switch (requirement.first)
         {
+            case PlayReq::REQ_WEAPON_EQUIPPED:
+                if (!source->owner->GetHero()->HasWeapon())
+                {
+                    return false;
+                }
+                break;
             case PlayReq::REQ_MINIMUM_ENEMY_MINIONS:
             {
                 auto& opField = source->owner->opponent->GetField();

--- a/Sources/Rosetta/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/Actions/PlayCard.cpp
@@ -132,7 +132,8 @@ bool IsPlayableByPlayer(Player& player, Entity* source)
     }
 
     // Check if entity is in hand to be played
-    if (player.GetHand().FindCardPos(*source) == std::nullopt)
+    if (dynamic_cast<HeroPower*>(source) == nullptr &&
+        player.GetHand().FindCardPos(*source) == std::nullopt)
     {
         return false;
     }

--- a/Sources/Rosetta/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/CoreCardsGen.cpp
@@ -441,7 +441,7 @@ void CoreCardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [CS2_005o] Claw (*) - COST:0
-    // - Set: Core,
+    // - Set: Core
     // --------------------------------------------------------
     // Text: +2 Attack this turn.
     // --------------------------------------------------------
@@ -454,7 +454,7 @@ void CoreCardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [CS2_009e] Mark of the Wild (*) - COST:0
-    // - Set: Core,
+    // - Set: Core
     // --------------------------------------------------------
     // Text: +2/+2 and <b>Taunt</b>.
     // --------------------------------------------------------
@@ -464,7 +464,7 @@ void CoreCardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [CS2_011o] Savage Roar (*) - COST:0
-    // - Set: Core,
+    // - Set: Core
     // --------------------------------------------------------
     // Text: +2 Attack this turn.
     // --------------------------------------------------------
@@ -477,7 +477,7 @@ void CoreCardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [CS2_017o] Claws (*) - COST:0
-    // - Set: Core,
+    // - Set: Core
     // --------------------------------------------------------
     // Text: Your hero has +1 Attack this turn.
     // --------------------------------------------------------
@@ -560,7 +560,7 @@ void CoreCardsGen::AddHunterNonCollect(std::map<std::string, Power>& cards)
 
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [CS2_084e] Hunter's Mark (*) - COST:0
-    // - Set: Core,
+    // - Set: Core
     // --------------------------------------------------------
     // Text: This minion has 1 Health.
     // --------------------------------------------------------
@@ -856,7 +856,7 @@ void CoreCardsGen::AddPaladinNonCollect(std::map<std::string, Power>& cards)
 
     // ---------------------------------- ENCHANTMENT - PALADIN
     // [CS2_092e] Blessing of Kings (*) - COST:0
-    // - Set: Core,
+    // - Set: Core
     // --------------------------------------------------------
     // Text: +4/+4.
     // --------------------------------------------------------
@@ -866,7 +866,7 @@ void CoreCardsGen::AddPaladinNonCollect(std::map<std::string, Power>& cards)
 
     // --------------------------------------- MINION - PALADIN
     // [CS2_101t] Silver Hand Recruit (*) - COST:1 [ATK:1/HP:1]
-    // - Set: core, Rarity: free
+    // - Set: Core, Rarity: Free
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -1015,7 +1015,7 @@ void CoreCardsGen::AddPriestNonCollect(std::map<std::string, Power>& cards)
 
     // ----------------------------------- ENCHANTMENT - PRIEST
     // [CS2_004e] Power Word: Shield (*) - COST:0
-    // - Set: Core,
+    // - Set: Core
     // --------------------------------------------------------
     // Text: +2 Health.
     // --------------------------------------------------------
@@ -1319,7 +1319,7 @@ void CoreCardsGen::AddShamanNonCollect(std::map<std::string, Power>& cards)
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [CS2_041e] Ancestral Infusion (*) - COST:0
-    // - Set: Core,
+    // - Set: Core
     // --------------------------------------------------------
     // Text: Taunt.
     // --------------------------------------------------------
@@ -1332,7 +1332,7 @@ void CoreCardsGen::AddShamanNonCollect(std::map<std::string, Power>& cards)
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [CS2_045e] Rockbiter Weapon (*) - COST:0
-    // - Set: Core,
+    // - Set: Core
     // --------------------------------------------------------
     // Text: This character has +3 Attack this turn.
     // --------------------------------------------------------
@@ -1345,7 +1345,7 @@ void CoreCardsGen::AddShamanNonCollect(std::map<std::string, Power>& cards)
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [CS2_046e] Bloodlust (*) - COST:0
-    // - Set: core,
+    // - Set: Core
     // --------------------------------------------------------
     // Text: +3 Attack this turn.
     // --------------------------------------------------------
@@ -1392,7 +1392,7 @@ void CoreCardsGen::AddShamanNonCollect(std::map<std::string, Power>& cards)
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [EX1_565o] Flametongue (*) - COST:0
-    // - Set: Core,
+    // - Set: Core
     // --------------------------------------------------------
     // Text: +2 Attack from Flametongue Totem.
     // --------------------------------------------------------
@@ -1549,7 +1549,7 @@ void CoreCardsGen::AddWarlockNonCollect(std::map<std::string, Power>& cards)
 
     // ---------------------------------- ENCHANTMENT - WARLOCK
     // [CS2_063e] Corruption (*) - COST:0
-    // - Set: core,
+    // - Set: Core
     // --------------------------------------------------------
     // Text: At the start of the corrupting player's turn, destroy this minion.
     // --------------------------------------------------------
@@ -1667,7 +1667,7 @@ void CoreCardsGen::AddWarriorNonCollect(std::map<std::string, Power>& cards)
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [CS2_105e] Heroic Strike (*) - COST:0
-    // - Set: Core,
+    // - Set: Core
     // --------------------------------------------------------
     // Text: +4 Attack this turn.
     // --------------------------------------------------------
@@ -2151,6 +2151,7 @@ void CoreCardsGen::AddNeutral(std::map<std::string, Power>& cards)
 void CoreCardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
 {
     Power power;
+
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [CS2_122e] Enhanced (*) - COST:0
     // - Set: Core

--- a/Sources/Rosetta/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/CoreCardsGen.cpp
@@ -1342,6 +1342,40 @@ void CoreCardsGen::AddShamanNonCollect(std::map<std::string, Power>& cards)
     power.AddEnchant(Enchants::GetEnchantFromText("CS2_046e"));
     cards.emplace("CS2_046e", power);
 
+    // ---------------------------------------- MINION - SHAMAN
+    // [CS2_050] Searing Totem (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Totem, Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CS2_050", power);
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [CS2_051] Stoneclaw Totem (*) - COST:1 [ATK:0/HP:2]
+    // - Race: Totem, Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CS2_051", power);
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [CS2_052] Wrath of Air Totem (*) - COST:1 [ATK:0/HP:2]
+    // - Race: Totem, Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: <b>Spell Damage +1</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPELLPOWER = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CS2_052", power);
+
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [EX1_565o] Flametongue (*) - COST:0
     // - Set: Core,
@@ -1351,6 +1385,18 @@ void CoreCardsGen::AddShamanNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddEnchant(Enchants::GetEnchantFromText("EX1_565o"));
     cards.emplace("EX1_565o", power);
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [NEW1_009] Healing Totem (*) - COST:1 [ATK:0/HP:2]
+    // - Race: Totem, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: At the end of your turn, restore 1 Health to all friendly minions.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(Trigger(TriggerType::TURN_END));
+    power.GetTrigger().value().singleTask =
+        new HealTask(EntityType::MINIONS, 1);
+    cards.emplace("NEW1_009", power);
 }
 
 void CoreCardsGen::AddWarlock(std::map<std::string, Power>& cards)

--- a/Sources/Rosetta/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/CoreCardsGen.cpp
@@ -17,6 +17,7 @@
 #include <Rosetta/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FlagTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/FuncNumberTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/HealFullTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/HealTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ManaCrystalTask.hpp>
@@ -26,6 +27,7 @@
 #include <Rosetta/Tasks/SimpleTasks/SummonTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/TempManaTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/TransformTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/WeaponTask.hpp>
 
 using namespace RosettaStone::SimpleTasks;
 
@@ -137,7 +139,128 @@ void CoreCardsGen::AddHeroes(std::map<std::string, Power>& cards)
 
 void CoreCardsGen::AddHeroPowers(std::map<std::string, Power>& cards)
 {
-    (void)cards;
+    Power power;
+
+    // ------------------------------------ HERO_POWER - PRIEST
+    // [CS1h_001] Lesser Heal (*) - COST:2
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b>
+    //       Restore #2 Health.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new HealTask(EntityType::TARGET, 2));
+    cards.emplace("CS1h_001", power);
+
+    // ------------------------------------- HERO_POWER - DRUID
+    // [CS2_017] Shapeshift (*) - COST:2
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b>
+    //       +1 Attack this turn.    +1 Armor.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new AddEnchantmentTask("CS2_170o", EntityType::HERO));
+    power.AddPowerTask(new ArmorTask(1));
+    cards.emplace("CS2_170", power);
+
+    // -------------------------------------- HERO_POWER - MAGE
+    // [CS2_034] Fireblast (*) - COST:2
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b>
+    //       Deal $1 damage.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new DamageTask(EntityType::TARGET, 1, false));
+    cards.emplace("CS2_034", power);
+
+    // ------------------------------------ HERO_POWER - SHAMAN
+    // [CS2_049] Totemic Call (*) - COST:2
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b>
+    //       Summon a random Totem.
+    // --------------------------------------------------------
+    // Entourage: CS2_050, CS2_051, CS2_052, NEW1_009
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // - REQ_ENTIRE_ENTOURAGE_NOT_IN_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        new FuncNumberTask([](Player& player) { (void)player; }));
+    cards.emplace("CS2_049", power);
+
+    // ----------------------------------- HERO_POWER - WARLOCK
+    // [CS2_056] Life Tap (*) - COST:2
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b>
+    //       Draw a card and take $2 damage.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new DamageTask(EntityType::HERO, 2, false));
+    power.AddPowerTask(new DrawTask(1));
+    cards.emplace("CS2_056", power);
+
+    // ------------------------------------- HERO_POWER - ROGUE
+    // [CS2_083b] Dagger Mastery (*) - COST:2
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b>
+    //       Equip a 1/2 Dagger.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new WeaponTask("CS2_082"));
+    cards.emplace("CS2_083b", power);
+
+    // ----------------------------------- HERO_POWER - PALADIN
+    // [CS2_101] Reinforce (*) - COST:2
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b>
+    //       Summon a 1/1 Silver Hand Recruit.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new SummonTask("CS2_101t", SummonSide::DEFAULT));
+    cards.emplace("CS2_101", power);
+
+    // ----------------------------------- HERO_POWER - WARRIOR
+    // [CS2_102] Armor Up! (*) - COST:2
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b>
+    //       Gain 2 Armor.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new ArmorTask(2));
+    cards.emplace("CS2_102", power);
+
+    // ------------------------------------ HERO_POWER - HUNTER
+    // [DS1h_292] Steady Shot (*) - COST:2
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b>
+    //       Deal $2 damage to the enemy hero.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_STEADY_SHOT = 0
+    // - REQ_MINION_OR_ENEMY_HERO = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new DamageTask(EntityType::ENEMY_HERO, 2, false));
+    cards.emplace("DS1h_292", power);
 }
 
 void CoreCardsGen::AddDruid(std::map<std::string, Power>& cards)
@@ -312,6 +435,19 @@ void CoreCardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddEnchant(Enchants::GetEnchantFromText("CS2_011o"));
     cards.emplace("CS2_011o", power);
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [CS2_017o] Claws (*) - COST:0
+    // - Set: Core,
+    // --------------------------------------------------------
+    // Text: Your hero has +1 Attack this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("CS2_170o"));
+    cards.emplace("CS2_017o", power);
 }
 
 void CoreCardsGen::AddHunter(std::map<std::string, Power>& cards)
@@ -689,6 +825,14 @@ void CoreCardsGen::AddPaladinNonCollect(std::map<std::string, Power>& cards)
     power.AddEnchant(Enchants::GetEnchantFromText("CS2_092e"));
     cards.emplace("CS2_092e", power);
 
+    // --------------------------------------- MINION - PALADIN
+    // [CS2_101t] Silver Hand Recruit (*) - COST:1 [ATK:1/HP:1]
+    // - Set: core, Rarity: free
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CS2_101t", power);
+
     // ---------------------------------- ENCHANTMENT - PALADIN
     // [EX1_360e] Humility (*) - COST:0
     // - Faction: Neutral, Set: Core,
@@ -949,7 +1093,18 @@ void CoreCardsGen::AddRogue(std::map<std::string, Power>& cards)
 
 void CoreCardsGen::AddRogueNonCollect(std::map<std::string, Power>& cards)
 {
-    (void)cards;
+    Power power;
+
+    // ----------------------------------------- WEAPON - ROGUE
+    // [CS2_082] Wicked Knife (*) - COST:1 [ATK:1/HP:0]
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 2
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CS2_082", power);
 }
 
 void CoreCardsGen::AddShaman(std::map<std::string, Power>& cards)

--- a/Sources/Rosetta/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/CoreCardsGen.cpp
@@ -9,9 +9,11 @@
 #include <Rosetta/Enchants/Effects.hpp>
 #include <Rosetta/Enchants/Enchants.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ControlTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/CopyTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DestroyTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DiscardTask.hpp>
@@ -925,6 +927,18 @@ void CoreCardsGen::AddPriest(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddPowerTask(new DamageTask(EntityType::TARGET, 2, true));
     cards.emplace("CS1_130", power);
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [CS2_003] Mind Vision - COST:1
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: Put a copy of a random card in your opponent's hand into your hand.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new RandomTask(EntityType::ENEMY_HAND, 1));
+    power.AddPowerTask(new CopyTask(EntityType::STACK, 1));
+    power.AddPowerTask(new AddStackToTask(EntityType::HAND));
+    cards.emplace("CS2_003", power);
 
     // ----------------------------------------- SPELL - PRIEST
     // [CS2_004] Power Word: Shield - COST:1

--- a/Sources/Rosetta/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/CoreCardsGen.cpp
@@ -163,9 +163,9 @@ void CoreCardsGen::AddHeroPowers(std::map<std::string, Power>& cards)
     //       +1 Attack this turn.    +1 Armor.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(new AddEnchantmentTask("CS2_170o", EntityType::HERO));
+    power.AddPowerTask(new AddEnchantmentTask("CS2_017o", EntityType::HERO));
     power.AddPowerTask(new ArmorTask(1));
-    cards.emplace("CS2_170", power);
+    cards.emplace("CS2_017", power);
 
     // -------------------------------------- HERO_POWER - MAGE
     // [CS2_034] Fireblast (*) - COST:2
@@ -446,7 +446,7 @@ void CoreCardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddEnchant(Enchants::GetEnchantFromText("CS2_170o"));
+    power.AddEnchant(Enchants::GetEnchantFromText("CS2_017o"));
     cards.emplace("CS2_017o", power);
 }
 

--- a/Sources/Rosetta/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/CoreCardsGen.cpp
@@ -1592,6 +1592,25 @@ void CoreCardsGen::AddWarrior(std::map<std::string, Power>& cards)
     Power power;
 
     // ---------------------------------------- SPELL - WARRIOR
+    // [CS2_103] Charge - COST:1
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: Give a friendly minion <b>Charge</b>. It can't attack heroes this
+    // turn.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - CHARGE = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new AddEnchantmentTask("CS2_103e2", EntityType::TARGET));
+    cards.emplace("CS2_103", power);
+
+    // ---------------------------------------- SPELL - WARRIOR
     // [CS2_105] Heroic Strike - COST:2
     // - Faction: Neutral, Set: Core, Rarity: Free
     // --------------------------------------------------------
@@ -1692,6 +1711,22 @@ void CoreCardsGen::AddWarrior(std::map<std::string, Power>& cards)
 void CoreCardsGen::AddWarriorNonCollect(std::map<std::string, Power>& cards)
 {
     Power power;
+
+    // ---------------------------------- ENCHANTMENT - WARRIOR
+    // [CS2_103e2] Charge (*) - COST:0
+    // - Set: core,
+    // --------------------------------------------------------
+    // Text: Has <b>Charge</b>.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(
+        Enchant({ Effects::Charge, Effect(GameTag::CANNOT_ATTACK_HEROES,
+                                          EffectOperator::SET, 1) }));
+    power.AddTrigger(Trigger(TriggerType::TURN_END));
+    power.GetTrigger().value().singleTask = new SetGameTagTask(
+        EntityType::TARGET, GameTag::CANNOT_ATTACK_HEROES, 0);
+    power.GetTrigger().value().removeAfterTriggered = true;
+    cards.emplace("CS2_103e2", power);
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [CS2_105e] Heroic Strike (*) - COST:0

--- a/Sources/Rosetta/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/CoreCardsGen.cpp
@@ -1044,6 +1044,19 @@ void CoreCardsGen::AddRogue(std::map<std::string, Power>& cards)
     cards.emplace("CS2_072", power);
 
     // ------------------------------------------ SPELL - ROGUE
+    // [CS2_074] Deadly Poison - COST:1
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: Give your weapon +2 Attack.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_WEAPON_EQUIPPED = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new AddEnchantmentTask("CS2_074e", EntityType::WEAPON));
+    cards.emplace("CS2_074", power);
+
+    // ------------------------------------------ SPELL - ROGUE
     // [CS2_075] Sinister Strike - COST:1
     // - Faction: Neutral, Set: Core, Rarity: Free
     // --------------------------------------------------------
@@ -2151,6 +2164,16 @@ void CoreCardsGen::AddNeutral(std::map<std::string, Power>& cards)
 void CoreCardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
 {
     Power power;
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CS2_074e] Deadly Poison (*) - COST:0
+    // - Set: Core
+    // --------------------------------------------------------
+    // Text: +2 Attack.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("CS2_074e"));
+    cards.emplace("CS2_074e", power);
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [CS2_122e] Enhanced (*) - COST:0

--- a/Sources/Rosetta/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/CoreCardsGen.cpp
@@ -807,6 +807,21 @@ void CoreCardsGen::AddPaladin(std::map<std::string, Power>& cards)
     power.AddPowerTask(new DrawTask(1));
     cards.emplace("CS2_094", power);
 
+    // --------------------------------------- WEAPON - PALADIN
+    // [CS2_097] Truesilver Champion - COST:4 [ATK:4/HP:0]
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: Whenever your hero attacks, restore 2 Health to it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 2
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(Trigger(TriggerType::ATTACK));
+    power.GetTrigger().value().triggerSource = TriggerSource::HERO;
+    power.GetTrigger().value().singleTask = new HealTask(EntityType::HERO, 2);
+    cards.emplace("CS2_097", power);
+
     // ---------------------------------------- SPELL - PALADIN
     // [EX1_360] Humility - COST:1
     // - Faction: Neutral, Set: Core, Rarity: Free

--- a/Sources/Rosetta/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/CoreCardsGen.cpp
@@ -14,6 +14,7 @@
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ControlTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/CopyTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/CountTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DestroyTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DiscardTask.hpp>
@@ -2116,6 +2117,21 @@ void CoreCardsGen::AddNeutral(std::map<std::string, Power>& cards)
     power.AddAura(Aura("CS2_222o", AuraType::FIELD_EXCEPT_SOURCE));
     cards.emplace("CS2_222", power);
 
+	// --------------------------------------- MINION - NEUTRAL
+    // [CS2_226] Frostwolf Warlord - COST:5 [ATK:4/HP:4]
+    // - Faction: Horde, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Gain +1/+1 for each other friendly minion on the
+    // battlefield.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new CountTask(EntityType::MINIONS_NOSOURCE));
+    power.AddPowerTask(new AddEnchantmentTask("CS2_226e", EntityType::SOURCE));
+    cards.emplace("CS2_226", power);
+
     // --------------------------------------- MINION - NEUTRAL
     // [DS1_055] Darkscale Healer - COST:5 [ATK:4/HP:5]
     // - Faction: Neutral, Set: Core, Rarity: Free
@@ -2244,6 +2260,16 @@ void CoreCardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddEnchant(Enchants::GetEnchantFromText("CS2_222o"));
     cards.emplace("CS2_222o", power);
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CS2_226e] Frostwolf Banner (*) - COST:0
+    // - Set: Core
+    // --------------------------------------------------------
+    // Text: Increased stats.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(std::move(Enchants::AddAttackHealthScriptTag));
+    cards.emplace("CS2_226e", power);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_boar] Boar (*) - COST:1 [ATK:1/HP:1]

--- a/Sources/Rosetta/Enchants/Effect.cpp
+++ b/Sources/Rosetta/Enchants/Effect.cpp
@@ -17,31 +17,30 @@ Effect::Effect(GameTag gameTag, EffectOperator effectOperator, int value)
     // Do nothing
 }
 
-void Effect::Apply(Character* character, bool isOneTurnEffect) const
+void Effect::Apply(Entity* entity, bool isOneTurnEffect) const
 {
-    auto& oneTurnEffects = character->owner->GetGame()->oneTurnEffects;
+    auto& oneTurnEffects = entity->owner->GetGame()->oneTurnEffects;
 
     if (isOneTurnEffect)
     {
-        oneTurnEffects.emplace_back(
-            std::make_pair(character, new Effect(*this)));
+        oneTurnEffects.emplace_back(std::make_pair(entity, new Effect(*this)));
     }
 
-    const int prevValue = character->GetGameTag(m_gameTag);
+    const int prevValue = entity->GetGameTag(m_gameTag);
 
     switch (m_effectOperator)
     {
         case EffectOperator::ADD:
-            character->SetGameTag(m_gameTag, prevValue + m_value);
+            entity->SetGameTag(m_gameTag, prevValue + m_value);
             break;
         case EffectOperator::SUB:
-            character->SetGameTag(m_gameTag, prevValue - m_value);
+            entity->SetGameTag(m_gameTag, prevValue - m_value);
             break;
         case EffectOperator::MUL:
-            character->SetGameTag(m_gameTag, prevValue * m_value);
+            entity->SetGameTag(m_gameTag, prevValue * m_value);
             break;
         case EffectOperator::SET:
-            character->SetGameTag(m_gameTag, m_value);
+            entity->SetGameTag(m_gameTag, m_value);
             break;
         default:
             throw std::invalid_argument("Invalid effect operator!");
@@ -68,21 +67,21 @@ void Effect::Apply(AuraEffects& auraEffects) const
     }
 }
 
-void Effect::Remove(Character* character) const
+void Effect::Remove(Entity* entity) const
 {
-    const int prevValue = character->GetGameTag(m_gameTag);
+    const int prevValue = entity->GetGameTag(m_gameTag);
 
     switch (m_effectOperator)
     {
         case EffectOperator::ADD:
-            character->SetGameTag(m_gameTag, prevValue - m_value);
+            entity->SetGameTag(m_gameTag, prevValue - m_value);
             break;
         case EffectOperator::SUB:
-            character->SetGameTag(
-                m_gameTag, character->card.gameTags.at(m_gameTag) + m_value);
+            entity->SetGameTag(m_gameTag,
+                               entity->card.gameTags.at(m_gameTag) + m_value);
             break;
         case EffectOperator::SET:
-            character->SetGameTag(m_gameTag, 0);
+            entity->SetGameTag(m_gameTag, 0);
             break;
         default:
             throw std::invalid_argument("Invalid effect operator!");

--- a/Sources/Rosetta/Enchants/Effect.cpp
+++ b/Sources/Rosetta/Enchants/Effect.cpp
@@ -40,6 +40,14 @@ void Effect::Apply(Entity* entity, bool isOneTurnEffect) const
             entity->SetGameTag(m_gameTag, prevValue * m_value);
             break;
         case EffectOperator::SET:
+            if (m_gameTag == GameTag::CHARGE)
+            {
+                if (entity->GetExhausted() &&
+                    entity->GetGameTag(GameTag::NUM_ATTACKS_THIS_TURN) == 0)
+                {
+                    entity->SetExhausted(false);
+                }
+            }
             entity->SetGameTag(m_gameTag, m_value);
             break;
         default:

--- a/Sources/Rosetta/Enchants/Effect.cpp
+++ b/Sources/Rosetta/Enchants/Effect.cpp
@@ -122,4 +122,9 @@ void Effect::Remove(AuraEffects& auraEffects) const
             throw std::invalid_argument("Invalid effect operator!");
     }
 }
+
+Effect Effect::ChangeValue(int newValue) const
+{
+    return Effect(m_gameTag, m_effectOperator, newValue);
+}
 }  // namespace RosettaStone

--- a/Sources/Rosetta/Enchants/Enchant.cpp
+++ b/Sources/Rosetta/Enchants/Enchant.cpp
@@ -6,6 +6,8 @@
 
 #include <Rosetta/Enchants/Enchant.hpp>
 
+#include <utility>
+
 namespace RosettaStone
 {
 Enchant::Enchant(GameTag gameTag, EffectOperator effectOperator, int value)
@@ -19,22 +21,41 @@ Enchant::Enchant(Effect& effect)
     effects.emplace_back(effect);
 }
 
-Enchant::Enchant(std::initializer_list<Effect> _effects) : effects(_effects)
+Enchant::Enchant(std::vector<Effect> _effects, bool _useScriptTag,
+                 bool _isOneTurnEffect)
+    : effects(std::move(_effects)),
+      useScriptTag(_useScriptTag),
+      isOneTurnEffect(_isOneTurnEffect)
 {
     // Do nothing
 }
 
-Enchant::Enchant(std::vector<Effect>& _effects, bool _isOneTurnEffect)
-    : effects(_effects), isOneTurnEffect(_isOneTurnEffect)
+void Enchant::ActivateTo(Entity* entity, int num1, int num2)
 {
-    // Do nothing
-}
-
-void Enchant::ActivateTo(Entity* entity)
-{
-    for (auto& effect : effects)
+    if (!useScriptTag)
     {
-        effect.Apply(entity, isOneTurnEffect);
+        for (auto& effect : effects)
+        {
+            effect.Apply(entity, isOneTurnEffect);
+        }
+    }
+    else
+    {
+        effects[0].ChangeValue(num1).Apply(entity, isOneTurnEffect);
+
+        if (effects.size() != 2)
+        {
+            return;
+        }
+
+        if (num2 > 0)
+        {
+            effects[1].ChangeValue(num2).Apply(entity, isOneTurnEffect);
+        }
+        else
+        {
+            effects[1].ChangeValue(num1).Apply(entity, isOneTurnEffect);
+        }
     }
 }
 }  // namespace RosettaStone

--- a/Sources/Rosetta/Enchants/Enchant.cpp
+++ b/Sources/Rosetta/Enchants/Enchant.cpp
@@ -25,11 +25,11 @@ Enchant::Enchant(std::vector<Effect>& _effects, bool _isOneTurnEffect)
     // Do nothing
 }
 
-void Enchant::ActivateTo(Character* character)
+void Enchant::ActivateTo(Entity* entity)
 {
     for (auto& effect : effects)
     {
-        effect.Apply(character, isOneTurnEffect);
+        effect.Apply(entity, isOneTurnEffect);
     }
 }
 }  // namespace RosettaStone

--- a/Sources/Rosetta/Enchants/Enchant.cpp
+++ b/Sources/Rosetta/Enchants/Enchant.cpp
@@ -19,6 +19,11 @@ Enchant::Enchant(Effect& effect)
     effects.emplace_back(effect);
 }
 
+Enchant::Enchant(std::initializer_list<Effect> _effects) : effects(_effects)
+{
+    // Do nothing
+}
+
 Enchant::Enchant(std::vector<Effect>& _effects, bool _isOneTurnEffect)
     : effects(_effects), isOneTurnEffect(_isOneTurnEffect)
 {

--- a/Sources/Rosetta/Enchants/Enchants.cpp
+++ b/Sources/Rosetta/Enchants/Enchants.cpp
@@ -48,6 +48,6 @@ Enchant Enchants::GetEnchantFromText(const std::string& cardID)
         isOneTurn = true;
     }
 
-    return Enchant(effects, isOneTurn);
+    return Enchant(effects, false, isOneTurn);
 }
 }  // namespace RosettaStone

--- a/Sources/Rosetta/Enchants/Trigger.cpp
+++ b/Sources/Rosetta/Enchants/Trigger.cpp
@@ -59,6 +59,11 @@ void Trigger::Activate(Entity& source)
                 std::bind(&Trigger::Process, instance, std::placeholders::_1,
                           std::placeholders::_2);
             break;
+        case TriggerType::ATTACK:
+            game->triggerManager.attackTrigger =
+                std::bind(&Trigger::Process, instance, std::placeholders::_1,
+                          std::placeholders::_2);
+            break;
         default:
             throw std::invalid_argument(
                 "Trigger::Activate() - Invalid trigger type!");
@@ -79,6 +84,9 @@ void Trigger::Remove()
             break;
         case TriggerType::HEAL:
             game->triggerManager.healTrigger = nullptr;
+            break;
+        case TriggerType::ATTACK:
+            game->triggerManager.attackTrigger = nullptr;
             break;
         default:
             throw std::invalid_argument(
@@ -148,6 +156,13 @@ void Trigger::Validate(Player* player, Entity* source)
     {
         case TriggerSource::NONE:
             break;
+        case TriggerSource::HERO:
+            if (dynamic_cast<Hero*>(source) == nullptr ||
+                source->owner != m_owner->owner)
+            {
+                return;
+            }
+            break;
         case TriggerSource::ALL_MINIONS:
             if (dynamic_cast<Minion*>(source) == nullptr)
             {
@@ -174,6 +189,7 @@ void Trigger::Validate(Player* player, Entity* source)
             }
             break;
         case TriggerType::HEAL:
+        case TriggerType::ATTACK:
             break;
         default:
             throw std::invalid_argument(

--- a/Sources/Rosetta/Enchants/Trigger.cpp
+++ b/Sources/Rosetta/Enchants/Trigger.cpp
@@ -28,6 +28,7 @@ Trigger::Trigger(Trigger& prototype, Entity& owner)
     : triggerSource(prototype.triggerSource),
       singleTask(prototype.singleTask),
       fastExecution(prototype.fastExecution),
+      removeAfterTriggered(prototype.removeAfterTriggered),
       m_triggerType(prototype.m_triggerType),
       m_sequenceType(prototype.m_sequenceType),
       m_owner(&owner)
@@ -116,6 +117,11 @@ void Trigger::ProcessInternal(Player* player, Entity* source)
     (void)player;
 
     m_isValidated = false;
+
+    if (removeAfterTriggered)
+    {
+        Remove();
+    }
 
     singleTask->SetSource(m_owner);
 

--- a/Sources/Rosetta/Enchants/Trigger.cpp
+++ b/Sources/Rosetta/Enchants/Trigger.cpp
@@ -114,8 +114,6 @@ void Trigger::Process(Player* player, Entity* source)
 
 void Trigger::ProcessInternal(Player* player, Entity* source)
 {
-    (void)player;
-
     m_isValidated = false;
 
     if (removeAfterTriggered)

--- a/Sources/Rosetta/Enchants/Trigger.cpp
+++ b/Sources/Rosetta/Enchants/Trigger.cpp
@@ -116,11 +116,6 @@ void Trigger::ProcessInternal(Player* player, Entity* source)
 {
     m_isValidated = false;
 
-    if (removeAfterTriggered)
-    {
-        Remove();
-    }
-
     singleTask->SetSource(m_owner);
 
     if (source != nullptr)
@@ -147,6 +142,11 @@ void Trigger::ProcessInternal(Player* player, Entity* source)
     else
     {
         m_owner->owner->GetGame()->taskQueue.push_back(singleTask);
+    }
+
+    if (removeAfterTriggered)
+    {
+        Remove();
     }
 
     m_isValidated = false;

--- a/Sources/Rosetta/Games/Game.cpp
+++ b/Sources/Rosetta/Games/Game.cpp
@@ -420,10 +420,10 @@ void Game::MainCleanUp()
     // Remove one-turn effects
     for (auto& effectPair : oneTurnEffects)
     {
-        Character* character = effectPair.first;
+        Entity* entity = effectPair.first;
         Effect* effect = effectPair.second;
 
-        effect->Remove(character);
+        effect->Remove(entity);
         delete effect;
     }
     oneTurnEffects.clear();

--- a/Sources/Rosetta/Games/Game.cpp
+++ b/Sources/Rosetta/Games/Game.cpp
@@ -401,6 +401,10 @@ void Game::MainAction()
 
 void Game::MainEnd()
 {
+    triggerManager.OnEndTurnTrigger(&GetCurrentPlayer(), nullptr);
+    ProcessTasks();
+    ProcessDestroyAndUpdateAura();
+
     // Set next step
     nextStep = Step::MAIN_CLEANUP;
     if (m_gameConfig.autoRun)

--- a/Sources/Rosetta/Games/Game.cpp
+++ b/Sources/Rosetta/Games/Game.cpp
@@ -208,18 +208,18 @@ void Game::MainReady()
     // Reset exhaust for current player
     auto& curPlayer = GetCurrentPlayer();
     // Hero
-    curPlayer.GetHero()->SetGameTag(GameTag::EXHAUSTED, 0);
+    curPlayer.GetHero()->SetExhausted(false);
     // Weapon
     if (curPlayer.GetHero()->weapon != nullptr)
     {
-        curPlayer.GetHero()->weapon->SetGameTag(GameTag::EXHAUSTED, 0);
+        curPlayer.GetHero()->weapon->SetExhausted(false);
     }
     // Hero power
-    curPlayer.GetHero()->heroPower->SetGameTag(GameTag::EXHAUSTED, 0);
+    curPlayer.GetHero()->heroPower->SetExhausted(false);
     // Field
     for (auto& m : curPlayer.GetField().GetAllMinions())
     {
-        m->SetGameTag(GameTag::EXHAUSTED, 0);
+        m->SetExhausted(false);
     }
 
     // Set next step
@@ -436,7 +436,7 @@ void Game::MainCleanUp()
     for (auto& m : curPlayer.GetField().GetAllMinions())
     {
         if (m->GetGameTag(GameTag::FROZEN) == 1 && m->numAttacked == 0 &&
-            m->GetGameTag(GameTag::EXHAUSTED) == 0)
+            !m->GetExhausted())
         {
             m->SetGameTag(GameTag::FROZEN, 0);
         }

--- a/Sources/Rosetta/Games/Game.cpp
+++ b/Sources/Rosetta/Games/Game.cpp
@@ -654,9 +654,9 @@ void Game::ProcessTasks()
     while (!taskQueue.empty())
     {
         ITask* task = taskQueue.front();
-        task->Run(GetCurrentPlayer());
-
         taskQueue.pop_front();
+
+        task->Run(GetCurrentPlayer());
     }
 }
 }  // namespace RosettaStone

--- a/Sources/Rosetta/Games/Game.cpp
+++ b/Sources/Rosetta/Games/Game.cpp
@@ -197,11 +197,11 @@ void Game::MainReady()
     for (auto& p : m_players)
     {
         // Hero
-        p.GetHero()->numAttacked = 0;
+        p.GetHero()->SetNumAttacksThisTurn(0);
         // Field
         for (auto& m : p.GetField().GetAllMinions())
         {
-            m->numAttacked = 0;
+            m->SetNumAttacksThisTurn(0);
         }
     }
 
@@ -432,15 +432,15 @@ void Game::MainCleanUp()
     // summoning sickness (or do have Charge) and have not attacked that turn
     // Hero
     if (curPlayer.GetHero()->GetGameTag(GameTag::FROZEN) == 1 &&
-        curPlayer.GetHero()->numAttacked == 0)
+        curPlayer.GetHero()->GetNumAttacksThisTurn() == 0)
     {
         curPlayer.GetHero()->SetGameTag(GameTag::FROZEN, 0);
     }
     // Field
     for (auto& m : curPlayer.GetField().GetAllMinions())
     {
-        if (m->GetGameTag(GameTag::FROZEN) == 1 && m->numAttacked == 0 &&
-            !m->GetExhausted())
+        if (m->GetGameTag(GameTag::FROZEN) == 1 &&
+            m->GetNumAttacksThisTurn() == 0 && !m->GetExhausted())
         {
             m->SetGameTag(GameTag::FROZEN, 0);
         }

--- a/Sources/Rosetta/Games/TriggerManager.cpp
+++ b/Sources/Rosetta/Games/TriggerManager.cpp
@@ -31,4 +31,12 @@ void TriggerManager::OnHealTrigger(Player* player, Entity* sender)
         healTrigger(player, sender);
     }
 }
+
+void TriggerManager::OnAttackTrigger(Player* player, Entity* sender)
+{
+    if (attackTrigger != nullptr)
+    {
+        attackTrigger(player, sender);
+    }
+}
 }  // namespace RosettaStone

--- a/Sources/Rosetta/Games/TriggerManager.cpp
+++ b/Sources/Rosetta/Games/TriggerManager.cpp
@@ -8,19 +8,27 @@
 
 namespace RosettaStone
 {
-void TriggerManager::OnHealTrigger(Player* player, Entity* sender)
-{
-    if (healTrigger != nullptr)
-    {
-        healTrigger(player, sender);
-    }
-}
-
 void TriggerManager::OnStartTurnTrigger(Player* player, Entity* sender)
 {
     if (startTurnTrigger != nullptr)
     {
         startTurnTrigger(player, sender);
+    }
+}
+
+void TriggerManager::OnEndTurnTrigger(Player* player, Entity* sender)
+{
+    if (endTurnTrigger != nullptr)
+    {
+        endTurnTrigger(player, sender);
+    }
+}
+
+void TriggerManager::OnHealTrigger(Player* player, Entity* sender)
+{
+    if (healTrigger != nullptr)
+    {
+        healTrigger(player, sender);
     }
 }
 }  // namespace RosettaStone

--- a/Sources/Rosetta/Models/Battlefield.cpp
+++ b/Sources/Rosetta/Models/Battlefield.cpp
@@ -84,7 +84,7 @@ void Battlefield::AddMinion(Minion& minion, std::size_t pos)
 
     if (minion.GetGameTag(GameTag::CHARGE) != 1)
     {
-        minion.SetGameTag(GameTag::EXHAUSTED, 1);
+        minion.SetExhausted(true);
     }
 
     for (auto& aura : auras)

--- a/Sources/Rosetta/Models/Character.cpp
+++ b/Sources/Rosetta/Models/Character.cpp
@@ -78,6 +78,16 @@ void Character::SetSpellPower(int spellPower)
     SetGameTag(GameTag::SPELLPOWER, spellPower);
 }
 
+int Character::GetNumAttacksThisTurn() const
+{
+    return GetGameTag(GameTag::NUM_ATTACKS_THIS_TURN);
+}
+
+void Character::SetNumAttacksThisTurn(int amount)
+{
+    SetGameTag(GameTag::NUM_ATTACKS_THIS_TURN, amount);
+}
+
 bool Character::CanAttack()
 {
     // If the value of attack is 0, returns false

--- a/Sources/Rosetta/Models/Character.cpp
+++ b/Sources/Rosetta/Models/Character.cpp
@@ -93,7 +93,7 @@ bool Character::CanAttack()
     }
 
     // If the character is exhausted, returns false
-    if (GetGameTag(GameTag::EXHAUSTED) == 1)
+    if (GetExhausted())
     {
         return false;
     }

--- a/Sources/Rosetta/Models/Character.cpp
+++ b/Sources/Rosetta/Models/Character.cpp
@@ -176,14 +176,23 @@ int Character::TakeDamage(Entity& source, int damage)
         return 0;
     }
 
+    const int armor = (hero != nullptr) ? hero->GetArmor() : 0;
+    const int amount =
+        (hero == nullptr) ? damage : armor < damage ? damage - armor : 0;
+
     if (GetGameTag(GameTag::IMMUNE) == 1)
     {
         return 0;
     }
 
-    SetDamage(GetDamage() + damage);
+    if (armor > 0)
+    {
+        hero->SetArmor(armor < damage ? 0 : armor - damage);
+    }
 
-    return damage;
+    SetDamage(GetDamage() + amount);
+
+    return amount;
 }
 
 void Character::TakeFullHeal(Entity& source)

--- a/Sources/Rosetta/Models/Character.cpp
+++ b/Sources/Rosetta/Models/Character.cpp
@@ -130,7 +130,7 @@ bool Character::IsValidCombatTarget(Player& opponent, Character* target) const
              hero->GetGameTag(GameTag::CANNOT_ATTACK_HEROES) == 1);
 }
 
-std::vector<Character*> Character::GetValidCombatTargets(Player& opponent)
+std::vector<Character*> Character::GetValidCombatTargets(Player& opponent) const
 {
     bool isExistTauntInField = false;
     std::vector<Character*> targets;
@@ -159,7 +159,7 @@ std::vector<Character*> Character::GetValidCombatTargets(Player& opponent)
         return targetsHaveTaunt;
     }
 
-    if (opponent.GetHero()->GetGameTag(GameTag::CANNOT_ATTACK_HEROES) == 0 &&
+    if (GetGameTag(GameTag::CANNOT_ATTACK_HEROES) == 0 &&
         opponent.GetHero()->GetGameTag(GameTag::IMMUNE) == 0 &&
         opponent.GetHero()->GetGameTag(GameTag::STEALTH) == 0)
     {

--- a/Sources/Rosetta/Models/Entity.cpp
+++ b/Sources/Rosetta/Models/Entity.cpp
@@ -134,6 +134,16 @@ void Entity::SetCost(int cost)
     SetGameTag(GameTag::COST, cost);
 }
 
+bool Entity::GetExhausted() const
+{
+    return static_cast<bool>(GetGameTag(GameTag::EXHAUSTED));
+}
+
+void Entity::SetExhausted(bool exhausted)
+{
+    SetGameTag(GameTag::EXHAUSTED, static_cast<int>(exhausted));
+}
+
 void Entity::Destroy()
 {
     isDestroyed = true;

--- a/Sources/Rosetta/Tasks/PlayerTasks/HeroPowerTask.cpp
+++ b/Sources/Rosetta/Tasks/PlayerTasks/HeroPowerTask.cpp
@@ -1,0 +1,56 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/Actions/PlayCard.hpp>
+#include <Rosetta/Actions/Targeting.hpp>
+#include <Rosetta/Games/Game.hpp>
+#include <Rosetta/Tasks/PlayerTasks/HeroPowerTask.hpp>
+
+namespace RosettaStone::SimpleTasks
+{
+HeroPowerTask::HeroPowerTask(Entity* target) : ITask(nullptr, target)
+{
+    // Do nothing
+}
+
+TaskID HeroPowerTask::GetTaskID() const
+{
+    return TaskID::HERO_POWER;
+}
+
+TaskStatus HeroPowerTask::Impl(Player& player)
+{
+    HeroPower* power = player.GetHero()->heroPower;
+
+    if (!Generic::IsPlayableByPlayer(player, power) ||
+        !Generic::IsPlayableByCardReq(power) ||
+        !Generic::IsValidTarget(power, m_target))
+    {
+        return TaskStatus::STOP;
+    }
+
+    // Spend mana to play cards
+    if (power->GetCost() > 0)
+    {
+        int tempUsed = std::min(player.GetTemporaryMana(), power->GetCost());
+        player.SetTemporaryMana(player.GetTemporaryMana() - tempUsed);
+        player.SetUsedMana(player.GetUsedMana() + power->GetCost() - tempUsed);
+    }
+
+    // Process power tasks
+    for (auto& powerTask : power->card.power.GetPowerTask())
+    {
+        powerTask->SetSource(power);
+        powerTask->SetTarget(m_target);
+        powerTask->Run(player);
+    }
+
+    power->SetExhausted(true);
+
+    player.GetGame()->ProcessDestroyAndUpdateAura();
+
+    return TaskStatus::COMPLETE;
+}
+}  // namespace RosettaStone::SimpleTasks

--- a/Sources/Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.cpp
@@ -51,8 +51,7 @@ TaskStatus AddEnchantmentTask::Impl(Player& player)
 
         if (power.GetEnchant().has_value())
         {
-            power.GetEnchant().value().ActivateTo(
-                dynamic_cast<Character*>(entity));
+            power.GetEnchant().value().ActivateTo(entity);
         }
     }
 

--- a/Sources/Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.cpp
@@ -52,7 +52,7 @@ TaskStatus AddEnchantmentTask::Impl(Player& player)
 
         if (power.GetEnchant().has_value())
         {
-            const auto taskStack = player.GetGame()->taskStack;
+            const auto& taskStack = player.GetGame()->taskStack;
             power.GetEnchant().value().ActivateTo(entity, taskStack.num,
                                                   taskStack.num1);
         }

--- a/Sources/Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.cpp
@@ -4,6 +4,7 @@
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 #include <Rosetta/Cards/Cards.hpp>
+#include <Rosetta/Games/Game.hpp>
 #include <Rosetta/Models/Enchantment.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/IncludeTask.hpp>
@@ -36,7 +37,7 @@ TaskStatus AddEnchantmentTask::Impl(Player& player)
 
     for (auto& entity : entities)
     {
-        auto enchantment =
+        const auto enchantment =
             Enchantment::GetInstance(player, enchantmentCard, entity);
 
         if (power.GetAura().has_value())
@@ -51,7 +52,9 @@ TaskStatus AddEnchantmentTask::Impl(Player& player)
 
         if (power.GetEnchant().has_value())
         {
-            power.GetEnchant().value().ActivateTo(entity);
+            const auto taskStack = player.GetGame()->taskStack;
+            power.GetEnchant().value().ActivateTo(entity, taskStack.num,
+                                                  taskStack.num1);
         }
     }
 

--- a/Sources/Rosetta/Tasks/SimpleTasks/AddStackToTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/AddStackToTask.cpp
@@ -1,0 +1,39 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/Actions/Generic.hpp>
+#include <Rosetta/Games/Game.hpp>
+#include <Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp>
+
+namespace RosettaStone::SimpleTasks
+{
+AddStackToTask::AddStackToTask(EntityType entityType) : ITask(entityType)
+{
+    // Do nothing
+}
+
+TaskID AddStackToTask::GetTaskID() const
+{
+    return TaskID::ADD_STACK_TO;
+}
+
+TaskStatus AddStackToTask::Impl(Player& player)
+{
+    switch (m_entityType)
+    {
+        case EntityType::HAND:
+            for (auto& entity : player.GetGame()->taskStack.entities)
+            {
+                Generic::AddCardToHand(player, entity);
+            }
+            break;
+        default:
+            throw std::invalid_argument(
+                "AddStackToTask::Impl() - Invalid entity type");
+    }
+
+    return TaskStatus::COMPLETE;
+}
+}  // namespace RosettaStone::SimpleTasks

--- a/Sources/Rosetta/Tasks/SimpleTasks/CopyTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/CopyTask.cpp
@@ -1,0 +1,46 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/Games/Game.hpp>
+#include <Rosetta/Tasks/SimpleTasks/CopyTask.hpp>
+
+namespace RosettaStone::SimpleTasks
+{
+CopyTask::CopyTask(EntityType entityType, int amount)
+    : ITask(entityType), m_amount(amount)
+{
+    // Do nothing
+}
+
+TaskID CopyTask::GetTaskID() const
+{
+    return TaskID::COPY;
+}
+
+TaskStatus CopyTask::Impl(Player& player)
+{
+    std::vector<Entity*> result;
+
+    switch (m_entityType)
+    {
+        case EntityType::STACK:
+            for (auto& entity : player.GetGame()->taskStack.entities)
+            {
+                for (int i = 0; i < m_amount; ++i)
+                {
+                    result.emplace_back(entity);
+                }
+            }
+            break;
+        default:
+            throw std::invalid_argument(
+                "CopyTask::Impl() - Invalid entity type");
+    }
+
+    player.GetGame()->taskStack.entities = result;
+
+    return TaskStatus::COMPLETE;
+}
+}  // namespace RosettaStone::SimpleTasks

--- a/Sources/Rosetta/Tasks/SimpleTasks/CountTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/CountTask.cpp
@@ -1,0 +1,52 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/Games/Game.hpp>
+#include <Rosetta/Tasks/SimpleTasks/CountTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/IncludeTask.hpp>
+
+namespace RosettaStone::SimpleTasks
+{
+CountTask::CountTask(EntityType entityType, int numIndex)
+    : ITask(entityType), m_numIndex(numIndex)
+{
+    // Do nothing
+}
+
+TaskID CountTask::GetTaskID() const
+{
+    return TaskID::COUNT;
+}
+
+TaskStatus CountTask::Impl(Player& player)
+{
+    const auto entities =
+        IncludeTask::GetEntities(m_entityType, player, m_source, m_target);
+    const int count = static_cast<int>(entities.size());
+
+    switch (m_numIndex)
+    {
+        case 0:
+            player.GetGame()->taskStack.num = count;
+            break;
+        case 1:
+            player.GetGame()->taskStack.num1 = count;
+            break;
+        case 2:
+            player.GetGame()->taskStack.num2 = count;
+            break;
+        case 3:
+            player.GetGame()->taskStack.num3 = count;
+            break;
+        case 4:
+            player.GetGame()->taskStack.num4 = count;
+            break;
+        default:
+            throw std::invalid_argument(
+                "CountTask::Impl() - Invalid number index");
+    }
+    return TaskStatus::COMPLETE;
+}
+}  // namespace RosettaStone::SimpleTasks

--- a/Sources/Rosetta/Tasks/SimpleTasks/CountTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/CountTask.cpp
@@ -34,15 +34,6 @@ TaskStatus CountTask::Impl(Player& player)
         case 1:
             player.GetGame()->taskStack.num1 = count;
             break;
-        case 2:
-            player.GetGame()->taskStack.num2 = count;
-            break;
-        case 3:
-            player.GetGame()->taskStack.num3 = count;
-            break;
-        case 4:
-            player.GetGame()->taskStack.num4 = count;
-            break;
         default:
             throw std::invalid_argument(
                 "CountTask::Impl() - Invalid number index");

--- a/Sources/Rosetta/Tasks/SimpleTasks/FuncNumberTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/FuncNumberTask.cpp
@@ -8,7 +8,7 @@
 
 namespace RosettaStone::SimpleTasks
 {
-FuncNumberTask::FuncNumberTask(std::function<void(Player&)> func)
+FuncNumberTask::FuncNumberTask(std::function<void(Entity*)> func)
     : m_func(std::move(func))
 {
     // Do nothing
@@ -19,11 +19,11 @@ TaskID FuncNumberTask::GetTaskID() const
     return TaskID::FUNC_NUMBER;
 }
 
-TaskStatus FuncNumberTask::Impl(Player& player)
+TaskStatus FuncNumberTask::Impl(Player&)
 {
     if (m_func != nullptr)
     {
-        m_func(player);
+        m_func(m_source);
     }
 
     return TaskStatus::COMPLETE;

--- a/Sources/Rosetta/Tasks/SimpleTasks/FuncNumberTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/FuncNumberTask.cpp
@@ -1,0 +1,31 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/Tasks/SimpleTasks/FuncNumberTask.hpp>
+#include <utility>
+
+namespace RosettaStone::SimpleTasks
+{
+FuncNumberTask::FuncNumberTask(std::function<void(Player&)> func)
+    : m_func(std::move(func))
+{
+    // Do nothing
+}
+
+TaskID FuncNumberTask::GetTaskID() const
+{
+    return TaskID::FUNC_NUMBER;
+}
+
+TaskStatus FuncNumberTask::Impl(Player& player)
+{
+    if (m_func != nullptr)
+    {
+        m_func(player);
+    }
+
+    return TaskStatus::COMPLETE;
+}
+}  // namespace RosettaStone::SimpleTasks

--- a/Sources/Rosetta/Tasks/SimpleTasks/IncludeTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/IncludeTask.cpp
@@ -102,6 +102,12 @@ std::vector<Entity*> IncludeTask::GetEntities(EntityType entityType,
                 entities.emplace_back(card);
             }
             break;
+        case EntityType::ENEMY_HAND:
+            for (auto& card : player.opponent->GetHand().GetAllCards())
+            {
+                entities.emplace_back(card);
+            }
+            break;
         case EntityType::ALL_MINIONS:
             for (auto& minion : player.GetField().GetAllMinions())
             {

--- a/Sources/Rosetta/Tasks/SimpleTasks/IncludeTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/IncludeTask.cpp
@@ -124,6 +124,17 @@ std::vector<Entity*> IncludeTask::GetEntities(EntityType entityType,
                 entities.emplace_back(minion);
             }
             break;
+        case EntityType::MINIONS_NOSOURCE:
+            for (auto& minion : player.GetField().GetAllMinions())
+            {
+                if (source == minion)
+                {
+                    continue;
+                }
+
+                entities.emplace_back(minion);
+            }
+            break;
         case EntityType::ENEMY_MINIONS:
             for (auto& minion : player.opponent->GetField().GetAllMinions())
             {
@@ -134,7 +145,7 @@ std::vector<Entity*> IncludeTask::GetEntities(EntityType entityType,
             entities = player.GetGame()->taskStack.entities;
             break;
         default:
-            throw std::domain_error(
+            throw std::invalid_argument(
                 "IncludeTask::GetEntities() - Invalid entity type");
     }
 

--- a/Sources/Rosetta/Tasks/SimpleTasks/SetGameTagTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/SetGameTagTask.cpp
@@ -32,7 +32,7 @@ TaskStatus SetGameTagTask::Impl(Player& player)
         if (m_gameTag == GameTag::WINDFURY && m_amount == 1)
         {
             auto m = dynamic_cast<Minion*>(entity);
-            if (m != nullptr && m->numAttacked == 1 &&
+            if (m != nullptr && m->GetNumAttacksThisTurn() == 1 &&
                 m->GetExhausted())
             {
                 m->SetExhausted(false);

--- a/Sources/Rosetta/Tasks/SimpleTasks/SetGameTagTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/SetGameTagTask.cpp
@@ -33,9 +33,9 @@ TaskStatus SetGameTagTask::Impl(Player& player)
         {
             auto m = dynamic_cast<Minion*>(entity);
             if (m != nullptr && m->numAttacked == 1 &&
-                m->GetGameTag(GameTag::EXHAUSTED) == 1)
+                m->GetExhausted())
             {
-                m->SetGameTag(GameTag::EXHAUSTED, 0);
+                m->SetExhausted(false);
             }
         }
     }

--- a/Sources/Rosetta/Tasks/SimpleTasks/WeaponTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/WeaponTask.cpp
@@ -1,0 +1,41 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/Actions/PlayCard.hpp>
+#include <Rosetta/Cards/Cards.hpp>
+#include <Rosetta/Tasks/SimpleTasks/WeaponTask.hpp>
+
+namespace RosettaStone::SimpleTasks
+{
+WeaponTask::WeaponTask(std::string&& cardID) : m_cardID(cardID)
+{
+    // Do nothing
+}
+
+TaskID WeaponTask::GetTaskID() const
+{
+    return TaskID::WEAPON;
+}
+
+TaskStatus WeaponTask::Impl(Player& player)
+{
+    Card weaponCard = Cards::FindCardByID(m_cardID);
+    if (weaponCard.id.empty())
+    {
+        return TaskStatus::STOP;
+    }
+
+    if (player.GetHero()->HasWeapon())
+    {
+        player.GetHero()->weapon->Destroy();
+    }
+
+    const auto weapon = dynamic_cast<Weapon*>(
+        Entity::GetFromCard(player, std::move(weaponCard)));
+    Generic::PlayWeapon(player, weapon, nullptr);
+
+    return TaskStatus::COMPLETE;
+}
+}  // namespace RosettaStone::SimpleTasks

--- a/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
@@ -159,6 +159,44 @@ TEST(CoreCardsGen, CS2_049)
     curPlayer.SetUsedMana(0);
     opPlayer.SetTotalMana(10);
     opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetField();
+    auto& opField = opPlayer.GetField();
+
+    Task::Run(curPlayer, HeroPowerTask());
+    Task::Run(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    Task::Run(opPlayer, HeroPowerTask());
+    Task::Run(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    Task::Run(curPlayer, HeroPowerTask());
+    Task::Run(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    Task::Run(opPlayer, HeroPowerTask());
+    Task::Run(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    Task::Run(curPlayer, HeroPowerTask());
+    Task::Run(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    Task::Run(opPlayer, HeroPowerTask());
+    Task::Run(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    Task::Run(curPlayer, HeroPowerTask());
+    Task::Run(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    Task::Run(opPlayer, HeroPowerTask());
+    Task::Run(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    EXPECT_EQ(curField.GetNumOfMinions(), 4u);
+    EXPECT_EQ(opField.GetNumOfMinions(), 4u);
 }
 
 TEST(CoreCardsGen, CS2_056)

--- a/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
@@ -4083,3 +4083,38 @@ TEST(CoreCardsGen, CS2_074)
     EXPECT_EQ(curPlayer.GetHero()->weapon->GetAttack(), 3);
     EXPECT_EQ(curPlayer.GetHero()->weapon->GetDurability(), 2);
 }
+
+TEST(CoreCardsGen, CS2_097)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+    curPlayer.GetHero()->SetDamage(4);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Truesilver Champion"));
+
+    Task::Run(curPlayer, PlayCardTask::Weapon(curPlayer, card1));
+    EXPECT_EQ(curPlayer.GetHero()->GetHealth(), 26);
+    EXPECT_EQ(curPlayer.GetHero()->weapon->GetAttack(), 4);
+    EXPECT_EQ(curPlayer.GetHero()->weapon->GetDurability(), 2);
+
+    Task::Run(curPlayer, AttackTask(curPlayer.GetHero(), opPlayer.GetHero()));
+    EXPECT_EQ(curPlayer.GetHero()->GetHealth(), 28);
+    EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 26);
+    EXPECT_EQ(curPlayer.GetHero()->weapon->GetDurability(), 1);
+}

--- a/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
@@ -4003,3 +4003,42 @@ TEST(CoreCardsGen, CS2_045)
     EXPECT_EQ(curPlayer.GetHero()->GetAttack(), 0);
     EXPECT_EQ(curField.GetMinion(0)->GetAttack(), 3);
 }
+
+TEST(CoreCardsGen, CS2_003)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Mind Vision"));
+
+    Task::Run(curPlayer, PlayCardTask::Spell(curPlayer, card1));
+    auto gainedCard = curPlayer.GetHand().GetCard(4);
+
+    bool flag = false;
+    for (auto& card : opPlayer.GetHand().GetAllCards())
+    {
+        if (card->id == gainedCard->id)
+        {
+            flag = true;
+            break;
+        }
+    }
+
+    EXPECT_TRUE(flag);
+}

--- a/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
@@ -4183,3 +4183,51 @@ TEST(CoreCardsGen, CS2_103)
     EXPECT_EQ(curField.GetMinion(0)->GetGameTag(GameTag::CANNOT_ATTACK_HEROES),
               0);
 }
+
+TEST(CoreCardsGen, CS2_226)
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetField();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Frostwolf Warlord"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Frostwolf Warlord"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Frostwolf Warlord"));
+
+    Task::Run(curPlayer, PlayCardTask::Minion(curPlayer, card1));
+    EXPECT_EQ(curField.GetMinion(0)->GetAttack(), 4);
+    EXPECT_EQ(curField.GetMinion(0)->GetHealth(), 4);
+
+    Task::Run(curPlayer, PlayCardTask::Minion(curPlayer, card2));
+    EXPECT_EQ(curField.GetMinion(1)->GetAttack(), 5);
+    EXPECT_EQ(curField.GetMinion(1)->GetHealth(), 5);
+
+    Task::Run(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    Task::Run(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    Task::Run(curPlayer, PlayCardTask::Minion(curPlayer, card3));
+    EXPECT_EQ(curField.GetMinion(2)->GetAttack(), 6);
+    EXPECT_EQ(curField.GetMinion(2)->GetHealth(), 6);
+}

--- a/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
@@ -43,6 +43,7 @@ TEST(CoreCardsGen, CS1h_001)
     game.ProcessUntil(Step::MAIN_START);
 
     Task::Run(curPlayer, HeroPowerTask(curPlayer.GetHero()));
+
     EXPECT_EQ(curPlayer.GetHero()->GetHealth(), 30);
 }
 
@@ -135,7 +136,170 @@ TEST(CoreCardsGen, CS2_034)
     game.ProcessUntil(Step::MAIN_START);
 
     Task::Run(curPlayer, HeroPowerTask(card1));
+
     EXPECT_EQ(opField.GetMinion(0)->GetHealth(), 2);
+}
+
+TEST(CoreCardsGen, CS2_049)
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+}
+
+TEST(CoreCardsGen, CS2_056)
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    EXPECT_EQ(curPlayer.GetHand().GetNumOfCards(), 4);
+
+    Task::Run(curPlayer, HeroPowerTask());
+
+    EXPECT_EQ(curPlayer.GetHand().GetNumOfCards(), 5);
+    EXPECT_EQ(curPlayer.GetHero()->GetHealth(), 28);
+}
+
+TEST(CoreCardsGen, CS2_083b)
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    EXPECT_EQ(curPlayer.GetHero()->HasWeapon(), false);
+
+    Task::Run(curPlayer, HeroPowerTask());
+
+    EXPECT_EQ(curPlayer.GetHero()->HasWeapon(), true);
+    EXPECT_EQ(curPlayer.GetHero()->weapon->GetAttack(), 1);
+    EXPECT_EQ(curPlayer.GetHero()->weapon->GetDurability(), 2);
+
+    Task::Run(curPlayer, AttackTask(curPlayer.GetHero(), opPlayer.GetHero()));
+    EXPECT_EQ(curPlayer.GetHero()->weapon->GetDurability(), 1);
+}
+
+TEST(CoreCardsGen, CS2_101)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetField();
+
+    Task::Run(curPlayer, HeroPowerTask());
+
+    EXPECT_EQ(curField.GetNumOfMinions(), 1u);
+    EXPECT_EQ(curField.GetMinion(0)->GetAttack(), 1);
+    EXPECT_EQ(curField.GetMinion(0)->GetHealth(), 1);
+}
+
+TEST(CoreCardsGen, CS2_102)
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    EXPECT_EQ(curPlayer.GetHero()->GetArmor(), 0);
+
+    Task::Run(curPlayer, HeroPowerTask());
+
+    EXPECT_EQ(curPlayer.GetHero()->GetArmor(), 2);
+}
+
+TEST(CoreCardsGen, DS1h_292)
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    Task::Run(curPlayer, HeroPowerTask());
+
+    EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 28);
 }
 
 TEST(CoreCardsGen, EX1_066)

--- a/Tests/UnitTests/Tasks/PlayerTasks/AttackTaskTests.cpp
+++ b/Tests/UnitTests/Tasks/PlayerTasks/AttackTaskTests.cpp
@@ -185,10 +185,10 @@ TEST(AttackTask, Charge)
     PlayMinionCard(player2, card1);
 
     Task::Run(player1, AttackTask(p1Field.GetMinion(0), p2Field.GetMinion(0)));
-    EXPECT_EQ(p1Field.GetMinion(0)->numAttacked, 0u);
+    EXPECT_EQ(p1Field.GetMinion(0)->GetNumAttacksThisTurn(), 0);
 
     Task::Run(player1, AttackTask(p1Field.GetMinion(1), p2Field.GetMinion(0)));
-    EXPECT_EQ(p1Field.GetMinion(1)->numAttacked, 1u);
+    EXPECT_EQ(p1Field.GetMinion(1)->GetNumAttacksThisTurn(), 1);
 }
 
 TEST(AttackTask, Taunt)
@@ -355,10 +355,10 @@ TEST(AttackTask, Windfury)
     auto& p2Field = player2.GetField();
 
     Task::Run(player1, AttackTask(p1Field.GetMinion(0), p2Field.GetMinion(0)));
-    EXPECT_EQ(p1Field.GetMinion(0)->numAttacked, 1u);
+    EXPECT_EQ(p1Field.GetMinion(0)->GetNumAttacksThisTurn(), 1);
 
     Task::Run(player1, AttackTask(p1Field.GetMinion(0), p2Field.GetMinion(0)));
-    EXPECT_EQ(p1Field.GetMinion(0)->numAttacked, 1u);
+    EXPECT_EQ(p1Field.GetMinion(0)->GetNumAttacksThisTurn(), 1);
 
     EndTurnTask().Run(player1);
     game.ProcessUntil(Step::MAIN_START);
@@ -368,13 +368,13 @@ TEST(AttackTask, Windfury)
     p1Field.GetMinion(0)->SetGameTag(GameTag::WINDFURY, 1);
 
     Task::Run(player1, AttackTask(p1Field.GetMinion(0), p2Field.GetMinion(0)));
-    EXPECT_EQ(p1Field.GetMinion(0)->numAttacked, 1u);
+    EXPECT_EQ(p1Field.GetMinion(0)->GetNumAttacksThisTurn(), 1);
 
     Task::Run(player1, AttackTask(p1Field.GetMinion(0), p2Field.GetMinion(0)));
-    EXPECT_EQ(p1Field.GetMinion(0)->numAttacked, 2u);
+    EXPECT_EQ(p1Field.GetMinion(0)->GetNumAttacksThisTurn(), 2);
 
     Task::Run(player1, AttackTask(p1Field.GetMinion(0), p2Field.GetMinion(0)));
-    EXPECT_EQ(p1Field.GetMinion(0)->numAttacked, 2u);
+    EXPECT_EQ(p1Field.GetMinion(0)->GetNumAttacksThisTurn(), 2);
 }
 
 TEST(AttackTask, DivineShield)

--- a/Tests/UnitTests/Utils/CardSetUtils.hpp
+++ b/Tests/UnitTests/Utils/CardSetUtils.hpp
@@ -12,6 +12,7 @@
 #include <Rosetta/Games/Game.hpp>
 #include <Rosetta/Tasks/PlayerTasks/AttackTask.hpp>
 #include <Rosetta/Tasks/PlayerTasks/EndTurnTask.hpp>
+#include <Rosetta/Tasks/PlayerTasks/HeroPowerTask.hpp>
 #include <Rosetta/Tasks/PlayerTasks/PlayCardTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DrawTask.hpp>
 


### PR DESCRIPTION
This revision includes:
- Implement hero powers
    - Lesser Heal (CS1h_001)
    - Shapeshift (CS2_017)
    - Fireblast (CS2_034)
    - Totemic Call (CS2_049)
    - Life Tap (CS2_056)
    - Dagger Mastery (CS2_083b)
    - Reinforce (CS2_101)
    - Armor Up! (CS2_102)
    - Steady Shot (DS1h_292)
- Implement 5 cards in CORE cardset
    - Mind Vision (CS2_003)
    - Deadly Poison (CS2_074)
    - Truesilver Champion (CS2_097)
    - Charge (CS2_103)
    - Frostwolf Warlord (CS2_226)
- Create some tasks
    - `AddStackToTask`
    - `CopyTask`
    - `CountTask`
    - `FuncNumberTask`
    - `HeroPowerTask`
    - `WeaponTask`