### PR TITLE
feat(card-impl): Implement 11 EXPERT1 cards and refactor task logic

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -327,7 +327,7 @@ EXPERT1 | EX1_564 | Faceless Manipulator | O
 EXPERT1 | EX1_567 | Doomhammer | O
 EXPERT1 | EX1_570 | Bite | O
 EXPERT1 | EX1_571 | Force of Nature |  
-EXPERT1 | EX1_572 | Ysera |  
+EXPERT1 | EX1_572 | Ysera | O
 EXPERT1 | EX1_573 | Cenarius |  
 EXPERT1 | EX1_575 | Mana Tide Totem |  
 EXPERT1 | EX1_577 | The Beast |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 46% (117 of 237 Cards)
+- Progress: 49% (118 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -239,7 +239,7 @@ EXPERT1 | EX1_170 | Emperor Cobra | O
 EXPERT1 | EX1_178 | Ancient of War |  
 EXPERT1 | EX1_179 | Icicle |  
 EXPERT1 | EX1_180 | Tome of Intellect |  
-EXPERT1 | EX1_181 | Call of the Void |  
+EXPERT1 | EX1_181 | Call of the Void | O
 EXPERT1 | EX1_182 | Pilfer |  
 EXPERT1 | EX1_238 | Lightning Bolt | O
 EXPERT1 | EX1_241 | Lava Burst | O
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 49% (118 of 237 Cards)
+- Progress: 50% (119 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -237,7 +237,7 @@ EXPERT1 | EX1_165 | Druid of the Claw |
 EXPERT1 | EX1_166 | Keeper of the Grove |  
 EXPERT1 | EX1_170 | Emperor Cobra | O
 EXPERT1 | EX1_178 | Ancient of War |  
-EXPERT1 | EX1_179 | Icicle |  
+EXPERT1 | EX1_179 | Icicle | O
 EXPERT1 | EX1_180 | Tome of Intellect |  
 EXPERT1 | EX1_181 | Call of the Void | O
 EXPERT1 | EX1_182 | Pilfer |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 50% (119 of 237 Cards)
+- Progress: 50% (120 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -367,7 +367,7 @@ EXPERT1 | NEW1_012 | Mana Wyrm | O
 EXPERT1 | NEW1_014 | Master of Disguise |  
 EXPERT1 | NEW1_017 | Hungry Crab |  
 EXPERT1 | NEW1_018 | Bloodsail Raider |  
-EXPERT1 | NEW1_019 | Knife Juggler |  
+EXPERT1 | NEW1_019 | Knife Juggler | O
 EXPERT1 | NEW1_020 | Wild Pyromancer | O
 EXPERT1 | NEW1_021 | Doomsayer | O
 EXPERT1 | NEW1_022 | Dread Corsair |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 46% (115 of 237 Cards)
+- Progress: 46% (116 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -363,7 +363,7 @@ EXPERT1 | NEW1_005 | Kidnapper | O
 EXPERT1 | NEW1_007 | Starfall |  
 EXPERT1 | NEW1_008 | Ancient of Lore |  
 EXPERT1 | NEW1_010 | Al'Akir the Windlord | O
-EXPERT1 | NEW1_012 | Mana Wyrm |  
+EXPERT1 | NEW1_012 | Mana Wyrm | O
 EXPERT1 | NEW1_014 | Master of Disguise |  
 EXPERT1 | NEW1_017 | Hungry Crab |  
 EXPERT1 | NEW1_018 | Bloodsail Raider |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 46% (109 of 237 Cards)
+- Progress: 46% (111 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -315,7 +315,7 @@ EXPERT1 | EX1_543 | King Krush | O
 EXPERT1 | EX1_544 | Flare |  
 EXPERT1 | EX1_549 | Bestial Wrath |  
 EXPERT1 | EX1_554 | Snake Trap |  
-EXPERT1 | EX1_556 | Harvest Golem |  
+EXPERT1 | EX1_556 | Harvest Golem | O 
 EXPERT1 | EX1_557 | Nat Pagle |  
 EXPERT1 | EX1_558 | Harrison Jones |  
 EXPERT1 | EX1_559 | Archmage Antonidas |  
@@ -332,7 +332,7 @@ EXPERT1 | EX1_573 | Cenarius |
 EXPERT1 | EX1_575 | Mana Tide Totem |  
 EXPERT1 | EX1_577 | The Beast |  
 EXPERT1 | EX1_578 | Savagery |  
-EXPERT1 | EX1_583 | Priestess of Elune |  
+EXPERT1 | EX1_583 | Priestess of Elune | O
 EXPERT1 | EX1_584 | Ancient Mage |  
 EXPERT1 | EX1_586 | Sea Giant |  
 EXPERT1 | EX1_590 | Blood Knight |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 46% (113 of 237 Cards)
+- Progress: 46% (115 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -345,7 +345,7 @@ EXPERT1 | EX1_603 | Cruel Taskmaster |
 EXPERT1 | EX1_604 | Frothing Berserker |  
 EXPERT1 | EX1_607 | Inner Rage | O
 EXPERT1 | EX1_608 | Sorcerer's Apprentice |  
-EXPERT1 | EX1_609 | Snipe |  
+EXPERT1 | EX1_609 | Snipe | O
 EXPERT1 | EX1_610 | Explosive Trap |  
 EXPERT1 | EX1_611 | Freezing Trap |  
 EXPERT1 | EX1_612 | Kirin Tor Mage |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 46% (111 of 237 Cards)
+- Progress: 46% (112 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -352,7 +352,7 @@ EXPERT1 | EX1_612 | Kirin Tor Mage |
 EXPERT1 | EX1_613 | Edwin VanCleef |  
 EXPERT1 | EX1_614 | Illidan Stormrage |  
 EXPERT1 | EX1_616 | Mana Wraith |  
-EXPERT1 | EX1_617 | Deadly Shot |  
+EXPERT1 | EX1_617 | Deadly Shot | O
 EXPERT1 | EX1_619 | Equality | O
 EXPERT1 | EX1_621 | Circle of Healing | O
 EXPERT1 | EX1_623 | Temple Enforcer | O
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 46% (112 of 237 Cards)
+- Progress: 46% (113 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -259,7 +259,7 @@ EXPERT1 | EX1_283 | Frost Elemental | O
 EXPERT1 | EX1_287 | Counterspell | O
 EXPERT1 | EX1_289 | Ice Barrier |  
 EXPERT1 | EX1_294 | Mirror Entity |  
-EXPERT1 | EX1_301 | Felguard |  
+EXPERT1 | EX1_301 | Felguard | O
 EXPERT1 | EX1_303 | Shadowflame |  
 EXPERT1 | EX1_304 | Void Terror |  
 EXPERT1 | EX1_309 | Siphon Soul | O
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 46% (116 of 237 Cards)
+- Progress: 46% (117 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Includes/Rosetta/Actions/Copy.hpp
+++ b/Includes/Rosetta/Actions/Copy.hpp
@@ -1,0 +1,24 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_COPY_HPP
+#define ROSETTASTONE_COPY_HPP
+
+#include <Rosetta/Enums/CardEnums.hpp>
+#include <Rosetta/Models/Entity.hpp>
+
+namespace RosettaStone::Generic
+{
+//! Copies the entity to target zone.
+//! \param player The owner of source entity.
+//! \param source The source entity to copy.
+//! \param targetZone The target zone to copy.
+//! \param deathrattle The flag to indicates whether copy operation via
+//! deathrattle power.
+Entity* Copy(Player& player, Entity* source, ZoneType targetZone,
+             bool deathrattle = false);
+}  // namespace RosettaStone::Generic
+
+#endif  // ROSETTASTONE_COPY_HPP

--- a/Includes/Rosetta/Actions/Generic.hpp
+++ b/Includes/Rosetta/Actions/Generic.hpp
@@ -23,6 +23,11 @@ void TakeDamageToCharacter(Entity* source, Character* target, int amount,
 //! \param entity A card to add.
 void AddCardToHand(Player& player, Entity* entity);
 
+//! Shuffles card into deck.
+//! \param player The player to shuffle card into deck.
+//! \param entity A card to shuffle into deck.
+void ShuffleIntoDeck(Player& player, Entity* entity);
+
 //! Changes mana crystal of the player.
 //! \param player The player to change mana crystal.
 //! \param amount A value indicating how much to change mana crystal.

--- a/Includes/Rosetta/CardSets/Expert1CardsGen.hpp
+++ b/Includes/Rosetta/CardSets/Expert1CardsGen.hpp
@@ -109,10 +109,6 @@ class Expert1CardsGen
     //! \param cards Data storage to store added cards with power.
     static void AddNeutralNonCollect(std::map<std::string, Power>& cards);
 
-    //! Adds dream cards that are collectible to \p cards.
-    //! \param cards Data storage to store added cards with power.
-    static void AddDream(std::map<std::string, Power>& cards);
-
     //! Adds Adds cards that are not collectible to \p cards.
     //! \param cards Data storage to store added cards with power.
     static void AddDreamNonCollect(std::map<std::string, Power>& cards);

--- a/Includes/Rosetta/CardSets/Expert1CardsGen.hpp
+++ b/Includes/Rosetta/CardSets/Expert1CardsGen.hpp
@@ -37,7 +37,7 @@ class Expert1CardsGen
     //! \param cards Data storage to store added cards with power.
     static void AddDruidNonCollect(std::map<std::string, Power>& cards);
 
-    //! Adds hunter cards that are not collectible to \p cards.
+    //! Adds hunter cards that are collectible to \p cards.
     //! \param cards Data storage to store added cards with power.
     static void AddHunter(std::map<std::string, Power>& cards);
 
@@ -45,7 +45,7 @@ class Expert1CardsGen
     //! \param cards Data storage to store added cards with power.
     static void AddHunterNonCollect(std::map<std::string, Power>& cards);
 
-    //! Adds mage cards that are not collectible to \p cards.
+    //! Adds mage cards that are collectible to \p cards.
     //! \param cards Data storage to store added cards with power.
     static void AddMage(std::map<std::string, Power>& cards);
 
@@ -53,7 +53,7 @@ class Expert1CardsGen
     //! \param cards Data storage to store added cards with power.
     static void AddMageNonCollect(std::map<std::string, Power>& cards);
 
-    //! Adds paladin cards that are not collectible to \p cards.
+    //! Adds paladin cards that are collectible to \p cards.
     //! \param cards Data storage to store added cards with power.
     static void AddPaladin(std::map<std::string, Power>& cards);
 
@@ -61,7 +61,7 @@ class Expert1CardsGen
     //! \param cards Data storage to store added cards with power.
     static void AddPaladinNonCollect(std::map<std::string, Power>& cards);
 
-    //! Adds priest cards that are not collectible to \p cards.
+    //! Adds priest cards that are collectible to \p cards.
     //! \param cards Data storage to store added cards with power.
     static void AddPriest(std::map<std::string, Power>& cards);
 
@@ -69,7 +69,7 @@ class Expert1CardsGen
     //! \param cards Data storage to store added cards with power.
     static void AddPriestNonCollect(std::map<std::string, Power>& cards);
 
-    //! Adds rogue cards that are not collectible to \p cards.
+    //! Adds rogue cards that are collectible to \p cards.
     //! \param cards Data storage to store added cards with power.
     static void AddRogue(std::map<std::string, Power>& cards);
 
@@ -77,7 +77,7 @@ class Expert1CardsGen
     //! \param cards Data storage to store added cards with power.
     static void AddRogueNonCollect(std::map<std::string, Power>& cards);
 
-    //! Adds shaman cards that are not collectible to \p cards.
+    //! Adds shaman cards that are collectible to \p cards.
     //! \param cards Data storage to store added cards with power.
     static void AddShaman(std::map<std::string, Power>& cards);
 
@@ -85,7 +85,7 @@ class Expert1CardsGen
     //! \param cards Data storage to store added cards with power.
     static void AddShamanNonCollect(std::map<std::string, Power>& cards);
 
-    //! Adds warlock cards that are not collectible to \p cards.
+    //! Adds warlock cards that are collectible to \p cards.
     //! \param cards Data storage to store added cards with power.
     static void AddWarlock(std::map<std::string, Power>& cards);
 
@@ -93,7 +93,7 @@ class Expert1CardsGen
     //! \param cards Data storage to store added cards with power.
     static void AddWarlockNonCollect(std::map<std::string, Power>& cards);
 
-    //! Adds warrior cards that are not collectible to \p cards.
+    //! Adds warrior cards that are collectible to \p cards.
     //! \param cards Data storage to store added cards with power.
     static void AddWarrior(std::map<std::string, Power>& cards);
 
@@ -101,7 +101,7 @@ class Expert1CardsGen
     //! \param cards Data storage to store added cards with power.
     static void AddWarriorNonCollect(std::map<std::string, Power>& cards);
 
-    //! Adds neutral cards that are not collectible to \p cards.
+    //! Adds neutral cards that are collectible to \p cards.
     //! \param cards Data storage to store added cards with power.
     static void AddNeutral(std::map<std::string, Power>& cards);
 

--- a/Includes/Rosetta/CardSets/Expert1CardsGen.hpp
+++ b/Includes/Rosetta/CardSets/Expert1CardsGen.hpp
@@ -109,6 +109,14 @@ class Expert1CardsGen
     //! \param cards Data storage to store added cards with power.
     static void AddNeutralNonCollect(std::map<std::string, Power>& cards);
 
+    //! Adds dream cards that are collectible to \p cards.
+    //! \param cards Data storage to store added cards with power.
+    static void AddDream(std::map<std::string, Power>& cards);
+
+    //! Adds Adds cards that are not collectible to \p cards.
+    //! \param cards Data storage to store added cards with power.
+    static void AddDreamNonCollect(std::map<std::string, Power>& cards);
+
     //! Adds all cards to \p cards.
     //! \param cards Data storage to store added cards with power.
     static void AddAll(std::map<std::string, Power>& cards);

--- a/Includes/Rosetta/Conditions/RelaCondition.hpp
+++ b/Includes/Rosetta/Conditions/RelaCondition.hpp
@@ -25,7 +25,11 @@ class RelaCondition
     //! \param func The function to check condition.
     explicit RelaCondition(std::function<bool(Entity*, Entity*)> func);
 
-    //! RelaCondition wrapper for checking an entity is positioned side by side.
+    //! RelaCondition wrapper for checking the entity is friendly.
+    //! \return Generated RelaCondition for intended purpose.
+    static RelaCondition IsFriendly();
+
+    //! RelaCondition wrapper for checking the entity is positioned side by side.
     //! \return Generated RelaCondition for intended purpose.
     static RelaCondition IsSideBySide();
 

--- a/Includes/Rosetta/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/Conditions/SelfCondition.hpp
@@ -87,11 +87,11 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsTagValue(GameTag tag, int value,
                                     RelaSign relaSign = RelaSign::EQ);
-   
-    //! SelfCondition wrapper for checking name of entity.
-    //! \param name The card name to check condition.
-    //! \param isEqual Decide whether to check for EQ or NE.
-    static SelfCondition IsName(std::string name, bool isEqual = true);
+
+    //! SelfCondition wrapper for checking the name of entity equals \p name.
+    //! \param name The name of card to check condition.
+    //! \param isEqual The flag to indicate the condition for equality.
+    static SelfCondition IsName(const std::string& name, bool isEqual = true);
 
     //! Evaluates condition using checking function.
     //! \param entity The owner entity.

--- a/Includes/Rosetta/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/Conditions/SelfCondition.hpp
@@ -31,6 +31,10 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsDead();
 
+    //! SelfCondition wrapper for checking the entity is not destroyed.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsNotDead();
+
     //! SelfCondition wrapper for checking the field is full.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsFieldFull();

--- a/Includes/Rosetta/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/Conditions/SelfCondition.hpp
@@ -87,6 +87,11 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsTagValue(GameTag tag, int value,
                                     RelaSign relaSign = RelaSign::EQ);
+   
+    //! SelfCondition wrapper for checking name of entity.
+    //! \param name The card name to check condition.
+    //! \param isEqual Decide whether to check for EQ or NE.
+    static SelfCondition IsName(std::string name, bool isEqual = true);
 
     //! Evaluates condition using checking function.
     //! \param entity The owner entity.

--- a/Includes/Rosetta/Enums/TriggerEnums.hpp
+++ b/Includes/Rosetta/Enums/TriggerEnums.hpp
@@ -24,6 +24,7 @@ enum class TriggerType
     AFTER_ATTACK,  //!< The effect will be triggered after an attack action is
                    //!< ended.
     SUMMON,  //!< The effect will be triggered whenever a minion is summoned.
+    AFTER_SUMMON,  //!< The effect will be triggered after a minion is summoned.
     AFTER_PLAY_MINION,  //!< The effect will be triggered after a minion is
                         //!< played.
     DEAL_DAMAGE,  //!< The effect will be triggered when a character is damaged.

--- a/Includes/Rosetta/Enums/TriggerEnums.hpp
+++ b/Includes/Rosetta/Enums/TriggerEnums.hpp
@@ -23,7 +23,9 @@ enum class TriggerType
     ATTACK,        //!< The effect will be triggered when characters attack.
     AFTER_ATTACK,  //!< The effect will be triggered after an attack action is
                    //!< ended.
-    SUMMON,     //!< The effect will be triggered whenever a minion is summoned.
+    SUMMON,  //!< The effect will be triggered whenever a minion is summoned.
+    AFTER_PLAY_MINION,  //!< The effect will be triggered after a minion is
+                        //!< played.
     DEAL_DAMAGE,  //!< The effect will be triggered when a character is damaged.
     TAKE_DAMAGE,  //!< The effect will be triggered when a spell or a character
                   //!< deals damages to source.
@@ -41,10 +43,11 @@ enum class TriggerSource
     SELF,
     HERO,
     ALL_MINIONS,
+    ENEMY_MINIONS,
     MINIONS_EXCEPT_SELF,
     ENCHANTMENT_TARGET,
+    ENEMY_SPELLS,
     FRIENDLY,
-    ENEMIES,
 };
 
 //! \brief An enumerator for identifying trigger activation.
@@ -61,6 +64,7 @@ enum class SequenceType
 {
     NONE,
     PLAY_CARD,
+    PLAY_MINION,
     PLAY_SPELL,
     TARGET
 };

--- a/Includes/Rosetta/Games/TriggerManager.hpp
+++ b/Includes/Rosetta/Games/TriggerManager.hpp
@@ -67,6 +67,11 @@ class TriggerManager
     //! \param sender An entity that is the source of trigger.
     void OnSummonTrigger(Player* player, Entity* sender) const;
 
+    //! Callback for trigger after entity is summoned.
+    //! \param player A player to execute trigger.
+    //! \param sender An entity that is the source of trigger.
+    void OnAfterSummonTrigger(Player* player, Entity* sender) const;
+
     //! Callback for trigger when entity deals damage.
     //! \param player A player to execute trigger.
     //! \param sender An entity that is the source of trigger.
@@ -91,6 +96,7 @@ class TriggerManager
     std::function<void(Player*, Entity*)> healTrigger;
     std::function<void(Player*, Entity*)> attackTrigger;
     std::function<void(Player*, Entity*)> summonTrigger;
+    std::function<void(Player*, Entity*)> afterSummonTrigger;
     std::function<void(Player*, Entity*)> dealDamageTrigger;
     std::function<void(Player*, Entity*)> takeDamageTrigger;
     std::function<void(Player*, Entity*)> targetTrigger;

--- a/Includes/Rosetta/Games/TriggerManager.hpp
+++ b/Includes/Rosetta/Games/TriggerManager.hpp
@@ -37,6 +37,11 @@ class TriggerManager
     //! \param sender An entity that is the source of trigger.
     void OnPlayCardTrigger(Player* player, Entity* sender) const;
 
+    //! Callback for trigger after player plays a minion.
+    //! \param player A player to execute trigger.
+    //! \param sender An entity that is the source of trigger.
+    void OnAfterPlayMinionTrigger(Player* player, Entity* sender) const;
+
     //! Callback for trigger when player plays a spell card.
     //! \param player A player to execute trigger.
     //! \param sender An entity that is the source of trigger.
@@ -80,6 +85,7 @@ class TriggerManager
     std::function<void(Player*, Entity*)> startTurnTrigger;
     std::function<void(Player*, Entity*)> endTurnTrigger;
     std::function<void(Player*, Entity*)> playCardTrigger;
+    std::function<void(Player*, Entity*)> afterPlayMinionTrigger;
     std::function<void(Player*, Entity*)> castSpellTrigger;
     std::function<void(Player*, Entity*)> afterCastTrigger;
     std::function<void(Player*, Entity*)> healTrigger;

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -13,6 +13,7 @@
 #include <Rosetta/Actions/AvailableActions.hpp>
 #include <Rosetta/Actions/CastSpell.hpp>
 #include <Rosetta/Actions/Choose.hpp>
+#include <Rosetta/Actions/Copy.hpp>
 #include <Rosetta/Actions/Draw.hpp>
 #include <Rosetta/Actions/Generic.hpp>
 #include <Rosetta/Actions/PlayCard.hpp>

--- a/Includes/Rosetta/Tasks/SimpleTasks/ConditionTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/ConditionTask.hpp
@@ -6,6 +6,7 @@
 #ifndef ROSETTASTONE_CONDITION_TASK_HPP
 #define ROSETTASTONE_CONDITION_TASK_HPP
 
+#include <Rosetta/Conditions/RelaCondition.hpp>
 #include <Rosetta/Conditions/SelfCondition.hpp>
 #include <Rosetta/Tasks/ITask.hpp>
 
@@ -19,11 +20,17 @@ namespace RosettaStone::SimpleTasks
 class ConditionTask : public ITask
 {
  public:
-    //! Constructs task with given \p entityType.
+    //! Constructs task with given \p entityType and \p selfConditions.
     //! \param entityType The entity type to check condition.
     //! \param selfConditions A container of self condition.
     explicit ConditionTask(EntityType entityType,
                            std::vector<SelfCondition> selfConditions);
+
+    //! Constructs task with given \p entityType and \p relaConditions.
+    //! \param entityType The entity type to check condition.
+    //! \param relaConditions A container of relation condition.
+    explicit ConditionTask(EntityType entityType,
+                           std::vector<RelaCondition> relaConditions);
 
     //! Returns task ID.
     //! \return Task ID.
@@ -36,6 +43,7 @@ class ConditionTask : public ITask
     TaskStatus Impl(Player& player) override;
 
     std::vector<SelfCondition> m_selfConditions;
+    std::vector<RelaCondition> m_relaConditions;
 };
 }  // namespace RosettaStone::SimpleTasks
 

--- a/Includes/Rosetta/Tasks/SimpleTasks/CopyTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/CopyTask.hpp
@@ -20,11 +20,13 @@ class CopyTask : public ITask
  public:
     //! Constructs task with given \p entityType and \p amount.
     //! \param entityType The type of entity.
-    //! \param amount The number of entities to copy.
-    //! \param isOpposite Whether an owner of entity is opposite player.
     //! \param zoneType The type of zone.
-    CopyTask(EntityType entityType, int amount, bool isOpposite = false,
-             ZoneType zoneType = ZoneType::INVALID);
+    //! \param amount The number of entities to copy.
+    //! \param addToStack The flag that indicates whether copied entity should
+    //! be added to the stack.
+    //! \param toOpposite The flag that indicates the owner of copied entity.
+    CopyTask(EntityType entityType, ZoneType zoneType, int amount = 1,
+             bool addToStack = false, bool toOpposite = false);
 
     //! Returns task ID.
     //! \return Task ID.
@@ -36,9 +38,10 @@ class CopyTask : public ITask
     //! \return The result of task processing.
     TaskStatus Impl(Player& player) override;
 
-    int m_amount = 0;
-    bool m_isOpposite = false;
     ZoneType m_zoneType = ZoneType::INVALID;
+    int m_amount = 0;
+    bool m_addToStack = false;
+    bool m_toOpposite = false;
 };
 }  // namespace RosettaStone::SimpleTasks
 

--- a/Includes/Rosetta/Tasks/SimpleTasks/FlagTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/FlagTask.hpp
@@ -20,8 +20,8 @@ class FlagTask : public ITask
  public:
     //! Constructs task with given \p flag and \p toDoTask.
     //! \param flag A flag to check previous task results.
-    //! \param toDoTask The task to run depending on flag.
-    explicit FlagTask(bool flag, ITask* toDoTask);
+    //! \param toDoTasks A list of tasks to run depending on flag.
+    explicit FlagTask(bool flag, std::vector<ITask*> toDoTasks);
 
     //! Returns task ID.
     //! \return Task ID.
@@ -34,7 +34,7 @@ class FlagTask : public ITask
     TaskStatus Impl(Player& player) override;
 
     bool m_flag = true;
-    ITask* m_toDoTask = nullptr;
+    std::vector<ITask*> m_toDoTasks;
 };
 }  // namespace RosettaStone::SimpleTasks
 

--- a/Includes/Rosetta/Tasks/SimpleTasks/SummonTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/SummonTask.hpp
@@ -31,18 +31,18 @@ class SummonTask : public ITask
  public:
     //! Constructs task with given \p side, \p card and \p amount.
     explicit SummonTask(SummonSide side = SummonSide::DEFAULT,
-                        const std::optional<Card>& card = std::nullopt,
+                        std::optional<Card> card = std::nullopt,
                         int amount = 1);
 
     //! Constructs task with given \p cardID and \p amount.
     //! \param cardID The card ID to summon.
     //! \param amount The number of minions to summon.
-    explicit SummonTask(std::string cardID, int amount);
+    explicit SummonTask(const std::string& cardID, int amount);
 
     //! Constructs task with given \p cardID and \p side.
     //! \param cardID The card ID to summon.
     //! \param side The side of summoned minion.
-    explicit SummonTask(std::string cardID,
+    explicit SummonTask(const std::string& cardID,
                         SummonSide side = SummonSide::DEFAULT);
 
     //! Returns task ID.

--- a/Sources/Rosetta/Actions/Copy.cpp
+++ b/Sources/Rosetta/Actions/Copy.cpp
@@ -62,7 +62,7 @@ Entity* Copy(Player& player, Entity* source, ZoneType targetZone,
             for (auto& e : source->appliedEnchantments)
             {
                 auto instance =
-                    Enchantment::GetInstance(player, e->card, source);
+                    Enchantment::GetInstance(player, e->card, copiedEntity);
                 if (e->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1) > 0)
                 {
                     instance->SetGameTag(

--- a/Sources/Rosetta/Actions/Copy.cpp
+++ b/Sources/Rosetta/Actions/Copy.cpp
@@ -1,0 +1,138 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/Actions/Copy.hpp>
+#include <Rosetta/Actions/Generic.hpp>
+#include <Rosetta/Actions/Summon.hpp>
+#include <Rosetta/Games/Game.hpp>
+#include <Rosetta/Models/Enchantment.hpp>
+
+namespace RosettaStone::Generic
+{
+Entity* Copy(Player& player, Entity* source, ZoneType targetZone,
+             bool deathrattle)
+{
+    //! \note Determine whether enchantments should be also copied.
+    //! Whenever a card moves forward in that flow (Deck -> Hand, Hand -> Play,
+    //! Deck -> Play), it retains enchantments. If a card moves backwards in
+    //! zones (Play -> Hand, Hand -> Deck, Play -> Deck, Play/Hand/Deck ->
+    //! Graveyard and Graveyard -> Play/Hand/Deck), it loses enchantments.
+    //! References: https://playhearthstone.com/en-gb/blog/21965466
+    bool copyEnchantments;
+    const ZoneType sourceZone =
+        (source->zone) ? source->zone->GetType() : ZoneType::PLAY;
+
+    if (sourceZone == ZoneType::GRAVEYARD)
+    {
+        copyEnchantments = false;
+    }
+    else if (sourceZone == targetZone)
+    {
+        copyEnchantments = true;
+    }
+    else if (targetZone == ZoneType::SETASIDE)
+    {
+        copyEnchantments = false;
+    }
+    else if (targetZone == ZoneType::PLAY)
+    {
+        copyEnchantments = true;
+    }
+    else if (sourceZone == ZoneType::DECK)
+    {
+        copyEnchantments = true;
+    }
+    else if (sourceZone == ZoneType::HAND && targetZone != ZoneType::DECK)
+    {
+        copyEnchantments = true;
+    }
+    else
+    {
+        copyEnchantments = false;
+    }
+
+    Entity* copiedEntity = Entity::GetFromCard(player, std::move(source->card));
+
+    if (copyEnchantments)
+    {
+        if (!source->appliedEnchantments.empty())
+        {
+            for (auto& e : source->appliedEnchantments)
+            {
+                auto instance =
+                    Enchantment::GetInstance(player, e->card, source);
+                if (e->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1) > 0)
+                {
+                    instance->SetGameTag(
+                        GameTag::TAG_SCRIPT_DATA_NUM_1,
+                        e->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1));
+
+                    if (e->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2) > 0)
+                    {
+                        instance->SetGameTag(
+                            GameTag::TAG_SCRIPT_DATA_NUM_2,
+                            e->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2));
+                    }
+                }
+            }
+        }
+
+        auto& oneTurnEffects = player.GetGame()->oneTurnEffects;
+        for (int i = static_cast<int>(oneTurnEffects.size()) - 1; i >= 0; --i)
+        {
+            if (oneTurnEffects[i].first->id == source->id)
+            {
+                oneTurnEffects.emplace_back(
+                    std::make_pair(copiedEntity, oneTurnEffects[i].second));
+            }
+        }
+    }
+
+    switch (targetZone)
+    {
+        case ZoneType::HAND:
+        {
+            AddCardToHand(player, copiedEntity);
+            break;
+        }
+        case ZoneType::DECK:
+        {
+            ShuffleIntoDeck(player, copiedEntity);
+            break;
+        }
+        case ZoneType::PLAY:
+        {
+            int position = -1;
+
+            if (deathrattle)
+            {
+                position = dynamic_cast<Minion*>(source)->GetLastBoardPos();
+                if (position > player.GetFieldZone().GetCount())
+                {
+                    position = player.GetFieldZone().GetCount();
+                }
+            }
+
+            Summon(player, dynamic_cast<Minion*>(copiedEntity), position);
+            break;
+        }
+        case ZoneType::SETASIDE:
+        {
+            player.GetSetasideZone().Add(*copiedEntity);
+            break;
+        }
+        default:
+            break;
+    }
+
+    if (copyEnchantments && source->onGoingEffect != nullptr &&
+        copiedEntity->onGoingEffect == nullptr)
+    {
+        source->onGoingEffect->Clone(copiedEntity);
+    }
+
+    return copiedEntity;
+}
+}  // namespace RosettaStone::Generic

--- a/Sources/Rosetta/Actions/Generic.cpp
+++ b/Sources/Rosetta/Actions/Generic.cpp
@@ -32,6 +32,19 @@ void AddCardToHand(Player& player, Entity* entity)
     player.GetHandZone().Add(*entity);
 }
 
+void ShuffleIntoDeck(Player& player, Entity* entity)
+{
+    // Add card to graveyard if deck is full
+    if (player.GetDeckZone().IsFull())
+    {
+        return;
+    }
+
+    // Add card into deck and shuffle it
+    player.GetDeckZone().Add(*entity);
+    player.GetDeckZone().Shuffle();
+}
+
 void ChangeManaCrystal(Player& player, int amount, bool fill)
 {
     // Available and maximum mana are up to a maximum of 10

--- a/Sources/Rosetta/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/Actions/PlayCard.cpp
@@ -96,6 +96,10 @@ void PlayCard(Player& player, Entity* source, Character* target, int fieldPos,
 void PlayMinion(Player& player, Minion* minion, Character* target, int fieldPos,
                 int chooseOne)
 {
+    // Validate play minion trigger
+    Trigger::ValidateTriggers(player.GetGame(), minion,
+                              SequenceType::PLAY_MINION);
+
     const int numMinionsPlayedThisTurn = player.GetNumMinionsPlayedThisTurn();
     player.SetNumMinionsPlayedThisTurn(numMinionsPlayedThisTurn + 1);
 
@@ -142,7 +146,14 @@ void PlayMinion(Player& player, Minion* minion, Character* target, int fieldPos,
     }
     player.GetGame()->ProcessTasks();
     player.GetGame()->taskQueue.EndEvent();
+
     player.GetGame()->ProcessDestroyAndUpdateAura();
+
+    // Process after play minion trigger
+    player.GetGame()->taskQueue.StartEvent();
+    player.GetGame()->triggerManager.OnAfterPlayMinionTrigger(&player, minion);
+    player.GetGame()->ProcessTasks();
+    player.GetGame()->taskQueue.EndEvent();
 }
 
 void PlaySpell(Player& player, Spell* spell, Character* target, int chooseOne)

--- a/Sources/Rosetta/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/Actions/PlayCard.cpp
@@ -154,6 +154,12 @@ void PlayMinion(Player& player, Minion* minion, Character* target, int fieldPos,
     player.GetGame()->triggerManager.OnAfterPlayMinionTrigger(&player, minion);
     player.GetGame()->ProcessTasks();
     player.GetGame()->taskQueue.EndEvent();
+
+    // Process after summon trigger
+    player.GetGame()->taskQueue.StartEvent();
+    player.GetGame()->triggerManager.OnAfterSummonTrigger(&player, minion);
+    player.GetGame()->ProcessTasks();
+    player.GetGame()->taskQueue.EndEvent();
 }
 
 void PlaySpell(Player& player, Spell* spell, Character* target, int chooseOne)

--- a/Sources/Rosetta/Actions/Summon.cpp
+++ b/Sources/Rosetta/Actions/Summon.cpp
@@ -15,5 +15,11 @@ void Summon(Player& player, Minion* minion, int fieldPos)
     player.GetGame()->UpdateAura();
 
     player.GetGame()->summonedMinions.emplace_back(minion);
+
+    // Process after summon trigger
+    player.GetGame()->taskQueue.StartEvent();
+    player.GetGame()->triggerManager.OnAfterSummonTrigger(&player, minion);
+    player.GetGame()->ProcessTasks();
+    player.GetGame()->taskQueue.EndEvent();
 }
 }  // namespace RosettaStone::Generic

--- a/Sources/Rosetta/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/CoreCardsGen.cpp
@@ -653,9 +653,9 @@ void CoreCardsGen::AddHunter(std::map<std::string, Power>& cards)
     power.AddPowerTask(new ConditionTask(
         EntityType::SOURCE, { SelfCondition::IsControllingRace(Race::BEAST) }));
     power.AddPowerTask(
-        new FlagTask(true, new DamageTask(EntityType::TARGET, 5, true)));
+        new FlagTask(true, { new DamageTask(EntityType::TARGET, 5, true) }));
     power.AddPowerTask(
-        new FlagTask(false, new DamageTask(EntityType::TARGET, 3, true)));
+        new FlagTask(false, { new DamageTask(EntityType::TARGET, 3, true) }));
     cards.emplace("EX1_539", power);
 
     // ----------------------------------------- SPELL - HUNTER
@@ -1786,7 +1786,7 @@ void CoreCardsGen::AddWarlock(std::map<std::string, Power>& cards)
     power.AddPowerTask(new DamageTask(EntityType::TARGET, 1, true));
     power.AddPowerTask(
         new ConditionTask(EntityType::TARGET, { SelfCondition::IsDead() }));
-    power.AddPowerTask(new FlagTask(true, new DrawTask(1)));
+    power.AddPowerTask(new FlagTask(true, { new DrawTask(1) }));
     cards.emplace("EX1_302", power);
 
     // --------------------------------------- MINION - NEUTRAL

--- a/Sources/Rosetta/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/CoreCardsGen.cpp
@@ -1151,7 +1151,7 @@ void CoreCardsGen::AddPriest(std::map<std::string, Power>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(new RandomTask(EntityType::ENEMY_HAND, 1));
-    power.AddPowerTask(new CopyTask(EntityType::STACK, 1));
+    power.AddPowerTask(new CopyTask(EntityType::STACK, ZoneType::HAND));
     power.AddPowerTask(new AddStackToTask(EntityType::HAND));
     cards.emplace("CS2_003", power);
 

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -906,8 +906,9 @@ void Expert1CardsGen::AddShamanNonCollect(std::map<std::string, Power>& cards)
     // Text: <b>Deathrattle:</b> Resummon this minion.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddDeathrattleTask(new CopyTask(EntityType::SOURCE, 1));
-    power.AddDeathrattleTask(new SummonTask(SummonSide::DEATHRATTLE));
+    power.AddDeathrattleTask(new CopyTask(EntityType::TARGET, 1));
+    power.AddDeathrattleTask(new SummonTask(SummonSide::RIGHT));
+    cards.emplace("CS2_038e", power);
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [CS2_053e] Far Sight (*) - COST:0

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -974,6 +974,21 @@ void Expert1CardsGen::AddWarlock(std::map<std::string, Power>& cards)
     power.AddPowerTask(new AddStackToTask(EntityType::HAND));
     cards.emplace("EX1_181", power);
 
+    // --------------------------------------- MINION - WARLOCK
+    // [EX1_301] Felguard - COST:3 [ATK:3/HP:5]
+    // - Race: Demon, Set: Expert1, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> Destroy one of your Mana Crystals.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - TAUNT = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new ManaCrystalTask(-1, false));
+    cards.emplace("EX1_301", power);
+    
     // ---------------------------------------- SPELL - WARLOCK
     // [EX1_309] Siphon Soul - COST:6
     // - Set: Expert1, Rarity: Rare

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -187,14 +187,15 @@ void Expert1CardsGen::AddHunter(std::map<std::string, Power>& cards)
     // - SECRET = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddTrigger(new Trigger(TriggerType::SUMMON));
-    power.GetTrigger()->triggerSource = TriggerSource::ENEMIES;
-    power.GetTrigger()->tasks = { new DamageTask(EntityType::TARGET, 4, true),
-                                  new SetGameTagTask(EntityType::SOURCE,
-                                                     GameTag::REVEALED, 1),
-                                  new MoveToGraveyardTask(EntityType::SOURCE) };
-    power.GetTrigger()->removeAfterTriggered = true;
-    power.GetTrigger()->fastExecution = true;
+    power.AddTrigger(new Trigger(TriggerType::AFTER_PLAY_MINION));
+    power.GetTrigger()->triggerSource = TriggerSource::ENEMY_MINIONS;
+    power.GetTrigger()->tasks = {
+        new ConditionTask(EntityType::TARGET, { SelfCondition::IsNotDead() }),
+        new FlagTask(true, { new DamageTask(EntityType::TARGET, 4, true),
+                             new SetGameTagTask(EntityType::SOURCE,
+                                                GameTag::REVEALED, 1),
+                             new MoveToGraveyardTask(EntityType::SOURCE) })
+    };
     cards.emplace("EX1_609", power);
 
     // ----------------------------------------- SPELL - HUNTER
@@ -265,7 +266,7 @@ void Expert1CardsGen::AddMage(std::map<std::string, Power>& cards)
     power.AddPowerTask(new DamageTask(EntityType::TARGET, 2, true));
     power.AddPowerTask(
         new ConditionTask(EntityType::TARGET, { SelfCondition::IsFrozen() }));
-    power.AddPowerTask(new FlagTask(true, new DrawTask(1)));
+    power.AddPowerTask(new FlagTask(true, { new DrawTask(1) }));
     cards.emplace("EX1_179", power);
 
     // ------------------------------------------- SPELL - MAGE
@@ -295,13 +296,12 @@ void Expert1CardsGen::AddMage(std::map<std::string, Power>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(new Trigger(TriggerType::CAST_SPELL));
-    power.GetTrigger()->triggerSource = TriggerSource::ENEMIES;
+    power.GetTrigger()->triggerSource = TriggerSource::ENEMY_SPELLS;
     power.GetTrigger()->tasks = {
         new SetGameTagTask(EntityType::TARGET, GameTag::CANT_PLAY, 1),
         new SetGameTagTask(EntityType::SOURCE, GameTag::REVEALED, 1),
         new MoveToGraveyardTask(EntityType::SOURCE)
     };
-    power.GetTrigger()->removeAfterTriggered = true;
     power.GetTrigger()->fastExecution = true;
     cards.emplace("EX1_287", power);
 
@@ -1816,10 +1816,10 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddPowerTask(new RandomTask(EntityType::ALL_MINIONS_NOSOURCE, 1));
     power.AddPowerTask(new ChanceTask(true));
-    power.AddPowerTask(
-        new FlagTask(true, new TransformTask(EntityType::STACK, "EX1_tk28")));
-    power.AddPowerTask(
-        new FlagTask(false, new TransformTask(EntityType::STACK, "EX1_tk29")));
+    power.AddPowerTask(new FlagTask(
+        true, { new TransformTask(EntityType::STACK, "EX1_tk28") }));
+    power.AddPowerTask(new FlagTask(
+        false, { new TransformTask(EntityType::STACK, "EX1_tk29") }));
     cards.emplace("EX1_083", power);
 
     // --------------------------------------- MINION - NEUTRAL
@@ -1841,8 +1841,10 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     power.AddPowerTask(new RandomTask(EntityType::STACK, 1));
     power.AddPowerTask(new ConditionTask(EntityType::SOURCE,
                                          { SelfCondition::IsFieldFull() }));
-    power.AddPowerTask(new FlagTask(true, new DestroyTask(EntityType::STACK)));
-    power.AddPowerTask(new FlagTask(false, new ControlTask(EntityType::STACK)));
+    power.AddPowerTask(
+        new FlagTask(true, { new DestroyTask(EntityType::STACK) }));
+    power.AddPowerTask(
+        new FlagTask(false, { new ControlTask(EntityType::STACK) }));
     cards.emplace("EX1_085", power);
 
     // --------------------------------------- MINION - NEUTRAL

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -33,6 +33,7 @@
 #include <Rosetta/Tasks/SimpleTasks/MathSubTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/MoveToGraveyardTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/RandomCardTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/RandomEntourageTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/RemoveEnchantmentTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/RemoveHandTask.hpp>
@@ -2050,6 +2051,21 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     cards.emplace("EX1_564", power);
 
     // --------------------------------------- MINION - NEUTRAL
+    // [EX1_572] Ysera - COST:9 [ATK:4/HP:12]
+    // - Race: Dragon, Set: Expert1, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: At the end of your turn, add a Dream Card to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new RandomEntourageTask(1));
+    power.AddPowerTask(new AddStackToTask(EntityType::HAND));
+    cards.emplace("EX1_572", power);
+
+    // --------------------------------------- MINION - NEUTRAL
     // [EX1_583] Priestess of Elune- COST:6 [ATK:5/HP:4]
     // - Set: Expert1, Rarity: Common
     // --------------------------------------------------------
@@ -2405,6 +2421,94 @@ void Expert1CardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
     cards.emplace("skele21", power);
 }
 
+void Expert1CardsGen::AddDream(std::map<std::string, Power>& cards)
+{
+    (void)cards;
+}
+
+void Expert1CardsGen::AddDreamNonCollect(std::map<std::string, Power>& cards)
+{
+    Power power;
+
+    // ----------------------------------------- MINION - DREAM
+    // [DREAM_01] Laughing Sister - COST:3 [ATK:3/HP:5]
+    // - Set: Expert1
+    // --------------------------------------------------------
+    // GameTag:
+    // - CANT_BE_TARGETED_BY_SPELLS = 1
+    // - CANT_BE_TARGETED_BY_HERO_POWERS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DREAM_01", power);
+
+    // ------------------------------------------ SPELL - DREAM
+    // [DREAM_02] Ysera Awakens - COST:2
+    // - Set: Expert1
+    // --------------------------------------------------------
+    // Text: Deal $5 damage to all characters except Ysera.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new IncludeTask(EntityType::ALL));
+    power.AddPowerTask(
+        new FilterStackTask(SelfCondition::IsName("Ysera", false)));
+    power.AddPowerTask(new DamageTask(EntityType::STACK, 5, true));
+    cards.emplace("DREAM_02", power);
+
+    // ----------------------------------------- MINION - DREAM
+    // [DREAM_03] Emerald Drake - COST:4 [ATK:7/HP:6]
+    // - Race: Dragon, Set: Expert1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DREAM_03", power);
+
+    // ------------------------------------------ SPELL - DREAM
+    // [DREAM_04] Dream - COST:0
+    // - Set: Expert1
+    // --------------------------------------------------------
+    // Text: Return a minion to its owner's hand.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new ReturnHandTask(EntityType::TARGET));
+    cards.emplace("DREAM_04", power);
+
+    // ------------------------------------------ SPELL - DREAM
+    // [DREAM_05] Nightmare - COST:0
+    // - Set: Expert1
+    // --------------------------------------------------------
+    // Text: Give a minion +5/+5.
+    //       At the start of your next turn, destroy it.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new AddEnchantmentTask("DREAM_05e", EntityType::TARGET));
+    cards.emplace("DREAM_05", power);
+
+    // ------------------------------------ ENCHANTMENT - DREAM
+    // [DREAM_05e] Nightmare (*) - COST:0
+    // - Set: Expert1
+    // --------------------------------------------------------
+    // Text: This minion has +5/+5, but will be destroyed soon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DREAM_05e"));
+    power.AddTrigger(new Trigger(TriggerType::TURN_START));
+    power.GetTrigger()->fastExecution = true;
+    power.GetTrigger()->tasks = { new DestroyTask(EntityType::TARGET) };
+    cards.emplace("DREAM_05e", power);
+}
+
 void Expert1CardsGen::AddAll(std::map<std::string, Power>& cards)
 {
     AddHeroes(cards);
@@ -2439,5 +2543,8 @@ void Expert1CardsGen::AddAll(std::map<std::string, Power>& cards)
 
     AddNeutral(cards);
     AddNeutralNonCollect(cards);
+
+    AddDream(cards);
+    AddDreamNonCollect(cards);
 }
 }  // namespace RosettaStone

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -249,6 +249,24 @@ void Expert1CardsGen::AddMage(std::map<std::string, Power>& cards)
     cards.emplace("CS2_028", power);
 
     // ------------------------------------------- SPELL - MAGE
+    // [EX1_179] Icicle - COST:2
+    // - Set: Expert1, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Deal $2 damage to a minion.
+    //       If it's <b>Frozen</b>, draw a card.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new DamageTask(EntityType::TARGET, 2, true));
+    power.AddPowerTask(new ConditionTask(EntityType::TARGET,
+                                        { SelfCondition::IsFrozen() }));
+    power.AddPowerTask(new FlagTask(true, new DrawTask(1)));
+    cards.emplace("EX1_179", power);
+
+    // ------------------------------------------- SPELL - MAGE
     // [EX1_279] Pyroblast - COST:10
     // - Faction: Neutral, Set: Expert1, Rarity: Epic
     // --------------------------------------------------------

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -196,6 +196,20 @@ void Expert1CardsGen::AddHunter(std::map<std::string, Power>& cards)
     power.GetTrigger()->removeAfterTriggered = true;
     power.GetTrigger()->fastExecution = true;
     cards.emplace("EX1_609", power);
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [EX1_617] Deadly Shot - COST:3
+    // - Set: EXPERT1, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Destroy a random enemy minion.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINIMUM_ENEMY_MINIONS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new RandomTask(EntityType::ENEMY_MINIONS, 1));
+    power.AddPowerTask(new DestroyTask(EntityType::STACK));
+    cards.emplace("EX1_617", power);
 }
 
 void Expert1CardsGen::AddHunterNonCollect(std::map<std::string, Power>& cards)

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -926,7 +926,7 @@ void Expert1CardsGen::AddShamanNonCollect(std::map<std::string, Power>& cards)
     // Text: <b>Deathrattle:</b> Resummon this minion.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddDeathrattleTask(new CopyTask(EntityType::SOURCE, 1));
