### PR TITLE
perf: Make cards not to construct on every method calls

### DIFF
--- a/Extensions/RosettaConsole/Console.cpp
+++ b/Extensions/RosettaConsole/Console.cpp
@@ -117,7 +117,7 @@ void Console::SignUp()
     }
 }
 
-std::optional<Card> Console::SearchCard() const
+std::optional<Card*> Console::SearchCard() const
 {
     std::cout << "========================================\n";
     std::cout << "              Search Card!              \n";
@@ -147,7 +147,7 @@ std::optional<Card> Console::SearchCard() const
         std::cout << "             Search Result!             \n";
         std::cout << "========================================\n";
 
-        std::vector<Card> result = ProcessSearchCommand(filter);
+        std::vector<Card*> result = ProcessSearchCommand(filter);
         if (result.empty())
         {
             std::cout << "There are no cards matching your search condition.\n";
@@ -156,10 +156,10 @@ std::optional<Card> Console::SearchCard() const
         {
             size_t cardIdx = 1;
 
-            for (auto& card : result)
+            for (Card* card : result)
             {
                 std::cout << cardIdx << ". ";
-                card.ShowBriefInfo();
+                card->ShowBriefInfo();
                 std::cout << '\n';
 
                 cardIdx++;
@@ -174,7 +174,7 @@ std::optional<Card> Console::SearchCard() const
         }
     }
 
-    return {};
+    return std::nullopt;
 }
 
 int Console::ManageDeck()
@@ -345,8 +345,8 @@ void Console::AddCardInDeck(size_t deckIndex)
     m_searchMode = SearchMode::AddCardInDeck;
     m_deckClass = deck->GetClass();
 
-    const Card card = SearchCard().value_or(Card());
-    if (card.id.empty())
+    const Card* card = SearchCard().value_or(nullptr);
+    if (card->id.empty())
     {
         std::cout << " doesn't exist. Try again.\n";
         return;
@@ -355,7 +355,7 @@ void Console::AddCardInDeck(size_t deckIndex)
     while (true)
     {
         size_t numCardToAddAvailable =
-            card.GetMaxAllowedInDeck() - deck->GetNumCardInDeck(card.id);
+            card->GetMaxAllowedInDeck() - deck->GetNumCardInDeck(card->id);
         if (deck->GetNumOfCards() + numCardToAddAvailable > START_DECK_SIZE)
         {
             numCardToAddAvailable =
@@ -373,7 +373,7 @@ void Console::AddCardInDeck(size_t deckIndex)
         }
         else
         {
-            deck->AddCard(card.id, numCardToAdd);
+            deck->AddCard(card->id, numCardToAdd);
             break;
         }
     }
@@ -614,50 +614,50 @@ std::tuple<SearchFilter, bool, bool> Console::InputAndParseSearchCommand(
     return std::make_tuple(filter, isValid, isFinish);
 }
 
-std::vector<Card> Console::ProcessSearchCommand(SearchFilter& filter) const
+std::vector<Card*> Console::ProcessSearchCommand(SearchFilter& filter) const
 {
-    std::vector<Card> result;
+    std::vector<Card*> result;
 
-    for (auto& card : Cards::GetInstance().GetAllCards())
+    for (Card* card : Cards::GetInstance().GetAllCards())
     {
-        if (card.gameTags.at(GameTag::COLLECTIBLE) == 0)
+        if (card->gameTags.at(GameTag::COLLECTIBLE) == 0)
         {
             continue;
         }
 
         bool rarityCondition = (filter.rarity == Rarity::INVALID ||
-                                filter.rarity == card.GetRarity());
+                                filter.rarity == card->GetRarity());
         bool classCondition = false;
 
         // When search mode is adding a card to a deck, the class is fixed to
         // the deck class and the neutral class.
         if (m_searchMode == SearchMode::AddCardInDeck)
         {
-            classCondition = (card.GetCardClass() == m_deckClass ||
-                              card.GetCardClass() == CardClass::NEUTRAL);
+            classCondition = (card->GetCardClass() == m_deckClass ||
+                              card->GetCardClass() == CardClass::NEUTRAL);
         }
         else if (m_searchMode == SearchMode::JustSearch)
         {
             classCondition = (filter.playerClass == CardClass::INVALID ||
-                              filter.playerClass == card.GetCardClass());
+                              filter.playerClass == card->GetCardClass());
         }
         bool typeCondition = (filter.cardType == CardType::INVALID ||
-                              filter.cardType == card.GetCardType());
+                              filter.cardType == card->GetCardType());
         bool raceCondition =
-            (filter.race == Race::INVALID || filter.race == card.GetRace());
+            (filter.race == Race::INVALID || filter.race == card->GetRace());
         bool nameCondition = (filter.name.empty() ||
-                              card.name.find(filter.name) != std::string::npos);
+             card->name.find(filter.name) != std::string::npos);
         bool costCondition =
-            filter.costMin <= card.gameTags.at(GameTag::COST) &&
-            filter.costMax >= card.gameTags.at(GameTag::COST);
+            filter.costMin <= card->gameTags.at(GameTag::COST) &&
+            filter.costMax >= card->gameTags.at(GameTag::COST);
         bool attackCondition =
-            filter.attackMin <= card.gameTags.at(GameTag::ATK) &&
-            filter.attackMax >= card.gameTags.at(GameTag::ATK);
+            filter.attackMin <= card->gameTags.at(GameTag::ATK) &&
+            filter.attackMax >= card->gameTags.at(GameTag::ATK);
         bool healthCondition =
-            filter.healthMin <= card.gameTags.at(GameTag::HEALTH) &&
-            filter.healthMax >= card.gameTags.at(GameTag::HEALTH);
+            filter.healthMin <= card->gameTags.at(GameTag::HEALTH) &&
+            filter.healthMax >= card->gameTags.at(GameTag::HEALTH);
         bool mechanicsCondition = (filter.gameTag == GameTag::INVALID ||
-                                   card.HasGameTag(filter.gameTag));
+                                   card->HasGameTag(filter.gameTag));
         const bool isMatched =
             AllCondIsTrue(rarityCondition, classCondition, typeCondition,
                           raceCondition, nameCondition, costCondition,

--- a/Extensions/RosettaConsole/Console.hpp
+++ b/Extensions/RosettaConsole/Console.hpp
@@ -105,7 +105,7 @@ class Console
  public:
     void SignIn();
     void SignUp();
-    std::optional<Card> SearchCard() const;
+    std::optional<Card*> SearchCard() const;
     int ManageDeck();
     void SimulateGame() const;
     void Leave();
@@ -137,7 +137,7 @@ class Console
 
     std::tuple<SearchFilter, bool, bool> InputAndParseSearchCommand(
         const std::string& commandStr) const;
-    std::vector<Card> ProcessSearchCommand(SearchFilter& filter) const;
+    std::vector<Card*> ProcessSearchCommand(SearchFilter& filter) const;
 
     std::vector<std::string> SplitString(std::string str,
                                          const std::string& delimiter) const;

--- a/Extensions/RosettaTool/main.cpp
+++ b/Extensions/RosettaTool/main.cpp
@@ -103,8 +103,8 @@ inline void ExportFile(const std::string& projectPath, CardSet cardSet)
         // Excludes cards that is not collectible
         cards.erase(
             std::remove_if(cards.begin(), cards.end(),
-                           [](const Card& c) {
-                               return c.gameTags.at(GameTag::COLLECTIBLE) == 0;
+                           [](const Card* c) {
+                               return c->gameTags.at(GameTag::COLLECTIBLE) == 0;
                            }),
             cards.end());
 
@@ -112,8 +112,8 @@ inline void ExportFile(const std::string& projectPath, CardSet cardSet)
         if (cardSet == CardSet::CORE)
         {
             cards.erase(std::remove_if(cards.begin(), cards.end(),
-                                       [](const Card& c) {
-                                           return c.GetCardType() ==
+                                       [](const Card* c) {
+                                           return c->GetCardType() ==
                                                   CardType::HERO;
                                        }),
                         cards.end());
@@ -128,19 +128,19 @@ inline void ExportFile(const std::string& projectPath, CardSet cardSet)
         for (auto& card : cards)
         {
             std::string gameTagStr;
-            for (auto& gameTag : card.gameTags)
+            for (auto& gameTag : card->gameTags)
             {
                 gameTagStr += EnumToStr<GameTag>(gameTag.first);
             }
 
-            const bool isImplemented = CheckCardImpl(projectPath, card.id);
+            const bool isImplemented = CheckCardImpl(projectPath, card->id);
             if (isImplemented)
             {
                 impledCardNum++;
             }
 
-            outputFile << EnumToStr<CardSet>(card.GetCardSet()) << " | "
-                       << card.id << " | " << card.name << " | "
+            outputFile << EnumToStr<CardSet>(card->GetCardSet()) << " | "
+                       << card->id << " | " << card->name << " | "
                        << (isImplemented ? 'O' : ' ') << '\n';
         }
 

--- a/Extensions/RosettaTorch/Includes/Agents/MCTSRunner.hpp
+++ b/Extensions/RosettaTorch/Includes/Agents/MCTSRunner.hpp
@@ -61,13 +61,14 @@ class MCTSRunner
 
                 for (size_t j = 0; j < START_DECK_SIZE; ++j)
                 {
-                    config.player1Deck[j] = Cards::FindCardByID(deck[j]);
-                    config.player2Deck[j] = Cards::FindCardByID(deck[j]);
+                    config.player1Deck[j] = *Cards::FindCardByID(deck[j]);
+                    config.player2Deck[j] = *Cards::FindCardByID(deck[j]);
                 }
 
                 while (!m_stopFlag.load())
                 {
-                    mcts.Iterate(config);
+                    Game game(config);
+                    mcts.Iterate(game);
 
                     m_statistics.IterateSucceeded();
                 }

--- a/Extensions/RosettaTorch/Includes/MCTS/MOMCTS.hpp
+++ b/Extensions/RosettaTorch/Includes/MCTS/MOMCTS.hpp
@@ -30,9 +30,9 @@ class MOMCTS
         // Do nothing
     }
 
-    void Iterate(GameConfig config)
+    void Iterate(const Game& game)
     {
-        m_playerController.StartGame(std::move(config));
+        m_playerController.SetGame(game);
         m_player1.StartIteration();
         m_player2.StartIteration();
 

--- a/Extensions/RosettaTorch/Includes/MCTS/Policies/PlayerController.hpp
+++ b/Extensions/RosettaTorch/Includes/MCTS/Policies/PlayerController.hpp
@@ -86,9 +86,9 @@ class PlayerController
         return RosettaStone::Board(*m_game, player.GetPlayerType());
     }
 
-    void StartGame(RosettaStone::GameConfig&& config)
+    void SetGame(const RosettaStone::Game& game)
     {
-        m_game = new RosettaStone::Game(config);
+        m_game = &const_cast<RosettaStone::Game&>(game);
         m_game->StartGame();
     }
 

--- a/Extensions/RosettaTorch/Sources/RosettaTorch/GameToVec.cpp
+++ b/Extensions/RosettaTorch/Sources/RosettaTorch/GameToVec.cpp
@@ -202,7 +202,7 @@ torch::Tensor GameToVec::CardToTensor(Entity* entity)
         }
     };
 
-    auto ability = character->card.power;
+    auto ability = character->card->power;
 
     auto aura = ability.GetAura();
     const auto enchant = ability.GetEnchant();

--- a/Includes/Rosetta/Accounts/DeckInfo.hpp
+++ b/Includes/Rosetta/Accounts/DeckInfo.hpp
@@ -54,7 +54,7 @@ class DeckInfo
 
     //! Creates a deck from a list of pointers to cards to play game.
     //! \return A deck from a list of pointers to cards.
-    std::vector<Card> GetPrimitiveDeck() const;
+    std::vector<Card*> GetPrimitiveDeck() const;
 
     //! Returns card ID and the number of card at \p idx in deck.
     //! \param idx Index of cards in deck.

--- a/Includes/Rosetta/Actions/Draw.hpp
+++ b/Includes/Rosetta/Actions/Draw.hpp
@@ -20,7 +20,7 @@ Entity* Draw(Player& player, Entity* cardToDraw = nullptr);
 //! \param player The player to add card to the hand.
 //! \param card A card to draw to the hand.
 //! \return A dynamic allocated entity object.
-Entity* DrawCard(Player& player, Card&& card);
+Entity* DrawCard(Player& player, Card* card);
 }  // namespace RosettaStone::Generic
 
 #endif  // ROSETTASTONE_DRAW_HPP

--- a/Includes/Rosetta/Actions/Generic.hpp
+++ b/Includes/Rosetta/Actions/Generic.hpp
@@ -33,7 +33,7 @@ void ChangeManaCrystal(Player& player, int amount, bool fill);
 //! \param player The owner of minion to transform.
 //! \param oldMinion An old minion to transform.
 //! \param card A new card ID to transform.
-void TransformMinion(Player& player, Minion* oldMinion, Card&& card);
+void TransformMinion(Player& player, Minion* oldMinion, Card* card);
 
 //! Returns the zone corresponding to the zone type.
 //! \param player An owner of zone.

--- a/Includes/Rosetta/Cards/Cards.hpp
+++ b/Includes/Rosetta/Cards/Cards.hpp
@@ -58,81 +58,81 @@ class Cards
 
     //! Returns a list of all cards.
     //! \return A list of all cards.
-    static const std::vector<Card>& GetAllCards();
+    static const std::vector<Card*>& GetAllCards();
 
     //! Returns a card that matches \p id.
     //! \param id The ID of the card.
     //! \return A card that matches \p id.
-    static Card FindCardByID(const std::string& id);
+    static Card* FindCardByID(const std::string& id);
 
     //! Returns a list of cards that matches \p rarity.
     //! \param rarity The rarity of the card.
     //! \return A list of cards that matches condition.
-    static std::vector<Card> FindCardByRarity(Rarity rarity);
+    static std::vector<Card*> FindCardByRarity(Rarity rarity);
 
     //! Returns a list of cards that matches \p cardClass.
     //! \param cardClass The class of the card.
     //! \return A list of cards that matches condition.
-    static std::vector<Card> FindCardByClass(CardClass cardClass);
+    static std::vector<Card*> FindCardByClass(CardClass cardClass);
 
     //! Returns a list of cards that matches \p cardSet.
     //! \param cardSet The set of the card.
     //! \return A list of cards that matches condition.
-    static std::vector<Card> FindCardBySet(CardSet cardSet);
+    static std::vector<Card*> FindCardBySet(CardSet cardSet);
 
     //! Returns a list of cards that matches \p cardType.
     //! \param cardType The type of the card.
     //! \return A list of cards that matches condition.
-    static std::vector<Card> FindCardByType(CardType cardType);
+    static std::vector<Card*> FindCardByType(CardType cardType);
 
     //! Returns a list of cards that matches \p race.
     //! \param race The race of the card.
     //! \return A list of cards that matches condition.
-    static std::vector<Card> FindCardByRace(Race race);
+    static std::vector<Card*> FindCardByRace(Race race);
 
     //! Returns a card that matches \p name.
     //! \param name The name of the card.
     //! \return A card that matches condition.
-    static Card FindCardByName(const std::string& name);
+    static Card* FindCardByName(const std::string& name);
 
     //! Returns a list of cards whose cost is between \p minVal and \p maxVal.
     //! \param minVal The minimum cost value of the card.
     //! \param maxVal The maximum cost value of the card.
     //! \return A list of cards that matches condition.
-    static std::vector<Card> FindCardByCost(int minVal, int maxVal);
+    static std::vector<Card*> FindCardByCost(int minVal, int maxVal);
 
     //! Returns a list of cards whose attack is between \p minVal and \p maxVal.
     //! \param minVal The minimum attack value of the card.
     //! \param maxVal The maximum attack value of the card.
     //! \return A list of cards that matches condition.
-    static std::vector<Card> FindCardByAttack(int minVal, int maxVal);
+    static std::vector<Card*> FindCardByAttack(int minVal, int maxVal);
 
     //! Returns a list of cards whose health is between \p minVal and \p maxVal.
     //! \param minVal The minimum health value of the card.
     //! \param maxVal The maximum health value of the card.
     //! \return A list of cards that matches condition.
-    static std::vector<Card> FindCardByHealth(int minVal, int maxVal);
+    static std::vector<Card*> FindCardByHealth(int minVal, int maxVal);
 
     //! Returns a list of cards whose spell power is between \p minVal and \p maxVal.
     //! \param minVal The minimum spell power value of the card.
     //! \param maxVal The maximum spell power value of the card.
     //! \return A list of cards that matches condition.
-    static std::vector<Card> FindCardBySpellPower(int minVal, int maxVal);
+    static std::vector<Card*> FindCardBySpellPower(int minVal, int maxVal);
 
     //! Returns a list of cards that has \p gameTags.
     //! \param gameTags A list of game tag of the card.
     //! \return A list of cards that matches condition.
-    static std::vector<Card> FindCardByGameTag(std::vector<GameTag> gameTags);
+    static std::vector<Card*> FindCardByGameTag(std::vector<GameTag> gameTags);
 
     //! Returns a hero card that matches \p cardClass.
     //! \param cardClass The class of the card.
     //! \return A hero card that matches condition.
-    static Card GetHeroCard(CardClass cardClass);
+    static Card* GetHeroCard(CardClass cardClass);
 
     //! Returns a default hero power card that matches \p cardClass.
     //! \param cardClass The class of the card.
     //! \return A default hero power card that matches condition.
-    static Card GetDefaultHeroPower(CardClass cardClass);
+    static Card* GetDefaultHeroPower(CardClass cardClass);
 
  private:
     //! Constructor: Loads card data.
@@ -141,7 +141,7 @@ class Cards
     //! Destructor: Releases card data.
     ~Cards();
 
-    static std::vector<Card> m_cards;
+    static std::vector<Card*> m_cards;
 };
 }  // namespace RosettaStone
 

