### PR TITLE
Implement 7 EXPERT1 cards and SpellPowerN effect

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -307,7 +307,7 @@ EXPERT1 | EX1_509 | Murloc Tidecaller |
 EXPERT1 | EX1_522 | Patient Assassin | O
 EXPERT1 | EX1_531 | Scavenging Hyena |  
 EXPERT1 | EX1_533 | Misdirection |  
-EXPERT1 | EX1_534 | Savannah Highmane |  
+EXPERT1 | EX1_534 | Savannah Highmane | O
 EXPERT1 | EX1_536 | Eaglehorn Bow |  
 EXPERT1 | EX1_537 | Explosive Shot |  
 EXPERT1 | EX1_538 | Unleash the Hounds |  

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -348,7 +348,7 @@ EXPERT1 | EX1_608 | Sorcerer's Apprentice |
 EXPERT1 | EX1_609 | Snipe | O
 EXPERT1 | EX1_610 | Explosive Trap |  
 EXPERT1 | EX1_611 | Freezing Trap |  
-EXPERT1 | EX1_612 | Kirin Tor Mage |  
+EXPERT1 | EX1_612 | Kirin Tor Mage | O
 EXPERT1 | EX1_613 | Edwin VanCleef |  
 EXPERT1 | EX1_614 | Illidan Stormrage |  
 EXPERT1 | EX1_616 | Mana Wraith |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 53% (126 of 237 Cards)