+    power.AddDeathrattleTask(new CopyTask(EntityType::SOURCE, ZoneType::PLAY));
     power.AddDeathrattleTask(new SummonTask(SummonSide::DEATHRATTLE));
     cards.emplace("CS2_038e", power);
 
@@ -1922,14 +1922,15 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     // - Faction: Neutral, Set: Expert1, Rarity: Legendary
     // --------------------------------------------------------
     // Text: Whenever a player casts a spell, put a copy
-    //       into the other player’s hand.
+    //       into the other player's hand.
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(new Trigger(TriggerType::CAST_SPELL));
-    power.GetTrigger()->tasks = { new CopyTask(EntityType::TARGET, 1, true),
+    power.GetTrigger()->tasks = { new CopyTask(EntityType::TARGET,
+                                               ZoneType::HAND),
                                   new AddStackToTask(EntityType::HAND) };
     cards.emplace("EX1_100", power);
 

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -244,6 +244,7 @@ void Expert1CardsGen::AddMage(std::map<std::string, Power>& cards)
         new SetGameTagTask(EntityType::SOURCE, GameTag::REVEALED, 1),
         new MoveToGraveyardTask(EntityType::SOURCE)
     };
+    power.GetTrigger()->removeAfterTriggered = true;
     power.GetTrigger()->fastExecution = true;
     cards.emplace("EX1_287", power);
 

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -199,7 +199,7 @@ void Expert1CardsGen::AddHunter(std::map<std::string, Power>& cards)
 
     // ----------------------------------------- SPELL - HUNTER
     // [EX1_617] Deadly Shot - COST:3