--- a/Includes/Rosetta/Commons/SpinLocks.hpp
+++ b/Includes/Rosetta/Commons/SpinLocks.hpp
@@ -28,7 +28,6 @@ class SpinLock
     {
         while (m_flag.test_and_set(std::memory_order_acquire))
         {
-            // Spin
             std::this_thread::yield();
         }
     }

--- a/Includes/Rosetta/Games/GameConfig.hpp
+++ b/Includes/Rosetta/Games/GameConfig.hpp
@@ -25,8 +25,8 @@ struct GameConfig
     CardClass player1Class = CardClass::MAGE;
     CardClass player2Class = CardClass::WARLOCK;
 
-    std::array<Card*, START_DECK_SIZE> player1Deck;
-    std::array<Card*, START_DECK_SIZE> player2Deck;
+    std::array<Card, START_DECK_SIZE> player1Deck;
+    std::array<Card, START_DECK_SIZE> player2Deck;
 
     std::array<std::string, NUM_PLAYER_CLASS> fillCardIDs = {
         "UNG_028", "UNG_067", "UNG_116", "UNG_829", "UNG_934",

--- a/Includes/Rosetta/Games/GameConfig.hpp
+++ b/Includes/Rosetta/Games/GameConfig.hpp
@@ -25,8 +25,8 @@ struct GameConfig
     CardClass player1Class = CardClass::MAGE;
     CardClass player2Class = CardClass::WARLOCK;
 
-    std::array<Card, START_DECK_SIZE> player1Deck;
-    std::array<Card, START_DECK_SIZE> player2Deck;
+    std::array<Card*, START_DECK_SIZE> player1Deck;
+    std::array<Card*, START_DECK_SIZE> player2Deck;
 
     std::array<std::string, NUM_PLAYER_CLASS> fillCardIDs = {
         "UNG_028", "UNG_067", "UNG_116", "UNG_829", "UNG_934",

--- a/Includes/Rosetta/Loaders/CardLoader.hpp
+++ b/Includes/Rosetta/Loaders/CardLoader.hpp
@@ -25,7 +25,7 @@ class CardLoader
  public:
     //! Loads card data from cards.json.
     //! \param cards Data storage to store added cards with power.
-    static void Load(std::vector<Card>& cards);
+    static void Load(std::vector<Card*>& cards);
 };
 }  // namespace RosettaStone
 

--- a/Includes/Rosetta/Loaders/PowerLoader.hpp
+++ b/Includes/Rosetta/Loaders/PowerLoader.hpp
@@ -23,7 +23,7 @@ class PowerLoader
  public:
     //! Loads power data from card data generators.
     //! \param cards Data storage to store added cards with power.
-    static void Load(std::vector<Card>& cards);
+    static void Load(std::vector<Card*>& cards);
 };
 }  // namespace RosettaStone
 

--- a/Includes/Rosetta/Models/Character.hpp
+++ b/Includes/Rosetta/Models/Character.hpp
@@ -28,7 +28,7 @@ class Character : public Entity
     //! \param _owner The owner of the card.
     //! \param _card The card.
     //! \param tags The game tags.
-    Character(Player& _owner, Card& _card, std::map<GameTag, int> tags);
+    Character(Player& _owner, Card* _card, std::map<GameTag, int> tags);
 
     //! Default destructor.
     virtual ~Character() = default;

--- a/Includes/Rosetta/Models/Enchantment.hpp
+++ b/Includes/Rosetta/Models/Enchantment.hpp
@@ -29,7 +29,7 @@ class Enchantment : public Entity
     //! \param _card The card.
     //! \param tags The game tags.
     //! \param target A target of enchantment.
-    Enchantment(Player& _owner, Card& _card, std::map<GameTag, int> tags,
+    Enchantment(Player& _owner, Card* _card, std::map<GameTag, int> tags,
                 Entity* target);
 
     //! Default destructor.
@@ -52,7 +52,7 @@ class Enchantment : public Entity
     //! \param card The card from which the enchantment must be derived.
     //! \param target The entity who is subjected to the enchantment.
     //! \return The resulting enchantment entity.
-    static Enchantment* GetInstance(Player& player, Card& card, Entity* target);
+    static Enchantment* GetInstance(Player& player, Card* card, Entity* target);
 
     //! Returns the target of enchantment.
     //! \return The target of enchantment.

--- a/Includes/Rosetta/Models/Entity.hpp
+++ b/Includes/Rosetta/Models/Entity.hpp
@@ -39,7 +39,7 @@ class Entity
     //! \param _owner The owner of the card.
     //! \param _card The card.
     //! \param tags The game tags.
-    Entity(Player& _owner, Card& _card, std::map<GameTag, int> tags);
+    Entity(Player& _owner, Card* _card, std::map<GameTag, int> tags);
 
     //! Destructor.
     virtual ~Entity();
@@ -143,12 +143,12 @@ class Entity
     //! \param id An entity ID to assign to the newly created entity.
     //! \return A pointer to entity that is allocated dynamically.
     static Entity* GetFromCard(
-        Player& player, Card&& card,
+        Player& player, Card* card,
         std::optional<std::map<GameTag, int>> cardTags = std::nullopt,
         IZone* zone = nullptr, int id = -1);
 
     Player* owner = nullptr;
-    Card card;
+    Card* card;
 
     IZone* zone = nullptr;
 

--- a/Includes/Rosetta/Models/Entity.hpp
+++ b/Includes/Rosetta/Models/Entity.hpp
@@ -148,7 +148,7 @@ class Entity
         IZone* zone = nullptr, int id = -1);
 
     Player* owner = nullptr;
-    Card* card;
+    Card* card = nullptr;
 
     IZone* zone = nullptr;
 

--- a/Includes/Rosetta/Models/Hero.hpp
+++ b/Includes/Rosetta/Models/Hero.hpp
@@ -29,7 +29,7 @@ class Hero : public Character
     //! \param _owner The owner of the card.
     //! \param _card The card.
     //! \param tags The game tags.
-    Hero(Player& _owner, Card& _card, std::map<GameTag, int> tags);
+    Hero(Player& _owner, Card* _card, std::map<GameTag, int> tags);
 
     //! Default destructor.
     ~Hero();

--- a/Includes/Rosetta/Models/HeroPower.hpp
+++ b/Includes/Rosetta/Models/HeroPower.hpp
@@ -26,7 +26,7 @@ class HeroPower : public Entity
     //! \param _owner The owner of the card.
     //! \param _card The card.
     //! \param tags The game tags.
-    HeroPower(Player& _owner, Card& _card, std::map<GameTag, int> tags);
+    HeroPower(Player& _owner, Card* _card, std::map<GameTag, int> tags);
 
     //! Default destructor.
     ~HeroPower() = default;

--- a/Includes/Rosetta/Models/Minion.hpp
+++ b/Includes/Rosetta/Models/Minion.hpp
@@ -26,7 +26,7 @@ class Minion : public Character
     //! \param _owner The owner of the card.
     //! \param _card The card.
     //! \param tags The game tags.
-    Minion(Player& _owner, Card& _card, std::map<GameTag, int> tags);
+    Minion(Player& _owner, Card* _card, std::map<GameTag, int> tags);
 
     //! Default destructor.
     ~Minion() = default;

--- a/Includes/Rosetta/Models/Player.hpp
+++ b/Includes/Rosetta/Models/Player.hpp
@@ -174,7 +174,7 @@ class Player
     //! Adds hero and hero power.
     //! \param heroCard A card that represents hero.
     //! \param powerCard A card that represents hero power.
-    void AddHeroAndPower(Card&& heroCard, Card&& powerCard);
+    void AddHeroAndPower(Card* heroCard, Card* powerCard);
 
     std::string nickname;
     PlayerType playerType = PlayerType::PLAYER1;

--- a/Includes/Rosetta/Models/Spell.hpp
+++ b/Includes/Rosetta/Models/Spell.hpp
@@ -26,7 +26,7 @@ class Spell : public Entity
     //! \param _owner The owner of the card.
     //! \param _card The card.
     //! \param tags The game tags.
-    Spell(Player& _owner, Card& _card, std::map<GameTag, int> tags);
+    Spell(Player& _owner, Card* _card, std::map<GameTag, int> tags);
 
     //! Default destructor.
     ~Spell() = default;

--- a/Includes/Rosetta/Models/Weapon.hpp
+++ b/Includes/Rosetta/Models/Weapon.hpp
@@ -28,7 +28,7 @@ class Weapon : public Entity
     //! \param _owner The owner of the card.
     //! \param _card The card.
     //! \param tags The game tags.
-    Weapon(Player& _owner, Card& _card, std::map<GameTag, int> tags);
+    Weapon(Player& _owner, Card* _card, std::map<GameTag, int> tags);
 
     //! Destructor.
     virtual ~Weapon();

--- a/Includes/Rosetta/Tasks/SimpleTasks/SummonTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/SummonTask.hpp
@@ -31,7 +31,7 @@ class SummonTask : public ITask
  public:
     //! Constructs task with given \p side, \p card and \p amount.
     explicit SummonTask(SummonSide side = SummonSide::DEFAULT,
-                        const std::optional<Card>& card = std::nullopt,
+                        const std::optional<Card*>& card = std::nullopt,
                         int amount = 1);
 
     //! Constructs task with given \p cardID and \p amount.
@@ -55,7 +55,7 @@ class SummonTask : public ITask
     //! \return The result of task processing.
     TaskStatus Impl(Player& player) override;
 
-    std::optional<Card> m_card = std::nullopt;
+    std::optional<Card*> m_card = std::nullopt;
     SummonSide m_side = SummonSide::DEFAULT;
     int m_amount = 1;
 };

--- a/Includes/Rosetta/Views/ViewTypes.hpp
+++ b/Includes/Rosetta/Views/ViewTypes.hpp
@@ -113,7 +113,7 @@ struct HeroPower
 
     void Fill(RosettaStone::HeroPower& power)
     {
-        cardID = power.card.id;
+        cardID = power.card->id;
         isExhausted = power.IsExhausted();
     }
 