+- Progress: 53% (127 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -348,7 +348,7 @@ EXPERT1 | EX1_608 | Sorcerer's Apprentice |
 EXPERT1 | EX1_609 | Snipe | O
 EXPERT1 | EX1_610 | Explosive Trap |  
 EXPERT1 | EX1_611 | Freezing Trap |  
-EXPERT1 | EX1_612 | Kirin Tor Mage | O
+EXPERT1 | EX1_612 | Kirin Tor Mage |  
 EXPERT1 | EX1_613 | Edwin VanCleef |  
 EXPERT1 | EX1_614 | Illidan Stormrage | O
 EXPERT1 | EX1_616 | Mana Wraith |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 57% (134 of 237 Cards)
+- Progress: 56% (133 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -228,7 +228,7 @@ EXPERT1 | EX1_137 | Headcrack |
 EXPERT1 | EX1_144 | Shadowstep | O
 EXPERT1 | EX1_145 | Preparation |  
 EXPERT1 | EX1_154 | Wrath | O
-EXPERT1 | EX1_155 | Mark of Nature |  
+EXPERT1 | EX1_155 | Mark of Nature | O
 EXPERT1 | EX1_158 | Soul of the Forest | O
 EXPERT1 | EX1_160 | Power of the Wild |  
 EXPERT1 | EX1_162 | Dire Wolf Alpha |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 55% (133 of 237 Cards)
+- Progress: 57% (134 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -350,7 +350,7 @@ EXPERT1 | EX1_610 | Explosive Trap |
 EXPERT1 | EX1_611 | Freezing Trap |  
 EXPERT1 | EX1_612 | Kirin Tor Mage | O
 EXPERT1 | EX1_613 | Edwin VanCleef |  
-EXPERT1 | EX1_614 | Illidan Stormrage |  
+EXPERT1 | EX1_614 | Illidan Stormrage | O
 EXPERT1 | EX1_616 | Mana Wraith |  
 EXPERT1 | EX1_617 | Deadly Shot | O
 EXPERT1 | EX1_619 | Equality | O
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 53% (127 of 237 Cards)
+- Progress: 53% (128 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -288,7 +288,7 @@ EXPERT1 | EX1_382 | Aldor Peacekeeper |
 EXPERT1 | EX1_383 | Tirion Fordring | O
 EXPERT1 | EX1_384 | Avenging Wrath |  
 EXPERT1 | EX1_390 | Tauren Warrior |  
-EXPERT1 | EX1_391 | Slam |  
+EXPERT1 | EX1_391 | Slam | O
 EXPERT1 | EX1_392 | Battle Rage |  
 EXPERT1 | EX1_393 | Amani Berserker |  
 EXPERT1 | EX1_396 | Mogu'shan Warden | O
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 53% (129 of 237 Cards)
+- Progress: 55% (130 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -284,7 +284,7 @@ EXPERT1 | EX1_363 | Blessing of Wisdom |
 EXPERT1 | EX1_365 | Holy Wrath |  
 EXPERT1 | EX1_366 | Sword of Justice |  
 EXPERT1 | EX1_379 | Repentance |  
-EXPERT1 | EX1_382 | Aldor Peacekeeper |  
+EXPERT1 | EX1_382 | Aldor Peacekeeper | O
 EXPERT1 | EX1_383 | Tirion Fordring | O
 EXPERT1 | EX1_384 | Avenging Wrath |  
 EXPERT1 | EX1_390 | Tauren Warrior |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 55% (131 of 237 Cards)
+- Progress: 55% (132 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -229,7 +229,7 @@ EXPERT1 | EX1_144 | Shadowstep | O
 EXPERT1 | EX1_145 | Preparation |  
 EXPERT1 | EX1_154 | Wrath | O
 EXPERT1 | EX1_155 | Mark of Nature |  
-EXPERT1 | EX1_158 | Soul of the Forest |  
+EXPERT1 | EX1_158 | Soul of the Forest | O
 EXPERT1 | EX1_160 | Power of the Wild |  
 EXPERT1 | EX1_162 | Dire Wolf Alpha |  
 EXPERT1 | EX1_164 | Nourish |  
@@ -266,9 +266,9 @@ EXPERT1 | EX1_309 | Siphon Soul | O
 EXPERT1 | EX1_312 | Twisting Nether | O
 EXPERT1 | EX1_313 | Pit Lord | O
 EXPERT1 | EX1_315 | Summoning Portal |  
-EXPERT1 | EX1_317 | Sense Demons | O
+EXPERT1 | EX1_317 | Sense Demons | 
 EXPERT1 | EX1_319 | Flame Imp |  
-EXPERT1 | EX1_320 | Bane of Doom |  
+EXPERT1 | EX1_320 | Bane of Doom | O
 EXPERT1 | EX1_323 | Lord Jaraxxus |  
 EXPERT1 | EX1_332 | Silence | O
 EXPERT1 | EX1_334 | Shadow Madness |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 55% (130 of 237 Cards)
+- Progress: 55% (131 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -266,7 +266,7 @@ EXPERT1 | EX1_309 | Siphon Soul | O
 EXPERT1 | EX1_312 | Twisting Nether | O
 EXPERT1 | EX1_313 | Pit Lord | O
 EXPERT1 | EX1_315 | Summoning Portal |  
-EXPERT1 | EX1_317 | Sense Demons |  
+EXPERT1 | EX1_317 | Sense Demons | O
 EXPERT1 | EX1_319 | Flame Imp |  
 EXPERT1 | EX1_320 | Bane of Doom |  
 EXPERT1 | EX1_323 | Lord Jaraxxus |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 53% (128 of 237 Cards)
+- Progress: 53% (129 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -333,7 +333,7 @@ EXPERT1 | EX1_575 | Mana Tide Totem |
 EXPERT1 | EX1_577 | The Beast | O
 EXPERT1 | EX1_578 | Savagery |  
 EXPERT1 | EX1_583 | Priestess of Elune | O
-EXPERT1 | EX1_584 | Ancient Mage |  
+EXPERT1 | EX1_584 | Ancient Mage | O
 EXPERT1 | EX1_586 | Sea Giant |  
 EXPERT1 | EX1_590 | Blood Knight |  
 EXPERT1 | EX1_591 | Auchenai Soulpriest |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 55% (132 of 237 Cards)
+- Progress: 55% (133 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Includes/Rosetta/Enchants/Effects.hpp
+++ b/Includes/Rosetta/Enchants/Effects.hpp
@@ -30,6 +30,12 @@ class Effects
         return new Effect(GameTag::HEALTH, EffectOperator::ADD, n);
     }
 
+    //! Creates effect that increases spell power by \p n.
+    static Effect* SpellPowerN(int n)
+    {
+        return new Effect(GameTag::SPELLPOWER, EffectOperator::ADD, n);
+    }
+
     //! Creates effect that increases attack and health by \p n.
     static std::vector<Effect*> AttackHealthN(int n)
     {

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 ### Basic & Classic
 
   * **100% Basic (133 of 133 Cards)**
-  * 53% Classic (126 of 237 Cards)
+  * 56% Classic (135 of 237 Cards)
   * 32% Hall of Fame (7 of 22 Cards)
 
 ### Adventures

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -84,6 +84,24 @@ void Expert1CardsGen::AddDruid(std::map<std::string, Power>& cards)
     cards.emplace("EX1_154", power);
 
     // ------------------------------------------ SPELL - DRUID
+    // [EX1_155] Mark of Nature - COST:3
+    // - Faction: Neutral, Set: Expert1, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Choose One -</b>
+    //       Give a minion +4 Attack; or +4 Health and <b>Taunt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CHOOSE_ONE = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("EX1_155", power);
+
+    // ------------------------------------------ SPELL - DRUID
     // [EX1_158] Soul of the Forest - COST:4
     // - Set: Expert1, Rarity: Common
     // --------------------------------------------------------
@@ -137,6 +155,54 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
     power.AddPowerTask(new DamageTask(EntityType::TARGET, 1, true));
     power.AddPowerTask(new DrawTask(1));
     cards.emplace("EX1_154b", power);
+
+    // ------------------------------------------ SPELL - DRUID
+    // [EX1_155a] Tiger's Fury (*) - COST:0
+    // - Faction: Neutral, Set: Expert1
+    // --------------------------------------------------------
+    // Text: +4 Attack.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new AddEnchantmentTask("EX1_155ae", EntityType::TARGET));
+    cards.emplace("EX1_155a", power);
+
+    // ------------------------------------------ SPELL - DRUID
+    // [EX1_155ae] Mark of Nature (*) - COST:0
+    // - Faction: Neutral, Set: Expert1
+    // --------------------------------------------------------
+    // Text: This minion has +4 Attack.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("EX1_155ae"));
+    cards.emplace("EX1_155ae", power);
+
+    // ------------------------------------------ SPELL - DRUID
+    // [EX1_155b] Thick Hide (*) - COST:0
+    // - Faction: Neutral, Set: Expert1
+    // --------------------------------------------------------
+    // Text: +4 Health and <b>Taunt</b>.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new AddEnchantmentTask("EX1_155be", EntityType::TARGET));
+    cards.emplace("EX1_155b", power);
+
+    // ------------------------------------------ SPELL - DRUID
+    // [EX1_155be] Mark of Nature (*) - COST:0
+    // - Faction: Neutral, Set: Expert1
+    // --------------------------------------------------------
+    // Text: This minion has +4 Health and <b>Taunt</b>.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("EX1_155be"));
+    cards.emplace("EX1_155be", power);
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [EX1_158e] Soul of the Forest (*) - COST:0

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -418,6 +418,24 @@ void Expert1CardsGen::AddPaladin(std::map<std::string, Power>& cards)
     cards.emplace("EX1_362", power);
 
     // --------------------------------------- MINION - PALADIN
+    // [EX1_382] Aldor Peacekeeper - COST:3 [ATK:3/HP:3]
+    // - Faction: Neutral, Set: Expert1, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Change an enemy minion's Attack to 1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_ENEMY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new AddEnchantmentTask("EX1_382e", EntityType::TARGET));
+    cards.emplace("EX1_382", power);
+
+    // --------------------------------------- MINION - PALADIN
     // [EX1_383] Tirion Fordring - COST:8 [ATK:6/HP:6]
     // - Faction: Neutral, Set: Expert1, Rarity: Legendary
     // --------------------------------------------------------
@@ -459,6 +477,16 @@ void Expert1CardsGen::AddPaladinNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddEnchant(new Enchant(GameTag::ATK, EffectOperator::MUL, 2));
     cards.emplace("EX1_355e", power);
+
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [EX1_382e] Stand Down! (*) - COST:0
+    // - Set: Expert1
+    // --------------------------------------------------------
+    // Text: Attack changed to 1.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(new Enchant(Effects::SetAttack(1)));
+    cards.emplace("EX1_382e", power);
 
     // --------------------------------------- WEAPON - PALADIN
     // [EX1_383t] Ashbringer (*) - COST:5 [ATK:5/HP:0]

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -87,15 +87,18 @@ void Expert1CardsGen::AddDruid(std::map<std::string, Power>& cards)
     // [EX1_155] Mark of Nature - COST:3
     // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Choose One -</b>
-    //       Give a minion +4 Attack; or +4 Health and <b>Taunt</b>.
+    // Text: <b>Choose One -</b> Give a minion +4 Attack;
+    //       or +4 Health and <b>Taunt</b>.
     // --------------------------------------------------------
     // GameTag:
     // - CHOOSE_ONE = 1
     // --------------------------------------------------------
     // PlayReq:
-    // - REQ_MINION_TARGET = 0
     // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -103,9 +106,12 @@ void Expert1CardsGen::AddDruid(std::map<std::string, Power>& cards)
 
     // ------------------------------------------ SPELL - DRUID
     // [EX1_158] Soul of the Forest - COST:4
-    // - Set: Expert1, Rarity: Common
+    // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
-    // Text: Give your minions \"<b>Deathrattle:</b> Summon a 2/2 Treant.\"
+    // Text: Give your minions "<b>Deathrattle:</b> Summon a 2/2 Treant."
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(new AddEnchantmentTask("EX1_158e", EntityType::MINIONS));
@@ -172,7 +178,7 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
 
     // ------------------------------------------ SPELL - DRUID
     // [EX1_155ae] Mark of Nature (*) - COST:0
-    // - Faction: Neutral, Set: Expert1
+    // - Set: Expert1
     // --------------------------------------------------------
     // Text: This minion has +4 Attack.
     // --------------------------------------------------------
@@ -196,7 +202,7 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
 
     // ------------------------------------------ SPELL - DRUID
     // [EX1_155be] Mark of Nature (*) - COST:0
-    // - Faction: Neutral, Set: Expert1
+    // - Set: Expert1
     // --------------------------------------------------------
     // Text: This minion has +4 Health and <b>Taunt</b>.
     // --------------------------------------------------------
@@ -206,12 +212,12 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [EX1_158e] Soul of the Forest (*) - COST:0
-    // - Faction: Neutral, Set: Expert1
+    // - Set: Expert1
     // --------------------------------------------------------
     // Text: Deathrattle: Summon a 2/2 Treant.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddDeathrattleTask(new SummonTask("EX1_158t", SummonSide::DEATHRATTLE));
+    power.AddDeathrattleTask(new SummonTask("EX1_158t", SummonSide::DEFAULT));
     cards.emplace("EX1_158e", power);
 
     // ----------------------------------------- MINION - DRUID
@@ -487,7 +493,7 @@ void Expert1CardsGen::AddPaladin(std::map<std::string, Power>& cards)
     // [EX1_382] Aldor Peacekeeper - COST:3 [ATK:3/HP:3]
     // - Faction: Neutral, Set: Expert1, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Change an enemy minion's Attack to 1.
+    // Text: <b>Battlecry:</b> Change an enemy minion's Attack to 1.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
@@ -1190,10 +1196,10 @@ void Expert1CardsGen::AddWarlock(std::map<std::string, Power>& cards)
 
     // ---------------------------------------- SPELL - WARLOCK
     // [EX1_320] Bane of Doom - COST:5
-    // - Set: Expert1, Rarity: Epic
+    // - Faction: Neutral, Set: Expert1, Rarity: Epic
     // --------------------------------------------------------
-    // Text: Deal $2 damage to a character.
-    //       If that kills it, summon a random Demon.
+    // Text: Deal $2 damage to a character. If that kills it,
+    //       summon a random Demon.
     // --------------------------------------------------------
     // PlayReq:
     // - REQ_TARGET_TO_PLAY = 0
@@ -1202,9 +1208,10 @@ void Expert1CardsGen::AddWarlock(std::map<std::string, Power>& cards)
     power.AddPowerTask(new DamageTask(EntityType::TARGET, 2, true));
     power.AddPowerTask(
         new ConditionTask(EntityType::TARGET, { SelfCondition::IsDead() }));
-    power.AddPowerTask(new FlagTask(true,
-    { new RandomCardTask(CardType::MINION, CardClass::INVALID, Race::DEMON),
-      new SummonTask(SummonSide::SPELL) }));
+    power.AddPowerTask(new FlagTask(
+        true,
+        { new RandomCardTask(CardType::MINION, CardClass::INVALID, Race::DEMON),
+          new SummonTask(SummonSide::SPELL) }));
     cards.emplace("EX1_320", power);
 }
 
@@ -1244,21 +1251,20 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, Power>& cards)
 
     // ---------------------------------------- SPELL - WARRIOR
     // [EX1_391] Slam - COST:2
-    // - Set: Expert1, Rarity: Common
+    // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
     // Text: Deal $2 damage to a minion. If it survives, draw a card.
     // --------------------------------------------------------
     // PlayReq:
-    // - REQ_MINION_TARGET = 0
     // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(new DamageTask(EntityType::TARGET, 2, true));
-    power.AddPowerTask(new ConditionTask(EntityType::TARGET, {
-        SelfCondition::IsNotDead()
-    }));
+    power.AddPowerTask(
+        new ConditionTask(EntityType::TARGET, { SelfCondition::IsNotDead() }));
     power.AddPowerTask(new FlagTask(true, { new DrawTask(1) }));
-    cards.emplace("EX1_391", power);    
+    cards.emplace("EX1_391", power);
 
     // ---------------------------------------- SPELL - WARRIOR
     // [EX1_407] Brawl - COST:5
@@ -2337,7 +2343,7 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_583] Priestess of Elune - COST:6 [ATK:5/HP:4]
-    // - Set: Expert1, Rarity: Common
+    // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Restore 4 Health to your hero.
     // --------------------------------------------------------
@@ -2350,13 +2356,15 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_584] Ancient Mage - COST:4 [ATK:2/HP:5]
-    // - Set: Expert1, Rarity: Rare
+    // - Faction: Neutral, Set: Expert1, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Give adjacent minions
-    //       <b>Spell Damage +1</b>.
+    // Text: <b>Battlecry:</b> Give adjacent minions <b>Spell Damage +1</b>.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SPELLPOWER = 1
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(new IncludeTask(EntityType::MINIONS));
@@ -2367,18 +2375,17 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_614] Illidan Stormrage - COST:6 [ATK:7/HP:5]
-    // - Race: Demon, Set: Expert1, Rarity: Legendary
+    // - Race: Demon, Faction: Neutral, Set: Expert1, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: Whenever you play a card,
-    //       summon a 2/1 Flame of Azzinoth.
+    // Text: Whenever you play a card, summon a 2/1 Flame of_Azzinoth.
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
-    // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(new Trigger(TriggerType::PLAY_CARD));
-    power.GetTrigger()->tasks = { new SummonTask("EX1_614t", SummonSide::RIGHT) };
+    power.GetTrigger()->tasks = { new SummonTask("EX1_614t",
+                                                 SummonSide::RIGHT) };
     cards.emplace("EX1_614", power);
 
     // --------------------------------------- MINION - NEUTRAL

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -2207,6 +2207,22 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     cards.emplace("EX1_584", power);
 
     // --------------------------------------- MINION - NEUTRAL
+    // [EX1_614] Illidan Stormrage - COST:6 [ATK:7/HP:5]
+    // - Race: Demon, Set: Expert1, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Whenever you play a card,
+    //       summon a 2/1 Flame of Azzinoth.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(new Trigger(TriggerType::PLAY_CARD));
+    power.GetTrigger()->tasks = { new SummonTask("EX1_614t", SummonSide::RIGHT) };
+    cards.emplace("EX1_614", power);
+
+    // --------------------------------------- MINION - NEUTRAL
     // [NEW1_019] Knife Juggler - COST:2 [ATK:2/HP:2]
     // - Set: Expert1, Rarity: Rare
     // --------------------------------------------------------
@@ -2545,6 +2561,14 @@ void Expert1CardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddEnchant(new Enchant(Effects::SpellPowerN(1)));
     cards.emplace("EX1_584e", power);
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [EX1_614t] Flame of Azzinoth (*) - COST:1 [ATK:2/HP:1]
+    // - Race: Elemental, Set: Expert1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("EX1_614t", power);
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_finkle] Finkle Einhorn (*) - COST:3 [ATK:3/HP:3]

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -2190,6 +2190,23 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     cards.emplace("EX1_583", power);
 
     // --------------------------------------- MINION - NEUTRAL
+    // [EX1_584] Ancient Mage - COST:4 [ATK:2/HP:5]
+    // - Faction: Neutral, Set: Expert1, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give adjacent minions
+    //       <b>Spell Damage +1</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new IncludeTask(EntityType::MINIONS));
+    power.AddPowerTask(
+        new FilterStackTask(EntityType::SOURCE, RelaCondition::IsSideBySide()));
+    power.AddPowerTask(new AddEnchantmentTask("EX1_584e", EntityType::STACK));
+    cards.emplace("EX1_584", power);
+
+    // --------------------------------------- MINION - NEUTRAL
     // [NEW1_019] Knife Juggler - COST:2 [ATK:2/HP:2]
     // - Set: Expert1, Rarity: Rare
     // --------------------------------------------------------
@@ -2518,6 +2535,16 @@ void Expert1CardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddPowerTask(nullptr);
     cards.emplace("EX1_116t", power);
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [EX1_584e] Teachings of the Kirin Tor (*) - COST:0
+    // - Set: Expert1
+    // --------------------------------------------------------
+    // Text: <b>Spell Damage +1</b>.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(new Enchant(Effects::SpellPowerN(1)));
+    cards.emplace("EX1_584e", power);
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_finkle] Finkle Einhorn (*) - COST:3 [ATK:3/HP:3]

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1121,6 +1121,24 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, Power>& cards)
     cards.emplace("CS2_104", power);
 
     // ---------------------------------------- SPELL - WARRIOR
+    // [EX1_391] Slam - COST:2
+    // - Set: Expert1, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Deal $2 damage to a minion. If it survives, draw a card.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new DamageTask(EntityType::TARGET, 2, true));
+    power.AddPowerTask(new ConditionTask(EntityType::TARGET, {
+        SelfCondition::IsNotDead()
+    }));
+    power.AddPowerTask(new FlagTask(true, { new DrawTask(1) }));
+    cards.emplace("EX1_391", power);    
+
+    // ---------------------------------------- SPELL - WARRIOR
     // [EX1_407] Brawl - COST:5
     // - Faction: Neutral, Set: Expert1, Rarity: Epic
     // --------------------------------------------------------

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -2533,7 +2533,7 @@ void Expert1CardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
     power.AddEnchant(Enchants::GetEnchantFromText("EX1_103e"));
     cards.emplace("EX1_103e", power);
 
-    // ---------------------------------- MINION - NEUTRAL
+    // --------------------------------------- MINION - NEUTRAL
     // [EX1_110t] Baine Bloodhoof (*) - COST:4 [ATK:4/HP:5]
     // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
@@ -2544,7 +2544,7 @@ void Expert1CardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
     power.AddPowerTask(nullptr);
     cards.emplace("EX1_110t", power);
 
-    // ---------------------------------- MINION - NEUTRAL
+    // --------------------------------------- MINION - NEUTRAL
     // [EX1_116t] Whelp (*) - COST:1 [ATK:1/HP:1]
     // - Race: Dragon, Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1110,7 +1110,7 @@ void Expert1CardsGen::AddWarlock(std::map<std::string, Power>& cards)
         new ConditionTask(EntityType::TARGET, { SelfCondition::IsDead() }));
     power.AddPowerTask(new FlagTask(true,
     { new RandomCardTask(CardType::MINION, CardClass::INVALID, Race::DEMON),
-      new SummonTask(SummonSide::DEFAULT) }));
+      new SummonTask(SummonSide::SPELL) }));
     cards.emplace("EX1_320", power);
 }
 

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1065,6 +1065,25 @@ void Expert1CardsGen::AddWarlock(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddPowerTask(new DamageTask(EntityType::HERO, 5));
     cards.emplace("EX1_313", power);
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [EX1_320] Bane of Doom - COST:5
+    // - Set: Expert1, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Deal $2 damage to a character.
+    //       If that kills it, summon a random Demon.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new DamageTask(EntityType::TARGET, 2, true));
+    power.AddPowerTask(
+        new ConditionTask(EntityType::TARGET, { SelfCondition::IsDead() }));
+    power.AddPowerTask(new FlagTask(true,
+    { new RandomCardTask(CardType::MINION, CardClass::INVALID, Race::DEMON),
+      new SummonTask(SummonSide::DEFAULT) }));
+    cards.emplace("EX1_320", power);
 }
 
 void Expert1CardsGen::AddWarlockNonCollect(std::map<std::string, Power>& cards)

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -156,7 +156,7 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
     power.AddPowerTask(nullptr);
     cards.emplace("EX1_158t", power);
 