-    // - Set: EXPERT1, Rarity: Common
+    // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
     // Text: Destroy a random enemy minion.
     // --------------------------------------------------------
@@ -257,6 +257,9 @@ void Expert1CardsGen::AddMage(std::map<std::string, Power>& cards)
     // PlayReq:
     // - REQ_MINION_TARGET = 0
     // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - FREEZE = 1
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(new DamageTask(EntityType::TARGET, 2, true));
@@ -993,14 +996,14 @@ void Expert1CardsGen::AddWarlock(std::map<std::string, Power>& cards)
 
     // --------------------------------------- MINION - WARLOCK
     // [EX1_301] Felguard - COST:3 [ATK:3/HP:5]
-    // - Race: Demon, Set: Expert1, Rarity: Rare
+    // - Race: Demon, Faction: Neutral, Set: Expert1, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     //       <b>Battlecry:</b> Destroy one of your Mana Crystals.
     // --------------------------------------------------------
     // GameTag:
-    // - BATTLECRY = 1
     // - TAUNT = 1
+    // - BATTLECRY = 1
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(new ManaCrystalTask(-1, false));
@@ -2069,13 +2072,14 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_572] Ysera - COST:9 [ATK:4/HP:12]
-    // - Race: Dragon, Set: Expert1, Rarity: Legendary
+    // - Race: Dragon, Faction: Neutral, Set: Expert1, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: At the end of your turn, add a Dream Card to your hand.
+    // Text: At the end of your turn, add a Dream Card to your hand.
+    // --------------------------------------------------------
+    // Entourage: DREAM_01, DREAM_02, DREAM_03, DREAM_04, DREAM_05
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
-    // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(new RandomEntourageTask(1));
@@ -2083,10 +2087,10 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     cards.emplace("EX1_572", power);
 
     // --------------------------------------- MINION - NEUTRAL
-    // [EX1_583] Priestess of Elune- COST:6 [ATK:5/HP:4]
-    // - Set: Expert1, Rarity: Common
+    // [EX1_583] Priestess of Elune - COST:6 [ATK:5/HP:4]
+    // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Restore #4 Health to your hero.
+    // Text: <b>Battlecry:</b> Restore 4 Health to your hero.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
@@ -2095,7 +2099,7 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     power.AddPowerTask(new HealTask(EntityType::HERO, 4));
     cards.emplace("EX1_583", power);
 
-    // ---- ----------------------------------- MINION - NEUTRAL
+    // --------------------------------------- MINION - NEUTRAL
     // [NEW1_019] Knife Juggler - COST:2 [ATK:2/HP:2]
     // - Set: Expert1, Rarity: Rare
     // --------------------------------------------------------
