### PR TITLE
Fix heap corruption in multithread

### DIFF
--- a/Includes/Rosetta/Tasks/ITask.hpp
+++ b/Includes/Rosetta/Tasks/ITask.hpp
@@ -82,6 +82,20 @@ class ITask
     //! Returns task ID (pure virtual).
     //! \return Task ID.
     virtual TaskID GetTaskID() const = 0;
+    
+    //! Return cloned object
+    //! This will be used for solving multithreading issues
+    //! Not to access same elements at same time.
+    ITask* Clone();
+
+    //! Check its freeable object
+    //! This will be used for solving multithreading issues, or leak issues
+    //! You'll need to free it if its cloned. or cause its memory leak.
+    bool IsFreeable() const;
+
+    //! Set as freeable object
+    //! See IsFreeable method for more informations
+    void SetFreeable();
 
  protected:
     EntityType m_entityType = EntityType::EMPTY;
@@ -89,11 +103,16 @@ class ITask
     Entity* m_source = nullptr;
     Entity* m_target = nullptr;
 
+    bool m_isFreeable = false;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.
     //! \return The result of task processing.
     virtual TaskStatus Impl(Player& player) = 0;
+
+    //! Returns internally cloned object
+    virtual ITask* CloneImpl() = 0;
 };
 
 namespace Task

--- a/Includes/Rosetta/Tasks/PlayerTasks/AttackTask.hpp
+++ b/Includes/Rosetta/Tasks/PlayerTasks/AttackTask.hpp
@@ -27,6 +27,11 @@ class AttackTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/PlayerTasks/ChooseTask.hpp
+++ b/Includes/Rosetta/Tasks/PlayerTasks/ChooseTask.hpp
@@ -40,6 +40,11 @@ class ChooseTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/PlayerTasks/EndTurnTask.hpp
+++ b/Includes/Rosetta/Tasks/PlayerTasks/EndTurnTask.hpp
@@ -22,6 +22,11 @@ class EndTurnTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/PlayerTasks/HeroPowerTask.hpp
+++ b/Includes/Rosetta/Tasks/PlayerTasks/HeroPowerTask.hpp
@@ -26,6 +26,11 @@ class HeroPowerTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/PlayerTasks/PlayCardTask.hpp
+++ b/Includes/Rosetta/Tasks/PlayerTasks/PlayCardTask.hpp
@@ -64,6 +64,11 @@ class PlayCardTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/AddAuraEffectTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/AddAuraEffectTask.hpp
@@ -27,6 +27,11 @@ class AddAuraEffectTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/AddCardTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/AddCardTask.hpp
@@ -29,6 +29,11 @@ class AddCardTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp
@@ -21,11 +21,16 @@ class AddEnchantmentTask : public ITask
     //! Constructs task with given \p cardID and \p entityType.
     //! \param cardID The card ID of enchantment to play.
     //! \param entityType The entity type of target to grant.
-    AddEnchantmentTask(std::string&& cardID, EntityType entityType);
+    AddEnchantmentTask(std::string cardID, EntityType entityType);
 
     //! Returns task ID.
     //! \return Task ID.
     TaskID GetTaskID() const override;
+
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
 
  private:
     //! Processes task logic internally and returns meta data.

--- a/Includes/Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp
@@ -26,6 +26,11 @@ class AddStackToTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/ArmorTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/ArmorTask.hpp
@@ -26,6 +26,11 @@ class ArmorTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/ChanceTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/ChanceTask.hpp
@@ -26,6 +26,11 @@ class ChanceTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/ConditionTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/ConditionTask.hpp
@@ -29,6 +29,11 @@ class ConditionTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/ControlTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/ControlTask.hpp
@@ -26,6 +26,11 @@ class ControlTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/CopyTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/CopyTask.hpp
@@ -30,6 +30,11 @@ class CopyTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/CountTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/CountTask.hpp
@@ -27,6 +27,11 @@ class CountTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/DamageNumberTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/DamageNumberTask.hpp
@@ -27,6 +27,11 @@ class DamageNumberTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/DamageTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/DamageTask.hpp
@@ -29,6 +29,11 @@ class DamageTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/DestroyTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/DestroyTask.hpp
@@ -26,6 +26,11 @@ class DestroyTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/DiscardTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/DiscardTask.hpp
@@ -26,6 +26,11 @@ class DiscardTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/DrawOpTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/DrawOpTask.hpp
@@ -27,6 +27,11 @@ class DrawOpTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/DrawTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/DrawTask.hpp
@@ -27,6 +27,11 @@ class DrawTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/EnqueueTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/EnqueueTask.hpp
@@ -28,6 +28,11 @@ class EnqueueTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/FilterStackTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/FilterStackTask.hpp
@@ -33,6 +33,11 @@ class FilterStackTask : public ITask
     //! Returns task ID.
     //! \return Task ID.
     TaskID GetTaskID() const override;