-    // ----------------------------------------- ENCHANTMENT - DRUID
+    // ------------------------------------ ENCHANTMENT - DRUID
     // [EX1_570e] Bite - COST:0
     // - Set: Expert1
     // --------------------------------------------------------

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -83,6 +83,16 @@ void Expert1CardsGen::AddDruid(std::map<std::string, Power>& cards)
     power.AddPowerTask(nullptr);
     cards.emplace("EX1_154", power);
 
+    // ------------------------------------------ SPELL - DRUID
+    // [EX1_158] Soul of the Forest - COST:4
+    // - Set: Expert1, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Give your minions \"<b>Deathrattle:</b> Summon a 2/2 Treant.\"
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new AddEnchantmentTask("EX1_158e", EntityType::MINIONS));
+    cards.emplace("EX1_158", power);
+
     // ------------------------------------------- SPELL - DRUID
     // [EX1_570] Bite - COST:4
     // - Faction: Neutral, Set: Expert1, Rarity: Rare
@@ -127,6 +137,24 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
     power.AddPowerTask(new DamageTask(EntityType::TARGET, 1, true));
     power.AddPowerTask(new DrawTask(1));
     cards.emplace("EX1_154b", power);
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [EX1_158e] Soul of the Forest (*) - COST:0
+    // - Faction: Neutral, Set: Expert1
+    // --------------------------------------------------------
+    // Text: Deathrattle: Summon a 2/2 Treant.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(new SummonTask("EX1_158t", SummonSide::DEATHRATTLE));
+    cards.emplace("EX1_158e", power);
+
+    // ----------------------------------------- MINION - DRUID
+    // [EX1_158t] Treant (*) - COST:2 [ATK:2/HP:2]
+    // - Faction: Neutral, Set: Expert1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("EX1_158t", power);
 
     // ----------------------------------------- ENCHANTMENT - DRUID
     // [EX1_570e] Bite - COST:0

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -2178,7 +2178,7 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_583] Priestess of Elune - COST:6 [ATK:5/HP:4]
-    // - Faction: Neutral, Set: Expert1, Rarity: Common
+    // - Set: Expert1, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Restore 4 Health to your hero.
     // --------------------------------------------------------