@@ -2186,6 +2190,9 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     // GameTag:
     // - ELITE = 1
     // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(new Trigger(TriggerType::TURN_END));
     power.GetTrigger()->tasks = { new SummonTask("NEW1_040t",
@@ -2245,6 +2252,19 @@ void Expert1CardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddAura(new EnrageEffect(AuraType::WEAPON, { Effects::AttackN(2) }));
     cards.emplace("CS2_221e", power);
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DREAM_05e] Nightmare (*) - COST:0
+    // - Set: Expert1
+    // --------------------------------------------------------
+    // Text: This minion has +5/+5, but will be destroyed soon.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DREAM_05e"));
+    power.AddTrigger(new Trigger(TriggerType::TURN_START));
+    power.GetTrigger()->fastExecution = true;
+    power.GetTrigger()->tasks = { new DestroyTask(EntityType::TARGET) };
+    cards.emplace("DREAM_05e", power);
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [EX1_001e] Warded (*) - COST:0
@@ -2419,6 +2439,8 @@ void Expert1CardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
     // [NEW1_040t] Gnoll (*) - COST:2 [ATK:2/HP:2]
     // - Set: Expert1
     // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
@@ -2427,8 +2449,8 @@ void Expert1CardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
     cards.emplace("NEW1_040t", power);
 
     // --------------------------------------- MINION - NEUTRAL
-    // [skele21] Damaged Golem - COST:1 [ATK:2/HP:1]
-    // - Race: Mechanical, Set: Expert1
+    // [skele21] Damaged Golem (*) - COST:1 [ATK:2/HP:1]
+    // - Race: Mechanical, Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -2440,8 +2462,10 @@ void Expert1CardsGen::AddDreamNonCollect(std::map<std::string, Power>& cards)
     Power power;
 
     // ----------------------------------------- MINION - DREAM
-    // [DREAM_01] Laughing Sister - COST:3 [ATK:3/HP:5]
+    // [DREAM_01] Laughing Sister (*) - COST:3 [ATK:3/HP:5]
     // - Set: Expert1
+    // --------------------------------------------------------
+    // Text: Can't be targeted by spells or Hero Powers.
     // --------------------------------------------------------
     // GameTag:
     // - CANT_BE_TARGETED_BY_SPELLS = 1
@@ -2465,7 +2489,7 @@ void Expert1CardsGen::AddDreamNonCollect(std::map<std::string, Power>& cards)
     cards.emplace("DREAM_02", power);
 
     // ----------------------------------------- MINION - DREAM
-    // [DREAM_03] Emerald Drake - COST:4 [ATK:7/HP:6]
+    // [DREAM_03] Emerald Drake (*) - COST:4 [ATK:7/HP:6]
     // - Race: Dragon, Set: Expert1
     // --------------------------------------------------------
     power.ClearData();
@@ -2473,49 +2497,32 @@ void Expert1CardsGen::AddDreamNonCollect(std::map<std::string, Power>& cards)
     cards.emplace("DREAM_03", power);
 
     // ------------------------------------------ SPELL - DREAM
-    // [DREAM_04] Dream - COST:0
+    // [DREAM_04] Dream (*) - COST:0
     // - Set: Expert1
     // --------------------------------------------------------
     // Text: Return a minion to its owner's hand.
     // --------------------------------------------------------
     // PlayReq:
-    // - REQ_MINION_TARGET = 0
     // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(new ReturnHandTask(EntityType::TARGET));
     cards.emplace("DREAM_04", power);
 
     // ------------------------------------------ SPELL - DREAM
-    // [DREAM_05] Nightmare - COST:0
+    // [DREAM_05] Nightmare (*) - COST:0
     // - Set: Expert1
     // --------------------------------------------------------
-    // Text: Give a minion +5/+5.
-    //       At the start of your next turn, destroy it.
+    // Text: Give a minion +5/+5. At the start of your next turn, destroy it.
     // --------------------------------------------------------
     // PlayReq:
-    // - REQ_MINION_TARGET = 0
     // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(new AddEnchantmentTask("DREAM_05e", EntityType::TARGET));
     cards.emplace("DREAM_05", power);
-
-    // ------------------------------------ ENCHANTMENT - DREAM
-    // [DREAM_05e] Nightmare (*) - COST:0
-    // - Set: Expert1
-    // --------------------------------------------------------
-    // Text: This minion has +5/+5, but will be destroyed soon.
-    // --------------------------------------------------------
-    // GameTag:
-    // - TRIGGER_VISUAL = 1
-    // --------------------------------------------------------
-    power.ClearData();
-    power.AddEnchant(Enchants::GetEnchantFromText("DREAM_05e"));
-    power.AddTrigger(new Trigger(TriggerType::TURN_START));
-    power.GetTrigger()->fastExecution = true;
-    power.GetTrigger()->tasks = { new DestroyTask(EntityType::TARGET) };
-    cards.emplace("DREAM_05e", power);
 }
 
 void Expert1CardsGen::AddAll(std::map<std::string, Power>& cards)

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -2021,6 +2021,19 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     cards.emplace("EX1_564", power);
 
     // --------------------------------------- MINION - NEUTRAL
+    // [EX1_583] Priestess of Elune- COST:6 [ATK:5/HP:4]
+    // - Set: Expert1, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Restore #4 Health to your hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new HealTask(EntityType::HERO, 4));
+    cards.emplace("EX1_583", power);
+
+    // --------------------------------------- MINION - NEUTRAL
     // [NEW1_020] Wild Pyromancer - COST:2 [ATK:3/HP:2]
     // - Set: Expert1, Rarity: Rare
     // --------------------------------------------------------

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -2039,7 +2039,8 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddDeathrattleTask(new SummonTask("skele21", SummonSide::RIGHT));
+    power.AddDeathrattleTask(
+        new SummonTask("skele21", SummonSide::DEATHRATTLE));
     cards.emplace("EX1_556", power);
 
     // --------------------------------------- MINION - NEUTRAL

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -174,6 +174,28 @@ void Expert1CardsGen::AddHunter(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddPowerTask(nullptr);
     cards.emplace("EX1_543", power);
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [EX1_609] Snipe - COST:2
+    // - Set: EXPERT1, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Secret:</b> After your opponent
+    //       plays a minion, deal $4 damage to it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(new Trigger(TriggerType::SUMMON));
+    power.GetTrigger()->triggerSource = TriggerSource::ENEMIES;
+    power.GetTrigger()->tasks = {
+        new DamageTask(EntityType::TARGET, 4, true),
+        new SetGameTagTask(EntityType::SOURCE, GameTag::REVEALED, 1),
+        new MoveToGraveyardTask(EntityType::SOURCE)
+    };
+    power.GetTrigger()->removeAfterTriggered = true;
+    power.GetTrigger()->fastExecution = true;
+    cards.emplace("EX1_609", power);
 }
 
 void Expert1CardsGen::AddHunterNonCollect(std::map<std::string, Power>& cards)

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1931,9 +1931,13 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(new Trigger(TriggerType::CAST_SPELL));
-    power.GetTrigger()->tasks = { new CopyTask(EntityType::TARGET,
-                                               ZoneType::HAND),
-                                  new AddStackToTask(EntityType::HAND) };
+    power.GetTrigger()->tasks = {
+        new ConditionTask(EntityType::TARGET, { RelaCondition::IsFriendly() }),
+        new FlagTask(true, { new CopyTask(EntityType::TARGET, ZoneType::HAND, 1,
+                                          false, true) }),
+        new FlagTask(false,
+                     { new CopyTask(EntityType::TARGET, ZoneType::HAND) })
+    };
     cards.emplace("EX1_100", power);
 
     // --------------------------------------- MINION - NEUTRAL
@@ -2482,7 +2486,7 @@ void Expert1CardsGen::AddDreamNonCollect(std::map<std::string, Power>& cards)
     cards.emplace("DREAM_01", power);
 
     // ------------------------------------------ SPELL - DREAM
-    // [DREAM_02] Ysera Awakens - COST:2
+    // [DREAM_02] Ysera Awakens (*) - COST:2
     // - Set: Expert1
     // --------------------------------------------------------
     // Text: Deal $5 damage to all characters except Ysera.

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -246,11 +246,35 @@ void Expert1CardsGen::AddMage(std::map<std::string, Power>& cards)
     };
     power.GetTrigger()->fastExecution = true;
     cards.emplace("EX1_287", power);
+
+    // ------------------------------------------ MINION - MAGE
+    // [NEW1_012] Mana Wyrm - COST:2 [ATK:1/HP:3]
+    // - Set: Expert1, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Whenever you cast a spell, gain +1 Attack.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(new Trigger(TriggerType::CAST_SPELL));
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    power.GetTrigger()->tasks = {
+        new AddEnchantmentTask("NEW1_012o", EntityType::SOURCE)
+    };
+    cards.emplace("NEW1_012", power);
 }
 
 void Expert1CardsGen::AddMageNonCollect(std::map<std::string, Power>& cards)
 {
-    (void)cards;
+    Power power;
+
+    // ------------------------------------- ENCHANTMENT - MAGE
+    // [NEW1_012o] Mana Gorged (*) - COST:0
+    // - Set: Expert1
+    // --------------------------------------------------------
+    // Text: Increased attack.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(new Enchant(Effects::AttackN(1)));
+    cards.emplace("NEW1_012o", power);
 }
 
 void Expert1CardsGen::AddPaladin(std::map<std::string, Power>& cards)

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -178,10 +178,10 @@ void Expert1CardsGen::AddHunter(std::map<std::string, Power>& cards)
 
     // ----------------------------------------- SPELL - HUNTER
     // [EX1_609] Snipe - COST:2
-    // - Set: EXPERT1, Rarity: Common
+    // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Secret:</b> After your opponent
-    //       plays a minion, deal $4 damage to it.
+    // Text: <b>Secret:</b> After your opponent plays a minion,
+    //       deal $4 damage to it.
     // --------------------------------------------------------
     // GameTag:
     // - SECRET = 1
@@ -189,11 +189,10 @@ void Expert1CardsGen::AddHunter(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddTrigger(new Trigger(TriggerType::SUMMON));
     power.GetTrigger()->triggerSource = TriggerSource::ENEMIES;
-    power.GetTrigger()->tasks = {
-        new DamageTask(EntityType::TARGET, 4, true),
-        new SetGameTagTask(EntityType::SOURCE, GameTag::REVEALED, 1),
-        new MoveToGraveyardTask(EntityType::SOURCE)
-    };
+    power.GetTrigger()->tasks = { new DamageTask(EntityType::TARGET, 4, true),
+                                  new SetGameTagTask(EntityType::SOURCE,
+                                                     GameTag::REVEALED, 1),
+                                  new MoveToGraveyardTask(EntityType::SOURCE) };
     power.GetTrigger()->removeAfterTriggered = true;
     power.GetTrigger()->fastExecution = true;
     cards.emplace("EX1_609", power);
@@ -261,8 +260,8 @@ void Expert1CardsGen::AddMage(std::map<std::string, Power>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(new DamageTask(EntityType::TARGET, 2, true));
-    power.AddPowerTask(new ConditionTask(EntityType::TARGET,
-                                        { SelfCondition::IsFrozen() }));
+    power.AddPowerTask(
+        new ConditionTask(EntityType::TARGET, { SelfCondition::IsFrozen() }));
     power.AddPowerTask(new FlagTask(true, new DrawTask(1)));
     cards.emplace("EX1_179", power);
 
@@ -312,9 +311,8 @@ void Expert1CardsGen::AddMage(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddTrigger(new Trigger(TriggerType::CAST_SPELL));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->tasks = {
-        new AddEnchantmentTask("NEW1_012o", EntityType::SOURCE)
-    };
+    power.GetTrigger()->tasks = { new AddEnchantmentTask("NEW1_012o",
+                                                         EntityType::SOURCE) };
     cards.emplace("NEW1_012", power);
 }
 
@@ -1007,7 +1005,7 @@ void Expert1CardsGen::AddWarlock(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddPowerTask(new ManaCrystalTask(-1, false));
     cards.emplace("EX1_301", power);
-    
+
     // ---------------------------------------- SPELL - WARLOCK
     // [EX1_309] Siphon Soul - COST:6
     // - Set: Expert1, Rarity: Rare
@@ -1997,7 +1995,8 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     // - REQ_TARGET_IF_AVAILABLE = 0
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(new SetGameTagTask(EntityType::TARGET, GameTag::FROZEN, 1));
+    power.AddPowerTask(
+        new SetGameTagTask(EntityType::TARGET, GameTag::FROZEN, 1));
     cards.emplace("EX1_283", power);
 
     // --------------------------------------- MINION - NEUTRAL
@@ -2109,10 +2108,8 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddTrigger(new Trigger(TriggerType::SUMMON));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->tasks = {
-        new RandomTask(EntityType::ENEMIES, 1),
-        new DamageTask(EntityType::STACK, 1)
-    };
+    power.GetTrigger()->tasks = { new RandomTask(EntityType::ENEMIES, 1),
+                                  new DamageTask(EntityType::STACK, 1) };
     cards.emplace("NEW1_019", power);
 
     // --------------------------------------- MINION - NEUTRAL
@@ -2191,9 +2188,8 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(new Trigger(TriggerType::TURN_END));
-    power.GetTrigger()->tasks = {
-        new SummonTask("NEW1_040t", SummonSide::RIGHT)
-    };
+    power.GetTrigger()->tasks = { new SummonTask("NEW1_040t",
+                                                 SummonSide::RIGHT) };
     cards.emplace("NEW1_040", power);
 
     // --------------------------------------- MINION - NEUTRAL
@@ -2208,8 +2204,8 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(new IncludeTask(EntityType::ENEMY_MINIONS));
-    power.AddPowerTask(
-        new FilterStackTask(SelfCondition::IsTagValue(GameTag::ATK, 2, RelaSign::LEQ)));
+    power.AddPowerTask(new FilterStackTask(
+        SelfCondition::IsTagValue(GameTag::ATK, 2, RelaSign::LEQ)));
     power.AddPowerTask(new RandomTask(EntityType::STACK, 1));
     power.AddPowerTask(new DestroyTask(EntityType::STACK));
     cards.emplace("NEW1_041", power);
@@ -2439,11 +2435,6 @@ void Expert1CardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
     cards.emplace("skele21", power);
 }
 
-void Expert1CardsGen::AddDream(std::map<std::string, Power>& cards)
-{
-    (void)cards;
-}
-
 void Expert1CardsGen::AddDreamNonCollect(std::map<std::string, Power>& cards)
 {
     Power power;
@@ -2562,7 +2553,6 @@ void Expert1CardsGen::AddAll(std::map<std::string, Power>& cards)
     AddNeutral(cards);
     AddNeutralNonCollect(cards);
 
-    AddDream(cards);
     AddDreamNonCollect(cards);
 }
 }  // namespace RosettaStone

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -2263,7 +2263,6 @@ void Expert1CardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddEnchant(Enchants::GetEnchantFromText("DREAM_05e"));
     power.AddTrigger(new Trigger(TriggerType::TURN_START));
-    power.GetTrigger()->fastExecution = true;
     power.GetTrigger()->tasks = { new DestroyTask(EntityType::TARGET) };
     cards.emplace("DREAM_05e", power);
 

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -926,8 +926,8 @@ void Expert1CardsGen::AddShamanNonCollect(std::map<std::string, Power>& cards)
     // Text: <b>Deathrattle:</b> Resummon this minion.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddDeathrattleTask(new CopyTask(EntityType::TARGET, 1));
-    power.AddDeathrattleTask(new SummonTask(SummonSide::RIGHT));
+    power.AddDeathrattleTask(new CopyTask(EntityType::SOURCE, 1));
+    power.AddDeathrattleTask(new SummonTask(SummonSide::DEATHRATTLE));
     cards.emplace("CS2_038e", power);
 
     // ----------------------------------- ENCHANTMENT - SHAMAN

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1992,6 +1992,19 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     cards.emplace("EX1_405", power);
 
     // --------------------------------------- MINION - NEUTRAL
+    // [EX1_556] Harvest Golem - COST:3 [ATK:2/HP:3]
+    // - Race: Mechanical, Set: Expert1, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon a 2/1 Damaged Golem.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(new SummonTask("skele21", SummonSide::RIGHT));
+    cards.emplace("EX1_556", power);
+
+    // --------------------------------------- MINION - NEUTRAL
     // [EX1_563] Malygos - COST:9 [ATK:4/HP:12]
     // - Race: Dragon, Faction: Neutral, Set: Expert1, Rarity: Legendary
     // --------------------------------------------------------
@@ -2347,6 +2360,14 @@ void Expert1CardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddPowerTask(nullptr);
     cards.emplace("NEW1_040t", power);
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [skele21] Damaged Golem - COST:1 [ATK:2/HP:1]
+    // - Race: Mechanical, Set: Expert1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("skele21", power);
 }
 
 void Expert1CardsGen::AddAll(std::map<std::string, Power>& cards)

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -2115,9 +2115,12 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddTrigger(new Trigger(TriggerType::SUMMON));
-    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->tasks = { new RandomTask(EntityType::ENEMIES, 1),
+    power.AddTrigger(new Trigger(TriggerType::AFTER_SUMMON));
+    power.GetTrigger()->triggerSource = TriggerSource::MINIONS_EXCEPT_SELF;
+    power.GetTrigger()->tasks = { new IncludeTask(EntityType::ENEMIES),
+                                  new FilterStackTask(
+                                      SelfCondition::IsNotDead()),
+                                  new RandomTask(EntityType::STACK, 1),
                                   new DamageTask(EntityType::STACK, 1) };
     cards.emplace("NEW1_019", power);
 
@@ -2222,7 +2225,6 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     power.AddPowerTask(new DestroyTask(EntityType::STACK));
     cards.emplace("NEW1_041", power);
 }
-
 void Expert1CardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
 {
     Power power;

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -2047,6 +2047,25 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     power.AddPowerTask(new HealTask(EntityType::HERO, 4));
     cards.emplace("EX1_583", power);
 
+    // ---- ----------------------------------- MINION - NEUTRAL
+    // [NEW1_019] Knife Juggler - COST:2 [ATK:2/HP:2]
+    // - Set: Expert1, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: After you summon a minion,
+    //       deal 1 damage to a random enemy.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(new Trigger(TriggerType::SUMMON));
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    power.GetTrigger()->tasks = {
+        new RandomTask(EntityType::ENEMIES, 1),
+        new DamageTask(EntityType::STACK, 1)
+    };
+    cards.emplace("NEW1_019", power);
+
     // --------------------------------------- MINION - NEUTRAL
     // [NEW1_020] Wild Pyromancer - COST:2 [ATK:3/HP:2]
     // - Set: Expert1, Rarity: Rare

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -2083,8 +2083,9 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     // - ELITE = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(new RandomEntourageTask(1));
-    power.AddPowerTask(new AddStackToTask(EntityType::HAND));
+    power.AddTrigger(new Trigger(TriggerType::TURN_END));
+    power.GetTrigger()->tasks = { new RandomEntourageTask(1),
+                                  new AddStackToTask(EntityType::HAND) };
     cards.emplace("EX1_572", power);
 
     // --------------------------------------- MINION - NEUTRAL

--- a/Sources/Rosetta/CardSets/HoFCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/HoFCardsGen.cpp
@@ -88,9 +88,9 @@ void HoFCardsGen::AddMage(std::map<std::string, Power>& cards)
     power.AddPowerTask(
         new ConditionTask(EntityType::TARGET, { SelfCondition::IsFrozen() }));
     power.AddPowerTask(
-        new FlagTask(true, new DamageTask(EntityType::TARGET, 4, true)));
+        new FlagTask(true, { new DamageTask(EntityType::TARGET, 4, true) }));
     power.AddPowerTask(new FlagTask(
-        false, new SetGameTagTask(EntityType::TARGET, GameTag::FROZEN, 1)));
+        false, { new SetGameTagTask(EntityType::TARGET, GameTag::FROZEN, 1) }));
     cards.emplace("CS2_031", power);
 }
 