+    
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
 
  private:
     //! Processes task logic internally and returns meta data.

--- a/Includes/Rosetta/Tasks/SimpleTasks/FlagTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/FlagTask.hpp
@@ -33,6 +33,11 @@ class FlagTask : public ITask
     //! \return The result of task processing.
     TaskStatus Impl(Player& player) override;
 
+     //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;
+
     bool m_flag = true;
     ITask* m_toDoTask = nullptr;
 };

--- a/Includes/Rosetta/Tasks/SimpleTasks/FuncEntityTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/FuncEntityTask.hpp
@@ -30,6 +30,11 @@ class FuncEntityTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/FuncNumberTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/FuncNumberTask.hpp
@@ -28,6 +28,11 @@ class FuncNumberTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/GetGameTagTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/GetGameTagTask.hpp
@@ -31,6 +31,11 @@ class GetGameTagTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/HealFullTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/HealFullTask.hpp
@@ -26,6 +26,11 @@ class HealFullTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/HealTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/HealTask.hpp
@@ -27,6 +27,11 @@ class HealTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/IncludeTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/IncludeTask.hpp
@@ -38,6 +38,11 @@ class IncludeTask : public ITask
                                             Entity* source = nullptr,
                                             Entity* target = nullptr);
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/ManaCrystalTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/ManaCrystalTask.hpp
@@ -29,6 +29,11 @@ class ManaCrystalTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/MathSubTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/MathSubTask.hpp
@@ -37,6 +37,11 @@ class MathSubTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/MoveToGraveyardTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/MoveToGraveyardTask.hpp
@@ -26,6 +26,11 @@ class MoveToGraveyardTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/RandomEntourageTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/RandomEntourageTask.hpp
@@ -27,6 +27,11 @@ class RandomEntourageTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/RandomTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/RandomTask.hpp
@@ -27,6 +27,11 @@ class RandomTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/RemoveEnchantmentTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/RemoveEnchantmentTask.hpp
@@ -25,6 +25,11 @@ class RemoveEnchantmentTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/RemoveHandTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/RemoveHandTask.hpp
@@ -26,6 +26,11 @@ class RemoveHandTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/ReturnHandTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/ReturnHandTask.hpp
@@ -26,6 +26,11 @@ class ReturnHandTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/SetGameTagTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/SetGameTagTask.hpp
@@ -28,6 +28,11 @@ class SetGameTagTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/SilenceTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/SilenceTask.hpp
@@ -26,6 +26,11 @@ class SilenceTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/SummonTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/SummonTask.hpp
@@ -49,6 +49,11 @@ class SummonTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/SwapAttackHealthTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/SwapAttackHealthTask.hpp
@@ -28,6 +28,11 @@ class SwapAttackHealthTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/TempManaTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/TempManaTask.hpp
@@ -26,6 +26,11 @@ class TempManaTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/TransformCopyTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/TransformCopyTask.hpp
@@ -26,6 +26,11 @@ class TransformCopyTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/TransformTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/TransformTask.hpp
@@ -27,6 +27,11 @@ class TransformTask : public ITask
     //! \return Task ID.
     TaskID GetTaskID() const override;
 
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/WeaponTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/WeaponTask.hpp
@@ -20,11 +20,16 @@ class WeaponTask : public ITask
  public:
     //! Constructs task with given \p cardID.
     //! \param cardID The card ID of weapon to equip.
-    explicit WeaponTask(std::string&& cardID);
+    explicit WeaponTask(std::string cardID);
 
     //! Returns task ID.
     //! \return Task ID.
     TaskID GetTaskID() const override;
+
+    //! Returns Clone Of Object (pure virtual).
+    //! \returns clone of object.
+    //! \this uses for thread safe. not to access same task in multiple threads
+    ITask* CloneImpl() override;;
 
  private:
     //! Processes task logic internally and returns meta data.