@@ -2191,7 +2191,7 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_584] Ancient Mage - COST:4 [ATK:2/HP:5]
-    // - Faction: Neutral, Set: Expert1, Rarity: Rare
+    // - Set: Expert1, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give adjacent minions
     //       <b>Spell Damage +1</b>.

--- a/Sources/Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.cpp
@@ -59,7 +59,7 @@ TaskStatus AddEnchantmentTask::Impl(Player& player)
 
         if (!power.GetDeathrattleTask().empty())
         {
-            m_target->SetGameTag(GameTag::DEATHRATTLE, 1);
+            entity->SetGameTag(GameTag::DEATHRATTLE, 1);
         }
     }
 

--- a/Sources/Rosetta/Tasks/SimpleTasks/SummonTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/SummonTask.cpp
@@ -113,6 +113,11 @@ TaskStatus SummonTask::Impl(Player& player)
                 summonPos = m_source->owner->GetGame()->taskStack.num - 1;
                 break;
             }
+            case SummonSide::SPELL:
+            {
+                summonPos = -1;
+                break;
+            }
             default:
                 throw std::invalid_argument(
                     "SummonTask::Impl() - Invalid summon side");

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -76,6 +76,65 @@ TEST(DruidExpert1Test, EX1_154_Wrath)
 }
 
 // ------------------------------------------ SPELL - DRUID