--- a/Sources/Rosetta/Conditions/RelaCondition.cpp
+++ b/Sources/Rosetta/Conditions/RelaCondition.cpp
@@ -16,6 +16,13 @@ RelaCondition::RelaCondition(std::function<bool(Entity*, Entity*)> func)
     // Do nothing
 }
 
+RelaCondition RelaCondition::IsFriendly()
+{
+    return RelaCondition([=](Entity* me, Entity* other) -> bool {
+        return me->owner == other->owner;
+    });
+}
+
 RelaCondition RelaCondition::IsSideBySide()
 {
     return RelaCondition([=](Entity* me, Entity* other) -> bool {

--- a/Sources/Rosetta/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/Conditions/SelfCondition.cpp
@@ -6,6 +6,7 @@
 #include <Rosetta/Conditions/SelfCondition.hpp>
 #include <Rosetta/Games/Game.hpp>
 
+#include <string>
 #include <utility>
 
 namespace RosettaStone
@@ -138,9 +139,15 @@ SelfCondition SelfCondition::IsTagValue(GameTag tag, int value,
 {
     return SelfCondition([=](Entity* entity) -> bool {
         return (relaSign == RelaSign::EQ && entity->GetGameTag(tag) == value) ||
-               (relaSign == RelaSign::GEQ &&
-                entity->GetGameTag(tag) >= value) ||
+               (relaSign == RelaSign::GEQ && entity->GetGameTag(tag) >= value) ||
                (relaSign == RelaSign::LEQ && entity->GetGameTag(tag) <= value);
+    });
+}
+
+SelfCondition SelfCondition::IsName(std::string name, bool isEqual)
+{
+    return SelfCondition([=](Entity* entity) -> bool {
+        return !((entity->card.name == name) ^ isEqual);
     });
 }
 

--- a/Sources/Rosetta/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/Conditions/SelfCondition.cpp
@@ -144,7 +144,7 @@ SelfCondition SelfCondition::IsTagValue(GameTag tag, int value,
     });
 }
 
-SelfCondition SelfCondition::IsName(std::string name, bool isEqual)
+SelfCondition SelfCondition::IsName(const std::string& name, bool isEqual)
 {
     return SelfCondition([=](Entity* entity) -> bool {
         return !((entity->card.name == name) ^ isEqual);

--- a/Sources/Rosetta/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/Conditions/SelfCondition.cpp
@@ -23,6 +23,12 @@ SelfCondition SelfCondition::IsDead()
         [=](Entity* entity) -> bool { return entity->isDestroyed; });
 }
 
+SelfCondition SelfCondition::IsNotDead()
+{
+    return SelfCondition(
+        [=](Entity* entity) -> bool { return !entity->isDestroyed; });
+}
+
 SelfCondition SelfCondition::IsFieldFull()
 {
     return SelfCondition([=](Entity* entity) -> bool {

--- a/Sources/Rosetta/Enchants/Trigger.cpp
+++ b/Sources/Rosetta/Enchants/Trigger.cpp
@@ -330,11 +330,11 @@ void Trigger::ProcessInternal(Entity* source)
         {
             m_owner->owner->GetGame()->taskQueue.Enqueue(task);
         }
+    }
 
-        if (removeAfterTriggered)
-        {
-            Remove();
-        }
+    if (removeAfterTriggered)
+    {
+        Remove();
     }
 
     m_isValidated = false;

--- a/Sources/Rosetta/Enchants/Trigger.cpp
+++ b/Sources/Rosetta/Enchants/Trigger.cpp
@@ -18,6 +18,9 @@ Trigger::Trigger(TriggerType type) : m_triggerType(type)
         case TriggerType::PLAY_CARD:
             m_sequenceType = SequenceType::PLAY_CARD;
             break;
+        case TriggerType::AFTER_PLAY_MINION:
+            m_sequenceType = SequenceType::PLAY_MINION;
+            break;
         case TriggerType::CAST_SPELL:
         case TriggerType::AFTER_CAST:
             m_sequenceType = SequenceType::PLAY_SPELL;
@@ -82,6 +85,10 @@ void Trigger::Activate(Entity* source, TriggerActivation activation,
             break;
         case TriggerType::PLAY_CARD:
             game->triggerManager.playCardTrigger = std::move(triggerFunc);
+            break;
+        case TriggerType::AFTER_PLAY_MINION:
+            game->triggerManager.afterPlayMinionTrigger =
+                std::move(triggerFunc);
             break;
         case TriggerType::CAST_SPELL:
             game->triggerManager.castSpellTrigger = std::move(triggerFunc);
@@ -180,6 +187,9 @@ void Trigger::Remove() const
             break;
         case TriggerType::PLAY_CARD:
             game->triggerManager.playCardTrigger = nullptr;
+            break;
+        case TriggerType::AFTER_PLAY_MINION:
+            game->triggerManager.afterPlayMinionTrigger = nullptr;
             break;
         case TriggerType::CAST_SPELL:
             game->triggerManager.castSpellTrigger = nullptr;
@@ -365,6 +375,13 @@ void Trigger::Validate(Player* player, Entity* source)
                 return;
             }
             break;
+        case TriggerSource::ENEMY_MINIONS:
+            if (dynamic_cast<Minion*>(source) == nullptr ||
+                source->owner == m_owner->owner)
+            {
+                return;
+            }
+            break;
         case TriggerSource::MINIONS_EXCEPT_SELF:
             if (dynamic_cast<Minion*>(source) == nullptr ||
                 source->owner != m_owner->owner || source == m_owner)
@@ -382,6 +399,15 @@ void Trigger::Validate(Player* player, Entity* source)
             }
             break;
         }
+        case TriggerSource::ENEMY_SPELLS:
+        {
+            if (dynamic_cast<Spell*>(source) == nullptr ||
+                source->owner == m_owner->owner)
+            {
+                return;
+            }
+            break;
+        }
         case TriggerSource::FRIENDLY:
         {
             if (source->owner != m_owner->owner)
@@ -390,12 +416,6 @@ void Trigger::Validate(Player* player, Entity* source)
             }
             break;
         }
-        case TriggerSource::ENEMIES:
-             if (source->owner == m_owner->owner)
-            {
-                return;
-            }
-            break;
         default:
             break;
     }

--- a/Sources/Rosetta/Enchants/Trigger.cpp
+++ b/Sources/Rosetta/Enchants/Trigger.cpp
@@ -132,6 +132,9 @@ void Trigger::Activate(Entity* source, TriggerActivation activation,
         case TriggerType::SUMMON:
             game->triggerManager.summonTrigger = std::move(triggerFunc);
             break;
+        case TriggerType::AFTER_SUMMON:
+            game->triggerManager.afterSummonTrigger = std::move(triggerFunc);
+            break;
         case TriggerType::DEAL_DAMAGE:
             game->triggerManager.dealDamageTrigger = std::move(triggerFunc);
             break;
@@ -231,6 +234,9 @@ void Trigger::Remove() const
             }
         case TriggerType::SUMMON:
             game->triggerManager.summonTrigger = nullptr;
+            break;
+        case TriggerType::AFTER_SUMMON:
+            game->triggerManager.afterSummonTrigger = nullptr;
             break;
         case TriggerType::DEAL_DAMAGE:
             game->triggerManager.dealDamageTrigger = nullptr;
@@ -431,6 +437,7 @@ void Trigger::Validate(Player* player, Entity* source)
             break;
         case TriggerType::PLAY_CARD:
         case TriggerType::SUMMON:
+        case TriggerType::AFTER_SUMMON:
             if (source == m_owner)
             {
                 return;

--- a/Sources/Rosetta/Games/Game.cpp
+++ b/Sources/Rosetta/Games/Game.cpp
@@ -10,6 +10,7 @@
 #include <Rosetta/Enchants/Power.hpp>
 #include <Rosetta/Games/Game.hpp>
 #include <Rosetta/Games/GameManager.hpp>
+#include <Rosetta/Models/Enchantment.hpp>
 #include <Rosetta/Policies/Policy.hpp>
 #include <Rosetta/Tasks/ITask.hpp>
 #include <Rosetta/Tasks/PlayerTasks/ChooseTask.hpp>
@@ -527,6 +528,11 @@ void Game::ProcessGraveyard()
             if (minion->HasDeathrattle())
             {
                 minion->ActivateTask(PowerType::DEATHRATTLE);
+            }
+            
+            for (Enchantment* enchant : minion->appliedEnchantments)
+            {
+                enchant->ActivateTask(PowerType::DEATHRATTLE, minion);
             }
 
             // Add minion to graveyard

--- a/Sources/Rosetta/Games/Game.cpp
+++ b/Sources/Rosetta/Games/Game.cpp
@@ -10,7 +10,6 @@
 #include <Rosetta/Enchants/Power.hpp>
 #include <Rosetta/Games/Game.hpp>
 #include <Rosetta/Games/GameManager.hpp>
-#include <Rosetta/Models/Enchantment.hpp>
 #include <Rosetta/Policies/Policy.hpp>
 #include <Rosetta/Tasks/ITask.hpp>
 #include <Rosetta/Tasks/PlayerTasks/ChooseTask.hpp>
@@ -528,11 +527,6 @@ void Game::ProcessGraveyard()
             if (minion->HasDeathrattle())
             {
                 minion->ActivateTask(PowerType::DEATHRATTLE);
-            }
-            
-            for (Enchantment* enchant : minion->appliedEnchantments)
-            {
-                enchant->ActivateTask(PowerType::DEATHRATTLE, minion);
             }
 
             // Add minion to graveyard

--- a/Sources/Rosetta/Games/TriggerManager.cpp
+++ b/Sources/Rosetta/Games/TriggerManager.cpp
@@ -81,6 +81,14 @@ void TriggerManager::OnSummonTrigger(Player* player, Entity* sender) const
     }
 }
 
+void TriggerManager::OnAfterSummonTrigger(Player* player, Entity* sender) const
+{
+    if (afterSummonTrigger != nullptr)
+    {
+        afterSummonTrigger(player, sender);
+    }
+}
+
 void TriggerManager::OnDealDamageTrigger(Player* player, Entity* sender) const
 {
     if (dealDamageTrigger != nullptr)

--- a/Sources/Rosetta/Games/TriggerManager.cpp
+++ b/Sources/Rosetta/Games/TriggerManager.cpp
@@ -32,6 +32,15 @@ void TriggerManager::OnPlayCardTrigger(Player* player, Entity* sender) const
     }
 }
 
+void TriggerManager::OnAfterPlayMinionTrigger(Player* player,
+                                              Entity* sender) const
+{
+    if (afterPlayMinionTrigger != nullptr)
+    {
+        afterPlayMinionTrigger(player, sender);
+    }
+}
+
 void TriggerManager::OnCastSpellTrigger(Player* player, Entity* sender) const
 {
     if (castSpellTrigger != nullptr)

--- a/Sources/Rosetta/Models/Enchantment.cpp
+++ b/Sources/Rosetta/Models/Enchantment.cpp
@@ -42,13 +42,25 @@ Entity* Enchantment::GetTarget() const
 
 void Enchantment::Remove()
 {
+    if (!card.power.GetDeathrattleTask().empty())
+    {
+        for (auto& power : card.power.GetDeathrattleTask())
+        {
+            power->SetPlayer(m_target->owner);
+            power->SetSource(m_target);
+            power->SetTarget(this);
+
+            owner->GetGame()->taskQueue.Enqueue(power);
+        }
+    }
+
     if (activatedTrigger != nullptr)
     {
         activatedTrigger->Remove();
     }
 
-    auto iter = std::find(m_target->appliedEnchantments.begin(),
-                          m_target->appliedEnchantments.end(), this);
+    const auto iter = std::find(m_target->appliedEnchantments.begin(),
+                                m_target->appliedEnchantments.end(), this);
     if (iter != m_target->appliedEnchantments.end())
     {
         m_target->appliedEnchantments.erase(iter);

--- a/Sources/Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.cpp
@@ -56,6 +56,11 @@ TaskStatus AddEnchantmentTask::Impl(Player& player)
             power.GetEnchant()->ActivateTo(entity, taskStack.num,
                                            taskStack.num1);
         }
+
+        if (!power.GetDeathrattleTask().empty())
+        {
+            m_target->SetGameTag(GameTag::DEATHRATTLE, 1);
+        }
     }
 
     return TaskStatus::COMPLETE;

--- a/Sources/Rosetta/Tasks/SimpleTasks/ConditionTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/ConditionTask.cpp
@@ -18,6 +18,13 @@ ConditionTask::ConditionTask(EntityType entityType,
     // Do nothing
 }
 
+ConditionTask::ConditionTask(EntityType entityType,
+                             std::vector<RelaCondition> relaConditions)
+    : ITask(entityType), m_relaConditions(std::move(relaConditions))
+{
+    // Do nothing
+}
+
 TaskID ConditionTask::GetTaskID() const
 {
     return TaskID::CONDITION;
@@ -39,6 +46,11 @@ TaskStatus ConditionTask::Impl(Player& player)
         for (auto& condition : m_selfConditions)
         {
             flag = flag && condition.Evaluate(entity);
+        }
+
+        for (auto& condition : m_relaConditions)
+        {
+            flag = flag && condition.Evaluate(m_source, entity);
         }
     }
 

--- a/Sources/Rosetta/Tasks/SimpleTasks/CopyTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/CopyTask.cpp
@@ -3,20 +3,22 @@
 // RosettaStone is hearthstone simulator using C++ with reinforcement learning.
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
+#include <Rosetta/Actions/Copy.hpp>
 #include <Rosetta/Actions/Generic.hpp>
 #include <Rosetta/Cards/Cards.hpp>
 #include <Rosetta/Games/Game.hpp>
+#include <Rosetta/Models/Enchantment.hpp>
 #include <Rosetta/Tasks/SimpleTasks/CopyTask.hpp>
-#include <Rosetta/Tasks/SimpleTasks/IncludeTask.hpp>
-#include <iostream>
+
 namespace RosettaStone::SimpleTasks
 {
-CopyTask::CopyTask(EntityType entityType, int amount, bool isOpposite,
-                   ZoneType zoneType)
+CopyTask::CopyTask(EntityType entityType, ZoneType zoneType, int amount,
+                   bool addToStack, bool toOpposite)
     : ITask(entityType),
+      m_zoneType(zoneType),
       m_amount(amount),
-      m_isOpposite(isOpposite),
-      m_zoneType(zoneType)
+      m_addToStack(addToStack),
+      m_toOpposite(toOpposite)
 {
     // Do nothing
 }
@@ -28,41 +30,102 @@ TaskID CopyTask::GetTaskID() const
 
 TaskStatus CopyTask::Impl(Player& player)
 {
+    Player& owner = (m_toOpposite) ? *player.opponent : player;
+    IZone* targetZone = Generic::GetZone(owner, m_zoneType);
+
+    if (targetZone == nullptr || targetZone->IsFull())
+    {
+        return TaskStatus::STOP;
+    }
+
     std::vector<Entity*> result;
 
-    Player* owner = (m_isOpposite) ? player.opponent : &player;
-    IZone* zone = Generic::GetZone(*owner, m_zoneType);
-
-    auto entities = IncludeTask::GetEntities(m_entityType, *owner, m_source, m_target);
-
-    if (entities.empty())
+    if (m_entityType == EntityType::STACK)
     {
-        return TaskStatus::STOP;
-    }
-
-    if (zone != nullptr && zone->IsFull())
-    {
-        return TaskStatus::STOP;
-    }
-
-    if (m_amount < 1 || (m_amount != 1 && entities.size() != 1))
-    {
-        return TaskStatus::STOP;
-    }
-
-    for (int i = 0; i < m_amount; ++i)
-    {
-        for (auto& entity : entities)
+        if (player.GetGame()->taskStack.entities.empty())
         {
-            Card card = 
-                Cards::GetInstance().FindCardByID(entity->card.id);
-            result.emplace_back(Entity::GetFromCard(
-                player, std::move(card), std::nullopt, zone
-            ));
+            return TaskStatus::STOP;
+        }
+
+        for (auto& entity : player.GetGame()->taskStack.entities)
+        {
+            Entity* copied = Generic::Copy(owner, entity, m_zoneType);
+
+            if (m_addToStack)
+            {
+                result.emplace_back(copied);
+            }
+
+            if (targetZone->IsFull())
+            {
+                if (m_addToStack)
+                {
+                    player.GetGame()->taskStack.entities = result;
+                }
+
+                return TaskStatus::COMPLETE;
+            }
         }
     }
-    
-    owner->GetGame()->taskStack.entities = result;
+    else
+    {
+        Entity* toBeCopied;
+        bool deathrattle = false;
+
+        switch (m_entityType)
+        {
+            case EntityType::SOURCE:
+            {
+                toBeCopied = m_source;
+
+                auto enchantment = dynamic_cast<Enchantment*>(m_target);
+                deathrattle =
+                    (m_zoneType == ZoneType::PLAY) &&
+                    (enchantment != nullptr) &&
+                    (!enchantment->card.power.GetDeathrattleTask().empty());
+                break;
+            }
+            case EntityType::TARGET:
+            {
+                toBeCopied = m_target;
+                break;
+            }
+            default:
+                throw std::invalid_argument(
+                    "CopyTask::Impl() - Invalid entity type");                
+        }
+
+        if (toBeCopied == nullptr)
+        {
+            return TaskStatus::STOP;
+        }
+
+        for (int i = 0; i < m_amount; ++i)
+        {
+            Entity* copied =
+                Generic::Copy(owner, toBeCopied, m_zoneType, deathrattle);
+
+            if (m_addToStack)
+            {
+                result.emplace_back(copied);
+            }
+
+            if (targetZone->IsFull())
+            {
+                if (m_addToStack)
+                {
+                    player.GetGame()->taskStack.entities = result;
+                }
+
+                return TaskStatus::COMPLETE;
+            }
+        }
+    }
+
+    if (m_addToStack)
+    {
+        player.GetGame()->taskStack.entities = result;
+    }
 
     return TaskStatus::COMPLETE;
 }

--- a/Sources/Rosetta/Tasks/SimpleTasks/FlagTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/FlagTask.cpp
@@ -6,10 +6,12 @@
 #include <Rosetta/Games/Game.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FlagTask.hpp>
 
+#include <utility>
+
 namespace RosettaStone::SimpleTasks
 {
-FlagTask::FlagTask(bool flag, ITask* toDoTask)
-    : m_flag(flag), m_toDoTask(toDoTask)
+FlagTask::FlagTask(bool flag, std::vector<ITask*> toDoTasks)
+    : m_flag(flag), m_toDoTasks(std::move(toDoTasks))
 {
     // Do nothing
 }
@@ -26,10 +28,15 @@ TaskStatus FlagTask::Impl(Player& player)
         return TaskStatus::COMPLETE;
     }
 
-    m_toDoTask->SetPlayer(&player);
-    m_toDoTask->SetSource(player.GetGame()->taskStack.source);
-    m_toDoTask->SetTarget(player.GetGame()->taskStack.target);
+    for (auto& task : m_toDoTasks)
+    {
+        task->SetPlayer(&player);
+        task->SetSource(player.GetGame()->taskStack.source);
+        task->SetTarget(player.GetGame()->taskStack.target);
 
-    return m_toDoTask->Run();
+        task->Run();
+    }
+
+    return TaskStatus::COMPLETE;
 }
 }  // namespace RosettaStone::SimpleTasks