--- a/Sources/Rosetta/Games/Game.cpp
+++ b/Sources/Rosetta/Games/Game.cpp
@@ -613,6 +613,11 @@ PlayState Game::Process(Player& player, ITask* task)
     task->SetPlayer(&player);
     Task::Run(task);
 
+    if (task->IsFreeable())
+    {
+        delete task;
+    }
+
     return CheckGameOver();
 }
 
@@ -731,6 +736,7 @@ PlayState Game::PerformAction(ActionParams& params)
             return PlayState::INVALID;
     }
 
+    task->SetFreeable();
     return Process(GetCurrentPlayer(), task);
 }
 

--- a/Sources/Rosetta/Models/Entity.cpp
+++ b/Sources/Rosetta/Models/Entity.cpp
@@ -255,11 +255,13 @@ void Entity::ActivateTask(PowerType type, Entity* target, int chooseOne)
 
     for (auto& task : tasks)
     {
-        task->SetPlayer(owner);
-        task->SetSource(this);
-        task->SetTarget(target);
+        ITask* clonedTask = task->Clone();
 
-        owner->GetGame()->taskQueue.Enqueue(task);
+        clonedTask->SetPlayer(owner);
+        clonedTask->SetSource(this);
+        clonedTask->SetTarget(target);
+
+        owner->GetGame()->taskQueue.Enqueue(clonedTask);
     }
 }
 

--- a/Sources/Rosetta/Tasks/ITask.cpp
+++ b/Sources/Rosetta/Tasks/ITask.cpp
@@ -49,4 +49,28 @@ TaskStatus ITask::Run()
 {
     return Impl(*m_player);
 }
+
+ITask* ITask::Clone()
+{
+    ITask* clonedTask = CloneImpl();
+    clonedTask->SetFreeable();
+
+    clonedTask->m_entityType = m_entityType;
+    clonedTask->m_player = m_player;
+    clonedTask->m_source = m_source;
+    clonedTask->m_target = m_target;
+
+    return clonedTask;
+}
+
+bool ITask::IsFreeable() const
+{
+    return m_isFreeable;
+}
+
+void ITask::SetFreeable()
+{
+    m_isFreeable = true;
+}
+
 }  // namespace RosettaStone

--- a/Sources/Rosetta/Tasks/PlayerTasks/AttackTask.cpp
+++ b/Sources/Rosetta/Tasks/PlayerTasks/AttackTask.cpp
@@ -18,6 +18,11 @@ TaskID AttackTask::GetTaskID() const
     return TaskID::ATTACK;
 }
 