+// [EX1_155] Mark of Nature - COST:3
+// - Faction: Neutral, Set: Expert1, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Choose One -</b>
+//       Give a minion +4 Attack; or +4 Health and <b>Taunt</b>.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINION_TARGET = 0
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST(DruidExpert1Test, EX1_155_MarkOfNature)
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+    
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByID("EX1_155"));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByID("EX1_155"));
+    
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card1, 1));
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card4, card2, 2));
+    
+    EXPECT_EQ(curField[0]->GetAttack(), 5);
+    EXPECT_EQ(curField[0]->GetHealth(), 1);
+    EXPECT_EQ(curField[0]->GetGameTag(GameTag::TAUNT), 0);
+    
+    EXPECT_EQ(curField[1]->GetAttack(), 1);
+    EXPECT_EQ(curField[1]->GetHealth(), 5);
+    EXPECT_EQ(curField[1]->GetGameTag(GameTag::TAUNT), 1);
+}
+
+// ------------------------------------------ SPELL - DRUID
 // [EX1_158] Soul of the Forest - COST:4
 // - Set: Expert1, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -5568,6 +5568,67 @@ TEST(WarlockExpert1Test, EX1_313_PitLord)
     EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 25);
 }
 
+
+// ---------------------------------------- SPELL - WARLOCK
+// [EX1_320] Bane of Doom - COST:5
+// - Set: Expert1, Rarity: Epic
+// --------------------------------------------------------
+// Text: Deal $2 damage to a character.
+//       If that kills it, summon a random Demon.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST(WarlockExpert1Test, EX1_320_BaneOfDoom)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+    auto& opField = opPlayer.GetFieldZone();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Chillwind Yeti"));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Bane of Doom"));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Bane of Doom"));
+    
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+    
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card2));
+    
+    EXPECT_EQ(curField.GetCount(), 2);
+    EXPECT_EQ(opField.GetCount(), 0);
+    
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card1));
+    
+    EXPECT_EQ(curField.GetCount(), 1);
+    EXPECT_EQ(opField.GetCount(), 1);
+    EXPECT_EQ(opField.GetAll()[0]->card->GetRace(), Race::DEMON);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_396] Mogu'shan Warden - COST:4 [ATK:1/HP:7]
 // - Faction: Neutral, Set: Expert1, Rarity: Common

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -75,6 +75,81 @@ TEST(DruidExpert1Test, EX1_154_Wrath)
     EXPECT_EQ(curPlayer.GetHandZone().GetCount(), 6);
 }
 
+// ------------------------------------------ SPELL - DRUID
+// [EX1_158] Soul of the Forest - COST:4
+// - Set: Expert1, Rarity: Common
+// --------------------------------------------------------
+// Text: Give your minions \"<b>Deathrattle:</b> Summon a 2/2 Treant.\"
+// --------------------------------------------------------
+TEST(DruidExpert1Test, EX1_158_SoulOfTheForest)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+    auto& opField = opPlayer.GetFieldZone();
+        
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Wisp"));
+    const auto card5 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Wisp"));
+    const auto card6 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Wisp"));
+    const auto card7 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Soul of the Forest"));
+    
+    // const auto card7 = Generic::DrawCard(
+    //     opPlayer, Cards::GetInstance().FindCardByID("EX1_158"));
+    const auto card8 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Hellfire"));
+    
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+    
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    game.Process(opPlayer, PlayCardTask::Minion(card6));
+    game.Process(opPlayer, PlayCardTask::Spell(card7));
+
+    EXPECT_FALSE(opField[0]->appliedEnchantments.empty());
+    EXPECT_FALSE(opField[1]->appliedEnchantments.empty());
+    EXPECT_FALSE(opField[2]->appliedEnchantments.empty());
+    
+    game.Process(opPlayer, PlayCardTask::Spell(card8));
+    
+    EXPECT_EQ(curField.GetCount(), 0);
+    EXPECT_EQ(opField.GetCount(), 3);
+
+    EXPECT_EQ(opField[0]->card->name, "Treant");
+    EXPECT_EQ(opField[1]->card->name, "Treant");
+    EXPECT_EQ(opField[2]->card->name, "Treant");
+}
+
 // ------------------------------------------- SPELL - DRUID
 // [EX1_570] Bite - COST:4
 // - Faction: Neutral, Set: Expert1, Rarity: Rare

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -5890,6 +5890,61 @@ TEST(NeutralExpert1Test, EX1_584_AncientMage)
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [EX1_614] Illidan Stormrage - COST:6 [ATK:7/HP:5]
+// - Race: Demon, Set: Expert1, Rarity: Legendary
+// --------------------------------------------------------
+// Text: Whenever you play a card,
+//       summon a 2/1 Flame of Azzinoth.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST(NeutralExpert1Test, EX1_614_IllidanStormrage)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByID("EX1_614"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Moonfire"));
+    
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    
+    EXPECT_EQ(curField.GetCount(), 3);
+    EXPECT_EQ(curField[1]->card->name, "Flame of Azzinoth");
+    EXPECT_EQ(curField[2]->card->name, "Wisp");
+    
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card1));
+    
+    EXPECT_EQ(curField.GetCount(), 4);
+    EXPECT_EQ(curField[1]->card->name, "Flame of Azzinoth");
+    EXPECT_EQ(curField[2]->card->name, "Flame of Azzinoth");
+    EXPECT_EQ(curField[3]->card->name, "Wisp");
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [NEW1_019] Knife Juggler - COST:2 [ATK:2/HP:2]
 // - Set: Expert1, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -79,15 +79,18 @@ TEST(DruidExpert1Test, EX1_154_Wrath)
 // [EX1_155] Mark of Nature - COST:3
 // - Faction: Neutral, Set: Expert1, Rarity: Common
 // --------------------------------------------------------