--- a/Sources/Rosetta/Tasks/SimpleTasks/MoveToGraveyardTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/MoveToGraveyardTask.cpp
@@ -26,6 +26,7 @@ TaskStatus MoveToGraveyardTask::Impl(Player& player)
 
     for (auto& entity : entities)
     {
+        entity->zone->Remove(*entity);
         entity->owner->GetGraveyardZone().Add(*entity);
     }
 

--- a/Sources/Rosetta/Tasks/SimpleTasks/SummonTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/SummonTask.cpp
@@ -6,6 +6,7 @@
 #include <Rosetta/Actions/Summon.hpp>
 #include <Rosetta/Cards/Cards.hpp>
 #include <Rosetta/Games/Game.hpp>
+#include <Rosetta/Models/Enchantment.hpp>
 #include <Rosetta/Tasks/SimpleTasks/SummonTask.hpp>
 #include <Rosetta/Zones/FieldZone.hpp>
 
@@ -37,6 +38,8 @@ TaskID SummonTask::GetTaskID() const
 
 TaskStatus SummonTask::Impl(Player& player)
 {
+    Entity* posBase;
+
     for (int i = 0; i < m_amount; ++i)
     {
         if (player.GetFieldZone().IsFull())
@@ -65,6 +68,17 @@ TaskStatus SummonTask::Impl(Player& player)
         {
             return TaskStatus::STOP;
         }
+        
+        const auto enchant =  dynamic_cast<Enchantment*>(m_source);
+        if (enchant != nullptr && enchant->GetTarget() != nullptr)
+        {
+            posBase = enchant->GetTarget();
+        }
+        else
+        {
+            posBase = m_source;
+        }
+        
 
         int summonPos;
         switch (m_side)
@@ -74,20 +88,21 @@ TaskStatus SummonTask::Impl(Player& player)
                 break;
             case SummonSide::RIGHT:
             {
-                if (m_source->zone->GetType() == ZoneType::PLAY)
+                if (posBase->zone->GetType() == ZoneType::PLAY)
                 {
-                    summonPos = m_source->GetZonePosition() + 1;
+                    summonPos = posBase->GetZonePosition() + 1;
                 }
                 else
                 {
                     summonPos =
-                        dynamic_cast<Minion*>(m_source)->GetLastBoardPos();
+                        dynamic_cast<Minion*>(posBase)->GetLastBoardPos();
                 }
                 break;
             }
             case SummonSide::NUMBER:
-                summonPos = m_source->owner->GetGame()->taskStack.num - 1;
+                summonPos = posBase->owner->GetGame()->taskStack.num - 1;
                 break;
+            
             default:
                 throw std::invalid_argument(
                     "SummonTask::Impl() - Invalid summon side");

--- a/Tests/UnitTests/Actions/ChooseTests.cpp
+++ b/Tests/UnitTests/Actions/ChooseTests.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#include "gtest/gtest.h"
+
+#include <Rosetta/Actions/Choose.hpp>
+#include <Rosetta/Enums/CardEnums.hpp>
+#include <Rosetta/Games/Game.hpp>
+
+using namespace RosettaStone;
+
+TEST(Choose, ChoiceMulligan)
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+
+    const std::vector<std::size_t> curChoices, opChoices;
+
+    auto curHand = curPlayer.GetHandZone().GetAll();
+    auto opHand = opPlayer.GetHandZone().GetAll();
+
+    Choice curChoice, opChoice;
+
+    curChoice.choiceAction = ChoiceAction::HAND;
+    curChoice.choices = curChoices;
+    curChoice.choiceType = ChoiceType::MULLIGAN;
+
+    opChoice.choiceAction = ChoiceAction::HAND;
+    opChoice.choices = opChoices;
+    opChoice.choiceType = ChoiceType::MULLIGAN;
+
+    curPlayer.choice = curChoice;
+    opPlayer.choice = opChoice;
+
+    int curHandCount = curPlayer.GetHandZone().GetCount();
+    int opHandCount = opPlayer.GetHandZone().GetCount();
+
+    Generic::ChoiceMulligan(curPlayer, curChoices);
+    Generic::ChoiceMulligan(opPlayer, opChoices);
+
+    EXPECT_EQ(curHandCount, curPlayer.GetHandZone().GetCount());
+    EXPECT_EQ(opHandCount, opPlayer.GetHandZone().GetCount());
+
+    EXPECT_EQ(curPlayer.choice, std::nullopt);
+    EXPECT_EQ(opPlayer.choice, std::nullopt);
+}

--- a/Tests/UnitTests/Actions/CopyTests.cpp
+++ b/Tests/UnitTests/Actions/CopyTests.cpp
@@ -1,0 +1,248 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#include "gtest/gtest.h"
+
+#include <Rosetta/Actions/Copy.hpp>
+#include <Rosetta/Cards/Cards.hpp>
+#include <Rosetta/Enums/CardEnums.hpp>
+#include <Rosetta/Games/Game.hpp>
+#include <Rosetta/Models/Enchantment.hpp>
+
+using namespace RosettaStone;
+
+TEST(Copy, Copy)
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+
+    Card card;
+    const std::map<GameTag, int> tags;
+
+    // Case 1-1: Deck -> Hand
+    {
+        Entity* entity = Entity::GetFromCard(
+            curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
+            std::nullopt, &curPlayer.GetDeckZone());
+        Enchantment* enchantment =
+            new Enchantment(curPlayer, card, tags, entity);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+        entity->appliedEnchantments.emplace_back(enchantment);
+
+        auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::HAND);
+        EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::HAND);
+    }
+
+    // Case 1-2: Hand -> Play
+    {
+        Entity* entity = Entity::GetFromCard(
+            curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
+            std::nullopt, &curPlayer.GetHandZone());
+        Enchantment* enchantment =
+            new Enchantment(curPlayer, card, tags, entity);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+        entity->appliedEnchantments.emplace_back(enchantment);
+
+        auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::PLAY);
+        EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::PLAY);
+    }
+
+    // Case 1-3: Deck -> Play
+    {
+        Entity* entity = Entity::GetFromCard(
+            curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
+            std::nullopt, &curPlayer.GetDeckZone());
+        Enchantment* enchantment =
+            new Enchantment(curPlayer, card, tags, entity);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+        entity->appliedEnchantments.emplace_back(enchantment);
+
+        auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::PLAY);
+        EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::PLAY);
+    }
+
+    // Case 2-1: Play -> Hand
+    {
+        Entity* entity = Entity::GetFromCard(
+            curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
+            std::nullopt, &curPlayer.GetFieldZone());
+        Enchantment* enchantment =
+            new Enchantment(curPlayer, card, tags, entity);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+        entity->appliedEnchantments.emplace_back(enchantment);
+
+        auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::HAND);
+        EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::HAND);
+    }
+
+    // Case 2-2: Hand -> Deck
+    {
+        Entity* entity = Entity::GetFromCard(
+            curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
+            std::nullopt, &curPlayer.GetHandZone());
+        Enchantment* enchantment =
+            new Enchantment(curPlayer, card, tags, entity);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+        entity->appliedEnchantments.emplace_back(enchantment);
+
+        auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::DECK);
+        EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::DECK);
+    }
+
+    // Case 2-3: Play -> Deck
+    {
+        Entity* entity = Entity::GetFromCard(
+            curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
+            std::nullopt, &curPlayer.GetFieldZone());
+        Enchantment* enchantment =
+            new Enchantment(curPlayer, card, tags, entity);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+        entity->appliedEnchantments.emplace_back(enchantment);
+
+        auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::DECK);
+        EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::DECK);
+    }
+
+    // Case 2-4: Play -> Graveyard
+    {
+        Entity* entity = Entity::GetFromCard(
+            curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
+            std::nullopt, &curPlayer.GetFieldZone());
+        Enchantment* enchantment =
+            new Enchantment(curPlayer, card, tags, entity);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+        entity->appliedEnchantments.emplace_back(enchantment);
+
+        auto copiedEntity =
+            Generic::Copy(curPlayer, entity, ZoneType::GRAVEYARD);
+        EXPECT_NE(copiedEntity->GetZoneType(), ZoneType::GRAVEYARD);
+    }
+
+    // Case 2-5: Hand -> Graveyard
+    {
+        Entity* entity = Entity::GetFromCard(
+            curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
+            std::nullopt, &curPlayer.GetHandZone());
+        Enchantment* enchantment =
+            new Enchantment(curPlayer, card, tags, entity);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+        entity->appliedEnchantments.emplace_back(enchantment);
+
+        auto copiedEntity =
+            Generic::Copy(curPlayer, entity, ZoneType::GRAVEYARD);
+        EXPECT_NE(copiedEntity->GetZoneType(), ZoneType::GRAVEYARD);
+    }
+
+    // Case 2-6: Deck -> Graveyard
+    {
+        Entity* entity = Entity::GetFromCard(
+            curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
+            std::nullopt, &curPlayer.GetDeckZone());
+        Enchantment* enchantment =
+            new Enchantment(curPlayer, card, tags, entity);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+        entity->appliedEnchantments.emplace_back(enchantment);
+
+        auto copiedEntity =
+            Generic::Copy(curPlayer, entity, ZoneType::GRAVEYARD);
+        EXPECT_NE(copiedEntity->GetZoneType(), ZoneType::GRAVEYARD);
+    }
+
+    // Case 2-7: Graveyard -> Play
+    {
+        Entity* entity = Entity::GetFromCard(
+            curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
+            std::nullopt, &curPlayer.GetGraveyardZone());
+        Enchantment* enchantment =
+            new Enchantment(curPlayer, card, tags, entity);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+        entity->appliedEnchantments.emplace_back(enchantment);
+
+        auto copiedEntity =
+            Generic::Copy(curPlayer, entity, ZoneType::PLAY);
+        EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::PLAY);
+    }
+
+    // Case 2-8: Graveyard -> Hand
+    {
+        Entity* entity = Entity::GetFromCard(
+            curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
+            std::nullopt, &curPlayer.GetGraveyardZone());
+        Enchantment* enchantment =
+            new Enchantment(curPlayer, card, tags, entity);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+        entity->appliedEnchantments.emplace_back(enchantment);
+
+        auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::HAND);
+        EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::HAND);
+    }
+
+    // Case 2-9: Graveyard -> Deck
+    {
+        Entity* entity = Entity::GetFromCard(
+            curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
+            std::nullopt, &curPlayer.GetGraveyardZone());
+        Enchantment* enchantment =
+            new Enchantment(curPlayer, card, tags, entity);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+        entity->appliedEnchantments.emplace_back(enchantment);
+
+        auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::DECK);
+        EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::DECK);
+    }
+
+    // Case 3-1: sourceZone equals targetZone
+    {
+        Entity* entity = Entity::GetFromCard(
+            curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
+            std::nullopt, &curPlayer.GetHandZone());
+        Enchantment* enchantment =
+            new Enchantment(curPlayer, card, tags, entity);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+        entity->appliedEnchantments.emplace_back(enchantment);
+
+        auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::HAND);
+        EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::HAND);
+    }
+
+    // Case 3-2: targetZone is setaside
+    {
+        Entity* entity = Entity::GetFromCard(
+            curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
+            std::nullopt, &curPlayer.GetHandZone());
+        Enchantment* enchantment =
+            new Enchantment(curPlayer, card, tags, entity);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
+        enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+        entity->appliedEnchantments.emplace_back(enchantment);
+
+        auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::SETASIDE);
+        EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::SETASIDE);
+    }
+}

--- a/Tests/UnitTests/Actions/CopyTests.cpp
+++ b/Tests/UnitTests/Actions/CopyTests.cpp
@@ -37,14 +37,19 @@ TEST(Copy, Copy)
         Entity* entity = Entity::GetFromCard(
             curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
             std::nullopt, &curPlayer.GetDeckZone());
+
         Enchantment* enchantment =
             new Enchantment(curPlayer, card, tags, entity);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+
         entity->appliedEnchantments.emplace_back(enchantment);
 
         auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::HAND);
         EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::HAND);
+
+        delete enchantment;
+        delete entity;
     }
 
     // Case 1-2: Hand -> Play
@@ -52,14 +57,19 @@ TEST(Copy, Copy)
         Entity* entity = Entity::GetFromCard(
             curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
             std::nullopt, &curPlayer.GetHandZone());
+
         Enchantment* enchantment =
             new Enchantment(curPlayer, card, tags, entity);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+
         entity->appliedEnchantments.emplace_back(enchantment);
 
         auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::PLAY);
         EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::PLAY);
+
+        delete entity;
+        delete enchantment;
     }
 
     // Case 1-3: Deck -> Play
@@ -67,14 +77,19 @@ TEST(Copy, Copy)
         Entity* entity = Entity::GetFromCard(
             curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
             std::nullopt, &curPlayer.GetDeckZone());
+
         Enchantment* enchantment =
             new Enchantment(curPlayer, card, tags, entity);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+
         entity->appliedEnchantments.emplace_back(enchantment);
 
         auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::PLAY);
         EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::PLAY);
+
+        delete entity;
+        delete enchantment;
     }
 
     // Case 2-1: Play -> Hand
@@ -82,14 +97,19 @@ TEST(Copy, Copy)
         Entity* entity = Entity::GetFromCard(
             curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
             std::nullopt, &curPlayer.GetFieldZone());
+
         Enchantment* enchantment =
             new Enchantment(curPlayer, card, tags, entity);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+
         entity->appliedEnchantments.emplace_back(enchantment);
 
         auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::HAND);
         EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::HAND);
+
+        delete entity;
+        delete enchantment;
     }
 
     // Case 2-2: Hand -> Deck
@@ -97,14 +117,19 @@ TEST(Copy, Copy)
         Entity* entity = Entity::GetFromCard(
             curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
             std::nullopt, &curPlayer.GetHandZone());
+
         Enchantment* enchantment =
             new Enchantment(curPlayer, card, tags, entity);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+
         entity->appliedEnchantments.emplace_back(enchantment);
 
         auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::DECK);
         EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::DECK);
+
+        delete entity;
+        delete enchantment;
     }
 
     // Case 2-3: Play -> Deck
@@ -112,14 +137,19 @@ TEST(Copy, Copy)
         Entity* entity = Entity::GetFromCard(
             curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
             std::nullopt, &curPlayer.GetFieldZone());
+
         Enchantment* enchantment =
             new Enchantment(curPlayer, card, tags, entity);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+
         entity->appliedEnchantments.emplace_back(enchantment);
 
         auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::DECK);
         EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::DECK);
+
+        delete entity;
+        delete enchantment;
     }
 
     // Case 2-4: Play -> Graveyard
@@ -127,15 +157,20 @@ TEST(Copy, Copy)
         Entity* entity = Entity::GetFromCard(
             curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
             std::nullopt, &curPlayer.GetFieldZone());
+
         Enchantment* enchantment =
             new Enchantment(curPlayer, card, tags, entity);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+
         entity->appliedEnchantments.emplace_back(enchantment);
 
         auto copiedEntity =
             Generic::Copy(curPlayer, entity, ZoneType::GRAVEYARD);
         EXPECT_NE(copiedEntity->GetZoneType(), ZoneType::GRAVEYARD);
+
+        delete entity;
+        delete enchantment;
     }
 
     // Case 2-5: Hand -> Graveyard
@@ -143,15 +178,20 @@ TEST(Copy, Copy)
         Entity* entity = Entity::GetFromCard(
             curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
             std::nullopt, &curPlayer.GetHandZone());
+
         Enchantment* enchantment =
             new Enchantment(curPlayer, card, tags, entity);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+
         entity->appliedEnchantments.emplace_back(enchantment);
 
         auto copiedEntity =
             Generic::Copy(curPlayer, entity, ZoneType::GRAVEYARD);
         EXPECT_NE(copiedEntity->GetZoneType(), ZoneType::GRAVEYARD);
+
+        delete entity;
+        delete enchantment;
     }
 
     // Case 2-6: Deck -> Graveyard
@@ -159,15 +199,20 @@ TEST(Copy, Copy)
         Entity* entity = Entity::GetFromCard(
             curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
             std::nullopt, &curPlayer.GetDeckZone());
+
         Enchantment* enchantment =
             new Enchantment(curPlayer, card, tags, entity);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+
         entity->appliedEnchantments.emplace_back(enchantment);
 
         auto copiedEntity =
             Generic::Copy(curPlayer, entity, ZoneType::GRAVEYARD);
         EXPECT_NE(copiedEntity->GetZoneType(), ZoneType::GRAVEYARD);
+
+        delete entity;
+        delete enchantment;
     }
 
     // Case 2-7: Graveyard -> Play