@@ -150,7 +150,7 @@ struct Weapon
 
     void Fill(const RosettaStone::Weapon& weapon)
     {
-        cardID = weapon.card.id;
+        cardID = weapon.card->id;
         attack = weapon.GetAttack();
         durability = weapon.GetDurability();
         isEquipped = true;
@@ -257,7 +257,7 @@ struct Minion
 
     void Fill(const RosettaStone::Minion& minion)
     {
-        cardID = minion.card.id;
+        cardID = minion.card->id;
         attack = minion.GetAttack();
         health = minion.GetHealth();
         isSilenced = (minion.GetGameTag(GameTag::SILENCED) == 1);
@@ -362,7 +362,7 @@ struct MyHandCard
 
     void Fill(RosettaStone::Entity& entity)
     {
-        cardID = entity.card.id;
+        cardID = entity.card->id;
         cost = entity.GetCost();
         attack = entity.GetGameTag(GameTag::ATK);
         health = entity.GetGameTag(GameTag::HEALTH);

--- a/Sources/Rosetta/Accounts/DeckInfo.cpp
+++ b/Sources/Rosetta/Accounts/DeckInfo.cpp
@@ -60,13 +60,13 @@ std::size_t DeckInfo::GetNumCardInDeck(std::string cardID)
     return 0;
 }
 
-std::vector<Card> DeckInfo::GetPrimitiveDeck() const
+std::vector<Card*> DeckInfo::GetPrimitiveDeck() const
 {
-    std::vector<Card> deck;
+    std::vector<Card*> deck;
 
     for (const auto& [id, num] : m_cards)
     {
-        Card card = Cards::GetInstance().FindCardByID(id);
+        Card* card = Cards::GetInstance().FindCardByID(id);
 
         for (std::size_t i = 0; i < num; ++i)
         {
@@ -88,14 +88,14 @@ void DeckInfo::ShowCardList() const
 
     for (auto& cardInfo : m_cards)
     {
-        Card card = Cards::GetInstance().FindCardByID(cardInfo.first);
-        if (card.id.empty())
+        Card* card = Cards::GetInstance().FindCardByID(cardInfo.first);
+        if (card->id.empty())
         {
             continue;
         }
 
         std::cout << idx << ". ";
-        card.ShowBriefInfo();
+        card->ShowBriefInfo();
         std::cout << "(" << cardInfo.second << " card(s))\n";
 
         idx++;
@@ -104,11 +104,11 @@ void DeckInfo::ShowCardList() const
 
 bool DeckInfo::AddCard(std::string cardID, std::size_t numCardToAdd)
 {
-    Card card = Cards::GetInstance().FindCardByID(cardID);
+    Card* card = Cards::GetInstance().FindCardByID(cardID);
 
-    const CardClass cardClass = card.GetCardClass();
+    const CardClass cardClass = card->GetCardClass();
     if ((cardClass != GetClass() && cardClass != CardClass::NEUTRAL) ||
-        card.GetMaxAllowedInDeck() < numCardToAdd)
+        card->GetMaxAllowedInDeck() < numCardToAdd)
     {
         return false;
     }
@@ -122,7 +122,7 @@ bool DeckInfo::AddCard(std::string cardID, std::size_t numCardToAdd)
     // A card is in deck
     if (cardIter != m_cards.end())
     {
-        if (card.GetMaxAllowedInDeck() < (*cardIter).second + numCardToAdd)
+        if (card->GetMaxAllowedInDeck() < (*cardIter).second + numCardToAdd)
             return false;
 
         (*cardIter).second += numCardToAdd;

--- a/Sources/Rosetta/Actions/ActionValidGetter.cpp
+++ b/Sources/Rosetta/Actions/ActionValidGetter.cpp
@@ -107,7 +107,7 @@ bool ActionValidGetter::CanUseHeroPower() const
 
 bool ActionValidGetter::IsPlayable(Entity* entity) const
 {
-    if (entity->card.GetCardType() == CardType::MINION)
+    if (entity->card->GetCardType() == CardType::MINION)
     {
         if (m_game.GetCurrentPlayer().GetFieldZone().IsFull())
         {
@@ -115,7 +115,7 @@ bool ActionValidGetter::IsPlayable(Entity* entity) const
         }
     }
 
-    if (entity->card.HasGameTag(GameTag::SECRET))
+    if (entity->card->HasGameTag(GameTag::SECRET))
     {
         if (m_game.GetCurrentPlayer().GetSecretZone().Exist(*entity))
         {

--- a/Sources/Rosetta/Actions/CastSpell.cpp
+++ b/Sources/Rosetta/Actions/CastSpell.cpp
@@ -17,9 +17,9 @@ void CastSpell(Player& player, Spell* spell, Character* target, int chooseOne)
     if (spell->IsSecret())
     {
         // Process trigger
-        if (spell->card.power.GetTrigger())
+        if (spell->card->power.GetTrigger())
         {
-            spell->card.power.GetTrigger()->Activate(spell);
+            spell->card->power.GetTrigger()->Activate(spell);
         }
 
         player.GetSecretZone().Add(*spell);
@@ -28,15 +28,15 @@ void CastSpell(Player& player, Spell* spell, Character* target, int chooseOne)
     else
     {
         // Process trigger
-        if (spell->card.power.GetTrigger())
+        if (spell->card->power.GetTrigger())
         {
-            spell->card.power.GetTrigger()->Activate(spell);
+            spell->card->power.GetTrigger()->Activate(spell);
         }
 
         // Process aura
-        if (spell->card.power.GetAura())
+        if (spell->card->power.GetAura())
         {
-            spell->card.power.GetAura()->Activate(spell);
+            spell->card->power.GetAura()->Activate(spell);
         }
 
         // Process power or combo tasks

--- a/Sources/Rosetta/Actions/Choose.cpp
+++ b/Sources/Rosetta/Actions/Choose.cpp
@@ -46,7 +46,7 @@ void ChoiceMulligan(Player& player, const std::vector<std::size_t>& choices)
             {
                 const bool isExist = std::find(choices.begin(), choices.end(),
                                                entity->id) == choices.end();
-                if (isExist && entity->card.id != "GAME_005")
+                if (isExist && entity->card->id != "GAME_005")
                 {
                     mulliganList.push_back(entity);
                 }

--- a/Sources/Rosetta/Actions/Draw.cpp
+++ b/Sources/Rosetta/Actions/Draw.cpp
@@ -32,9 +32,9 @@ Entity* Draw(Player& player, Entity* cardToDraw)
     return entity;
 }
 
-Entity* DrawCard(Player& player, Card&& card)
+Entity* DrawCard(Player& player, Card* card)
 {
-    Entity* entity = Entity::GetFromCard(player, std::move(card));
+    Entity* entity = Entity::GetFromCard(player, card);
     AddCardToHand(player, entity);
 
     return entity;

--- a/Sources/Rosetta/Actions/Generic.cpp
+++ b/Sources/Rosetta/Actions/Generic.cpp
@@ -61,10 +61,10 @@ void ChangeManaCrystal(Player& player, int amount, bool fill)
     }
 }
 
-void TransformMinion(Player& player, Minion* oldMinion, Card&& card)
+void TransformMinion(Player& player, Minion* oldMinion, Card* card)
 {
     const auto newMinion =
-        dynamic_cast<Minion*>(Entity::GetFromCard(player, std::move(card)));
+        dynamic_cast<Minion*>(Entity::GetFromCard(player, card));
     if (newMinion == nullptr)
     {
         return;

--- a/Sources/Rosetta/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/Actions/PlayCard.cpp
@@ -61,7 +61,7 @@ void PlayCard(Player& player, Entity* source, Character* target, int fieldPos,
                               SequenceType::PLAY_CARD);
 
     // Pass to sub-logic
-    switch (source->card.GetCardType())
+    switch (source->card->GetCardType())
     {
         case CardType::MINION:
         {
@@ -103,7 +103,7 @@ void PlayMinion(Player& player, Minion* minion, Character* target, int fieldPos,
     player.GetFieldZone().Add(*minion, fieldPos);
 
     // Apply card mechanics tags
-    for (const auto tags : minion->card.gameTags)
+    for (const auto tags : minion->card->gameTags)
     {
         minion->SetGameTag(tags.first, tags.second);
     }
@@ -196,15 +196,15 @@ void PlayWeapon(Player& player, Weapon* weapon, Character* target)
     player.GetGame()->triggerManager.OnPlayCardTrigger(&player, weapon);
 
     // Process trigger
-    if (weapon->card.power.GetTrigger())
+    if (weapon->card->power.GetTrigger())
     {
-        weapon->card.power.GetTrigger()->Activate(weapon);
+        weapon->card->power.GetTrigger()->Activate(weapon);
     }
 
     // Process aura
-    if (weapon->card.power.GetAura())
+    if (weapon->card->power.GetAura())
     {
-        weapon->card.power.GetAura()->Activate(weapon);
+        weapon->card->power.GetAura()->Activate(weapon);
     }
 
     // Process target trigger
@@ -255,7 +255,7 @@ bool IsPlayableByPlayer(Player& player, Entity* source)
 
 bool IsPlayableByCardReq(Entity* source)
 {
-    for (auto& requirement : source->card.playRequirements)
+    for (auto& requirement : source->card->playRequirements)
     {
         switch (requirement.first)
         {
@@ -283,14 +283,14 @@ bool IsPlayableByCardReq(Entity* source)
             case PlayReq::REQ_ENTIRE_ENTOURAGE_NOT_IN_PLAY:
             {
                 auto& curField = source->owner->GetFieldZone();
-                auto& entourages = source->card.entourages;
+                auto& entourages = source->card->entourages;
                 size_t entourageCount = 0;
 
                 for (auto& minion : curField.GetAll())
                 {
                     for (auto& entourage : entourages)
                     {
-                        if (minion->card.id == entourage)
+                        if (minion->card->id == entourage)
                         {
                             ++entourageCount;
                         }

--- a/Sources/Rosetta/Actions/Targeting.cpp
+++ b/Sources/Rosetta/Actions/Targeting.cpp
@@ -24,7 +24,7 @@ constexpr std::array<PlayReq, 8> NEEDS_TARGET_LIST = {
 
 bool IsSourceNeedsTarget(Entity* source)
 {
-    for (auto& requirement : source->card.playRequirements)
+    for (auto& requirement : source->card->playRequirements)
     {
         auto iter = std::find(NEEDS_TARGET_LIST.begin(),
                               NEEDS_TARGET_LIST.end(), requirement.first);
@@ -50,7 +50,7 @@ bool IsValidTarget(Entity* source, Entity* target)
 
     // Check source must require a target
     bool requiresTarget = false;
-    for (auto& requirement : source->card.playRequirements)
+    for (auto& requirement : source->card->playRequirements)
     {
         if (requirement.first == PlayReq::REQ_TARGET_TO_PLAY)
         {
@@ -118,7 +118,7 @@ std::vector<Character*> GetValidTargets(Entity* source)
 
 bool CheckRequirements(Entity* source, Character* target)
 {
-    for (auto& requirement : source->card.playRequirements)
+    for (auto& requirement : source->card->playRequirements)
     {
         const PlayReq req = requirement.first;
         const int param = requirement.second;
@@ -173,7 +173,7 @@ bool CheckRequirements(Entity* source, Character* target)
             }
             case PlayReq::REQ_TARGET_WITH_RACE:
             {
-                if (target->card.GetRace() != static_cast<Race>(param))
+                if (target->card->GetRace() != static_cast<Race>(param))
                 {
                     return false;
                 }

--- a/Sources/Rosetta/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/CoreCardsGen.cpp
@@ -211,15 +211,15 @@ void CoreCardsGen::AddHeroPowers(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddPowerTask(new FuncNumberTask([](Entity* entity) {
         auto minions = entity->owner->GetFieldZone().GetAll();
-        std::vector<Card> totemCards;
+        std::vector<Card*> totemCards;
         totemCards.reserve(4);
 
-        for (const auto& id : entity->card.entourages)
+        for (const auto& id : entity->card->entourages)
         {
             bool exist = false;
             for (auto minion : minions)
             {
-                if (id == minion->card.id)
+                if (id == minion->card->id)
                 {
                     exist = true;
                     break;
@@ -239,7 +239,7 @@ void CoreCardsGen::AddHeroPowers(std::map<std::string, Power>& cards)
 
         const auto idx = Random::get<int>(0, totemCards.size() - 1);
         Entity* totem =
-            Entity::GetFromCard(*entity->owner, std::move(totemCards[idx]));
+            Entity::GetFromCard(*entity->owner, totemCards[idx]);
         entity->owner->GetFieldZone().Add(*dynamic_cast<Minion*>(totem));
     }));
     cards.emplace("CS2_049", power);

--- a/Sources/Rosetta/Cards/Cards.cpp
+++ b/Sources/Rosetta/Cards/Cards.cpp
@@ -11,6 +11,8 @@
 
 namespace RosettaStone
 {
+
+Card emptyCard;
 std::vector<Card*> Cards::m_cards;
 
 Cards::Cards()
@@ -50,7 +52,7 @@ Card* Cards::FindCardByID(const std::string& id)
         }
     }
 
-    return nullptr;
+    return &emptyCard;
 }
 
 std::vector<Card*> Cards::FindCardByRarity(Rarity rarity)
@@ -138,7 +140,7 @@ Card* Cards::FindCardByName(const std::string& name)
         }
     }
 
-    return nullptr;
+    return &emptyCard;
 }
 
 std::vector<Card*> Cards::FindCardByCost(int minVal, int maxVal)
@@ -260,7 +262,7 @@ Card* Cards::GetHeroCard(CardClass cardClass)
         case CardClass::WARRIOR:
             return FindCardByID("HERO_01");
         default:
-            return nullptr;
+            return &emptyCard;
     }
 }
 
@@ -287,7 +289,7 @@ Card* Cards::GetDefaultHeroPower(CardClass cardClass)
         case CardClass::WARRIOR:
             return FindCardByID("CS2_102");
         default:
-            return nullptr;
+            return &emptyCard;
     }
 }
 }  // namespace RosettaStone

--- a/Sources/Rosetta/Cards/Cards.cpp
+++ b/Sources/Rosetta/Cards/Cards.cpp
@@ -11,7 +11,7 @@
 
 namespace RosettaStone
 {
-std::vector<Card> Cards::m_cards;
+std::vector<Card*> Cards::m_cards;
 
 Cards::Cards()
 {
@@ -21,6 +21,11 @@ Cards::Cards()
 
 Cards::~Cards()
 {
+    for (Card* card : m_cards)
+    {
+        delete card;
+    }
+
     m_cards.clear();
 }
 
@@ -30,31 +35,31 @@ Cards& Cards::GetInstance()
     return instance;
 }
 
-const std::vector<Card>& Cards::GetAllCards()
+const std::vector<Card*>& Cards::GetAllCards()
 {
     return m_cards;
 }
 
-Card Cards::FindCardByID(const std::string& id)
+Card* Cards::FindCardByID(const std::string& id)
 {
-    for (auto card : m_cards)
+    for (Card* card : m_cards)
     {
-        if (card.id == id)
+        if (card->id == id)
         {
             return card;
         }
     }
 
-    return Card();
+    return nullptr;
 }
 
-std::vector<Card> Cards::FindCardByRarity(Rarity rarity)
+std::vector<Card*> Cards::FindCardByRarity(Rarity rarity)
 {
-    std::vector<Card> result;
+    std::vector<Card*> result;
 
-    for (auto card : m_cards)
+    for (Card* card : m_cards)
     {
-        if (card.GetRarity() == rarity)
+        if (card->GetRarity() == rarity)
         {
             result.emplace_back(card);
         }
@@ -63,13 +68,13 @@ std::vector<Card> Cards::FindCardByRarity(Rarity rarity)
     return result;
 }
 
-std::vector<Card> Cards::FindCardByClass(CardClass cardClass)
+std::vector<Card*> Cards::FindCardByClass(CardClass cardClass)
 {
-    std::vector<Card> result;
+    std::vector<Card*> result;
 
-    for (auto card : m_cards)
+    for (Card* card : m_cards)
     {
-        if (card.GetCardClass() == cardClass)
+        if (card->GetCardClass() == cardClass)
         {
             result.emplace_back(card);
         }
@@ -78,13 +83,13 @@ std::vector<Card> Cards::FindCardByClass(CardClass cardClass)
     return result;
 }
 
-std::vector<Card> Cards::FindCardBySet(CardSet cardSet)
+std::vector<Card*> Cards::FindCardBySet(CardSet cardSet)
 {
-    std::vector<Card> result;
+    std::vector<Card*> result;
 
-    for (auto card : m_cards)
+    for (Card* card : m_cards)
     {
-        if (card.GetCardSet() == cardSet)
+        if (card->GetCardSet() == cardSet)
         {
             result.emplace_back(card);
         }
@@ -93,13 +98,13 @@ std::vector<Card> Cards::FindCardBySet(CardSet cardSet)
     return result;
 }
 
-std::vector<Card> Cards::FindCardByType(CardType cardType)
+std::vector<Card*> Cards::FindCardByType(CardType cardType)
 {
-    std::vector<Card> result;
+    std::vector<Card*> result;
 
-    for (auto card : m_cards)
+    for (Card* card : m_cards)
     {
-        if (card.GetCardType() == cardType)
+        if (card->GetCardType() == cardType)
         {
             result.emplace_back(card);
         }
@@ -108,13 +113,13 @@ std::vector<Card> Cards::FindCardByType(CardType cardType)
     return result;
 }
 
-std::vector<Card> Cards::FindCardByRace(Race race)
+std::vector<Card*> Cards::FindCardByRace(Race race)
 {
-    std::vector<Card> result;
+    std::vector<Card*> result;
 
-    for (auto card : m_cards)
+    for (Card* card : m_cards)
     {
-        if (card.GetRace() == race)
+        if (card->GetRace() == race)
         {
             result.emplace_back(card);
         }
@@ -123,27 +128,27 @@ std::vector<Card> Cards::FindCardByRace(Race race)
     return result;
 }
 
-Card Cards::FindCardByName(const std::string& name)
+Card* Cards::FindCardByName(const std::string& name)
 {
-    for (auto card : m_cards)
+    for (Card* card : m_cards)
     {
-        if (card.name == name)
+        if (card->name == name)
         {
             return card;
         }
     }
 
-    return Card();
+    return nullptr;
 }
 
-std::vector<Card> Cards::FindCardByCost(int minVal, int maxVal)
+std::vector<Card*> Cards::FindCardByCost(int minVal, int maxVal)
 {
-    std::vector<Card> result;
+    std::vector<Card*> result;
 
-    for (auto card : m_cards)
+    for (Card* card : m_cards)
     {
-        if (card.gameTags.at(GameTag::COST) >= minVal &&
-            card.gameTags.at(GameTag::COST) <= maxVal)
+        if (card->gameTags.at(GameTag::COST) >= minVal &&
+            card->gameTags.at(GameTag::COST) <= maxVal)
         {
             result.emplace_back(card);
         }
@@ -152,20 +157,20 @@ std::vector<Card> Cards::FindCardByCost(int minVal, int maxVal)
     return result;
 }
 
-std::vector<Card> Cards::FindCardByAttack(int minVal, int maxVal)
+std::vector<Card*> Cards::FindCardByAttack(int minVal, int maxVal)
 {
-    std::vector<Card> result;
+    std::vector<Card*> result;
 
-    for (auto card : m_cards)
+    for (Card* card : m_cards)
     {
-        if (!(card.GetCardType() == CardType::MINION) &&
-            !(card.GetCardType() == CardType::WEAPON))
+        if (!(card->GetCardType() == CardType::MINION) &&
+            !(card->GetCardType() == CardType::WEAPON))
         {
             continue;
         }
 
-        if (card.gameTags.at(GameTag::ATK) >= minVal &&
-            card.gameTags.at(GameTag::ATK) <= maxVal)
+        if (card->gameTags.at(GameTag::ATK) >= minVal &&
+            card->gameTags.at(GameTag::ATK) <= maxVal)
         {
             result.emplace_back(card);
         }
@@ -174,20 +179,20 @@ std::vector<Card> Cards::FindCardByAttack(int minVal, int maxVal)
     return result;
 }
 
-std::vector<Card> Cards::FindCardByHealth(int minVal, int maxVal)
+std::vector<Card*> Cards::FindCardByHealth(int minVal, int maxVal)
 {
-    std::vector<Card> result;
+    std::vector<Card*> result;
 
-    for (auto card : m_cards)
+    for (Card* card : m_cards)
     {
-        if (!(card.GetCardType() == CardType::MINION) &&
-            !(card.GetCardType() == CardType::HERO))
+        if (!(card->GetCardType() == CardType::MINION) &&
+            !(card->GetCardType() == CardType::HERO))
         {
             continue;
         }
 
-        if (card.gameTags.at(GameTag::HEALTH) >= minVal &&
-            card.gameTags.at(GameTag::HEALTH) <= maxVal)
+        if (card->gameTags.at(GameTag::HEALTH) >= minVal &&
+            card->gameTags.at(GameTag::HEALTH) <= maxVal)
         {
             result.emplace_back(card);
         }
@@ -196,14 +201,14 @@ std::vector<Card> Cards::FindCardByHealth(int minVal, int maxVal)
     return result;
 }
 
-std::vector<Card> Cards::FindCardBySpellPower(int minVal, int maxVal)
+std::vector<Card*> Cards::FindCardBySpellPower(int minVal, int maxVal)
 {
-    std::vector<Card> result;
+    std::vector<Card*> result;
 
-    for (auto card : m_cards)
+    for (Card* card : m_cards)
     {
-        if (card.gameTags.at(GameTag::SPELLPOWER) >= minVal &&
-            card.gameTags.at(GameTag::SPELLPOWER) <= maxVal)
+        if (card->gameTags.at(GameTag::SPELLPOWER) >= minVal &&
+            card->gameTags.at(GameTag::SPELLPOWER) <= maxVal)
         {
             result.emplace_back(card);
         }
@@ -212,13 +217,13 @@ std::vector<Card> Cards::FindCardBySpellPower(int minVal, int maxVal)
     return result;
 }
 
-std::vector<Card> Cards::FindCardByGameTag(std::vector<GameTag> gameTags)
+std::vector<Card*> Cards::FindCardByGameTag(std::vector<GameTag> gameTags)
 {
-    std::vector<Card> result;
+    std::vector<Card*> result;
 
-    for (auto card : m_cards)
+    for (auto& card : m_cards)
     {
-        auto cardGameTags = card.gameTags;
+        auto cardGameTags = card->gameTags;
 
         for (const auto gameTag : gameTags)
         {
@@ -232,7 +237,7 @@ std::vector<Card> Cards::FindCardByGameTag(std::vector<GameTag> gameTags)
     return result;
 }
 
-Card Cards::GetHeroCard(CardClass cardClass)
+Card* Cards::GetHeroCard(CardClass cardClass)
 {
     switch (cardClass)
     {
@@ -255,11 +260,11 @@ Card Cards::GetHeroCard(CardClass cardClass)
         case CardClass::WARRIOR:
             return FindCardByID("HERO_01");
         default:
-            return Card();
+            return nullptr;
     }
 }
 
-Card Cards::GetDefaultHeroPower(CardClass cardClass)
+Card* Cards::GetDefaultHeroPower(CardClass cardClass)
 {
     switch (cardClass)
     {
@@ -282,7 +287,7 @@ Card Cards::GetDefaultHeroPower(CardClass cardClass)
         case CardClass::WARRIOR:
             return FindCardByID("CS2_102");
         default:
-            return Card();
+            return nullptr;
     }
 }
 }  // namespace RosettaStone

--- a/Sources/Rosetta/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/Conditions/SelfCondition.cpp
@@ -52,7 +52,7 @@ SelfCondition SelfCondition::IsWeaponEquipped()
 SelfCondition SelfCondition::IsRace(Race race)
 {
     return SelfCondition(
-        [=](Entity* entity) -> bool { return entity->card.GetRace() == race; });
+        [=](Entity* entity) -> bool { return entity->card->GetRace() == race; });
 }
 
 SelfCondition SelfCondition::IsControllingRace(Race race)
@@ -60,7 +60,7 @@ SelfCondition SelfCondition::IsControllingRace(Race race)
     return SelfCondition([=](Entity* entity) -> bool {
         for (auto& minion : entity->owner->GetFieldZone().GetAll())
         {
-            if (minion->card.GetRace() == race)
+            if (minion->card->GetRace() == race)
             {
                 return true;
             }

--- a/Sources/Rosetta/Enchants/Aura.cpp
+++ b/Sources/Rosetta/Enchants/Aura.cpp
@@ -35,11 +35,11 @@ void Aura::SetToBeUpdated(bool value)
 
 void Aura::Activate(Entity* owner, bool cloning)
 {
-    Card card = Cards::FindCardByID(m_enchantmentID);
+    Card* card = Cards::FindCardByID(m_enchantmentID);
 
     if (m_effects.empty())
     {
-        m_effects = card.power.GetEnchant()->effects;
+        m_effects = card->power.GetEnchant()->effects;
     }
 
     auto instance = new Aura(*this, *owner);
@@ -65,11 +65,11 @@ void Aura::Activate(Entity* owner, bool cloning)
             {
                 if (condition == nullptr || condition->Evaluate(minion))
                 {
-                    if (card.power.GetTrigger())
+                    if (card->power.GetTrigger())
                     {
                         const auto enchantment = Enchantment::GetInstance(
                             *owner->owner, card, minion);
-                        card.power.GetTrigger()->Activate(enchantment);
+                        card->power.GetTrigger()->Activate(enchantment);
                     }
                 }
 
@@ -88,11 +88,11 @@ void Aura::Activate(Entity* owner, bool cloning)
 
                 if (condition == nullptr || condition->Evaluate(minion))
                 {
-                    if (card.power.GetTrigger())
+                    if (card->power.GetTrigger())
                     {
                         const auto enchantment = Enchantment::GetInstance(
                             *owner->owner, card, minion);
-                        card.power.GetTrigger()->Activate(enchantment);
+                        card->power.GetTrigger()->Activate(enchantment);
                     }
                 }
 

--- a/Sources/Rosetta/Enchants/Effect.cpp
+++ b/Sources/Rosetta/Enchants/Effect.cpp
@@ -86,7 +86,7 @@ void Effect::Remove(Entity* entity) const
             break;
         case EffectOperator::SUB:
             entity->SetGameTag(m_gameTag,
-                               entity->card.gameTags.at(m_gameTag) + m_value);
+                               entity->card->gameTags.at(m_gameTag) + m_value);
             break;
         case EffectOperator::SET:
             entity->SetGameTag(m_gameTag, 0);

--- a/Sources/Rosetta/Enchants/Enchants.cpp
+++ b/Sources/Rosetta/Enchants/Enchants.cpp
@@ -21,7 +21,7 @@ Enchant* Enchants::GetEnchantFromText(const std::string& cardID)
     static std::regex attackRegex("\\+([[:digit:]]+) Attack");
     static std::regex healthRegex("\\+([[:digit:]]+) Health");
 
-    const std::string text = Cards::FindCardByID(cardID).text;
+    const std::string text = Cards::FindCardByID(cardID)->text;
     std::smatch values;
 
     if (std::regex_search(text, values, attackHealthRegex))

--- a/Sources/Rosetta/Games/Game.cpp
+++ b/Sources/Rosetta/Games/Game.cpp
@@ -172,8 +172,8 @@ void Game::BeginDraw()
             Generic::Draw(p);
 
             // Give "The Coin" card to second player
-            Card coin = Cards::FindCardByID("GAME_005");
-            p.GetHandZone().Add(*Entity::GetFromCard(p, std::move(coin)));
+            Card* coin = Cards::FindCardByID("GAME_005");
+            p.GetHandZone().Add(*Entity::GetFromCard(p, coin));
         }
     }
 
@@ -444,19 +444,19 @@ void Game::StartGame()
     }
 
     // Set up decks
-    for (auto& card : m_gameConfig.player1Deck)
+    for (auto* card : m_gameConfig.player1Deck)
     {
-        if (card.id.empty())
+        if (card->id.empty())
         {
             continue;
         }
 
-        Entity* entity = Entity::GetFromCard(GetPlayer1(), std::move(card));
+        Entity* entity = Entity::GetFromCard(GetPlayer1(), card);
         GetPlayer1().GetDeckZone().Add(*entity);
     }
     for (auto& card : m_gameConfig.player2Deck)
     {
-        if (card.id.empty())
+        if (card->id.empty())
         {
             continue;
         }
@@ -472,8 +472,8 @@ void Game::StartGame()
         {
             for (auto& cardID : m_gameConfig.fillCardIDs)
             {
-                Card card = Cards::FindCardByID(cardID);
-                Entity* entity = Entity::GetFromCard(p, std::move(card));
+                Card* card = Cards::FindCardByID(cardID);
+                Entity* entity = Entity::GetFromCard(p, card);
                 p.GetDeckZone().Add(*entity);
             }
         }
@@ -683,9 +683,9 @@ PlayState Game::PerformAction(ActionParams& params)
             if (card->HasChooseOne())
             {
                 const size_t card1ID =
-                    std::hash<std::string>{}(card->chooseOneCard[0]->card.id);
+                    std::hash<std::string>{}(card->chooseOneCard[0]->card->id);
                 const size_t card2ID =
-                    std::hash<std::string>{}(card->chooseOneCard[1]->card.id);
+                    std::hash<std::string>{}(card->chooseOneCard[1]->card->id);
 
                 std::vector<size_t> cardIDs;
                 cardIDs.emplace_back(card1ID);

--- a/Sources/Rosetta/Games/Game.cpp
+++ b/Sources/Rosetta/Games/Game.cpp
@@ -444,24 +444,24 @@ void Game::StartGame()
     }
 
     // Set up decks
-    for (auto* card : m_gameConfig.player1Deck)
+    for (auto& card : m_gameConfig.player1Deck)
     {
-        if (card->id.empty())
+        if (card.id.empty())
         {
             continue;
         }
 
-        Entity* entity = Entity::GetFromCard(GetPlayer1(), card);
+        Entity* entity = Entity::GetFromCard(GetPlayer1(), &card);
         GetPlayer1().GetDeckZone().Add(*entity);
     }
     for (auto& card : m_gameConfig.player2Deck)
     {
-        if (card->id.empty())
+        if (card.id.empty())
         {
             continue;
         }
 
-        Entity* entity = Entity::GetFromCard(GetPlayer2(), std::move(card));
+        Entity* entity = Entity::GetFromCard(GetPlayer2(), &card);
         GetPlayer2().GetDeckZone().Add(*entity);
     }
 

--- a/Sources/Rosetta/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/Loaders/CardLoader.cpp
@@ -10,7 +10,7 @@
 
 namespace RosettaStone
 {
-void CardLoader::Load(std::vector<Card>& cards)
+void CardLoader::Load(std::vector<Card*>& cards)
 {
     // Read card data from JSON file
     std::ifstream cardFile(RESOURCES_DIR "cards.json");
@@ -107,31 +107,31 @@ void CardLoader::Load(std::vector<Card>& cards)
             entourages.emplace_back(entourage.get<std::string>());
         }
 
-        Card card;
-        card.id = id;
-        card.name = name;
-        card.text = text;
+        Card* card = new Card();
+        card->id = id;
+        card->name = name;
+        card->text = text;
 
-        card.gameTags = gameTags;
-        card.playRequirements = playRequirements;
-        card.entourages = entourages;
+        card->gameTags = gameTags;
+        card->playRequirements = playRequirements;
+        card->entourages = entourages;
 
-        card.gameTags[GameTag::ATK] = attack;
-        card.gameTags[GameTag::CARDRACE] = cardRace;
-        card.gameTags[GameTag::CARD_SET] = cardSet;
-        card.gameTags[GameTag::CARDTYPE] = cardType;
-        card.gameTags[GameTag::CLASS] = cardClass;
-        card.gameTags[GameTag::COLLECTIBLE] = collectible;
-        card.gameTags[GameTag::COST] = cost;
-        card.gameTags[GameTag::DAMAGE] = 0;
-        card.gameTags[GameTag::DURABILITY] = durability;
-        card.gameTags[GameTag::FACTION] = faction;
-        card.gameTags[GameTag::HEALTH] = health;
-        card.gameTags[GameTag::RARITY] = rarity;
-        card.gameTags[GameTag::SPELLPOWER] = spellPower;
-        card.gameTags[GameTag::OVERLOAD] = overload;
+        card->gameTags[GameTag::ATK] = attack;
+        card->gameTags[GameTag::CARDRACE] = cardRace;
+        card->gameTags[GameTag::CARD_SET] = cardSet;
+        card->gameTags[GameTag::CARDTYPE] = cardType;
+        card->gameTags[GameTag::CLASS] = cardClass;
+        card->gameTags[GameTag::COLLECTIBLE] = collectible;
+        card->gameTags[GameTag::COST] = cost;
+        card->gameTags[GameTag::DAMAGE] = 0;
+        card->gameTags[GameTag::DURABILITY] = durability;
+        card->gameTags[GameTag::FACTION] = faction;
+        card->gameTags[GameTag::HEALTH] = health;
+        card->gameTags[GameTag::RARITY] = rarity;
+        card->gameTags[GameTag::SPELLPOWER] = spellPower;
+        card->gameTags[GameTag::OVERLOAD] = overload;
 
-        card.Initialize();
+        card->Initialize();
 
         cards.emplace_back(card);
     }

--- a/Sources/Rosetta/Loaders/PowerLoader.cpp
+++ b/Sources/Rosetta/Loaders/PowerLoader.cpp
@@ -9,11 +9,11 @@
 
 namespace RosettaStone
 {
-void PowerLoader::Load(std::vector<Card>& cards)
+void PowerLoader::Load(std::vector<Card*>& cards)
 {
     for (auto& card : cards)
     {
-        card.power = Powers::GetInstance().FindPowerByCardID(card.id);
+        card->power = Powers::GetInstance().FindPowerByCardID(card->id);
     }
 }
 }  // namespace RosettaStone

--- a/Sources/Rosetta/Models/Character.cpp
+++ b/Sources/Rosetta/Models/Character.cpp
@@ -12,7 +12,7 @@
 
 namespace RosettaStone
 {
-Character::Character(Player& _owner, Card& _card, std::map<GameTag, int> tags)
+Character::Character(Player& _owner, Card* _card, std::map<GameTag, int> tags)
     : Entity(_owner, _card, tags)
 {
     // Do nothing

--- a/Sources/Rosetta/Models/Enchantment.cpp
+++ b/Sources/Rosetta/Models/Enchantment.cpp
@@ -13,14 +13,14 @@
 
 namespace RosettaStone
 {
-Enchantment::Enchantment(Player& _owner, Card& _card,
+Enchantment::Enchantment(Player& _owner, Card* _card,
                          std::map<GameTag, int> tags, Entity* target)
     : Entity(_owner, _card, std::move(tags)), m_target(target)
 {
     // Do nothing
 }
 
-Enchantment* Enchantment::GetInstance(Player& player, Card& card,
+Enchantment* Enchantment::GetInstance(Player& player, Card* card,
                                       Entity* target)
 {
     std::map<GameTag, int> tags;

--- a/Sources/Rosetta/Models/Entity.cpp
+++ b/Sources/Rosetta/Models/Entity.cpp
@@ -14,10 +14,10 @@
 
 namespace RosettaStone
 {
-Entity::Entity(Player& _owner, Card& _card, std::map<GameTag, int> tags)
+Entity::Entity(Player& _owner, Card* _card, std::map<GameTag, int> tags)
     : owner(&_owner), card(_card), m_gameTags(std::move(tags))
 {
-    for (auto& gameTag : _card.gameTags)
+    for (auto& gameTag : _card->gameTags)
     {
         Entity::SetGameTag(gameTag.first, gameTag.second);
     }
@@ -105,8 +105,8 @@ int Entity::GetGameTag(GameTag tag) const
     const auto entityVal = m_gameTags.find(tag);
     if (entityVal == m_gameTags.end())
     {
-        const auto cardVal = card.gameTags.find(tag);
-        if (cardVal != card.gameTags.end())
+        const auto cardVal = card->gameTags.find(tag);
+        if (cardVal != card->gameTags.end())
         {
             value = cardVal->second;
         }
@@ -235,13 +235,13 @@ void Entity::ActivateTask(PowerType type, Entity* target, int chooseOne)
     switch (type)
     {
         case PowerType::POWER:
-            tasks = card.power.GetPowerTask();
+            tasks = card->power.GetPowerTask();
             break;
         case PowerType::DEATHRATTLE:
-            tasks = card.power.GetDeathrattleTask();
+            tasks = card->power.GetDeathrattleTask();
             break;
         case PowerType::COMBO:
-            tasks = card.power.GetComboTask();
+            tasks = card->power.GetComboTask();
             break;
     }
 
@@ -260,7 +260,7 @@ void Entity::ActivateTask(PowerType type, Entity* target, int chooseOne)
     }
 }
 
-Entity* Entity::GetFromCard(Player& player, Card&& card,
+Entity* Entity::GetFromCard(Player& player, Card* card,
                             std::optional<std::map<GameTag, int>> cardTags,
                             IZone* zone, int id)
 {
@@ -277,7 +277,7 @@ Entity* Entity::GetFromCard(Player& player, Card&& card,
 
     Entity* result;
 
-    switch (card.GetCardType())
+    switch (card->GetCardType())
     {
         case CardType::HERO:
             result = new Hero(player, card, tags);
@@ -306,10 +306,10 @@ Entity* Entity::GetFromCard(Player& player, Card&& card,
         delete result->chooseOneCard[1];
 
         result->chooseOneCard[0] =
-            GetFromCard(player, Cards::FindCardByID(result->card.id + "a"),
+            GetFromCard(player, Cards::FindCardByID(result->card->id + "a"),
                         std::nullopt, &player.GetSetasideZone());
         result->chooseOneCard[1] =
-            GetFromCard(player, Cards::FindCardByID(result->card.id + "b"),
+            GetFromCard(player, Cards::FindCardByID(result->card->id + "b"),
                         std::nullopt, &player.GetSetasideZone());
     }
 

--- a/Sources/Rosetta/Models/Entity.cpp
+++ b/Sources/Rosetta/Models/Entity.cpp
@@ -105,10 +105,13 @@ int Entity::GetGameTag(GameTag tag) const
     const auto entityVal = m_gameTags.find(tag);
     if (entityVal == m_gameTags.end())
     {
-        const auto cardVal = card->gameTags.find(tag);
-        if (cardVal != card->gameTags.end())
+        if (card != nullptr)
         {
-            value = cardVal->second;
+            const auto cardVal = card->gameTags.find(tag);
+            if (cardVal != card->gameTags.end())
+            {
+                value = cardVal->second;
+            }
         }
 
         if (auraEffects != nullptr)

--- a/Sources/Rosetta/Models/Hero.cpp
+++ b/Sources/Rosetta/Models/Hero.cpp
@@ -12,7 +12,7 @@
 
 namespace RosettaStone
 {
-Hero::Hero(Player& _owner, Card& _card, std::map<GameTag, int> tags)
+Hero::Hero(Player& _owner, Card* _card, std::map<GameTag, int> tags)
     : Character(_owner, _card, std::move(tags))
 {
     // Do nothing

--- a/Sources/Rosetta/Models/HeroPower.cpp
+++ b/Sources/Rosetta/Models/HeroPower.cpp
@@ -10,7 +10,7 @@
 
 namespace RosettaStone
 {
-HeroPower::HeroPower(Player& _owner, Card& _card, std::map<GameTag, int> tags)
+HeroPower::HeroPower(Player& _owner, Card* _card, std::map<GameTag, int> tags)
     : Entity(_owner, _card, std::move(tags))
 {
     // Do nothing

--- a/Sources/Rosetta/Models/Minion.cpp
+++ b/Sources/Rosetta/Models/Minion.cpp
@@ -14,7 +14,7 @@
 
 namespace RosettaStone
 {
-Minion::Minion(Player& _owner, Card& _card, std::map<GameTag, int> tags)
+Minion::Minion(Player& _owner, Card* _card, std::map<GameTag, int> tags)
     : Character(_owner, _card, std::move(tags))
 {
     // Do nothing
@@ -75,27 +75,27 @@ void Minion::Silence()
         const auto size = static_cast<int>(appliedEnchantments.size());
         for (int i = size - 1; i >= 0; --i)
         {
-            if (appliedEnchantments[i]->card.power.GetAura() != nullptr)
+            if (appliedEnchantments[i]->card->power.GetAura() != nullptr)
             {
                 appliedEnchantments[i]->Remove();
             }
         }
     }
 
-    SetGameTag(GameTag::ATK, card.gameTags[GameTag::ATK]);
-    if (GetHealth() > card.gameTags[GameTag::HEALTH])
+    SetGameTag(GameTag::ATK, card->gameTags[GameTag::ATK]);
+    if (GetHealth() > card->gameTags[GameTag::HEALTH])
     {
-        SetHealth(card.gameTags[GameTag::HEALTH]);
+        SetHealth(card->gameTags[GameTag::HEALTH]);
     }
     else
     {
-        const int cardBaseHealth = card.gameTags[GameTag::HEALTH];
+        const int cardBaseHealth = card->gameTags[GameTag::HEALTH];
         const int delta = GetGameTag(GameTag::HEALTH) - cardBaseHealth;
         if (delta > 0)
         {
             SetDamage(GetDamage() - delta);
         }
-        SetGameTag(GameTag::HEALTH, card.gameTags[GameTag::HEALTH]);
+        SetGameTag(GameTag::HEALTH, card->gameTags[GameTag::HEALTH]);
     }
 
     SetGameTag(GameTag::SILENCED, 1);

--- a/Sources/Rosetta/Models/Player.cpp
+++ b/Sources/Rosetta/Models/Player.cpp
@@ -218,12 +218,12 @@ ITask* Player::GetNextAction()
     return ret;
 }
 
-void Player::AddHeroAndPower(Card&& heroCard, Card&& powerCard)
+void Player::AddHeroAndPower(Card* heroCard, Card* powerCard)
 {
     m_hero =
-        dynamic_cast<Hero*>(Entity::GetFromCard(*this, std::move(heroCard)));
+        dynamic_cast<Hero*>(Entity::GetFromCard(*this, heroCard));
     m_hero->heroPower = dynamic_cast<HeroPower*>(
-        Entity::GetFromCard(*this, std::move(powerCard)));
+        Entity::GetFromCard(*this, powerCard));
 }
 
 ITask* Player::GetTaskByAction(TaskMeta& next, TaskMeta& req)

--- a/Sources/Rosetta/Models/Spell.cpp
+++ b/Sources/Rosetta/Models/Spell.cpp
@@ -10,7 +10,7 @@
 
 namespace RosettaStone
 {
-Spell::Spell(Player& _owner, Card& _card, std::map<GameTag, int> tags)
+Spell::Spell(Player& _owner, Card* _card, std::map<GameTag, int> tags)
     : Entity(_owner, _card, std::move(tags))
 {
     // Do nothing

--- a/Sources/Rosetta/Models/Weapon.cpp
+++ b/Sources/Rosetta/Models/Weapon.cpp
@@ -11,7 +11,7 @@
 
 namespace RosettaStone
 {
-Weapon::Weapon(Player& _owner, Card& _card, std::map<GameTag, int> tags)
+Weapon::Weapon(Player& _owner, Card* _card, std::map<GameTag, int> tags)
     : Entity(_owner, _card, std::move(tags))
 {
     // Do nothing

--- a/Sources/Rosetta/Policies/RandomPolicy.cpp
+++ b/Sources/Rosetta/Policies/RandomPolicy.cpp
@@ -62,7 +62,7 @@ TaskMeta RandomPolicy::RequirePlayCard(Player& player)
             continue;
         }
 
-        if (entity->card.GetCardType() == CardType::MINION &&
+        if (entity->card->GetCardType() == CardType::MINION &&
             player.GetFieldZone().IsFull())
         {
             continue;

--- a/Sources/Rosetta/Tasks/SimpleTasks/AddCardTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/AddCardTask.cpp
@@ -31,10 +31,10 @@ TaskStatus AddCardTask::Impl(Player& player)
         case EntityType::ENEMY_HAND:
             for (int i = 0; i < m_amount; ++i)
             {
-                Card card = Cards::GetInstance().FindCardByID(m_cardID);
+                Card* card = Cards::GetInstance().FindCardByID(m_cardID);
                 Generic::AddCardToHand(
                     *player.opponent,
-                    Entity::GetFromCard(*player.opponent, std::move(card)));
+                    Entity::GetFromCard(*player.opponent, card));
             }
             break;
         default:

--- a/Sources/Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.cpp
@@ -25,15 +25,15 @@ TaskID AddEnchantmentTask::GetTaskID() const
 
 TaskStatus AddEnchantmentTask::Impl(Player& player)
 {
-    Card enchantmentCard = Cards::FindCardByID(m_cardID);
-    if (enchantmentCard.id.empty())
+    Card* enchantmentCard = Cards::FindCardByID(m_cardID);
+    if (enchantmentCard->id.empty())
     {
         return TaskStatus::STOP;
     }
 
     auto entities =
         IncludeTask::GetEntities(m_entityType, player, m_source, m_target);
-    Power power = enchantmentCard.power;
+    Power power = enchantmentCard->power;
 
     for (auto& entity : entities)
     {

--- a/Sources/Rosetta/Tasks/SimpleTasks/CopyTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/CopyTask.cpp
@@ -41,7 +41,7 @@ TaskStatus CopyTask::Impl(Player& player)
             for (int i = 0; i < m_amount; ++i)
             {
                 auto card =
-                    Cards::GetInstance().FindCardByID(m_target->card.id);
+                    Cards::GetInstance().FindCardByID(m_target->card->id);
 
                 result.emplace_back(
                     m_isOpposite
@@ -72,7 +72,7 @@ TaskStatus CopyTask::Impl(Player& player)
                     }
 
                     auto card =
-                        Cards::GetInstance().FindCardByID(entity->card.id);
+                        Cards::GetInstance().FindCardByID(entity->card->id);
 
                     result.emplace_back(
                         m_isOpposite

--- a/Sources/Rosetta/Tasks/SimpleTasks/CopyTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/CopyTask.cpp
@@ -45,9 +45,8 @@ TaskStatus CopyTask::Impl(Player& player)
 
                 result.emplace_back(
                     m_isOpposite
-                        ? Entity::GetFromCard(*m_target->owner->opponent,
-                                              std::move(card))
-                        : Entity::GetFromCard(player, std::move(card)));
+                        ? Entity::GetFromCard(*m_target->owner->opponent, card)
+                        : Entity::GetFromCard(player, card));
             }
         }
         break;
@@ -76,11 +75,10 @@ TaskStatus CopyTask::Impl(Player& player)
 
                     result.emplace_back(
                         m_isOpposite
-                            ? Entity::GetFromCard(*player.opponent,
-                                                  std::move(card), std::nullopt,
-                                                  zone)
-                            : Entity::GetFromCard(player, std::move(card),
-                                                  std::nullopt, zone));
+                            ? Entity::GetFromCard(*player.opponent, card,
+                                                  std::nullopt, zone)
+                            : Entity::GetFromCard(player, card, std::nullopt,
+                                                  zone));
                 }
             }
             break;

--- a/Sources/Rosetta/Tasks/SimpleTasks/RandomEntourageTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/RandomEntourageTask.cpp
@@ -28,12 +28,12 @@ TaskStatus RandomEntourageTask::Impl(Player& player)
 {
     (void)m_isOpponent;
 
-    if (m_source == nullptr || m_source->card.entourages.empty())
+    if (m_source == nullptr || m_source->card->entourages.empty())
     {
         return TaskStatus::STOP;
     }
 
-    if (m_count > static_cast<int>(m_source->card.entourages.size()))
+    if (m_count > static_cast<int>(m_source->card->entourages.size()))
     {
         return TaskStatus::STOP;
     }
@@ -43,9 +43,9 @@ TaskStatus RandomEntourageTask::Impl(Player& player)
     for (int i = 0; i < m_count; ++i)
     {
         const auto idx =
-            Random::get<std::size_t>(0, m_source->card.entourages.size() - 1);
+            Random::get<std::size_t>(0, m_source->card->entourages.size() - 1);
         auto entourageCard =
-            Cards::GetInstance().FindCardByID(m_source->card.entourages[idx]);
+            Cards::GetInstance().FindCardByID(m_source->card->entourages[idx]);
 
         Entity* entourageEntity =
             Entity::GetFromCard(player, std::move(entourageCard));

--- a/Sources/Rosetta/Tasks/SimpleTasks/RandomEntourageTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/RandomEntourageTask.cpp
@@ -47,8 +47,7 @@ TaskStatus RandomEntourageTask::Impl(Player& player)
         auto entourageCard =
             Cards::GetInstance().FindCardByID(m_source->card->entourages[idx]);
 
-        Entity* entourageEntity =
-            Entity::GetFromCard(player, std::move(entourageCard));
+        Entity* entourageEntity = Entity::GetFromCard(player, entourageCard);
         player.GetGame()->taskStack.entities.emplace_back(entourageEntity);
     }
 

--- a/Sources/Rosetta/Tasks/SimpleTasks/RemoveEnchantmentTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/RemoveEnchantmentTask.cpp
@@ -21,9 +21,9 @@ TaskStatus RemoveEnchantmentTask::Impl(Player&)
         return TaskStatus::STOP;
     }
 
-    if (enchantment->card.power.GetEnchant() != nullptr)
+    if (enchantment->card->power.GetEnchant() != nullptr)
     {
-        for (auto& effect : enchantment->card.power.GetEnchant()->effects)
+        for (auto& effect : enchantment->card->power.GetEnchant()->effects)
         {
             effect->Remove(m_target);
         }

--- a/Sources/Rosetta/Tasks/SimpleTasks/SummonTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/SummonTask.cpp
@@ -13,9 +13,9 @@
 
 namespace RosettaStone::SimpleTasks
 {
-SummonTask::SummonTask(SummonSide side, const std::optional<Card>& card,
+SummonTask::SummonTask(SummonSide side, const std::optional<Card*>& card,
                        int amount)
-    : m_card(std::move(card)), m_side(side), m_amount(amount)
+    : m_card(card), m_side(side), m_amount(amount)
 {
     // Do nothing
 }

--- a/Sources/Rosetta/Tasks/SimpleTasks/SummonTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/SummonTask.cpp
@@ -47,8 +47,7 @@ TaskStatus SummonTask::Impl(Player& player)
         Entity* summonEntity = nullptr;
         if (m_card.has_value())
         {
-            summonEntity =
-                Entity::GetFromCard(player, std::move(m_card.value()));
+            summonEntity = Entity::GetFromCard(player, m_card.value());
         }
         else if (!player.GetGame()->taskStack.entities.empty())
         {

--- a/Sources/Rosetta/Tasks/SimpleTasks/TransformCopyTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/TransformCopyTask.cpp
@@ -27,7 +27,7 @@ TaskStatus TransformCopyTask::Impl(Player& player)
         return TaskStatus::STOP;
     }
 
-    const auto copy = Entity::GetFromCard(player, Card(m_target->card), {});
+    const auto copy = Entity::GetFromCard(player, m_target->card, {});
     IAura* aura = target->onGoingEffect;
 
     source->owner->GetFieldZone().Replace(*source, *copy);

--- a/Sources/Rosetta/Tasks/SimpleTasks/TransformTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/TransformTask.cpp
@@ -30,7 +30,7 @@ TaskStatus TransformTask::Impl(Player& player)
 
     for (auto& entity : entities)
     {
-        Card card = Cards::FindCardByID(m_cardID);
+        Card* card = Cards::FindCardByID(m_cardID);
 
         auto* minion = dynamic_cast<Minion*>(entity);
         if (minion == nullptr)
@@ -38,7 +38,7 @@ TaskStatus TransformTask::Impl(Player& player)
             return TaskStatus::STOP;
         }
 
-        Generic::TransformMinion(*minion->owner, minion, std::move(card));
+        Generic::TransformMinion(*minion->owner, minion, card);
     }
 
     return TaskStatus::COMPLETE;

--- a/Sources/Rosetta/Tasks/SimpleTasks/WeaponTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/WeaponTask.cpp
@@ -21,8 +21,8 @@ TaskID WeaponTask::GetTaskID() const
 
 TaskStatus WeaponTask::Impl(Player& player)
 {
-    Card weaponCard = Cards::FindCardByID(m_cardID);
-    if (weaponCard.id.empty())
+    Card* weaponCard = Cards::FindCardByID(m_cardID);
+    if (weaponCard->id.empty())
     {
         return TaskStatus::STOP;
     }
@@ -33,7 +33,7 @@ TaskStatus WeaponTask::Impl(Player& player)
     }
 
     const auto weapon = dynamic_cast<Weapon*>(
-        Entity::GetFromCard(player, std::move(weaponCard)));
+        Entity::GetFromCard(player, weaponCard));
     Generic::PlayWeapon(player, weapon, nullptr);
 
     return TaskStatus::COMPLETE;

--- a/Sources/Rosetta/Views/BoardRefView.cpp
+++ b/Sources/Rosetta/Views/BoardRefView.cpp
@@ -190,13 +190,13 @@ std::vector<Entity*> BoardRefView::GetOpponentHandCards() const
 
     for (auto& entity : result)
     {
-        if (entity->card.id == "GAME_005")
+        if (entity->card->id == "GAME_005")
         {
             // The Coin. This also reveals to opponent.
         }
         else
         {
-            entity->card.id = "INVALID";
+            entity->card->id = "INVALID";
         }
     }
 

--- a/Sources/Rosetta/Zones/DeckZone.cpp
+++ b/Sources/Rosetta/Zones/DeckZone.cpp
@@ -28,9 +28,9 @@ void DeckZone::Add(Entity& entity, int zonePos)
 {
     LimitedZone::Add(entity, zonePos);
 
-    if (entity.card.power.GetTrigger())
+    if (entity.card->power.GetTrigger())
     {
-        entity.card.power.GetTrigger()->Activate(&entity,
+        entity.card->power.GetTrigger()->Activate(&entity,
                                                  TriggerActivation::DECK);
     }
 }

--- a/Sources/Rosetta/Zones/FieldZone.cpp
+++ b/Sources/Rosetta/Zones/FieldZone.cpp
@@ -73,14 +73,14 @@ void FieldZone::Replace(Entity& oldEntity, Entity& newEntity)
 
 void FieldZone::ActivateAura(Entity& entity)
 {
-    if (entity.card.power.GetTrigger())
+    if (entity.card->power.GetTrigger())
     {
-        entity.card.power.GetTrigger()->Activate(&entity);
+        entity.card->power.GetTrigger()->Activate(&entity);
     }
 
-    if (entity.card.power.GetAura())
+    if (entity.card->power.GetAura())
     {
-        entity.card.power.GetAura()->Activate(&entity);
+        entity.card->power.GetAura()->Activate(&entity);
     }
 
     const int spellPower = entity.GetGameTag(GameTag::SPELLPOWER);

--- a/Sources/Rosetta/Zones/HandZone.cpp
+++ b/Sources/Rosetta/Zones/HandZone.cpp
@@ -20,9 +20,9 @@ void HandZone::Add(Entity& entity, int zonePos)
 {
     PositioningZone::Add(entity, zonePos);
 
-    if (entity.card.power.GetTrigger())
+    if (entity.card->power.GetTrigger())
     {
-        entity.card.power.GetTrigger()->Activate(&entity,
+        entity.card->power.GetTrigger()->Activate(&entity,
                                                  TriggerActivation::HAND);
     }
 }

--- a/Sources/Rosetta/Zones/SecretZone.cpp
+++ b/Sources/Rosetta/Zones/SecretZone.cpp
@@ -27,7 +27,7 @@ bool SecretZone::Exist(Entity& entity)
 {
     for (auto& secret : m_entities)
     {
-        if (entity.card.id == secret->card.id)
+        if (entity.card->id == secret->card->id)
         {
             return true;
         }

--- a/Tests/UnitTests/Accounts/DeckInfoTests.cpp
+++ b/Tests/UnitTests/Accounts/DeckInfoTests.cpp
@@ -27,50 +27,50 @@ TEST(DeckInfo, Constructors)
 
 TEST(DeckInfo, CardControl)
 {
-    std::vector<Card> druidCards =
+    std::vector<Card*> druidCards =
         Cards::GetInstance().FindCardByClass(CardClass::DRUID);
-    std::vector<Card> mageCards =
+    std::vector<Card*> mageCards =
         Cards::GetInstance().FindCardByClass(CardClass::MAGE);
 
     DeckInfo deck("Ice Magician", CardClass::MAGE);
     EXPECT_NO_THROW(deck.ShowCardList());
-    EXPECT_EQ(true, deck.AddCard(mageCards.at(0).id, 1));
-    EXPECT_EQ(true, deck.AddCard(mageCards.at(0).id, 1));
-    EXPECT_EQ(false, deck.AddCard(mageCards.at(0).id, 1));
-    EXPECT_EQ(false, deck.AddCard(mageCards.at(1).id, 3));
-    EXPECT_EQ(false, deck.AddCard(druidCards.at(0).id, 1));
+    EXPECT_EQ(true, deck.AddCard(mageCards.at(0)->id, 1));
+    EXPECT_EQ(true, deck.AddCard(mageCards.at(0)->id, 1));
+    EXPECT_EQ(false, deck.AddCard(mageCards.at(0)->id, 1));
+    EXPECT_EQ(false, deck.AddCard(mageCards.at(1)->id, 3));
+    EXPECT_EQ(false, deck.AddCard(druidCards.at(0)->id, 1));
     EXPECT_NO_THROW(deck.ShowCardList());
 
     EXPECT_EQ(1, static_cast<int>(deck.GetUniqueNumOfCards()));
     EXPECT_EQ(2, static_cast<int>(deck.GetNumOfCards()));
 
-    EXPECT_EQ(true, deck.DeleteCard(mageCards.at(0).id, 1));
-    EXPECT_EQ(false, deck.DeleteCard(mageCards.at(0).id, 4));
-    EXPECT_EQ(false, deck.DeleteCard(druidCards.at(0).id, 1));
+    EXPECT_EQ(true, deck.DeleteCard(mageCards.at(0)->id, 1));
+    EXPECT_EQ(false, deck.DeleteCard(mageCards.at(0)->id, 4));
+    EXPECT_EQ(false, deck.DeleteCard(druidCards.at(0)->id, 1));
     EXPECT_NO_THROW(deck.ShowCardList());
 }
 
 TEST(DeckInfo, GetNumCardInDeck)
 {
-    std::vector<Card> mageCards =
+    std::vector<Card*> mageCards =
         Cards::GetInstance().FindCardByClass(CardClass::MAGE);
 
     DeckInfo deck("Ice Magician", CardClass::MAGE);
-    deck.AddCard(mageCards.at(0).id, 1);
+    deck.AddCard(mageCards.at(0)->id, 1);
 
-    EXPECT_EQ(1, static_cast<int>(deck.GetNumCardInDeck(mageCards.at(0).id)));
-    EXPECT_EQ(0, static_cast<int>(deck.GetNumCardInDeck(mageCards.at(1).id)));
+    EXPECT_EQ(1, static_cast<int>(deck.GetNumCardInDeck(mageCards.at(0)->id)));
+    EXPECT_EQ(0, static_cast<int>(deck.GetNumCardInDeck(mageCards.at(1)->id)));
 }
 
 TEST(DeckInfo, GetPrimitiveDeck)
 {
-    std::vector<Card> mageCards =
+    std::vector<Card*> mageCards =
         Cards::GetInstance().FindCardByClass(CardClass::MAGE);
 
     DeckInfo deck("Ice Magician", CardClass::MAGE);
-    deck.AddCard(mageCards.at(0).id, 1);
+    deck.AddCard(mageCards.at(0)->id, 1);
 
-    std::vector<Card> priDeck = deck.GetPrimitiveDeck();
+    std::vector<Card*> priDeck = deck.GetPrimitiveDeck();
 
-    EXPECT_EQ(priDeck.at(0).id, mageCards.at(0).id);
+    EXPECT_EQ(priDeck.at(0)->id, mageCards.at(0)->id);
 }

--- a/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
@@ -1503,23 +1503,23 @@ TEST(HunterCoreTest, NEW1_031_AnimalCompanion)
     game.Process(curPlayer, PlayCardTask::Spell(card1));
     game.Process(curPlayer, PlayCardTask::Spell(card2));
 
-    if (curField[0]->card.name == "Leokk")
+    if (curField[0]->card->name == "Leokk")
     {
-        EXPECT_EQ(curField[1]->card.gameTags[GameTag::ATK] + 1,
+        EXPECT_EQ(curField[1]->card->gameTags[GameTag::ATK] + 1,
                   curField[1]->GetAttack());
     }
 
-    if (curField[1]->card.name == "Leokk")
+    if (curField[1]->card->name == "Leokk")
     {
-        EXPECT_EQ(curField[0]->card.gameTags[GameTag::ATK] + 1,
+        EXPECT_EQ(curField[0]->card->gameTags[GameTag::ATK] + 1,
                   curField[0]->GetAttack());
     }
 
-    if (curField[0]->card.name != "Leokk" && curField[1]->card.name != "Leokk")
+    if (curField[0]->card->name != "Leokk" && curField[1]->card->name != "Leokk")
     {
-        EXPECT_EQ(curField[0]->card.gameTags[GameTag::ATK],
+        EXPECT_EQ(curField[0]->card->gameTags[GameTag::ATK],
                   curField[0]->GetAttack());
-        EXPECT_EQ(curField[1]->card.gameTags[GameTag::ATK],
+        EXPECT_EQ(curField[1]->card->gameTags[GameTag::ATK],
                   curField[1]->GetAttack());
     }
 }

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -1485,7 +1485,7 @@ TEST(ShamanExpert1Test, CS2_053_FarSight)
     EXPECT_EQ(curHand.GetCount(), 5);
 
     Entity* drawCard = curHand[curHand.GetCount() - 1];
-    int cost = drawCard->card.gameTags[GameTag::COST] - 3;
+    int cost = drawCard->card->gameTags[GameTag::COST] - 3;
     EXPECT_EQ(cost < 0 ? 0 : cost, drawCard->GetCost());
 }
 
@@ -2601,8 +2601,8 @@ TEST(NeutralExpert1Test, EX1_006_AlarmOBot)
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     game.Process(curPlayer, PlayCardTask::Minion(card2));
-    EXPECT_EQ(curField[0]->card.name, "Alarm-o-Bot");
-    EXPECT_EQ(curField[1]->card.name, "Loot Hoarder");
+    EXPECT_EQ(curField[0]->card->name, "Alarm-o-Bot");
+    EXPECT_EQ(curField[1]->card->name, "Loot Hoarder");
     EXPECT_EQ(card3->zone->GetType(), ZoneType::HAND);
 
     game.Process(curPlayer, EndTurnTask());
@@ -2613,8 +2613,8 @@ TEST(NeutralExpert1Test, EX1_006_AlarmOBot)
 
     EXPECT_EQ(curHand.GetCount(), 1);
     EXPECT_EQ(curField.GetCount(), 2);
-    EXPECT_EQ(curHand[0]->card.name, "Alarm-o-Bot");
-    EXPECT_EQ(curField[0]->card.name, "Acolyte of Pain");
+    EXPECT_EQ(curHand[0]->card->name, "Alarm-o-Bot");
+    EXPECT_EQ(curField[0]->card->name, "Acolyte of Pain");
 }
 
 // --------------------------------------- MINION - NEUTRAL
@@ -2851,8 +2851,8 @@ TEST(NeutralExpert1Test, EX1_014_KingMukla)
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     EXPECT_EQ(opHand.GetCount(), 4);
-    EXPECT_EQ(opHand[2]->card.name, "Bananas");
-    EXPECT_EQ(opHand[3]->card.name, "Bananas");
+    EXPECT_EQ(opHand[2]->card->name, "Bananas");
+    EXPECT_EQ(opHand[3]->card->name, "Bananas");
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
@@ -3720,8 +3720,8 @@ TEST(NeutralExpert1Test, EX1_083_TinkmasterOverspark)
     game.ProcessUntil(Step::MAIN_START);
 
     game.Process(opPlayer, PlayCardTask::Minion(card2));
-    EXPECT_TRUE(curField[0]->card.id == "EX1_tk28" ||
-                curField[0]->card.id == "EX1_tk29");
+    EXPECT_TRUE(curField[0]->card->id == "EX1_tk28" ||
+                curField[0]->card->id == "EX1_tk29");
     EXPECT_TRUE(curField[0]->GetAttack() == 1 || curField[0]->GetAttack() == 5);
     EXPECT_TRUE(curField[0]->GetHealth() == 1 || curField[0]->GetHealth() == 5);
 }
@@ -4151,10 +4151,10 @@ TEST(NeutralExpert1Test, EX1_100_LorewalkerCho)
 
     game.Process(opPlayer,
                  PlayCardTask::SpellTarget(card2, curPlayer.GetHero()));
-    EXPECT_EQ(curHand[0]->card.name, "Fireball");
+    EXPECT_EQ(curHand[0]->card->name, "Fireball");
 
     game.Process(opPlayer, PlayCardTask::Spell(card3));
-    EXPECT_EQ(curHand[1]->card.name, "Blizzard");
+    EXPECT_EQ(curHand[1]->card->name, "Blizzard");
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/Cards/CardsTests.cpp
+++ b/Tests/UnitTests/Cards/CardsTests.cpp
@@ -13,7 +13,7 @@ using namespace RosettaStone;
 
 TEST(Cards, GetAllCards)
 {
-    const std::vector<Card> cards = Cards::GetInstance().GetAllCards();
+    const std::vector<Card*> cards = Cards::GetInstance().GetAllCards();
 
     ASSERT_FALSE(cards.empty());
     EXPECT_EQ(cards.size(), 6717u);
@@ -21,31 +21,31 @@ TEST(Cards, GetAllCards)
 
 TEST(Cards, FindCardByID)
 {
-    const Card card1 = Cards::GetInstance().FindCardByID("AT_001");
-    const Card card2 = Cards::GetInstance().FindCardByID("");
+    const Card* card1 = Cards::GetInstance().FindCardByID("AT_001");
+    const Card* card2 = Cards::GetInstance().FindCardByID("");
 
-    EXPECT_EQ(card1.id, "AT_001");
-    EXPECT_EQ(card2.id, "");
+    EXPECT_EQ(card1->id, "AT_001");
+    EXPECT_EQ(card2->id, "");
 }
 
 TEST(Cards, FindCardByRarity)
 {
     Cards& instance = Cards::GetInstance();
 
-    std::vector<Card> cards1 = instance.FindCardByRarity(Rarity::COMMON);
-    std::vector<Card> cards2 = instance.FindCardByRarity(Rarity::RARE);
-    std::vector<Card> cards3 = instance.FindCardByRarity(Rarity::EPIC);
-    std::vector<Card> cards4 = instance.FindCardByRarity(Rarity::LEGENDARY);
-    std::vector<Card> cards5 = instance.FindCardByRarity(Rarity::FREE);
-    std::vector<Card> cards6 = instance.FindCardByRarity(Rarity::INVALID);
-    std::vector<Card> cards7 = instance.FindCardByRarity(Rarity::UNKNOWN_6);
+    std::vector<Card*> cards1 = instance.FindCardByRarity(Rarity::COMMON);
+    std::vector<Card*> cards2 = instance.FindCardByRarity(Rarity::RARE);
+    std::vector<Card*> cards3 = instance.FindCardByRarity(Rarity::EPIC);
+    std::vector<Card*> cards4 = instance.FindCardByRarity(Rarity::LEGENDARY);
+    std::vector<Card*> cards5 = instance.FindCardByRarity(Rarity::FREE);
+    std::vector<Card*> cards6 = instance.FindCardByRarity(Rarity::INVALID);
+    std::vector<Card*> cards7 = instance.FindCardByRarity(Rarity::UNKNOWN_6);
 
-    EXPECT_EQ(Rarity::COMMON, cards1.front().GetRarity());
-    EXPECT_EQ(Rarity::RARE, cards2.front().GetRarity());
-    EXPECT_EQ(Rarity::EPIC, cards3.front().GetRarity());
-    EXPECT_EQ(Rarity::LEGENDARY, cards4.front().GetRarity());
-    EXPECT_EQ(Rarity::FREE, cards5.front().GetRarity());
-    EXPECT_EQ(Rarity::INVALID, cards6.front().GetRarity());
+    EXPECT_EQ(Rarity::COMMON, cards1.front()->GetRarity());
+    EXPECT_EQ(Rarity::RARE, cards2.front()->GetRarity());
+    EXPECT_EQ(Rarity::EPIC, cards3.front()->GetRarity());
+    EXPECT_EQ(Rarity::LEGENDARY, cards4.front()->GetRarity());
+    EXPECT_EQ(Rarity::FREE, cards5.front()->GetRarity());
+    EXPECT_EQ(Rarity::INVALID, cards6.front()->GetRarity());
     EXPECT_TRUE(cards7.empty());
 }
 
@@ -53,65 +53,65 @@ TEST(Cards, FindCardByClass)
 {
     Cards& instance = Cards::GetInstance();
 
-    std::vector<Card> cards1 = instance.FindCardByClass(CardClass::DEATHKNIGHT);
-    std::vector<Card> cards2 = instance.FindCardByClass(CardClass::DREAM);
-    std::vector<Card> cards3 = instance.FindCardByClass(CardClass::DRUID);
-    std::vector<Card> cards4 = instance.FindCardByClass(CardClass::HUNTER);
-    std::vector<Card> cards5 = instance.FindCardByClass(CardClass::MAGE);
-    std::vector<Card> cards6 = instance.FindCardByClass(CardClass::NEUTRAL);
-    std::vector<Card> cards7 = instance.FindCardByClass(CardClass::PALADIN);
-    std::vector<Card> cards8 = instance.FindCardByClass(CardClass::PRIEST);
-    std::vector<Card> cards9 = instance.FindCardByClass(CardClass::INVALID);
+    std::vector<Card*> cards1 = instance.FindCardByClass(CardClass::DEATHKNIGHT);
+    std::vector<Card*> cards2 = instance.FindCardByClass(CardClass::DREAM);
+    std::vector<Card*> cards3 = instance.FindCardByClass(CardClass::DRUID);
+    std::vector<Card*> cards4 = instance.FindCardByClass(CardClass::HUNTER);
+    std::vector<Card*> cards5 = instance.FindCardByClass(CardClass::MAGE);
+    std::vector<Card*> cards6 = instance.FindCardByClass(CardClass::NEUTRAL);
+    std::vector<Card*> cards7 = instance.FindCardByClass(CardClass::PALADIN);
+    std::vector<Card*> cards8 = instance.FindCardByClass(CardClass::PRIEST);
+    std::vector<Card*> cards9 = instance.FindCardByClass(CardClass::INVALID);
 
-    EXPECT_EQ(CardClass::DEATHKNIGHT, cards1.front().GetCardClass());
-    EXPECT_EQ(CardClass::DREAM, cards2.front().GetCardClass());
-    EXPECT_EQ(CardClass::DRUID, cards3.front().GetCardClass());
-    EXPECT_EQ(CardClass::HUNTER, cards4.front().GetCardClass());
-    EXPECT_EQ(CardClass::MAGE, cards5.front().GetCardClass());
-    EXPECT_EQ(CardClass::NEUTRAL, cards6.front().GetCardClass());
-    EXPECT_EQ(CardClass::PALADIN, cards7.front().GetCardClass());
-    EXPECT_EQ(CardClass::PRIEST, cards8.front().GetCardClass());
-    EXPECT_EQ(CardClass::INVALID, cards9.front().GetCardClass());
+    EXPECT_EQ(CardClass::DEATHKNIGHT, cards1.front()->GetCardClass());
+    EXPECT_EQ(CardClass::DREAM, cards2.front()->GetCardClass());
+    EXPECT_EQ(CardClass::DRUID, cards3.front()->GetCardClass());
+    EXPECT_EQ(CardClass::HUNTER, cards4.front()->GetCardClass());
+    EXPECT_EQ(CardClass::MAGE, cards5.front()->GetCardClass());
+    EXPECT_EQ(CardClass::NEUTRAL, cards6.front()->GetCardClass());
+    EXPECT_EQ(CardClass::PALADIN, cards7.front()->GetCardClass());
+    EXPECT_EQ(CardClass::PRIEST, cards8.front()->GetCardClass());
+    EXPECT_EQ(CardClass::INVALID, cards9.front()->GetCardClass());
 }
 
 TEST(Cards, FindCardBySet)
 {
     Cards& instance = Cards::GetInstance();
 
-    std::vector<Card> cards1 = instance.FindCardBySet(CardSet::CORE);
-    std::vector<Card> cards2 = instance.FindCardBySet(CardSet::EXPERT1);
-    std::vector<Card> cards3 = instance.FindCardBySet(CardSet::HOF);
-    std::vector<Card> cards4 = instance.FindCardBySet(CardSet::NAXX);
-    std::vector<Card> cards5 = instance.FindCardBySet(CardSet::GVG);
-    std::vector<Card> cards6 = instance.FindCardBySet(CardSet::BRM);
-    std::vector<Card> cards7 = instance.FindCardBySet(CardSet::TGT);
-    std::vector<Card> cards8 = instance.FindCardBySet(CardSet::LOE);
-    std::vector<Card> cards9 = instance.FindCardBySet(CardSet::OG);
-    std::vector<Card> cards10 = instance.FindCardBySet(CardSet::KARA);
-    std::vector<Card> cards11 = instance.FindCardBySet(CardSet::GANGS);
-    std::vector<Card> cards12 = instance.FindCardBySet(CardSet::UNGORO);
-    std::vector<Card> cards13 = instance.FindCardBySet(CardSet::ICECROWN);
-    std::vector<Card> cards14 = instance.FindCardBySet(CardSet::LOOTAPALOOZA);
-    std::vector<Card> cards15 = instance.FindCardBySet(CardSet::GILNEAS);
-    std::vector<Card> cards16 = instance.FindCardBySet(CardSet::BOOMSDAY);
-    std::vector<Card> cards17 = instance.FindCardBySet(CardSet::INVALID);
+    std::vector<Card*> cards1 = instance.FindCardBySet(CardSet::CORE);
+    std::vector<Card*> cards2 = instance.FindCardBySet(CardSet::EXPERT1);
+    std::vector<Card*> cards3 = instance.FindCardBySet(CardSet::HOF);
+    std::vector<Card*> cards4 = instance.FindCardBySet(CardSet::NAXX);
+    std::vector<Card*> cards5 = instance.FindCardBySet(CardSet::GVG);
+    std::vector<Card*> cards6 = instance.FindCardBySet(CardSet::BRM);
+    std::vector<Card*> cards7 = instance.FindCardBySet(CardSet::TGT);
+    std::vector<Card*> cards8 = instance.FindCardBySet(CardSet::LOE);
+    std::vector<Card*> cards9 = instance.FindCardBySet(CardSet::OG);
+    std::vector<Card*> cards10 = instance.FindCardBySet(CardSet::KARA);
+    std::vector<Card*> cards11 = instance.FindCardBySet(CardSet::GANGS);
+    std::vector<Card*> cards12 = instance.FindCardBySet(CardSet::UNGORO);
+    std::vector<Card*> cards13 = instance.FindCardBySet(CardSet::ICECROWN);
+    std::vector<Card*> cards14 = instance.FindCardBySet(CardSet::LOOTAPALOOZA);
+    std::vector<Card*> cards15 = instance.FindCardBySet(CardSet::GILNEAS);
+    std::vector<Card*> cards16 = instance.FindCardBySet(CardSet::BOOMSDAY);
+    std::vector<Card*> cards17 = instance.FindCardBySet(CardSet::INVALID);
 
-    EXPECT_EQ(CardSet::CORE, cards1.front().GetCardSet());
-    EXPECT_EQ(CardSet::EXPERT1, cards2.front().GetCardSet());
-    EXPECT_EQ(CardSet::HOF, cards3.front().GetCardSet());
-    EXPECT_EQ(CardSet::NAXX, cards4.front().GetCardSet());
-    EXPECT_EQ(CardSet::GVG, cards5.front().GetCardSet());
-    EXPECT_EQ(CardSet::BRM, cards6.front().GetCardSet());
-    EXPECT_EQ(CardSet::TGT, cards7.front().GetCardSet());
-    EXPECT_EQ(CardSet::LOE, cards8.front().GetCardSet());
-    EXPECT_EQ(CardSet::OG, cards9.front().GetCardSet());
-    EXPECT_EQ(CardSet::KARA, cards10.front().GetCardSet());
-    EXPECT_EQ(CardSet::GANGS, cards11.front().GetCardSet());
-    EXPECT_EQ(CardSet::UNGORO, cards12.front().GetCardSet());
-    EXPECT_EQ(CardSet::ICECROWN, cards13.front().GetCardSet());
-    EXPECT_EQ(CardSet::LOOTAPALOOZA, cards14.front().GetCardSet());
-    EXPECT_EQ(CardSet::GILNEAS, cards15.front().GetCardSet());
-    EXPECT_EQ(CardSet::BOOMSDAY, cards16.front().GetCardSet());
+    EXPECT_EQ(CardSet::CORE, cards1.front()->GetCardSet());
+    EXPECT_EQ(CardSet::EXPERT1, cards2.front()->GetCardSet());
+    EXPECT_EQ(CardSet::HOF, cards3.front()->GetCardSet());
+    EXPECT_EQ(CardSet::NAXX, cards4.front()->GetCardSet());
+    EXPECT_EQ(CardSet::GVG, cards5.front()->GetCardSet());
+    EXPECT_EQ(CardSet::BRM, cards6.front()->GetCardSet());
+    EXPECT_EQ(CardSet::TGT, cards7.front()->GetCardSet());
+    EXPECT_EQ(CardSet::LOE, cards8.front()->GetCardSet());
+    EXPECT_EQ(CardSet::OG, cards9.front()->GetCardSet());
+    EXPECT_EQ(CardSet::KARA, cards10.front()->GetCardSet());
+    EXPECT_EQ(CardSet::GANGS, cards11.front()->GetCardSet());
+    EXPECT_EQ(CardSet::UNGORO, cards12.front()->GetCardSet());
+    EXPECT_EQ(CardSet::ICECROWN, cards13.front()->GetCardSet());
+    EXPECT_EQ(CardSet::LOOTAPALOOZA, cards14.front()->GetCardSet());
+    EXPECT_EQ(CardSet::GILNEAS, cards15.front()->GetCardSet());
+    EXPECT_EQ(CardSet::BOOMSDAY, cards16.front()->GetCardSet());
     EXPECT_TRUE(cards17.empty());
 }
 
@@ -119,24 +119,24 @@ TEST(Cards, FindCardByType)
 {
     Cards& instance = Cards::GetInstance();
 
-    std::vector<Card> cards1 = instance.FindCardByType(CardType::WEAPON);
-    std::vector<Card> cards2 = instance.FindCardByType(CardType::GAME);
-    std::vector<Card> cards3 = instance.FindCardByType(CardType::HERO);
-    std::vector<Card> cards4 = instance.FindCardByType(CardType::HERO_POWER);
-    std::vector<Card> cards5 = instance.FindCardByType(CardType::ENCHANTMENT);
-    std::vector<Card> cards6 = instance.FindCardByType(CardType::ITEM);
-    std::vector<Card> cards7 = instance.FindCardByType(CardType::MINION);
-    std::vector<Card> cards8 = instance.FindCardByType(CardType::PLAYER);
-    std::vector<Card> cards9 = instance.FindCardByType(CardType::SPELL);
-    std::vector<Card> cards10 = instance.FindCardByType(CardType::TOKEN);
-    std::vector<Card> cards11 = instance.FindCardByType(CardType::INVALID);
+    std::vector<Card*> cards1 = instance.FindCardByType(CardType::WEAPON);
+    std::vector<Card*> cards2 = instance.FindCardByType(CardType::GAME);
+    std::vector<Card*> cards3 = instance.FindCardByType(CardType::HERO);
+    std::vector<Card*> cards4 = instance.FindCardByType(CardType::HERO_POWER);
+    std::vector<Card*> cards5 = instance.FindCardByType(CardType::ENCHANTMENT);
+    std::vector<Card*> cards6 = instance.FindCardByType(CardType::ITEM);
+    std::vector<Card*> cards7 = instance.FindCardByType(CardType::MINION);
+    std::vector<Card*> cards8 = instance.FindCardByType(CardType::PLAYER);
+    std::vector<Card*> cards9 = instance.FindCardByType(CardType::SPELL);
+    std::vector<Card*> cards10 = instance.FindCardByType(CardType::TOKEN);
+    std::vector<Card*> cards11 = instance.FindCardByType(CardType::INVALID);
 
-    EXPECT_EQ(CardType::WEAPON, cards1.front().GetCardType());
-    EXPECT_EQ(CardType::HERO, cards3.front().GetCardType());
-    EXPECT_EQ(CardType::HERO_POWER, cards4.front().GetCardType());
-    EXPECT_EQ(CardType::ENCHANTMENT, cards5.front().GetCardType());
-    EXPECT_EQ(CardType::MINION, cards7.front().GetCardType());
-    EXPECT_EQ(CardType::SPELL, cards9.front().GetCardType());
+    EXPECT_EQ(CardType::WEAPON, cards1.front()->GetCardType());
+    EXPECT_EQ(CardType::HERO, cards3.front()->GetCardType());
+    EXPECT_EQ(CardType::HERO_POWER, cards4.front()->GetCardType());
+    EXPECT_EQ(CardType::ENCHANTMENT, cards5.front()->GetCardType());
+    EXPECT_EQ(CardType::MINION, cards7.front()->GetCardType());
+    EXPECT_EQ(CardType::SPELL, cards9.front()->GetCardType());
     EXPECT_TRUE(cards2.empty());
     EXPECT_TRUE(cards6.empty());
     EXPECT_TRUE(cards8.empty());
@@ -148,7 +148,7 @@ TEST(Cards, FindCardByRace)
 {
     Cards& instance = Cards::GetInstance();
 
-    std::vector<Card> cards = instance.FindCardByRace(Race::INVALID);
+    std::vector<Card*> cards = instance.FindCardByRace(Race::INVALID);
 
     EXPECT_FALSE(cards.empty());
     EXPECT_NO_THROW(instance.FindCardByRace(Race::ALL));
@@ -158,17 +158,17 @@ TEST(Cards, FindCardByName)
 {
     Cards& instance = Cards::GetInstance();
 
-    const Card card = instance.FindCardByName("Flame Lance");
+    const Card* card = instance.FindCardByName("Flame Lance");
 
-    EXPECT_EQ("Flame Lance", card.name);
+    EXPECT_EQ("Flame Lance", card->name);
 }
 
 TEST(Cards, FindCardByCost)
 {
     Cards& instance = Cards::GetInstance();
 
-    std::vector<Card> cards1 = instance.FindCardByCost(0, 1);
-    std::vector<Card> cards2 = instance.FindCardByCost(2, 1);
+    std::vector<Card*> cards1 = instance.FindCardByCost(0, 1);
+    std::vector<Card*> cards2 = instance.FindCardByCost(2, 1);
 
     EXPECT_FALSE(cards1.empty());
     EXPECT_TRUE(cards2.empty());
@@ -178,8 +178,8 @@ TEST(Cards, FindCardByAttack)
 {
     Cards& instance = Cards::GetInstance();
 
-    std::vector<Card> cards1 = instance.FindCardByAttack(0, 1);
-    std::vector<Card> cards2 = instance.FindCardByAttack(2, 1);
+    std::vector<Card*> cards1 = instance.FindCardByAttack(0, 1);
+    std::vector<Card*> cards2 = instance.FindCardByAttack(2, 1);
 
     EXPECT_FALSE(cards1.empty());
     EXPECT_TRUE(cards2.empty());
@@ -189,8 +189,8 @@ TEST(Cards, FindCardByHealth)
 {
     Cards& instance = Cards::GetInstance();
 
-    std::vector<Card> cards1 = instance.FindCardByHealth(0, 1);
-    std::vector<Card> cards2 = instance.FindCardByHealth(2, 1);
+    std::vector<Card*> cards1 = instance.FindCardByHealth(0, 1);
+    std::vector<Card*> cards2 = instance.FindCardByHealth(2, 1);
 
     EXPECT_FALSE(cards1.empty());
     EXPECT_TRUE(cards2.empty());
@@ -204,9 +204,9 @@ TEST(Cards, FindCardByGameTag)
     const std::vector<GameTag> tags2;
     tags1.emplace_back(GameTag::CANT_ATTACK);
 
-    std::vector<Card> cards1 = instance.FindCardByGameTag(tags1);
-    std::vector<Card> cards2 = instance.FindCardByGameTag(tags2);
-    auto gameTags = cards1.front().gameTags;
+    std::vector<Card*> cards1 = instance.FindCardByGameTag(tags1);
+    std::vector<Card*> cards2 = instance.FindCardByGameTag(tags2);
+    auto gameTags = cards1.front()->gameTags;
 
     EXPECT_TRUE(gameTags.find(GameTag::CANT_ATTACK) != gameTags.end());
     EXPECT_TRUE(cards2.empty());
@@ -216,58 +216,58 @@ TEST(Cards, GetHeroCard)
 {
     Cards& instance = Cards::GetInstance();
 
-    EXPECT_EQ(instance.FindCardByID("HERO_06").id,
-              instance.GetHeroCard(CardClass::DRUID).id);
-    EXPECT_EQ(instance.FindCardByID("HERO_05").id,
-              instance.GetHeroCard(CardClass::HUNTER).id);
-    EXPECT_EQ(instance.FindCardByID("HERO_08").id,
-              instance.GetHeroCard(CardClass::MAGE).id);
-    EXPECT_EQ(instance.FindCardByID("HERO_04").id,
-              instance.GetHeroCard(CardClass::PALADIN).id);
-    EXPECT_EQ(instance.FindCardByID("HERO_09").id,
-              instance.GetHeroCard(CardClass::PRIEST).id);
-    EXPECT_EQ(instance.FindCardByID("HERO_03").id,
-              instance.GetHeroCard(CardClass::ROGUE).id);
-    EXPECT_EQ(instance.FindCardByID("HERO_02").id,
-              instance.GetHeroCard(CardClass::SHAMAN).id);
-    EXPECT_EQ(instance.FindCardByID("HERO_07").id,
-              instance.GetHeroCard(CardClass::WARLOCK).id);
-    EXPECT_EQ(instance.FindCardByID("HERO_01").id,
-              instance.GetHeroCard(CardClass::WARRIOR).id);
-    EXPECT_EQ(instance.GetHeroCard(CardClass::DEATHKNIGHT).id, "");
+    EXPECT_EQ(instance.FindCardByID("HERO_06")->id,
+              instance.GetHeroCard(CardClass::DRUID)->id);
+    EXPECT_EQ(instance.FindCardByID("HERO_05")->id,
+              instance.GetHeroCard(CardClass::HUNTER)->id);
+    EXPECT_EQ(instance.FindCardByID("HERO_08")->id,
+              instance.GetHeroCard(CardClass::MAGE)->id);
+    EXPECT_EQ(instance.FindCardByID("HERO_04")->id,
+              instance.GetHeroCard(CardClass::PALADIN)->id);
+    EXPECT_EQ(instance.FindCardByID("HERO_09")->id,
+              instance.GetHeroCard(CardClass::PRIEST)->id);
+    EXPECT_EQ(instance.FindCardByID("HERO_03")->id,
+              instance.GetHeroCard(CardClass::ROGUE)->id);
+    EXPECT_EQ(instance.FindCardByID("HERO_02")->id,
+              instance.GetHeroCard(CardClass::SHAMAN)->id);
+    EXPECT_EQ(instance.FindCardByID("HERO_07")->id,
+              instance.GetHeroCard(CardClass::WARLOCK)->id);
+    EXPECT_EQ(instance.FindCardByID("HERO_01")->id,
+              instance.GetHeroCard(CardClass::WARRIOR)->id);
+    EXPECT_EQ(instance.GetHeroCard(CardClass::DEATHKNIGHT)->id, "");
 }
 
 TEST(Cards, GetDefaultHeroPower)
 {
     Cards& instance = Cards::GetInstance();
 
-    EXPECT_EQ(instance.FindCardByID("CS2_017").id,
-              instance.GetDefaultHeroPower(CardClass::DRUID).id);
-    EXPECT_EQ(instance.FindCardByID("DS1h_292").id,
-              instance.GetDefaultHeroPower(CardClass::HUNTER).id);
-    EXPECT_EQ(instance.FindCardByID("CS2_034").id,
-              instance.GetDefaultHeroPower(CardClass::MAGE).id);
-    EXPECT_EQ(instance.FindCardByID("CS2_101").id,
-              instance.GetDefaultHeroPower(CardClass::PALADIN).id);
-    EXPECT_EQ(instance.FindCardByID("CS1h_001").id,
-              instance.GetDefaultHeroPower(CardClass::PRIEST).id);
-    EXPECT_EQ(instance.FindCardByID("CS2_083b").id,
-              instance.GetDefaultHeroPower(CardClass::ROGUE).id);
-    EXPECT_EQ(instance.FindCardByID("CS2_049").id,
-              instance.GetDefaultHeroPower(CardClass::SHAMAN).id);
-    EXPECT_EQ(instance.FindCardByID("CS2_056").id,
-              instance.GetDefaultHeroPower(CardClass::WARLOCK).id);
-    EXPECT_EQ(instance.FindCardByID("CS2_102").id,
-              instance.GetDefaultHeroPower(CardClass::WARRIOR).id);
-    EXPECT_EQ(instance.GetDefaultHeroPower(CardClass::DEATHKNIGHT).id, "");
+    EXPECT_EQ(instance.FindCardByID("CS2_017")->id,
+              instance.GetDefaultHeroPower(CardClass::DRUID)->id);
+    EXPECT_EQ(instance.FindCardByID("DS1h_292")->id,
+              instance.GetDefaultHeroPower(CardClass::HUNTER)->id);
+    EXPECT_EQ(instance.FindCardByID("CS2_034")->id,
+              instance.GetDefaultHeroPower(CardClass::MAGE)->id);
+    EXPECT_EQ(instance.FindCardByID("CS2_101")->id,
+              instance.GetDefaultHeroPower(CardClass::PALADIN)->id);
+    EXPECT_EQ(instance.FindCardByID("CS1h_001")->id,
+              instance.GetDefaultHeroPower(CardClass::PRIEST)->id);
+    EXPECT_EQ(instance.FindCardByID("CS2_083b")->id,
+              instance.GetDefaultHeroPower(CardClass::ROGUE)->id);
+    EXPECT_EQ(instance.FindCardByID("CS2_049")->id,
+              instance.GetDefaultHeroPower(CardClass::SHAMAN)->id);
+    EXPECT_EQ(instance.FindCardByID("CS2_056")->id,
+              instance.GetDefaultHeroPower(CardClass::WARLOCK)->id);
+    EXPECT_EQ(instance.FindCardByID("CS2_102")->id,
+              instance.GetDefaultHeroPower(CardClass::WARRIOR)->id);
+    EXPECT_EQ(instance.GetDefaultHeroPower(CardClass::DEATHKNIGHT)->id, "");
 }
 
 TEST(Cards, FindCardBySpellDamage)
 {
     Cards& instance = Cards::GetInstance();
 
-    std::vector<Card> cards1 = instance.FindCardBySpellPower(1, 1);
-    std::vector<Card> cards2 = instance.FindCardBySpellPower(2, 1);
+    std::vector<Card*> cards1 = instance.FindCardBySpellPower(1, 1);
+    std::vector<Card*> cards2 = instance.FindCardBySpellPower(2, 1);
 
     EXPECT_FALSE(cards1.empty());
     EXPECT_TRUE(cards2.empty());

--- a/Tests/UnitTests/Enchants/TriggerTests.cpp
+++ b/Tests/UnitTests/Enchants/TriggerTests.cpp
@@ -40,7 +40,7 @@ TEST(Trigger, None)
     auto card1 = GenerateMinionCard("minion1", 3, 6);
     card1.power.AddTrigger(new Trigger(TriggerType::NONE));
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -71,7 +71,7 @@ TEST(Trigger, TurnStart)
     auto card1 = GenerateMinionCard("minion1", 3, 6);
     card1.power.AddTrigger(new Trigger(TriggerType::TURN_START));
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -102,7 +102,7 @@ TEST(Trigger, TurnEnd)
     auto card1 = GenerateMinionCard("minion1", 3, 6);
     card1.power.AddTrigger(new Trigger(TriggerType::TURN_END));
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -133,7 +133,7 @@ TEST(Trigger, PlayCard)
     auto card1 = GenerateMinionCard("minion1", 3, 6);
     card1.power.AddTrigger(new Trigger(TriggerType::PLAY_CARD));
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -164,7 +164,7 @@ TEST(Trigger, CastSpell)
     auto card1 = GenerateMinionCard("minion1", 3, 6);
     card1.power.AddTrigger(new Trigger(TriggerType::CAST_SPELL));
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -195,7 +195,7 @@ TEST(Trigger, AfterCast)
     auto card1 = GenerateMinionCard("minion1", 3, 6);
     card1.power.AddTrigger(new Trigger(TriggerType::AFTER_CAST));
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -226,7 +226,7 @@ TEST(Trigger, Heal)
     auto card1 = GenerateMinionCard("minion1", 3, 6);
     card1.power.AddTrigger(new Trigger(TriggerType::HEAL));
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -257,7 +257,7 @@ TEST(Trigger, Attack)
     auto card1 = GenerateMinionCard("minion1", 3, 6);
     card1.power.AddTrigger(new Trigger(TriggerType::ATTACK));
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -289,7 +289,7 @@ TEST(Trigger, AfterAttack_None)
     card1.power.AddTrigger(new Trigger(TriggerType::AFTER_ATTACK));
     card1.power.GetTrigger()->triggerSource = TriggerSource::NONE;
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -321,7 +321,7 @@ TEST(Trigger, AfterAttack_Hero)
     card1.power.AddTrigger(new Trigger(TriggerType::AFTER_ATTACK));
     card1.power.GetTrigger()->triggerSource = TriggerSource::HERO;
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -353,7 +353,7 @@ TEST(Trigger, AfterAttack_Self)
     card1.power.AddTrigger(new Trigger(TriggerType::AFTER_ATTACK));
     card1.power.GetTrigger()->triggerSource = TriggerSource::SELF;
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -386,8 +386,8 @@ TEST(Trigger, AfterAttack_EnchantmentTarget)
     card1.power.AddTrigger(new Trigger(TriggerType::AFTER_ATTACK));
     card1.power.GetTrigger()->triggerSource = TriggerSource::ENCHANTMENT_TARGET;
 
-    PlayMinionCard(curPlayer, card2);
-    PlayEnchantmentCard(curPlayer, card1, curField[0]);
+    PlayMinionCard(curPlayer, &card2);
+    PlayEnchantmentCard(curPlayer, &card1, curField[0]);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -418,7 +418,7 @@ TEST(Trigger, Summon)
     auto card1 = GenerateMinionCard("minion1", 3, 6);
     card1.power.AddTrigger(new Trigger(TriggerType::SUMMON));
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -450,7 +450,7 @@ TEST(Trigger, Predamage_None)
     card1.power.AddTrigger(new Trigger(TriggerType::PREDAMAGE));
     card1.power.GetTrigger()->triggerSource = TriggerSource::NONE;
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -482,7 +482,7 @@ TEST(Trigger, Predamage_Hero)
     card1.power.AddTrigger(new Trigger(TriggerType::PREDAMAGE));
     card1.power.GetTrigger()->triggerSource = TriggerSource::HERO;
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -514,7 +514,7 @@ TEST(Trigger, Predamage_Self)
     card1.power.AddTrigger(new Trigger(TriggerType::PREDAMAGE));
     card1.power.GetTrigger()->triggerSource = TriggerSource::SELF;
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -547,8 +547,8 @@ TEST(Trigger, Predamage_EnchantmentTarget)
     card1.power.AddTrigger(new Trigger(TriggerType::PREDAMAGE));
     card1.power.GetTrigger()->triggerSource = TriggerSource::ENCHANTMENT_TARGET;
 
-    PlayMinionCard(curPlayer, card2);
-    PlayEnchantmentCard(curPlayer, card1, curField[0]);
+    PlayMinionCard(curPlayer, &card2);
+    PlayEnchantmentCard(curPlayer, &card1, curField[0]);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -579,7 +579,7 @@ TEST(Trigger, TakeDamage)
     auto card1 = GenerateMinionCard("minion1", 3, 6);
     card1.power.AddTrigger(new Trigger(TriggerType::TAKE_DAMAGE));
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();
@@ -610,7 +610,7 @@ TEST(Trigger, Target)
     auto card1 = GenerateMinionCard("minion1", 3, 6);
     card1.power.AddTrigger(new Trigger(TriggerType::TARGET));
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     curField[0]->Destroy();
     game.ProcessDestroyAndUpdateAura();

--- a/Tests/UnitTests/Models/CharacterTests.cpp
+++ b/Tests/UnitTests/Models/CharacterTests.cpp
@@ -31,7 +31,7 @@ TEST(Character, Health)
     auto& curField = curPlayer.GetFieldZone();
 
     auto card1 = GenerateMinionCard("minion1", 3, 6);
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
     EXPECT_EQ(curField[0]->GetHealth(), 6);
 
     curField[0]->SetDamage(2);
@@ -63,7 +63,7 @@ TEST(Character, SpellPower)
     auto& curField = curPlayer.GetFieldZone();
 
     auto card1 = GenerateMinionCard("minion1", 3, 6);
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
     EXPECT_EQ(curField[0]->GetSpellPower(), 0);
 
     curField[0]->SetSpellPower(4);

--- a/Tests/UnitTests/Policies/RandomPolicyTests.cpp
+++ b/Tests/UnitTests/Policies/RandomPolicyTests.cpp
@@ -38,8 +38,8 @@ TEST(RandomPolicy, AutoRun)
 
     for (size_t i = 0; i < START_DECK_SIZE; ++i)
     {
-        config.player1Deck[i] = Cards::GetInstance().FindCardByID(deck[i]);
-        config.player2Deck[i] = Cards::GetInstance().FindCardByID(deck[i]);
+        config.player1Deck[i] = *Cards::GetInstance().FindCardByID(deck[i]);
+        config.player2Deck[i] = *Cards::GetInstance().FindCardByID(deck[i]);
     }
 
     Game game(config);
@@ -77,8 +77,8 @@ TEST(RandomPolicy, Mulligan)
 
         for (size_t j = 0; j < START_DECK_SIZE; ++j)
         {
-            config.player1Deck[j] = Cards::GetInstance().FindCardByID(deck[j]);
-            config.player2Deck[j] = Cards::GetInstance().FindCardByID(deck[j]);
+            config.player1Deck[j] = *Cards::GetInstance().FindCardByID(deck[j]);
+            config.player2Deck[j] = *Cards::GetInstance().FindCardByID(deck[j]);
         }
 
         Game game(config);

--- a/Tests/UnitTests/Tasks/PlayerTasks/AttackTaskTests.cpp
+++ b/Tests/UnitTests/Tasks/PlayerTasks/AttackTaskTests.cpp
@@ -48,12 +48,12 @@ TEST(AttackTask, Default)
     auto card1 = GenerateMinionCard("minion1", 3, 6);
     auto card2 = GenerateMinionCard("minion2", 5, 4);
 
-    PlayMinionCard(curPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
-    PlayMinionCard(opPlayer, card2);
+    PlayMinionCard(opPlayer, &card2);
 
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
@@ -79,8 +79,8 @@ TEST(AttackTask, Default)
     auto card3 = GenerateMinionCard("minion3", 5, 6);
     auto card4 = GenerateMinionCard("minion4", 5, 4);
 
-    PlayMinionCard(curPlayer, card3);
-    PlayMinionCard(opPlayer, card4);
+    PlayMinionCard(curPlayer, &card3);
+    PlayMinionCard(opPlayer, &card4);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
@@ -95,7 +95,7 @@ TEST(AttackTask, Default)
     auto card5 = GenerateMinionCard("minion5", 5, 4);
 
     curField[0]->SetAttack(1);
-    PlayMinionCard(opPlayer, card5);
+    PlayMinionCard(opPlayer, &card5);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
@@ -137,7 +137,7 @@ TEST(AttackTask, Weapon)
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
-    PlayMinionCard(opPlayer, card);
+    PlayMinionCard(opPlayer, &card);
 
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
@@ -181,7 +181,7 @@ TEST(AttackTask, ZeroAttack)
 
     auto card = GenerateMinionCard("minion1", 0, 6);
 
-    PlayMinionCard(curPlayer, card);
+    PlayMinionCard(curPlayer, &card);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
@@ -217,9 +217,9 @@ TEST(AttackTask, Charge)
     auto card2 = GenerateMinionCard("minion1", 1, 10);
     card2.gameTags[GameTag::CHARGE] = 1;
 
-    PlayMinionCard(curPlayer, card1);
-    PlayMinionCard(curPlayer, card2);
-    PlayMinionCard(opPlayer, card1);
+    PlayMinionCard(curPlayer, &card1);
+    PlayMinionCard(curPlayer, &card2);
+    PlayMinionCard(opPlayer, &card1);
 
     game.Process(curPlayer, AttackTask(curField[0], opField[0]));
     EXPECT_EQ(curField[0]->GetNumAttacksThisTurn(), 0);
@@ -250,13 +250,13 @@ TEST(AttackTask, Taunt)
 
     auto card = GenerateMinionCard("minion1", 1, 10);
 
-    PlayMinionCard(curPlayer, card);
+    PlayMinionCard(curPlayer, &card);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
-    PlayMinionCard(opPlayer, card);
-    PlayMinionCard(opPlayer, card);
+    PlayMinionCard(opPlayer, &card);
+    PlayMinionCard(opPlayer, &card);
 
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
@@ -294,12 +294,12 @@ TEST(AttackTask, Stealth)
 
     auto card = GenerateMinionCard("minion", 1, 10);
 
-    PlayMinionCard(curPlayer, card);
+    PlayMinionCard(curPlayer, &card);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
-    PlayMinionCard(opPlayer, card);
+    PlayMinionCard(opPlayer, &card);
 
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
@@ -339,12 +339,12 @@ TEST(AttackTask, Immune)
 
     auto card = GenerateMinionCard("minion", 1, 10);
 
-    PlayMinionCard(curPlayer, card);
+    PlayMinionCard(curPlayer, &card);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
-    PlayMinionCard(opPlayer, card);
+    PlayMinionCard(opPlayer, &card);
 
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
@@ -390,12 +390,12 @@ TEST(AttackTask, Windfury)
 
     auto card = GenerateMinionCard("minion", 1, 10);
 
-    PlayMinionCard(curPlayer, card);
+    PlayMinionCard(curPlayer, &card);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
-    PlayMinionCard(opPlayer, card);
+    PlayMinionCard(opPlayer, &card);
 
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
@@ -446,12 +446,12 @@ TEST(AttackTask, DivineShield)
 
     auto card = GenerateMinionCard("minion", 1, 10);
 
-    PlayMinionCard(curPlayer, card);
+    PlayMinionCard(curPlayer, &card);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
-    PlayMinionCard(opPlayer, card);
+    PlayMinionCard(opPlayer, &card);
 
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
@@ -497,12 +497,12 @@ TEST(AttackTask, Poisonous)
 
     auto card = GenerateMinionCard("minion", 1, 10);
 
-    PlayMinionCard(curPlayer, card);
+    PlayMinionCard(curPlayer, &card);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
-    PlayMinionCard(opPlayer, card);
+    PlayMinionCard(opPlayer, &card);
 
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
@@ -516,7 +516,7 @@ TEST(AttackTask, Poisonous)
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
-    PlayMinionCard(opPlayer, card);
+    PlayMinionCard(opPlayer, &card);
 
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
@@ -551,14 +551,14 @@ TEST(AttackTask, Freeze)
 
     auto card = GenerateMinionCard("minion", 1, 10);
 
-    PlayMinionCard(curPlayer, card);
-    PlayMinionCard(curPlayer, card);
+    PlayMinionCard(curPlayer, &card);
+    PlayMinionCard(curPlayer, &card);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
-    PlayMinionCard(opPlayer, card);
-    PlayMinionCard(opPlayer, card);
+    PlayMinionCard(opPlayer, &card);
+    PlayMinionCard(opPlayer, &card);
 
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
@@ -612,7 +612,7 @@ TEST(AttackTask, Silence)
 
     auto card = GenerateMinionCard("minion", 1, 10);
 
-    PlayMinionCard(curPlayer, card);
+    PlayMinionCard(curPlayer, &card);
     curField[0]->SetGameTag(GameTag::CANT_ATTACK, 1);
 
     game.Process(curPlayer, EndTurnTask());

--- a/Tests/UnitTests/Tasks/SimpleTasks/ControlTaskTests.cpp
+++ b/Tests/UnitTests/Tasks/SimpleTasks/ControlTaskTests.cpp
@@ -40,8 +40,8 @@ TEST(ControlTask, Run)
     {
         const auto id = static_cast<char>(i + 0x30);
         cards.emplace_back(GenerateMinionCard(name + id, 1, 1));
-        PlayMinionCard(player1, cards[i]);
-        PlayMinionCard(player2, cards[i]);
+        PlayMinionCard(player1, &cards[i]);
+        PlayMinionCard(player2, &cards[i]);
     }
 
     ControlTask control(EntityType::TARGET);

--- a/Tests/UnitTests/Tasks/SimpleTasks/DamageTaskTests.cpp
+++ b/Tests/UnitTests/Tasks/SimpleTasks/DamageTaskTests.cpp
@@ -43,7 +43,7 @@ TEST(DamageTask, Run)
     {
         const auto id = static_cast<char>(i + 0x30);
         cards.emplace_back(GenerateMinionCard(name + id, 1, 1));
-        PlayMinionCard(player1, cards[i]);
+        PlayMinionCard(player1, &cards[i]);
     }
 
     DamageTask damage(EntityType::FRIENDS, 1);
@@ -78,7 +78,7 @@ TEST(DamageTask, SpellPower)
     {
         const auto id = static_cast<char>(i + 0x30);
         cards.emplace_back(GenerateMinionCard(name + id, 1, 5));
-        PlayMinionCard(player1, cards[i]);
+        PlayMinionCard(player1, &cards[i]);
     }
 
     DamageTask damage1(EntityType::FRIENDS, 1, true);

--- a/Tests/UnitTests/Tasks/SimpleTasks/DestroyTaskTests.cpp
+++ b/Tests/UnitTests/Tasks/SimpleTasks/DestroyTaskTests.cpp
@@ -41,7 +41,7 @@ TEST(DestroyTask, Run)
     const std::map<GameTag, int> tags;
 
     // Destroy Source Minion
-    const auto minion1 = new Minion(player1, card, tags);
+    const auto minion1 = new Minion(player1, &card, tags);
     minion1->owner = &player1;
     player1.GetFieldZone().Add(*minion1, 0);
 
@@ -56,7 +56,7 @@ TEST(DestroyTask, Run)
     EXPECT_EQ(player1.GetFieldZone().GetCount(), 0);
 
     // Destroy Target Minion
-    const auto minion2 = new Minion(player2, card, tags);
+    const auto minion2 = new Minion(player2, &card, tags);
     minion2->owner = &player2;
     player2.GetFieldZone().Add(*minion2, 0);
 
@@ -72,7 +72,7 @@ TEST(DestroyTask, Run)
 
     // Destroy Target Weapon
     Card weaponCard;
-    player2.GetHero()->weapon = new Weapon(player2, weaponCard, tags);
+    player2.GetHero()->weapon = new Weapon(player2, &weaponCard, tags);
     player2.GetHero()->weapon->owner = &player2;
 
     DestroyTask task3(EntityType::ENEMY_WEAPON);

--- a/Tests/UnitTests/Tasks/SimpleTasks/DrawTaskTests.cpp
+++ b/Tests/UnitTests/Tasks/SimpleTasks/DrawTaskTests.cpp
@@ -42,7 +42,7 @@ TEST(DrawTask, GetTaskID)
 
 TEST(DrawTask, Run)
 {
-    std::vector<Card> cards;
+    std::vector<Card*> cards;
     std::vector<Entity*> minions;
 
     GameConfig config;
@@ -52,10 +52,10 @@ TEST(DrawTask, Run)
     Player& p = game.GetPlayer1();
 
     const auto Generate = [&](std::string&& id) -> Entity* {
-        cards.emplace_back(Card());
+        cards.emplace_back(new Card());
 
-        Card card = cards.back();
-        card.id = std::move(id);
+        Card* card = cards.back();
+        card->id = std::move(id);
         const std::map<GameTag, int> tags;
 
         minions.emplace_back(new Minion(p, card, tags));
@@ -78,8 +78,13 @@ TEST(DrawTask, Run)
 
     for (std::size_t i = 0; i < 3; ++i)
     {
-        EXPECT_EQ(p.GetHandZone()[i]->card.id,
+        EXPECT_EQ(p.GetHandZone()[i]->card->id,
                   id + static_cast<char>(2 - i + 0x30));
+    }
+
+    for (Card* card : cards)
+    {
+        delete card;
     }
 }
 
@@ -106,21 +111,23 @@ TEST(DrawTask, RunExhaust)
     card.id = "card1";
     const std::map<GameTag, int> tags;
 
-    const auto minion = new Minion(p, card, tags);
+    const auto minion = new Minion(p, &card, tags);
     p.GetDeckZone().Add(*minion);
 
     result = draw.Run();
     EXPECT_EQ(result, TaskStatus::COMPLETE);
     EXPECT_EQ(p.GetHandZone().GetCount(), 1);
-    EXPECT_EQ(p.GetHandZone()[0]->card.id, "card1");
+    EXPECT_EQ(p.GetHandZone()[0]->card->id, "card1");
     EXPECT_EQ(p.GetDeckZone().GetCount(), 0);
     // Health: 30 - (1 + 2 + 3 + 4 + 5)
     EXPECT_EQ(p.GetHero()->GetHealth(), 15);
+
+    delete minion;
 }
 
 TEST(DrawTask, RunOverDraw)
 {
-    std::vector<Card> cards;
+    std::vector<Card*> cards;
     std::vector<Entity*> minions;
 
     GameConfig config;
@@ -130,10 +137,10 @@ TEST(DrawTask, RunOverDraw)
     Player& p = game.GetPlayer1();
 
     const auto Generate = [&](std::string&& id) -> Entity* {
-        cards.emplace_back(Card());
+        cards.emplace_back(new Card());
 
-        Card card = cards.back();
-        card.id = std::move(id);
+        Card* card = cards.back();
+        card->id = std::move(id);
         const std::map<GameTag, int> tags;
 
         minions.emplace_back(new Minion(p, card, tags));
@@ -164,7 +171,7 @@ TEST(DrawTask, RunOverDraw)
         const auto& entities = burnt.GetObject<SizedPtr<Entity*>>();
         for (std::size_t i = 0; i < 3; ++i)
         {
-            EXPECT_EQ(entities[i]->card.id,
+            EXPECT_EQ(entities[i]->card->id,
                       id + static_cast<char>(2 - i + 0x30));
         }
     });
@@ -174,11 +181,16 @@ TEST(DrawTask, RunOverDraw)
     EXPECT_EQ(result, TaskStatus::COMPLETE);
     EXPECT_EQ(p.GetDeckZone().GetCount(), 0);
     EXPECT_EQ(p.GetHandZone().GetCount(), 10);
+
+    for (Card* card : cards)
+    {
+        delete card;
+    }
 }
 
 TEST(DrawTask, RunExhaustOverdraw)
 {
-    std::vector<Card> cards;
+    std::vector<Card*> cards;
     std::vector<Minion*> minions;
 
     GameConfig config;
@@ -188,10 +200,10 @@ TEST(DrawTask, RunExhaustOverdraw)
     Player& p = game.GetPlayer1();
 
     const auto Generate = [&](std::string&& id) -> Entity* {
-        cards.emplace_back(Card());
+        cards.emplace_back(new Card());
 
-        Card card = cards.back();
-        card.id = std::move(id);
+        Card* card = cards.back();
+        card->id = std::move(id);
         const std::map<GameTag, int> tags;
 
         minions.emplace_back(new Minion(p, card, tags));
@@ -221,7 +233,7 @@ TEST(DrawTask, RunExhaustOverdraw)
         const auto& entities = burnt.GetObject<SizedPtr<Entity*>>();
         for (std::size_t i = 0; i < 2; ++i)
         {
-            EXPECT_EQ(entities[i]->card.id,
+            EXPECT_EQ(entities[i]->card->id,
                       id + static_cast<char>(2 - i + 0x30));
         }
     });
@@ -231,5 +243,10 @@ TEST(DrawTask, RunExhaustOverdraw)
     EXPECT_EQ(result, TaskStatus::COMPLETE);
     EXPECT_EQ(p.GetDeckZone().GetCount(), 0);
     EXPECT_EQ(p.GetHandZone().GetCount(), 10);
-    EXPECT_EQ(p.GetHandZone()[9]->card.id, "card2");
+    EXPECT_EQ(p.GetHandZone()[9]->card->id, "card2");
+
+    for (Card* card : cards)
+    {
+        delete card;
+    }
 }

--- a/Tests/UnitTests/Utils/TestUtils.cpp
+++ b/Tests/UnitTests/Utils/TestUtils.cpp
@@ -71,7 +71,7 @@ Card GenerateEnchantmentCard(std::string&& id)
     return card;
 }
 
-void PlayMinionCard(Player& player, Card& card)
+void PlayMinionCard(Player& player, Card* card)
 {
     FieldZone& fieldZone = player.GetFieldZone();
     const std::map<GameTag, int> tags;
@@ -81,7 +81,7 @@ void PlayMinionCard(Player& player, Card& card)
     fieldZone[minion->GetZonePosition()]->owner = &player;
 }
 
-void PlayEnchantmentCard(Player& player, Card& card, Entity* target)
+void PlayEnchantmentCard(Player& player, Card* card, Entity* target)
 {
     GraveyardZone& graveyardZone = player.GetGraveyardZone();
     const std::map<GameTag, int> tags;

--- a/Tests/UnitTests/Utils/TestUtils.hpp
+++ b/Tests/UnitTests/Utils/TestUtils.hpp
@@ -24,8 +24,8 @@ TaskMeta GenerateRandomTaskMeta();
 Card GenerateMinionCard(std::string&& id, int attack, int health);
 Card GenerateEnchantmentCard(std::string&& id);
 
-void PlayMinionCard(Player& player, Card& card);
-void PlayEnchantmentCard(Player& player, Card& card, Entity* target);
+void PlayMinionCard(Player& player, Card* card);
+void PlayEnchantmentCard(Player& player, Card* card, Entity* target);
 
 void ExpectCardEqual(const Card& card1, const Card& card2);
 }  // namespace TestUtils


### PR DESCRIPTION
* 카드가 계속 복사되는 부분을 수정했습니다.
* 카드는 맨 처음 로드될때 한 번만 생성되고 프로그램이 종료될때 해제됩니다.
* 카드가 Entity 등 오브젝트 내에서 움직이거나 Construct될때 Copy 또는 Move되지 않습니다.
* 카드를 사용하는 Container들이 이제 더 적은 용량을 사용하게 됩니다.