-// Text: <b>Choose One -</b>
-//       Give a minion +4 Attack; or +4 Health and <b>Taunt</b>.
+// Text: <b>Choose One -</b> Give a minion +4 Attack;
+//       or +4 Health and <b>Taunt</b>.
 // --------------------------------------------------------
 // GameTag:
 // - CHOOSE_ONE = 1
 // --------------------------------------------------------
 // PlayReq:
-// - REQ_MINION_TARGET = 0
 // - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
 // --------------------------------------------------------
 TEST(DruidExpert1Test, EX1_155_MarkOfNature)
 {
@@ -110,7 +113,7 @@ TEST(DruidExpert1Test, EX1_155_MarkOfNature)
     opPlayer.SetUsedMana(0);
 
     auto& curField = curPlayer.GetFieldZone();
-    
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
     const auto card2 = Generic::DrawCard(
@@ -119,16 +122,16 @@ TEST(DruidExpert1Test, EX1_155_MarkOfNature)
         curPlayer, Cards::GetInstance().FindCardByID("EX1_155"));
     const auto card4 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByID("EX1_155"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     game.Process(curPlayer, PlayCardTask::Minion(card2));
+
     game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card1, 1));
-    game.Process(curPlayer, PlayCardTask::SpellTarget(card4, card2, 2));
-    
     EXPECT_EQ(curField[0]->GetAttack(), 5);
     EXPECT_EQ(curField[0]->GetHealth(), 1);
     EXPECT_EQ(curField[0]->GetGameTag(GameTag::TAUNT), 0);
-    
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card4, card2, 2));
     EXPECT_EQ(curField[1]->GetAttack(), 1);
     EXPECT_EQ(curField[1]->GetHealth(), 5);
     EXPECT_EQ(curField[1]->GetGameTag(GameTag::TAUNT), 1);
@@ -136,9 +139,12 @@ TEST(DruidExpert1Test, EX1_155_MarkOfNature)
 
 // ------------------------------------------ SPELL - DRUID
 // [EX1_158] Soul of the Forest - COST:4
-// - Set: Expert1, Rarity: Common
+// - Faction: Neutral, Set: Expert1, Rarity: Common
 // --------------------------------------------------------
-// Text: Give your minions \"<b>Deathrattle:</b> Summon a 2/2 Treant.\"
+// Text: Give your minions "<b>Deathrattle:</b> Summon a 2/2 Treant."
+// --------------------------------------------------------
+// RefTag:
+// - DEATHRATTLE = 1
 // --------------------------------------------------------
 TEST(DruidExpert1Test, EX1_158_SoulOfTheForest)
 {
@@ -162,7 +168,7 @@ TEST(DruidExpert1Test, EX1_158_SoulOfTheForest)
 
     auto& curField = curPlayer.GetFieldZone();
     auto& opField = opPlayer.GetFieldZone();
-        
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
     const auto card2 = Generic::DrawCard(
@@ -177,33 +183,28 @@ TEST(DruidExpert1Test, EX1_158_SoulOfTheForest)
         opPlayer, Cards::GetInstance().FindCardByName("Wisp"));
     const auto card7 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Soul of the Forest"));
-    
-    // const auto card7 = Generic::DrawCard(
-    //     opPlayer, Cards::GetInstance().FindCardByID("EX1_158"));
     const auto card8 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Hellfire"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     game.Process(curPlayer, PlayCardTask::Minion(card2));
     game.Process(curPlayer, PlayCardTask::Minion(card3));
-    
+
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
-    
+
     game.Process(opPlayer, PlayCardTask::Minion(card4));
     game.Process(opPlayer, PlayCardTask::Minion(card5));
     game.Process(opPlayer, PlayCardTask::Minion(card6));
-    game.Process(opPlayer, PlayCardTask::Spell(card7));
 
-    EXPECT_FALSE(opField[0]->appliedEnchantments.empty());
-    EXPECT_FALSE(opField[1]->appliedEnchantments.empty());
-    EXPECT_FALSE(opField[2]->appliedEnchantments.empty());
-    
+    game.Process(opPlayer, PlayCardTask::Spell(card7));
+    EXPECT_TRUE(!opField[0]->appliedEnchantments.empty());
+    EXPECT_TRUE(!opField[1]->appliedEnchantments.empty());
+    EXPECT_TRUE(!opField[2]->appliedEnchantments.empty());
+
     game.Process(opPlayer, PlayCardTask::Spell(card8));
-    
     EXPECT_EQ(curField.GetCount(), 0);
     EXPECT_EQ(opField.GetCount(), 3);
-
     EXPECT_EQ(opField[0]->card->name, "Treant");
     EXPECT_EQ(opField[1]->card->name, "Treant");
     EXPECT_EQ(opField[2]->card->name, "Treant");
@@ -948,7 +949,7 @@ TEST(PaladinExpert1Test, EX1_362_ArgentProtector)
 // [EX1_382] Aldor Peacekeeper - COST:3 [ATK:3/HP:3]
 // - Faction: Neutral, Set: Expert1, Rarity: Rare
 // --------------------------------------------------------
-// Text: <b>Battlecry:</b> Change an enemy minion's Attack to 1.
+// Text: <b>Battlecry:</b> Change an enemy minion's Attack to 1.
 // --------------------------------------------------------
 // GameTag:
 // - BATTLECRY = 1
@@ -979,19 +980,18 @@ TEST(PaladinExpert1Test, EX1_382_AldorPeacekeeper)
     opPlayer.SetUsedMana(0);
 
     auto& curField = curPlayer.GetFieldZone();
-    
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
     const auto card2 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Aldor Peacekeeper"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card1));
-    
+
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
-    
+
     game.Process(opPlayer, PlayCardTask::MinionTarget(card2, card1));
-    
     EXPECT_EQ(curField[0]->GetAttack(), 1);
 }
 
@@ -1180,13 +1180,13 @@ TEST(WarriorExpert1Test, CS2_104_Rampage)
 
 // ---------------------------------------- SPELL - WARRIOR
 // [EX1_391] Slam - COST:2
-// - Set: Expert1, Rarity: Common
+// - Faction: Neutral, Set: Expert1, Rarity: Common
 // --------------------------------------------------------
 // Text: Deal $2 damage to a minion. If it survives, draw a card.
 // --------------------------------------------------------
 // PlayReq:
-// - REQ_MINION_TARGET = 0
 // - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
 // --------------------------------------------------------
 TEST(WarriorExpert1Test, EX1_391_Slam)
 {
@@ -1210,7 +1210,7 @@ TEST(WarriorExpert1Test, EX1_391_Slam)
 
     auto& curField = curPlayer.GetFieldZone();
     auto& opHand = opPlayer.GetHandZone();
-    
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
     const auto card2 = Generic::DrawCard(
@@ -1219,22 +1219,20 @@ TEST(WarriorExpert1Test, EX1_391_Slam)
         opPlayer, Cards::GetInstance().FindCardByName("Slam"));
     const auto card4 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Slam"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     game.Process(curPlayer, PlayCardTask::Minion(card2));
-    
+
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
     int opHandCount = opHand.GetCount();
 
     game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card2));