@@ -175,15 +220,19 @@ TEST(Copy, Copy)
         Entity* entity = Entity::GetFromCard(
             curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
             std::nullopt, &curPlayer.GetGraveyardZone());
+
         Enchantment* enchantment =
             new Enchantment(curPlayer, card, tags, entity);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+
         entity->appliedEnchantments.emplace_back(enchantment);
 
-        auto copiedEntity =
-            Generic::Copy(curPlayer, entity, ZoneType::PLAY);
+        auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::PLAY);
         EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::PLAY);
+
+        delete entity;
+        delete enchantment;
     }
 
     // Case 2-8: Graveyard -> Hand
@@ -191,14 +240,19 @@ TEST(Copy, Copy)
         Entity* entity = Entity::GetFromCard(
             curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
             std::nullopt, &curPlayer.GetGraveyardZone());
+
         Enchantment* enchantment =
             new Enchantment(curPlayer, card, tags, entity);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+
         entity->appliedEnchantments.emplace_back(enchantment);
 
         auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::HAND);
         EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::HAND);
+
+        delete entity;
+        delete enchantment;
     }
 
     // Case 2-9: Graveyard -> Deck
@@ -206,14 +260,19 @@ TEST(Copy, Copy)
         Entity* entity = Entity::GetFromCard(
             curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
             std::nullopt, &curPlayer.GetGraveyardZone());
+
         Enchantment* enchantment =
             new Enchantment(curPlayer, card, tags, entity);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+
         entity->appliedEnchantments.emplace_back(enchantment);
 
         auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::DECK);
         EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::DECK);
+
+        delete entity;
+        delete enchantment;
     }
 
     // Case 3-1: sourceZone equals targetZone
@@ -221,14 +280,19 @@ TEST(Copy, Copy)
         Entity* entity = Entity::GetFromCard(
             curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
             std::nullopt, &curPlayer.GetHandZone());
+
         Enchantment* enchantment =
             new Enchantment(curPlayer, card, tags, entity);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+
         entity->appliedEnchantments.emplace_back(enchantment);
 
         auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::HAND);
         EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::HAND);
+
+        delete entity;
+        delete enchantment;
     }
 
     // Case 3-2: targetZone is setaside
@@ -236,13 +300,19 @@ TEST(Copy, Copy)
         Entity* entity = Entity::GetFromCard(
             curPlayer, Cards::GetInstance().FindCardByName("Ysera"),
             std::nullopt, &curPlayer.GetHandZone());
+
         Enchantment* enchantment =
             new Enchantment(curPlayer, card, tags, entity);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1, 1);
         enchantment->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, 2);
+
         entity->appliedEnchantments.emplace_back(enchantment);
 
-        auto copiedEntity = Generic::Copy(curPlayer, entity, ZoneType::SETASIDE);
+        auto copiedEntity =
+            Generic::Copy(curPlayer, entity, ZoneType::SETASIDE);
         EXPECT_EQ(copiedEntity->GetZoneType(), ZoneType::SETASIDE);
+
+        delete entity;
+        delete enchantment;
     }
 }

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -5324,6 +5324,60 @@ TEST(NeutralExpert1Test, EX1_564_Faceless_Manipulator)
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [EX1_583] Priestess of Elune- COST:6 [ATK:5/HP:4]
+// - Set: Expert1, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Restore #4 Health to your hero.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST(NeutralExpert1Test, EX1_583_PriestessOfElune)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Priestess of Elune"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Chillwind Yeti"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+
+    curPlayer.GetHero()->SetDamage(5);
+    opPlayer.GetHero()->SetDamage(5);
+    curField[0]->SetDamage(4);
+
+    EXPECT_EQ(curPlayer.GetHero()->GetHealth(), 25);
+    EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 25);
+    EXPECT_EQ(curField[0]->GetHealth(), 1);
+    
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    EXPECT_EQ(curPlayer.GetHero()->GetHealth(), 29);
+    EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 25);
+    EXPECT_EQ(curField[0]->GetHealth(), 1);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [NEW1_020] Wild Pyromancer - COST:2 [ATK:3/HP:2]
 // - Set: Expert1, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -5466,6 +5466,75 @@ TEST(NeutralExpert1Test, EX1_583_PriestessOfElune)
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [NEW1_019] Knife Juggler - COST:2 [ATK:2/HP:2]
+// - Set: Expert1, Rarity: Rare
+// --------------------------------------------------------
+// Text: After you summon a minion,
+//       deal 1 damage to a random enemy.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST(NeutralExpert1Test, NEW1_019_KnifeJuggler)
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+    auto& opField = opPlayer.GetFieldZone();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByID("NEW1_019"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Chillwind Yeti"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 30);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+
+    EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 29);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+
+    EXPECT_EQ(curPlayer.GetHero()->GetHealth(), 30);
+    EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 29);
+
+    EXPECT_EQ(curField[0]->GetHealth(), 2);
+    EXPECT_EQ(opField[0]->GetHealth(), 5);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+
+    EXPECT_TRUE((opPlayer.GetHero()->GetHealth() == 28) ^ (opField[0]->GetHealth() == 4));
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [NEW1_020] Wild Pyromancer - COST:2 [ATK:3/HP:2]
 // - Set: Expert1, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -5461,6 +5461,54 @@ TEST(NeutralExpert1Test, EX1_564_Faceless_Manipulator)
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [EX1_572] Ysera - COST:9 [ATK:4/HP:12]
+// - Race: Dragon, Set: Expert1, Rarity: Legendary
+// --------------------------------------------------------
+// Text: At the end of your turn, add a Dream Card to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST(NeutralExpert1Test, EX1_572_Ysera)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Ysera"));
+
+    auto& curHand = curPlayer.GetHandZone();
+    
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    EXPECT_EQ(curHand.GetCount(), 5);
+
+    const Card& dreamCard = curHand.GetAll()[4]->card;
+    Card yseraCard = Cards::GetInstance().FindCardByName("Ysera");
+    auto& entourages = yseraCard.entourages;
+
+    EXPECT_TRUE(std::find(
+        entourages.begin(), entourages.end(), dreamCard.id) != entourages.end())
+        << "dreamCard's name: " << dreamCard.name << std::endl;
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [EX1_583] Priestess of Elune- COST:6 [ATK:5/HP:4]
 // - Set: Expert1, Rarity: Common
 // --------------------------------------------------------
@@ -6027,4 +6075,226 @@ TEST(NeutralExpert1Test, NEW1_041_StampedingKodo)
     game.Process(opPlayer, PlayCardTask::Minion(card3));
 
     EXPECT_EQ(curField.GetCount(), 1);
+}
+
+// ----------------------------------------- MINION - DREAM
+// [DREAM_01] Laughing Sister - COST:3 [ATK:3/HP:5]
+// - Set: Expert1
+// --------------------------------------------------------
+// GameTag:
+// - CANT_BE_TARGETED_BY_SPELLS = 1
+// - CANT_BE_TARGETED_BY_HERO_POWERS = 1
+// --------------------------------------------------------
+TEST(DreamExpert1Test, DREAM_01_LaughingSister)
+{
+    // Do nothing
+}
+
+// ------------------------------------------ SPELL - DREAM
+// [DREAM_02] Ysera Awakens - COST:2
+// - Set: Expert1
+// --------------------------------------------------------
+// Text: Deal $5 damage to all characters except Ysera.
+// --------------------------------------------------------
+TEST(DreamExpert1Test, DREAM_02_YseraAwakens)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Ysera Awakens"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Ysera"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Fen Creeper"));
+    
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Ysera"));
+    const auto card5 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Fen Creeper"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    curPlayer.SetUsedMana(0);
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    opPlayer.SetUsedMana(0);
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+
+    EXPECT_EQ(curPlayer.GetHero()->GetHealth(), 25);
+    EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 25);
+
+    EXPECT_EQ(card2->GetGameTag(GameTag::DAMAGE), 0);
+    EXPECT_EQ(card4->GetGameTag(GameTag::DAMAGE), 0);
+ 
+    EXPECT_EQ(card3->GetGameTag(GameTag::DAMAGE), 5);
+    EXPECT_EQ(card5->GetGameTag(GameTag::DAMAGE), 5);
+}
+
+// ----------------------------------------- MINION - DREAM
+// [DREAM_03] Emerald Drake - COST:4 [ATK:7/HP:6]
+// - Race: Dragon, Set: Expert1
+// --------------------------------------------------------
+TEST(DreamExpert1Test, DREAM_03_EmeraldDrake)
+{
+    // Do nothing
+}
+
+// ------------------------------------------ SPELL - DREAM
+// [DREAM_04] Dream - COST:0
+// - Set: Expert1
+// --------------------------------------------------------
+// Text: Return a minion to its owner's hand.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINION_TARGET = 0
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST(DreamExpert1Test, DREAM_04_Dream)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+    auto& opField = opPlayer.GetFieldZone();
+
+    auto& curHand = curPlayer.GetHandZone();
+    auto& opHand = opPlayer.GetHandZone();
+
+    const auto card1 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByID("DREAM_04"));
+    const auto card2 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByID("DREAM_04"));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
+    
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
+    
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+
+    EXPECT_EQ(curField.GetCount(), 1);
+    EXPECT_EQ(opField.GetCount(), 1);
+
+    const int curHandCount = curHand.GetCount();
+    const int opHandCount = opHand.GetCount();
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card1, card3));
+
+    EXPECT_EQ(curHand.GetCount(), curHandCount);
+    EXPECT_EQ(opHand.GetCount(), opHandCount);
+
+    EXPECT_EQ(opHand[opHandCount - 1]->card.name, "Magma Rager");
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card4));
+
+    EXPECT_EQ(curHand.GetCount(), curHandCount + 1);
+    EXPECT_EQ(opHand.GetCount(), opHandCount - 1);
+
+    EXPECT_EQ(curHand[curHandCount]->card.name, "Magma Rager");
+}
+
+// ------------------------------------------ SPELL - DREAM
+// [DREAM_05] Nightmare - COST:0
+// - Set: Expert1
+// --------------------------------------------------------
+// Text: Give a minion +5/+5.
+//       At the start of your next turn, destroy it.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINION_TARGET = 0
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST(DreamExpert1Test, DREAM_05_Nightmare)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+
+    const auto card1 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Nightmare"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
+    
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);   
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card1, card2));
+
+    EXPECT_FALSE(curField[0]->appliedEnchantments.empty());
+
+    EXPECT_EQ(curField.GetCount(), 1);
+
+    EXPECT_EQ(curField[0]->GetAttack(), 10);
+    
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    EXPECT_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);   
+
+    EXPECT_EQ(curField.GetCount(), 0);
 }

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -379,6 +379,8 @@ TEST(MageExpert1Test, EX1_287_Counterspell)
         curPlayer, Cards::GetInstance().FindCardByName("Fireball"));
     const auto card3 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Lightning Bolt"));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Lightning Bolt"));
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
 
@@ -397,6 +399,66 @@ TEST(MageExpert1Test, EX1_287_Counterspell)
     EXPECT_EQ(curPlayer.GetHero()->GetHealth(), 30);
     EXPECT_EQ(opPlayer.GetRemainingMana(), 9);
     EXPECT_EQ(opPlayer.GetOverloadOwed(), 1);
+    
+    game.Process(opPlayer,
+                PlayCardTask::SpellTarget(card4, curPlayer.GetHero()));
+    
+    EXPECT_EQ(curPlayer.GetHero()->GetHealth(), 27);
+}
+
+// ------------------------------------------ MINION - MAGE
+// [NEW1_012] Mana Wyrm - COST:2 [ATK:1/HP:3]
+// - Set: Expert1, Rarity: Common
+// --------------------------------------------------------
+// Text: Whenever you cast a spell, gain +1 Attack.
+// --------------------------------------------------------
+TEST(MageExpert1Test, NEW1_012_ManaWyrm)
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByID("NEW1_012"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Fireball"));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Lightning Bolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    EXPECT_EQ(curField[0]->GetAttack(), 1);
+
+    game.Process(curPlayer,
+                PlayCardTask::SpellTarget(card2, opPlayer.GetHero()));
+
+    EXPECT_EQ(curField[0]->GetAttack(), 2);
+    EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 24);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer,
+                 PlayCardTask::SpellTarget(card3, curPlayer.GetHero()));
+    
+    EXPECT_EQ(curField[0]->GetAttack(), 2);
+    EXPECT_EQ(curPlayer.GetHero()->GetHealth(), 27);
 }
 
 // ---------------------------------------- SPELL - PALADIN

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -328,7 +328,7 @@ TEST(HunterExpert1Test, EX1_617_DeadlyShot)
     EXPECT_EQ(curField.GetCount(), 1);
 
     opPlayer.SetUsedMana(0);
-    
+
     game.Process(opPlayer, PlayCardTask::Spell(card3));
     EXPECT_EQ(curField.GetCount(), 0);
 }
@@ -435,7 +435,7 @@ TEST(MageExpert1Test, EX1_179_Icicle)
     auto& curField = curPlayer.GetFieldZone();
 
     auto& opHand = opPlayer.GetHandZone();
-    
+
     const auto card1 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Icicle"));
     const auto card2 = Generic::DrawCard(
@@ -447,26 +447,25 @@ TEST(MageExpert1Test, EX1_179_Icicle)
         curPlayer, Cards::GetInstance().FindCardByName("Chillwind Yeti"));
 
     game.Process(curPlayer, PlayCardTask::Minion(card4));
-    
+
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
     int opHandCount = opHand.GetCount();
-    
+
     game.Process(opPlayer, PlayCardTask::SpellTarget(card1, card4));
-    
+
     EXPECT_EQ(curField[0]->GetHealth(), 3);
     EXPECT_EQ(opHand.GetCount(), opHandCount - 1);
     opHandCount = opHand.GetCount();
 
     game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card4));
     game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card4));
-    
+
     EXPECT_EQ(curField[0]->GetHealth(), 1);
     EXPECT_EQ(curField[0]->GetGameTag(GameTag::FROZEN), 1);
     EXPECT_EQ(opHand.GetCount(), opHandCount - 1);
 }
-
 
 // ------------------------------------------- SPELL - MAGE
 // [EX1_279] Pyroblast - COST:10
@@ -598,7 +597,8 @@ TEST(MageExpert1Test, EX1_287_Counterspell)
 
     EXPECT_NE(card1->GetGameTag(GameTag::REVEALED), 1);
 
-    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, opPlayer.GetHero()));
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer.GetHero()));
 
     EXPECT_NE(card1->GetGameTag(GameTag::REVEALED), 1);
     EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 24);
@@ -611,10 +611,10 @@ TEST(MageExpert1Test, EX1_287_Counterspell)
     EXPECT_EQ(curPlayer.GetHero()->GetHealth(), 30);
     EXPECT_EQ(opPlayer.GetRemainingMana(), 9);
     EXPECT_EQ(opPlayer.GetOverloadOwed(), 1);
-    
+
     game.Process(opPlayer,
-                PlayCardTask::SpellTarget(card4, curPlayer.GetHero()));
-    
+                 PlayCardTask::SpellTarget(card4, curPlayer.GetHero()));
+
     EXPECT_EQ(curPlayer.GetHero()->GetHealth(), 27);
 }
 
@@ -658,7 +658,7 @@ TEST(MageExpert1Test, NEW1_012_ManaWyrm)
     EXPECT_EQ(curField[0]->GetAttack(), 1);
 
     game.Process(curPlayer,
-                PlayCardTask::SpellTarget(card2, opPlayer.GetHero()));
+                 PlayCardTask::SpellTarget(card2, opPlayer.GetHero()));
 
     EXPECT_EQ(curField[0]->GetAttack(), 2);
     EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 24);
@@ -668,7 +668,7 @@ TEST(MageExpert1Test, NEW1_012_ManaWyrm)
 
     game.Process(opPlayer,
                  PlayCardTask::SpellTarget(card3, curPlayer.GetHero()));
-    
+
     EXPECT_EQ(curField[0]->GetAttack(), 2);
     EXPECT_EQ(curPlayer.GetHero()->GetHealth(), 27);
 }
@@ -2090,9 +2090,9 @@ TEST(ShamanExpert1Test, CS2_038_AncestralSpirit)
 
     EXPECT_EQ(curField.GetCount(), 0);
     EXPECT_EQ(opField.GetCount(), 3);
-    
+
     EXPECT_EQ(opField[1]->card.name, "River Crocolisk");
-    
+
     EXPECT_FALSE(opField[1]->HasDeathrattle());
 }
 
@@ -5424,7 +5424,7 @@ TEST(NeutralExpert1Test, EX1_556_HarvestGolem)
         curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
     const auto card4 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Fireball"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     game.Process(curPlayer, PlayCardTask::Minion(card2));
     game.Process(curPlayer, PlayCardTask::Minion(card3));
@@ -5557,22 +5557,26 @@ TEST(NeutralExpert1Test, EX1_572_Ysera)
     opPlayer.SetTotalMana(10);
     opPlayer.SetUsedMana(0);
 
+    auto& curHand = curPlayer.GetHandZone();
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Ysera"));
 
-    auto& curHand = curPlayer.GetHandZone();
-    
     game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    EXPECT_EQ(curHand.GetCount(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
 
     EXPECT_EQ(curHand.GetCount(), 5);
 
-    const Card& dreamCard = curHand.GetAll()[4]->card;
-    Card yseraCard = Cards::GetInstance().FindCardByName("Ysera");
+    const Card& dreamCard = curHand[4]->card;
+    const Card& yseraCard = Cards::GetInstance().FindCardByName("Ysera");
     auto& entourages = yseraCard.entourages;
 
-    EXPECT_TRUE(std::find(
-        entourages.begin(), entourages.end(), dreamCard.id) != entourages.end())
-        << "dreamCard's name: " << dreamCard.name << std::endl;
+    EXPECT_TRUE(std::find(entourages.begin(), entourages.end(), dreamCard.id) !=
+                entourages.end());
 }
 
 // --------------------------------------- MINION - NEUTRAL
@@ -5620,7 +5624,6 @@ TEST(NeutralExpert1Test, EX1_583_PriestessOfElune)
     EXPECT_EQ(curPlayer.GetHero()->GetHealth(), 25);
     EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 25);
     EXPECT_EQ(curField[0]->GetHealth(), 1);