+ITask* AttackTask::CloneImpl()
+{
+    return new AttackTask(m_source, m_target);
+}
+
 TaskStatus AttackTask::Impl(Player& player)
 {
     Generic::Attack(player, dynamic_cast<Character*>(m_source),

--- a/Sources/Rosetta/Tasks/PlayerTasks/ChooseTask.cpp
+++ b/Sources/Rosetta/Tasks/PlayerTasks/ChooseTask.cpp
@@ -32,6 +32,11 @@ TaskID ChooseTask::GetTaskID() const
     return TaskID::CHOOSE;
 }
 
+ITask* ChooseTask::CloneImpl()
+{
+    return new ChooseTask(m_choices);
+}
+
 TaskStatus ChooseTask::Impl(Player& player)
 {
     switch (player.choice.value().choiceType)

--- a/Sources/Rosetta/Tasks/PlayerTasks/EndTurnTask.cpp
+++ b/Sources/Rosetta/Tasks/PlayerTasks/EndTurnTask.cpp
@@ -15,6 +15,11 @@ TaskID EndTurnTask::GetTaskID() const
     return TaskID::END_TURN;
 }
 
+ITask* EndTurnTask::CloneImpl()
+{
+    return new EndTurnTask();
+}
+
 TaskStatus EndTurnTask::Impl(Player& player)
 {
     auto game = player.GetGame();

--- a/Sources/Rosetta/Tasks/PlayerTasks/HeroPowerTask.cpp
+++ b/Sources/Rosetta/Tasks/PlayerTasks/HeroPowerTask.cpp
@@ -20,6 +20,11 @@ TaskID HeroPowerTask::GetTaskID() const
     return TaskID::HERO_POWER;
 }
 
+ITask* HeroPowerTask::CloneImpl()
+{
+    return new HeroPowerTask(m_target);
+}
+
 TaskStatus HeroPowerTask::Impl(Player& player)
 {
     HeroPower* power = player.GetHero()->heroPower;

--- a/Sources/Rosetta/Tasks/PlayerTasks/PlayCardTask.cpp
+++ b/Sources/Rosetta/Tasks/PlayerTasks/PlayCardTask.cpp
@@ -46,6 +46,11 @@ TaskID PlayCardTask::GetTaskID() const
     return TaskID::PLAY_CARD;
 }
 
+ITask* PlayCardTask::CloneImpl()
+{
+    return new PlayCardTask(m_source, m_target, m_fieldPos, m_chooseOne);
+}
+
 TaskStatus PlayCardTask::Impl(Player& player)
 {
     const auto target = dynamic_cast<Character*>(m_target);

--- a/Sources/Rosetta/Tasks/SimpleTasks/AddAuraEffectTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/AddAuraEffectTask.cpp
@@ -19,6 +19,11 @@ TaskID AddAuraEffectTask::GetTaskID() const
     return TaskID::ADD_AURA_EFFECT;
 }
 
+ITask* AddAuraEffectTask::CloneImpl()
+{
+    return new AddAuraEffectTask(m_effect, m_entityType);
+}
+
 TaskStatus AddAuraEffectTask::Impl(Player& player)
 {
     auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/AddCardTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/AddCardTask.cpp
@@ -22,6 +22,11 @@ TaskID AddCardTask::GetTaskID() const
     return TaskID::ADD_CARD;
 }
 
+ITask* AddCardTask::CloneImpl()
+{
+    return new AddCardTask(m_entityType, m_cardID, m_amount);
+}
+
 TaskStatus AddCardTask::Impl(Player& player)
 {
     std::vector<Entity*> entities;

--- a/Sources/Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.cpp
@@ -11,9 +11,9 @@
 
 namespace RosettaStone::SimpleTasks
 {
-AddEnchantmentTask::AddEnchantmentTask(std::string&& cardID,
+AddEnchantmentTask::AddEnchantmentTask(std::string cardID,
                                        EntityType entityType)
-    : ITask(entityType), m_cardID(cardID)
+    : ITask(entityType), m_cardID(std::move(cardID))
 {
     // Do nothing
 }
@@ -21,6 +21,11 @@ AddEnchantmentTask::AddEnchantmentTask(std::string&& cardID,
 TaskID AddEnchantmentTask::GetTaskID() const
 {
     return TaskID::ADD_ENCHANTMENT;
+}
+
+ITask* AddEnchantmentTask::CloneImpl()
+{
+    return new AddEnchantmentTask(m_cardID, m_entityType);
 }
 
 TaskStatus AddEnchantmentTask::Impl(Player& player)

--- a/Sources/Rosetta/Tasks/SimpleTasks/AddStackToTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/AddStackToTask.cpp
@@ -19,6 +19,11 @@ TaskID AddStackToTask::GetTaskID() const
     return TaskID::ADD_STACK_TO;
 }
 
+ITask* AddStackToTask::CloneImpl()
+{
+    return new AddStackToTask(m_entityType);
+}
+
 TaskStatus AddStackToTask::Impl(Player& player)
 {
     switch (m_entityType)

--- a/Sources/Rosetta/Tasks/SimpleTasks/ArmorTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/ArmorTask.cpp
@@ -17,6 +17,11 @@ TaskID ArmorTask::GetTaskID() const
     return TaskID::ARMOR;
 }
 
+ITask* ArmorTask::CloneImpl()
+{
+    return new ArmorTask(m_amount);
+}
+
 TaskStatus ArmorTask::Impl(Player& player)
 {
     player.GetHero()->GainArmor(m_amount);  

--- a/Sources/Rosetta/Tasks/SimpleTasks/ChanceTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/ChanceTask.cpp
@@ -22,6 +22,11 @@ TaskID ChanceTask::GetTaskID() const
     return TaskID::CHANCE;
 }
 
+ITask* ChanceTask::CloneImpl()
+{
+    return new ChanceTask(m_useFlag);
+}
+
 TaskStatus ChanceTask::Impl(Player& player)
 {
     const auto num = Random::get<int>(0, 1);

--- a/Sources/Rosetta/Tasks/SimpleTasks/ConditionTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/ConditionTask.cpp
@@ -23,6 +23,11 @@ TaskID ConditionTask::GetTaskID() const
     return TaskID::CONDITION;
 }
 
+ITask* ConditionTask::CloneImpl()
+{
+    return new ConditionTask(m_entityType, m_selfConditions);
+}
+
 TaskStatus ConditionTask::Impl(Player& player)
 {
     auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/ControlTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/ControlTask.cpp
@@ -18,6 +18,11 @@ TaskID ControlTask::GetTaskID() const
     return TaskID::CONTROL;
 }
 
+ITask* ControlTask::CloneImpl()
+{
+    return new ControlTask(m_entityType);
+}
+
 TaskStatus ControlTask::Impl(Player& player)
 {
     auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/CopyTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/CopyTask.cpp
@@ -25,6 +25,11 @@ TaskID CopyTask::GetTaskID() const
     return TaskID::COPY;
 }
 
+ITask* CopyTask::CloneImpl()
+{
+    return new CopyTask(m_entityType, m_amount, m_isOpposite, m_zoneType);
+}
+
 TaskStatus CopyTask::Impl(Player& player)
 {
     std::vector<Entity*> result;

--- a/Sources/Rosetta/Tasks/SimpleTasks/CountTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/CountTask.cpp
@@ -20,6 +20,11 @@ TaskID CountTask::GetTaskID() const
     return TaskID::COUNT;
 }
 
+ITask* CountTask::CloneImpl()
+{
+    return new CountTask(m_entityType, m_numIndex);
+}
+
 TaskStatus CountTask::Impl(Player& player)
 {
     const auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/DamageNumberTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/DamageNumberTask.cpp
@@ -21,6 +21,11 @@ TaskID DamageNumberTask::GetTaskID() const
     return TaskID::DAMAGE_NUMBER;
 }
 
+ITask* DamageNumberTask::CloneImpl()
+{
+    return new DamageNumberTask(m_entityType, m_isSpellDamage);
+}
+
 TaskStatus DamageNumberTask::Impl(Player& player)
 {
     const int damage = m_source->owner->GetGame()->taskStack.num;

--- a/Sources/Rosetta/Tasks/SimpleTasks/DamageTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/DamageTask.cpp
@@ -22,6 +22,11 @@ TaskID DamageTask::GetTaskID() const
     return TaskID::DAMAGE;
 }
 
+ITask* DamageTask::CloneImpl()
+{
+    return new DamageTask(m_entityType, m_damage, m_isSpellDamage);
+}
+
 TaskStatus DamageTask::Impl(Player& player)
 {
     auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/DestroyTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/DestroyTask.cpp
@@ -18,6 +18,11 @@ TaskID DestroyTask::GetTaskID() const
     return TaskID::DESTROY;
 }
 
+ITask* DestroyTask::CloneImpl()
+{
+    return new DestroyTask(m_entityType);
+}
+
 TaskStatus DestroyTask::Impl(Player& player)
 {
     auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/DiscardTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/DiscardTask.cpp
@@ -23,6 +23,11 @@ TaskID DiscardTask::GetTaskID() const
     return TaskID::DISCARD;
 }
 
+ITask* DiscardTask::CloneImpl()
+{
+    return new DiscardTask(m_entityType);
+}
+
 TaskStatus DiscardTask::Impl(Player& player)
 {
     auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/DrawOpTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/DrawOpTask.cpp
@@ -18,6 +18,11 @@ TaskID DrawOpTask::GetTaskID() const
     return TaskID::DRAW_OP;
 }
 
+ITask* DrawOpTask::CloneImpl()
+{
+    return new DrawOpTask(m_amount);
+}
+
 TaskStatus DrawOpTask::Impl(Player& player)
 {
     for (int i = 0; i < m_amount; ++i)

--- a/Sources/Rosetta/Tasks/SimpleTasks/DrawTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/DrawTask.cpp
@@ -20,6 +20,11 @@ TaskID DrawTask::GetTaskID() const
     return TaskID::DRAW;
 }
 
+ITask* DrawTask::CloneImpl()
+{
+    return new DrawTask(m_amount, m_toStack);
+}
+
 TaskStatus DrawTask::Impl(Player& player)
 {
     std::vector<Entity*> cards;

--- a/Sources/Rosetta/Tasks/SimpleTasks/EnqueueTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/EnqueueTask.cpp
@@ -19,6 +19,11 @@ TaskID EnqueueTask::GetTaskID() const
     return TaskID::ENQUEUE;
 }
 
+ITask* EnqueueTask::CloneImpl()
+{
+    return new EnqueueTask(m_tasks, m_num, m_isSpellDamage);
+}
+
 TaskStatus EnqueueTask::Impl(Player& player)
 {
     const int times =

--- a/Sources/Rosetta/Tasks/SimpleTasks/FilterStackTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/FilterStackTask.cpp
@@ -28,6 +28,21 @@ TaskID FilterStackTask::GetTaskID() const
     return TaskID::FILTER_STACK;
 }
 
+ITask* FilterStackTask::CloneImpl()
+{
+    if (m_selfCondition != nullptr)
+    {
+        return new FilterStackTask(*m_selfCondition);
+    }
+
+    if (m_relaCondition != nullptr)
+    {
+        return new FilterStackTask(m_entityType, *m_relaCondition);
+    }
+
+    return nullptr;
+}
+
 TaskStatus FilterStackTask::Impl(Player& player)
 {
     if (m_relaCondition != nullptr)

--- a/Sources/Rosetta/Tasks/SimpleTasks/FlagTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/FlagTask.cpp
@@ -19,6 +19,11 @@ TaskID FlagTask::GetTaskID() const
     return TaskID::FLAG;
 }
 
+ITask* FlagTask::CloneImpl()
+{
+    return new FlagTask(m_flag, m_toDoTask);
+}
+
 TaskStatus FlagTask::Impl(Player& player)
 {
     if (player.GetGame()->taskStack.flag != m_flag)

--- a/Sources/Rosetta/Tasks/SimpleTasks/FuncEntityTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/FuncEntityTask.cpp
@@ -22,6 +22,11 @@ TaskID FuncEntityTask::GetTaskID() const
     return TaskID::FUNC_ENTITY;
 }
 
+ITask* FuncEntityTask::CloneImpl()
+{
+    return new FuncEntityTask(m_func);
+}
+
 TaskStatus FuncEntityTask::Impl(Player& player)
 {
     if (m_func != nullptr)

--- a/Sources/Rosetta/Tasks/SimpleTasks/FuncNumberTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/FuncNumberTask.cpp
@@ -20,6 +20,11 @@ TaskID FuncNumberTask::GetTaskID() const
     return TaskID::FUNC_NUMBER;
 }
 
+ITask* FuncNumberTask::CloneImpl()
+{
+    return new FuncNumberTask(m_func);
+}
+
 TaskStatus FuncNumberTask::Impl(Player&)
 {
     if (m_func != nullptr)

--- a/Sources/Rosetta/Tasks/SimpleTasks/GetGameTagTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/GetGameTagTask.cpp
@@ -24,6 +24,11 @@ TaskID GetGameTagTask::GetTaskID() const
     return TaskID::GET_GAME_TAG;
 }
 
+ITask* GetGameTagTask::CloneImpl()
+{
+    return new GetGameTagTask(m_entityType, m_gameTag, m_entityIndex, m_numIndex);
+}
+
 TaskStatus GetGameTagTask::Impl(Player& player)
 {
     auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/HealFullTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/HealFullTask.cpp
@@ -18,6 +18,11 @@ TaskID HealFullTask::GetTaskID() const
     return TaskID::HEAL_FULL;
 }
 
+ITask* HealFullTask::CloneImpl()
+{
+    return new HealFullTask(m_entityType);
+}
+
 TaskStatus HealFullTask::Impl(Player& player)
 {
     auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/HealTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/HealTask.cpp
@@ -19,6 +19,11 @@ TaskID HealTask::GetTaskID() const
     return TaskID::HEAL;
 }
 
+ITask* HealTask::CloneImpl()
+{
+    return new HealTask(m_entityType, m_amount);
+}
+
 TaskStatus HealTask::Impl(Player& player)
 {
     auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/IncludeTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/IncludeTask.cpp
@@ -20,6 +20,11 @@ TaskID IncludeTask::GetTaskID() const
     return TaskID::INCLUDE;
 }
 
+ITask* IncludeTask::CloneImpl()
+{
+    return new IncludeTask(m_entityType);
+}
+
 std::vector<Entity*> IncludeTask::GetEntities(EntityType entityType,
                                               Player& player, Entity* source,
                                               Entity* target)

--- a/Sources/Rosetta/Tasks/SimpleTasks/ManaCrystalTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/ManaCrystalTask.cpp
@@ -19,6 +19,11 @@ TaskID ManaCrystalTask::GetTaskID() const
     return TaskID::MANA_CRYSTAL;
 }
 
+ITask* ManaCrystalTask::CloneImpl()
+{
+    return new ManaCrystalTask(m_amount, m_fill, m_isOpponent);
+}
+
 TaskStatus ManaCrystalTask::Impl(Player& player)
 {
     if (m_isOpponent)

--- a/Sources/Rosetta/Tasks/SimpleTasks/MathSubTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/MathSubTask.cpp
@@ -21,6 +21,11 @@ MathSubTask::MathSubTask(EntityType entityType, GameTag tag)
     // Do nothing
 }
 
+ITask* MathSubTask::CloneImpl()
+{
+    return new MathSubTask(m_entityType, m_gameTag, m_amount);
+}
+
 MathSubTask::MathSubTask(int amount) : m_amount(amount)
 {
     // Do nothing

--- a/Sources/Rosetta/Tasks/SimpleTasks/MoveToGraveyardTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/MoveToGraveyardTask.cpp
@@ -19,6 +19,11 @@ TaskID MoveToGraveyardTask::GetTaskID() const
     return TaskID::MOVE_TO_GRAVEYARD;
 }
 
+ITask* MoveToGraveyardTask::CloneImpl()
+{
+    return new MoveToGraveyardTask(m_entityType);
+}
+
 TaskStatus MoveToGraveyardTask::Impl(Player& player)
 {
     auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/RandomEntourageTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/RandomEntourageTask.cpp
@@ -24,6 +24,11 @@ TaskID RandomEntourageTask::GetTaskID() const
     return TaskID::RANDOM_ENTOURAGE;
 }
 
+ITask* RandomEntourageTask::CloneImpl()
+{
+    return new RandomEntourageTask(m_count, m_isOpponent);
+}
+
 TaskStatus RandomEntourageTask::Impl(Player& player)
 {
     (void)m_isOpponent;

--- a/Sources/Rosetta/Tasks/SimpleTasks/RandomTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/RandomTask.cpp
@@ -24,6 +24,11 @@ TaskID RandomTask::GetTaskID() const
     return TaskID::RANDOM;
 }
 
+ITask* RandomTask::CloneImpl()
+{
+    return new RandomTask(m_entityType, m_num);
+}
+
 TaskStatus RandomTask::Impl(Player& player)
 {
     auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/RemoveEnchantmentTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/RemoveEnchantmentTask.cpp
@@ -13,6 +13,11 @@ TaskID RemoveEnchantmentTask::GetTaskID() const
     return TaskID::REMOVE_ENCHANTMENT;
 }
 
+ITask* RemoveEnchantmentTask::CloneImpl()
+{
+    return new RemoveEnchantmentTask();
+}
+
 TaskStatus RemoveEnchantmentTask::Impl(Player&)
 {
     auto enchantment = dynamic_cast<Enchantment*>(m_source);

--- a/Sources/Rosetta/Tasks/SimpleTasks/RemoveHandTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/RemoveHandTask.cpp
@@ -19,6 +19,11 @@ TaskID RemoveHandTask::GetTaskID() const
     return TaskID::REMOVE_HAND;
 }
 
+ITask* RemoveHandTask::CloneImpl()
+{
+    return new RemoveHandTask(m_entityType);
+}
+
 TaskStatus RemoveHandTask::Impl(Player& player)
 {
     auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/ReturnHandTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/ReturnHandTask.cpp
@@ -19,6 +19,11 @@ TaskID ReturnHandTask::GetTaskID() const
     return TaskID::RETURN_HAND;
 }
 
+ITask* ReturnHandTask::CloneImpl()
+{
+    return new ReturnHandTask(m_entityType);
+}
+
 TaskStatus ReturnHandTask::Impl(Player& player)
 {
     auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/SetGameTagTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/SetGameTagTask.cpp
@@ -19,6 +19,11 @@ TaskID SetGameTagTask::GetTaskID() const
     return TaskID::SET_GAME_TAG;
 }
 
+ITask* SetGameTagTask::CloneImpl()
+{
+    return new SetGameTagTask(m_entityType, m_gameTag, m_amount);
+}
+
 TaskStatus SetGameTagTask::Impl(Player& player)
 {
     auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/SilenceTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/SilenceTask.cpp
@@ -18,6 +18,11 @@ TaskID SilenceTask::GetTaskID() const
     return TaskID::SILENCE;
 }
 
+ITask* SilenceTask::CloneImpl()
+{
+    return new SilenceTask(m_entityType);
+}
+
 TaskStatus SilenceTask::Impl(Player& player)
 {
     auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/SummonTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/SummonTask.cpp
@@ -30,6 +30,11 @@ SummonTask::SummonTask(std::string cardID, SummonSide side) : m_side(side)
     m_card = Cards::FindCardByID(cardID);
 }
 
+ITask* SummonTask::CloneImpl()
+{
+    return new SummonTask(m_side, m_card, m_amount);
+}
+
 TaskID SummonTask::GetTaskID() const
 {
     return TaskID::SUMMON;

--- a/Sources/Rosetta/Tasks/SimpleTasks/SwapAttackHealthTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/SwapAttackHealthTask.cpp
@@ -22,6 +22,11 @@ TaskID SwapAttackHealthTask::GetTaskID() const
     return TaskID::SWAP_ATTACK_HEALTH;
 }
 
+ITask* SwapAttackHealthTask::CloneImpl()
+{
+    return new SwapAttackHealthTask(m_entityType, m_enchantmentID);
+}
+
 TaskStatus SwapAttackHealthTask::Impl(Player& player)
 {
     auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/TempManaTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/TempManaTask.cpp
@@ -17,6 +17,11 @@ TaskID TempManaTask::GetTaskID() const
     return TaskID::TEMP_MANA;
 }
 
+ITask* TempManaTask::CloneImpl()
+{
+    return new TempManaTask(m_amount);
+}
+
 TaskStatus TempManaTask::Impl(Player& player)
 {
     if (player.GetRemainingMana() + m_amount > MANA_UPPER_LIMIT)

--- a/Sources/Rosetta/Tasks/SimpleTasks/TransformCopyTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/TransformCopyTask.cpp
@@ -13,6 +13,11 @@ TaskID TransformCopyTask::GetTaskID() const
     return TaskID::TRANSFORM_COPY;
 }
 
+ITask* TransformCopyTask::CloneImpl()
+{
+    return new TransformCopyTask();
+}
+
 TaskStatus TransformCopyTask::Impl(Player& player)
 {
     const auto target = dynamic_cast<Minion*>(m_target);

--- a/Sources/Rosetta/Tasks/SimpleTasks/TransformTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/TransformTask.cpp
@@ -23,6 +23,11 @@ TaskID TransformTask::GetTaskID() const
     return TaskID::TRANSFORM;
 }
 
+ITask* TransformTask::CloneImpl()
+{
+    return new TransformTask(m_entityType, m_cardID);
+}
+
 TaskStatus TransformTask::Impl(Player& player)
 {
     auto entities =

--- a/Sources/Rosetta/Tasks/SimpleTasks/WeaponTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/WeaponTask.cpp
@@ -9,7 +9,7 @@
 
 namespace RosettaStone::SimpleTasks
 {
-WeaponTask::WeaponTask(std::string&& cardID) : m_cardID(cardID)
+WeaponTask::WeaponTask(std::string cardID) : m_cardID(std::move(cardID))
 {
     // Do nothing
 }
@@ -17,6 +17,11 @@ WeaponTask::WeaponTask(std::string&& cardID) : m_cardID(cardID)
 TaskID WeaponTask::GetTaskID() const
 {
     return TaskID::WEAPON;
+}
+
+ITask* WeaponTask::CloneImpl()
+{
+    return new WeaponTask(m_cardID);
 }
 
 TaskStatus WeaponTask::Impl(Player& player)

--- a/Sources/Rosetta/Tasks/TaskQueue.cpp
+++ b/Sources/Rosetta/Tasks/TaskQueue.cpp
@@ -59,6 +59,11 @@ TaskStatus TaskQueue::Process()
 
     const TaskStatus status = currentTask->Run();
 
+    if (currentTask->IsFreeable())
+    {
+        delete currentTask;
+    }
+
     m_currentTask = nullptr;
 
     return status;


### PR DESCRIPTION
* Fix that NOT to use same `ITask` in multiple threads that `Power` contains.
* Fix that copy `ITask` if when its potential to accessed across via multiple threads.
* Fix that free `ITask` if it's available.