-    
     EXPECT_EQ(curField.GetCount(), 2);
     EXPECT_EQ(opHandCount, opHand.GetCount());
-    
+
     game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card1));
-    
     EXPECT_EQ(curField.GetCount(), 1);
     EXPECT_EQ(opHandCount - 1, opHand.GetCount());
 }
@@ -5814,13 +5812,12 @@ TEST(WarlockExpert1Test, EX1_313_PitLord)
     EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 25);
 }
 
-
 // ---------------------------------------- SPELL - WARLOCK
 // [EX1_320] Bane of Doom - COST:5
-// - Set: Expert1, Rarity: Epic
+// - Faction: Neutral, Set: Expert1, Rarity: Epic
 // --------------------------------------------------------
-// Text: Deal $2 damage to a character.
-//       If that kills it, summon a random Demon.
+// Text: Deal $2 damage to a character. If that kills it,
+//       summon a random Demon.
 // --------------------------------------------------------
 // PlayReq:
 // - REQ_TARGET_TO_PLAY = 0
@@ -5856,23 +5853,23 @@ TEST(WarlockExpert1Test, EX1_320_BaneOfDoom)
         opPlayer, Cards::GetInstance().FindCardByName("Bane of Doom"));
     const auto card4 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Bane of Doom"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     game.Process(curPlayer, PlayCardTask::Minion(card2));
-    
+
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
-    
+
     game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card2));
-    
+
     EXPECT_EQ(curField.GetCount(), 2);
     EXPECT_EQ(opField.GetCount(), 0);
-    
+
     game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card1));
-    
+
     EXPECT_EQ(curField.GetCount(), 1);
     EXPECT_EQ(opField.GetCount(), 1);
-    EXPECT_EQ(opField.GetAll()[0]->card->GetRace(), Race::DEMON);
+    EXPECT_EQ(opField[0]->card->GetRace(), Race::DEMON);
 }
 
 // --------------------------------------- MINION - NEUTRAL
@@ -6200,13 +6197,15 @@ TEST(NeutralExpert1Test, EX1_583_PriestessOfElune)
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_584] Ancient Mage - COST:4 [ATK:2/HP:5]
-// - Set: Expert1, Rarity: Rare
+// - Faction: Neutral, Set: Expert1, Rarity: Rare
 // --------------------------------------------------------
-// Text: <b>Battlecry:</b> Give adjacent minions
-//       <b>Spell Damage +1</b>.
+// Text: <b>Battlecry:</b> Give adjacent minions <b>Spell Damage +1</b>.
 // --------------------------------------------------------
 // GameTag:
 // - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - SPELLPOWER = 1
 // --------------------------------------------------------
 TEST(NeutralExpert1Test, EX1_584_AncientMage)
 {
@@ -6238,7 +6237,7 @@ TEST(NeutralExpert1Test, EX1_584_AncientMage)
         curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
     const auto card4 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card2));
     game.Process(curPlayer, PlayCardTask::Minion(card3));
     game.Process(curPlayer, PlayCardTask::Minion(card4));
@@ -6252,14 +6251,12 @@ TEST(NeutralExpert1Test, EX1_584_AncientMage)
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_614] Illidan Stormrage - COST:6 [ATK:7/HP:5]
-// - Race: Demon, Set: Expert1, Rarity: Legendary
+// - Race: Demon, Faction: Neutral, Set: Expert1, Rarity: Legendary
 // --------------------------------------------------------
-// Text: Whenever you play a card,
-//       summon a 2/1 Flame of Azzinoth.
+// Text: Whenever you play a card, summon a 2/1 Flame of_Azzinoth.
 // --------------------------------------------------------
 // GameTag:
 // - ELITE = 1
-// - TRIGGER_VISUAL = 1
 // --------------------------------------------------------
 TEST(NeutralExpert1Test, EX1_614_IllidanStormrage)
 {
@@ -6289,16 +6286,15 @@ TEST(NeutralExpert1Test, EX1_614_IllidanStormrage)
         curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
     const auto card3 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Moonfire"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card1));
+
     game.Process(curPlayer, PlayCardTask::Minion(card2));
-    
     EXPECT_EQ(curField.GetCount(), 3);
     EXPECT_EQ(curField[1]->card->name, "Flame of Azzinoth");
     EXPECT_EQ(curField[2]->card->name, "Wisp");
-    
+
     game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card1));