-    
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
 
@@ -5695,7 +5698,8 @@ TEST(NeutralExpert1Test, NEW1_019_KnifeJuggler)
 
     game.Process(curPlayer, PlayCardTask::Minion(card3));
 
-    EXPECT_TRUE((opPlayer.GetHero()->GetHealth() == 28) ^ (opField[0]->GetHealth() == 4));
+    EXPECT_TRUE((opPlayer.GetHero()->GetHealth() == 28) ^
+                (opField[0]->GetHealth() == 4));
 }
 
 // --------------------------------------- MINION - NEUTRAL
@@ -6111,7 +6115,7 @@ TEST(NeutralExpert1Test, NEW1_041_StampedingKodo)
         opPlayer, Cards::GetInstance().FindCardByName("Stampeding Kodo"));
     const auto card3 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Stampeding Kodo"));
-    
+
     const auto card4 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Voidwalker"));
     const auto card5 = Generic::DrawCard(
@@ -6189,7 +6193,7 @@ TEST(DreamExpert1Test, DREAM_02_YseraAwakens)
         curPlayer, Cards::GetInstance().FindCardByName("Ysera"));
     const auto card3 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Fen Creeper"));
-    
+
     const auto card4 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Ysera"));
     const auto card5 = Generic::DrawCard(
@@ -6205,7 +6209,7 @@ TEST(DreamExpert1Test, DREAM_02_YseraAwakens)
     game.Process(opPlayer, PlayCardTask::Minion(card4));
     opPlayer.SetUsedMana(0);
     game.Process(opPlayer, PlayCardTask::Minion(card5));
-    
+
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
@@ -6216,7 +6220,7 @@ TEST(DreamExpert1Test, DREAM_02_YseraAwakens)
 
     EXPECT_EQ(card2->GetGameTag(GameTag::DAMAGE), 0);
     EXPECT_EQ(card4->GetGameTag(GameTag::DAMAGE), 0);
- 
+
     EXPECT_EQ(card3->GetGameTag(GameTag::DAMAGE), 5);
     EXPECT_EQ(card5->GetGameTag(GameTag::DAMAGE), 5);
 }
@@ -6272,10 +6276,10 @@ TEST(DreamExpert1Test, DREAM_04_Dream)
         opPlayer, Cards::GetInstance().FindCardByID("DREAM_04"));
     const auto card3 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
-    
+
     const auto card4 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card4));
 
     game.Process(curPlayer, EndTurnTask());
@@ -6341,11 +6345,11 @@ TEST(DreamExpert1Test, DREAM_05_Nightmare)
         opPlayer, Cards::GetInstance().FindCardByName("Nightmare"));
     const auto card2 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card2));
 
     game.Process(curPlayer, EndTurnTask());
-    game.ProcessUntil(Step::MAIN_START);   
+    game.ProcessUntil(Step::MAIN_START);
 
     game.Process(opPlayer, PlayCardTask::SpellTarget(card1, card2));
 
@@ -6354,14 +6358,14 @@ TEST(DreamExpert1Test, DREAM_05_Nightmare)
     EXPECT_EQ(curField.GetCount(), 1);
 
     EXPECT_EQ(curField[0]->GetAttack(), 10);
-    
+
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
     EXPECT_EQ(curField.GetCount(), 1);
 
     game.Process(curPlayer, EndTurnTask());
-    game.ProcessUntil(Step::MAIN_START);   
+    game.ProcessUntil(Step::MAIN_START);
 
     EXPECT_EQ(curField.GetCount(), 0);
 }

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -5086,6 +5086,55 @@ TEST(WarlockExpert1Test, EX1_181_CallOfTheVoid)
     EXPECT_EQ(curHand[4]->card.GetRace(), Race::DEMON);
 }
 
+// --------------------------------------- MINION - WARLOCK
+// [EX1_301] Felguard - COST:3 [ATK:3/HP:5]
+// - Race: Demon, Set: Expert1, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Battlecry:</b> Destroy one of your Mana Crystals.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST(WarlockExpert1Test, EX1_301_Felguard)
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Felguard"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Felguard"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    EXPECT_EQ(curPlayer.GetTotalMana(), 9);
+    EXPECT_EQ(curPlayer.GetRemainingMana(), 7);
+    EXPECT_EQ(opPlayer.GetTotalMana(), 10);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+
+    EXPECT_EQ(curPlayer.GetTotalMana(), 8);
+    EXPECT_EQ(curPlayer.GetRemainingMana(), 4);
+    EXPECT_EQ(opPlayer.GetTotalMana(), 10);
+}
+
 // ---------------------------------------- SPELL - WARLOCK
 // [EX1_309] Siphon Soul - COST:6
 // - Set: Expert1, Rarity: Rare

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -1986,25 +1986,47 @@ TEST(ShamanExpert1Test, CS2_038_AncestralSpirit)
     opPlayer.SetUsedMana(0);
 
     auto& curField = curPlayer.GetFieldZone();
+    auto& opField = opPlayer.GetFieldZone();
 
     const auto card1 = Generic::DrawCard(
-        curPlayer, Cards::GetInstance().FindCardByName("Ancestral Spirit"));
+        curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
     const auto card2 = Generic::DrawCard(
-        curPlayer, Cards::GetInstance().FindCardByName("Acidic Swamp Ooze"));
+        opPlayer, Cards::GetInstance().FindCardByName("Ancestral Spirit"));
     const auto card3 = Generic::DrawCard(
-        opPlayer, Cards::GetInstance().FindCardByName("Wolfrider"));
+        opPlayer, Cards::GetInstance().FindCardByName("Murloc Raider"));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("River Crocolisk"));
+    const auto card5 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Murloc Raider"));
 
-    game.Process(curPlayer, PlayCardTask::Minion(card2));
-    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
     game.Process(opPlayer, PlayCardTask::Minion(card3));
-    game.Process(opPlayer, AttackTask(card3, card1));
-    EXPECT_EQ(curField.GetCount(), 1);
-    EXPECT_EQ(curField[0]->GetAttack(), 3);
-    EXPECT_EQ(curField[0]->GetHealth(), 2);
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+
+    EXPECT_EQ(opField[0]->card.name, "Murloc Raider");
+    EXPECT_EQ(opField[1]->card.name, "River Crocolisk");
+    EXPECT_EQ(opField[2]->card.name, "Murloc Raider");
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card4));
+
+    EXPECT_TRUE(opField[1]->HasDeathrattle());
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(curPlayer, AttackTask(card1, card4));
+
+    EXPECT_EQ(curField.GetCount(), 0);
+    EXPECT_EQ(opField.GetCount(), 3);
+    
+    EXPECT_EQ(opField[1]->card.name, "River Crocolisk");
+    
+    EXPECT_FALSE(opField[1]->HasDeathrattle());
 }
 
 // ----------------------------------------- SPELL - SHAMAN

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -266,6 +266,73 @@ TEST(HunterExpert1Test, EX1_609_Snipe)
     EXPECT_EQ(card8->GetGameTag(GameTag::DAMAGE), 0);
 }
 
+// ----------------------------------------- SPELL - HUNTER
+// [EX1_617] Deadly Shot - COST:3
+// - Set: EXPERT1, Rarity: Common
+// --------------------------------------------------------
+// Text: Destroy a random enemy minion.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINIMUM_ENEMY_MINIONS = 1
+// --------------------------------------------------------
+TEST(HunterExpert1Test, EX1_617_DeadlyShot)
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+
+    const auto card0 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
+    const auto card1 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Deadly Shot"));
+    const auto card2 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Deadly Shot"));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Deadly Shot"));
+
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
+    const auto card5 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
+    const auto card6 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+    game.Process(curPlayer, PlayCardTask::Minion(card6));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card0));
+    game.Process(opPlayer, PlayCardTask::Spell(card1));
+    EXPECT_EQ(curField.GetCount(), 2);
+
+    game.Process(opPlayer, PlayCardTask::Spell(card2));
+    EXPECT_EQ(curField.GetCount(), 1);
+
+    opPlayer.SetUsedMana(0);
+    
+    game.Process(opPlayer, PlayCardTask::Spell(card3));
+    EXPECT_EQ(curField.GetCount(), 0);
+}
+
 // ------------------------------------------- SPELL - MAGE
 // [CS2_028] Blizzard - COST:6
 // - Faction: Neutral, Set: Expert1, Rarity: Rare

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -226,7 +226,6 @@ TEST(HunterExpert1Test, EX1_609_Snipe)
         curPlayer, Cards::GetInstance().FindCardByName("Chillwind Yeti"));
     const auto card5 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Bloodmage Thalnos"));
-
     const auto card6 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Chillwind Yeti"));
     const auto card7 = Generic::DrawCard(
@@ -258,11 +257,9 @@ TEST(HunterExpert1Test, EX1_609_Snipe)
     game.ProcessUntil(Step::MAIN_START);
 
     game.Process(opPlayer, PlayCardTask::Minion(card7));
-
     EXPECT_TRUE(card7->isDestroyed);
 
     game.Process(opPlayer, PlayCardTask::Minion(card8));
-
     EXPECT_EQ(card8->GetGameTag(GameTag::DAMAGE), 0);
 }
 

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -5672,21 +5672,17 @@ TEST(NeutralExpert1Test, NEW1_019_KnifeJuggler)
         opPlayer, Cards::GetInstance().FindCardByName("Chillwind Yeti"));
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
-
     EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 30);
 
     game.Process(curPlayer, PlayCardTask::Minion(card2));
-
     EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 29);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
     game.Process(opPlayer, PlayCardTask::Minion(card4));
-
     EXPECT_EQ(curPlayer.GetHero()->GetHealth(), 30);
     EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 29);
-
     EXPECT_EQ(curField[0]->GetHealth(), 2);
     EXPECT_EQ(opField[0]->GetHealth(), 5);
 
@@ -5694,7 +5690,6 @@ TEST(NeutralExpert1Test, NEW1_019_KnifeJuggler)
     game.ProcessUntil(Step::MAIN_START);
 
     game.Process(curPlayer, PlayCardTask::Minion(card3));
-
     EXPECT_TRUE((opPlayer.GetHero()->GetHealth() == 28) ^
                 (opField[0]->GetHealth() == 4));
 }

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -188,6 +188,84 @@ TEST(HunterExpert1Test, EX1_543_KingKrush)
     // Do nothing
 }
 
+// ----------------------------------------- SPELL - HUNTER
+// [EX1_609] Snipe - COST:2
+// - Set: EXPERT1, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Secret:</b> After your opponent
+//       plays a minion, deal $4 damage to it.
+// --------------------------------------------------------
+// GameTag:
+// - SECRET = 1
+// --------------------------------------------------------
+TEST(HunterExpert1Test, EX1_609_Snipe)
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Snipe"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Snipe"));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Chillwind Yeti"));
+    const auto card5 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Bloodmage Thalnos"));
+
+    const auto card6 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Chillwind Yeti"));
+    const auto card7 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Chillwind Yeti"));
+    const auto card8 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Chillwind Yeti"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+
+    EXPECT_EQ(card4->GetGameTag(GameTag::DAMAGE), 0);
+    EXPECT_EQ(card1->GetGameTag(GameTag::REVEALED), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card6));
+
+    EXPECT_EQ(card6->GetGameTag(GameTag::DAMAGE), 4);
+    EXPECT_EQ(card1->GetGameTag(GameTag::REVEALED), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card7));
+
+    EXPECT_TRUE(card7->isDestroyed);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card8));
+
+    EXPECT_EQ(card8->GetGameTag(GameTag::DAMAGE), 0);
+}
+
 // ------------------------------------------- SPELL - MAGE
 // [CS2_028] Blizzard - COST:6
 // - Faction: Neutral, Set: Expert1, Rarity: Rare

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -5238,6 +5238,21 @@ TEST(NeutralExpert1Test, EX1_405_Shieldbearer)
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [EX1_563] Malygos - COST:9 [ATK:4/HP:12]
+// - Race: Dragon, Faction: Neutral, Set: Expert1, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Spell Damage +5</b>
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - SPELLPOWER = 5
+// --------------------------------------------------------
+TEST(NeutralExpert1Test, EX1_563_Malygos)
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [EX1_564] Faceless Manipulator - COST:5 [ATK:3/HP:3]
 // - Faction: Neutral, Set: Expert1, Rarity: Epic
 // --------------------------------------------------------
@@ -5306,21 +5321,6 @@ TEST(NeutralExpert1Test, EX1_564_Faceless_Manipulator)
 
     game.Process(curPlayer, HeroPowerTask(curField[1]));
     EXPECT_EQ(curPlayer.GetHandZone().GetCount(), 6);
-}
-
-// --------------------------------------- MINION - NEUTRAL
-// [EX1_563] Malygos - COST:9 [ATK:4/HP:12]
-// - Race: Dragon, Faction: Neutral, Set: Expert1, Rarity: Legendary
-// --------------------------------------------------------
-// Text: <b>Spell Damage +5</b>
-// --------------------------------------------------------
-// GameTag:
-// - ELITE = 1
-// - SPELLPOWER = 5
-// --------------------------------------------------------
-TEST(NeutralExpert1Test, EX1_563_Malygos)
-{
-    // Do nothing
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -5238,6 +5238,62 @@ TEST(NeutralExpert1Test, EX1_405_Shieldbearer)
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [EX1_556] Harvest Golem - COST:3 [ATK:2/HP:3]
+// - Race: Mechanical, Set: Expert1, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Summon a 2/1 Damaged Golem.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST(NeutralExpert1Test, EX1_556_HarvestGolem)
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Harvest Golem"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Fireball"));
+    
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+
+    EXPECT_EQ(curField[0]->card.name, "Magma Rager");
+    EXPECT_EQ(curField[1]->card.name, "Harvest Golem");
+    EXPECT_EQ(curField[2]->card.name, "Magma Rager");
+
+    curPlayer.SetUsedMana(0);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card4, card2));
+
+    EXPECT_EQ(curField.GetCount(), 3);
+    EXPECT_EQ(curField[1]->card.name, "Damaged Golem");
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [EX1_563] Malygos - COST:9 [ATK:4/HP:12]
 // - Race: Dragon, Faction: Neutral, Set: Expert1, Rarity: Legendary
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -1968,8 +1968,8 @@ TEST(RogueExpert1Test, NEW1_005_Kidnapper)
 TEST(ShamanExpert1Test, CS2_038_AncestralSpirit)
 {
     GameConfig config;
-    config.player1Class = CardClass::SHAMAN;
-    config.player2Class = CardClass::WARRIOR;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::SHAMAN;
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = true;
     config.autoRun = false;
@@ -2014,7 +2014,7 @@ TEST(ShamanExpert1Test, CS2_038_AncestralSpirit)
 
     game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card4));
 
-    EXPECT_TRUE(opField[1]->HasDeathrattle());
+    EXPECT_EQ(opField[1]->appliedEnchantments.size(), 1);
 
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
@@ -4715,6 +4715,7 @@ TEST(NeutralExpert1Test, EX1_100_LorewalkerCho)
     opPlayer.SetUsedMana(0);
 
     auto& curHand = curPlayer.GetHandZone();
+    auto& opHand = opPlayer.GetHandZone();
 
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Lorewalker Cho"));
@@ -4722,6 +4723,8 @@ TEST(NeutralExpert1Test, EX1_100_LorewalkerCho)
         opPlayer, Cards::GetInstance().FindCardByName("Fireball"));
     const auto card3 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Blizzard"));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Inner Rage"));
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
 
@@ -4734,6 +4737,13 @@ TEST(NeutralExpert1Test, EX1_100_LorewalkerCho)
 
     game.Process(opPlayer, PlayCardTask::Spell(card3));
     EXPECT_EQ(curHand[1]->card.name, "Blizzard");
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card4, card1));
+
+    EXPECT_EQ(opHand[1]->card.name, "Inner Rage");
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -4792,7 +4792,7 @@ TEST(NeutralExpert1Test, EX1_100_LorewalkerCho)
 
     game.Process(curPlayer,
                  PlayCardTask::SpellTarget(card2, opPlayer.GetHero()));
-    EXPECT_EQ(opHand[2]->card.name, "Fireball");
+    EXPECT_EQ(opHand[3]->card.name, "Fireball");
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);


### PR DESCRIPTION
This revision includes:
- Implement 11 cards in EXPERT1 cardset
    - Hogger (NEW1_040)
    - Stampeding Kodo (NEW1_041)
    - Mana Wyrm (NEW1_012)
    - Snipe (EX1_609)
    - Deadly Shot (EX1_617)
    - Priestess of Elune (EX1_583)
    - Harvest Golem (EX1_556)
    - Knife Juggler (NEW1_019)
    - Felguard (EX1_301)
    - Ysera (EX1_572)
    - Icicle (EX1_179)
- Implement 5 dream cards for Ysera
    - Laughing Sister (DREAM_01)
    - Ysera Awakens (DREAM_02)
    - Emerald Drake (DREAM_03)
    - Dream (DREAM_04)
    - Nightmare (DREAM_05)
- Add trigger and related enums
    - Trigger: `afterPlayMinionTrigger`, `afterSummonTrigger`
    - Trigger type: `AFTER_SUMMON`, `AFTER_PLAY_MINION`
    - Trigger source: `ENEMY_MINIONS`, `ENEMY_SPELLS`
    - Sequence type: `PLAY_MINION`
- Add self and rela condition methods
    - Self condition: `IsNotDead()`, `IsName()`
    - Rela condition: `IsFriendly()`
- Add action methods: `ShuffleIntoDeck()`, `Copy()`
- Refactor and fix some task logic
    - `AddEnchantmentTask`
    - `ConditionTask`
    - `CopyTask`
    - `FlagTask` (Rework: #305)
    - `SummonTask`
    - `MoveToGraveyardTask`
- Fix 'Counterspell' logic issue (#295)