-    
     EXPECT_EQ(curField.GetCount(), 4);
     EXPECT_EQ(curField[1]->card->name, "Flame of Azzinoth");
     EXPECT_EQ(curField[2]->card->name, "Flame of Azzinoth");

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -5838,6 +5838,58 @@ TEST(NeutralExpert1Test, EX1_583_PriestessOfElune)
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [EX1_584] Ancient Mage - COST:4 [ATK:2/HP:5]
+// - Faction: Neutral, Set: Expert1, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give adjacent minions
+//       <b>Spell Damage +1</b>.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST(NeutralExpert1Test, EX1_584_AncientMage)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Ancient Mage"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
+    
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    game.Process(curPlayer, new PlayCardTask(card1, nullptr, 1, 0));
+
+    EXPECT_EQ(curField[1]->card->name, "Ancient Mage");
+    EXPECT_EQ(curField[0]->GetSpellPower(), 1);
+    EXPECT_EQ(curField[2]->GetSpellPower(), 1);
+    EXPECT_EQ(curField[3]->GetSpellPower(), 0);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [NEW1_019] Knife Juggler - COST:2 [ATK:2/HP:2]
 // - Set: Expert1, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -5792,6 +5792,60 @@ TEST(NeutralExpert1Test, EX1_572_Ysera)
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [EX1_577] The Beast - COST:6 [ATK:9/HP:7]
+// - Race: Beast, Faction: Neutral, Set: Expert1, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Summon a 3/3 Finkle Einhorn for your opponent.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST(NeutralExpert1Test, EX1_577_TheBeast)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+    auto& opField = opPlayer.GetFieldZone();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("The Beast"));
+    const auto card2 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    curField[0]->SetHealth(1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    opField[0]->SetHealth(99);
+
+    game.Process(opPlayer, AttackTask(card2, card1));
+    EXPECT_TRUE(card1->isDestroyed);
+    EXPECT_EQ(opField.GetCount(), 2);
+    EXPECT_EQ(opField[1]->GetHealth(), 3);
+    EXPECT_EQ(opField[1]->GetAttack(), 3);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [EX1_583] Priestess of Elune - COST:6 [ATK:5/HP:4]
 // - Faction: Neutral, Set: Expert1, Rarity: Common
 // --------------------------------------------------------
@@ -6007,60 +6061,6 @@ TEST(NeutralExpert1Test, NEW1_019_KnifeJuggler)
     game.Process(curPlayer, PlayCardTask::Minion(card3));
     EXPECT_TRUE((opPlayer.GetHero()->GetHealth() == 28) ^
                 (opField[0]->GetHealth() == 4));
-}
-
-// --------------------------------------- MINION - NEUTRAL
-// [EX1_577] The Beast - COST:6 [ATK:9/HP:7]
-// - Race: Beast, Faction: Neutral, Set: Expert1, Rarity: Legendary
-// --------------------------------------------------------
-// Text: <b>Deathrattle:</b> Summon a 3/3 Finkle Einhorn for your opponent.
-// --------------------------------------------------------
-// GameTag:
-// - ELITE = 1
-// - DEATHRATTLE = 1
-// --------------------------------------------------------
-TEST(NeutralExpert1Test, EX1_577_TheBeast)
-{
-    GameConfig config;
-    config.player1Class = CardClass::PALADIN;
-    config.player2Class = CardClass::MAGE;
-    config.startPlayer = PlayerType::PLAYER1;
-    config.doFillDecks = true;
-    config.autoRun = false;
-
-    Game game(config);
-    game.StartGame();
-    game.ProcessUntil(Step::MAIN_START);
-
-    Player& curPlayer = game.GetCurrentPlayer();
-    Player& opPlayer = game.GetOpponentPlayer();
-    curPlayer.SetTotalMana(10);
-    curPlayer.SetUsedMana(0);
-    opPlayer.SetTotalMana(10);
-    opPlayer.SetUsedMana(0);
-
-    auto& curField = curPlayer.GetFieldZone();
-    auto& opField = opPlayer.GetFieldZone();
-
-    const auto card1 = Generic::DrawCard(
-        curPlayer, Cards::GetInstance().FindCardByName("The Beast"));
-    const auto card2 = Generic::DrawCard(
-        opPlayer, Cards::GetInstance().FindCardByName("Wolfrider"));
-
-    game.Process(curPlayer, PlayCardTask::Minion(card1));
-    curField[0]->SetHealth(1);
-
-    game.Process(curPlayer, EndTurnTask());
-    game.ProcessUntil(Step::MAIN_START);
-
-    game.Process(opPlayer, PlayCardTask::Minion(card2));
-    opField[0]->SetHealth(99);
-
-    game.Process(opPlayer, AttackTask(card2, card1));
-    EXPECT_TRUE(card1->isDestroyed);
-    EXPECT_EQ(opField.GetCount(), 2);
-    EXPECT_EQ(opField[1]->GetHealth(), 3);
-    EXPECT_EQ(opField[1]->GetAttack(), 3);
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -886,6 +886,57 @@ TEST(PaladinExpert1Test, EX1_362_ArgentProtector)
 }
 
 // --------------------------------------- MINION - PALADIN
+// [EX1_382] Aldor Peacekeeper - COST:3 [ATK:3/HP:3]
+// - Faction: Neutral, Set: Expert1, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Change an enemy minion's Attack to 1.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_ENEMY_TARGET = 0
+// - REQ_MINION_TARGET = 0
+// - REQ_TARGET_IF_AVAILABLE = 0
+// --------------------------------------------------------
+TEST(PaladinExpert1Test, EX1_382_AldorPeacekeeper)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+    
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
+    const auto card2 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Aldor Peacekeeper"));
+    
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+    
+    game.Process(opPlayer, PlayCardTask::MinionTarget(card2, card1));
+    
+    EXPECT_EQ(curField[0]->GetAttack(), 1);
+}
+
+// --------------------------------------- MINION - PALADIN
 // [EX1_383] Tirion Fordring - COST:8 [ATK:6/HP:6]
 // - Faction: Neutral, Set: Expert1, Rarity: Legendary
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -994,6 +994,67 @@ TEST(WarriorExpert1Test, CS2_104_Rampage)
 }
 
 // ---------------------------------------- SPELL - WARRIOR
+// [EX1_391] Slam - COST:2
+// - Set: Expert1, Rarity: Common
+// --------------------------------------------------------
+// Text: Deal $2 damage to a minion. If it survives, draw a card.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINION_TARGET = 0
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST(WarriorExpert1Test, EX1_391_Slam)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+    auto& opHand = opPlayer.GetHandZone();
+    
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Chillwind Yeti"));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Slam"));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Slam"));
+    
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    int opHandCount = opHand.GetCount();
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card2));
+    
+    EXPECT_EQ(curField.GetCount(), 2);
+    EXPECT_EQ(opHandCount, opHand.GetCount());
+    
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card1));
+    
+    EXPECT_EQ(curField.GetCount(), 1);
+    EXPECT_EQ(opHandCount - 1, opHand.GetCount());
+}
+
+// ---------------------------------------- SPELL - WARRIOR
 // [EX1_407] Brawl - COST:5
 // - Faction: Neutral, Set: Expert1, Rarity: Epic
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -5847,7 +5847,7 @@ TEST(NeutralExpert1Test, EX1_577_TheBeast)
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_583] Priestess of Elune - COST:6 [ATK:5/HP:4]
-// - Faction: Neutral, Set: Expert1, Rarity: Common
+// - Set: Expert1, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Restore 4 Health to your hero.
 // --------------------------------------------------------
@@ -5893,7 +5893,7 @@ TEST(NeutralExpert1Test, EX1_583_PriestessOfElune)
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_584] Ancient Mage - COST:4 [ATK:2/HP:5]
-// - Faction: Neutral, Set: Expert1, Rarity: Rare
+// - Set: Expert1, Rarity: Rare
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Give adjacent minions
 //       <b>Spell Damage +1</b>.

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -6271,11 +6271,13 @@ TEST(NeutralExpert1Test, EX1_583_PriestessOfElune)
 // [EX1_584] Ancient Mage - COST:4 [ATK:2/HP:5]
 // - Faction: Neutral, Set: Expert1, Rarity: Rare
 // --------------------------------------------------------
-// Text: <b>Battlecry:</b> Give adjacent minions
-//       <b>Spell Damage +1</b>.
+// Text: <b>Battlecry:</b> Give adjacent minions <b>Spell Damage +1</b>.
 // --------------------------------------------------------
 // GameTag:
 // - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - SPELLPOWER = 1
 // --------------------------------------------------------
 TEST(NeutralExpert1Test, EX1_584_AncientMage)
 {


### PR DESCRIPTION
This revision includes:
- Implement 7 cards in the EXPERT1 card set
    - Ancient Mage (EX1_584)
    - Illidan Stormrage (EX1_614)
    - Bane of Doom (EX1_320)
    - Slam (EX1_391)
    - Soul of the Forest (EX1_158)
    - Aldor Peacekeeper (EX1_382)
    - Mark of Nature (EX1_155)
- Implement `SpellPowerN` effect
- Implement `SummonSide::SPELL` (currently like `SummonSide::DEFAULT`)
- Sort `EXPERT1` unit tests by card ID
- Fix some incorrect comments
- Fix `AddEnchantmentTask` logic (#313)
- Update card implementation progress