### PR TITLE
Implement 19 EXPERT1 cards, DrawStackTask, ChangeHeroPowerTask and IsStackNum

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -300,7 +300,7 @@ EXPERT1 | EX1_408 | Mortal Strike |
 EXPERT1 | EX1_409 | Upgrade! |  
 EXPERT1 | EX1_410 | Shield Slam |  
 EXPERT1 | EX1_411 | Gorehowl |  
-EXPERT1 | EX1_412 | Raging Worgen |  
+EXPERT1 | EX1_412 | Raging Worgen | O 
 EXPERT1 | EX1_414 | Grommash Hellscream |  
 EXPERT1 | EX1_507 | Murloc Warleader | O 
 EXPERT1 | EX1_509 | Murloc Tidecaller |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 63% (152 of 237 Cards)
+- Progress: 65% (153 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -301,7 +301,7 @@ EXPERT1 | EX1_409 | Upgrade! |
 EXPERT1 | EX1_410 | Shield Slam |  
 EXPERT1 | EX1_411 | Gorehowl |  
 EXPERT1 | EX1_412 | Raging Worgen | O 
-EXPERT1 | EX1_414 | Grommash Hellscream |  
+EXPERT1 | EX1_414 | Grommash Hellscream | O 
 EXPERT1 | EX1_507 | Murloc Warleader | O 
 EXPERT1 | EX1_509 | Murloc Tidecaller |  
 EXPERT1 | EX1_522 | Patient Assassin | O
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 65% (153 of 237 Cards)
+- Progress: 65% (154 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -357,7 +357,7 @@ EXPERT1 | EX1_619 | Equality | O
 EXPERT1 | EX1_621 | Circle of Healing | O
 EXPERT1 | EX1_623 | Temple Enforcer | O
 EXPERT1 | EX1_624 | Holy Fire | O
-EXPERT1 | EX1_625 | Shadowform |  
+EXPERT1 | EX1_625 | Shadowform | O 
 EXPERT1 | EX1_626 | Mass Dispel | O
 EXPERT1 | NEW1_005 | Kidnapper | O
 EXPERT1 | NEW1_007 | Starfall |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 66% (157 of 237 Cards)
+- Progress: 67% (158 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -303,7 +303,7 @@ EXPERT1 | EX1_411 | Gorehowl |
 EXPERT1 | EX1_412 | Raging Worgen | O 
 EXPERT1 | EX1_414 | Grommash Hellscream | O 
 EXPERT1 | EX1_507 | Murloc Warleader | O 
-EXPERT1 | EX1_509 | Murloc Tidecaller |  
+EXPERT1 | EX1_509 | Murloc Tidecaller | O 
 EXPERT1 | EX1_522 | Patient Assassin | O
 EXPERT1 | EX1_531 | Scavenging Hyena |  
 EXPERT1 | EX1_533 | Misdirection |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 65% (154 of 237 Cards)
+- Progress: 65% (155 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -326,7 +326,7 @@ EXPERT1 | EX1_563 | Malygos | O
 EXPERT1 | EX1_564 | Faceless Manipulator | O
 EXPERT1 | EX1_567 | Doomhammer | O
 EXPERT1 | EX1_570 | Bite | O
-EXPERT1 | EX1_571 | Force of Nature |  
+EXPERT1 | EX1_571 | Force of Nature | O 
 EXPERT1 | EX1_572 | Ysera | O
 EXPERT1 | EX1_573 | Cenarius |  
 EXPERT1 | EX1_575 | Mana Tide Totem |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 66% (156 of 237 Cards)
+- Progress: 66% (157 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -233,7 +233,7 @@ EXPERT1 | EX1_158 | Soul of the Forest | O
 EXPERT1 | EX1_160 | Power of the Wild | O
 EXPERT1 | EX1_162 | Dire Wolf Alpha | O 
 EXPERT1 | EX1_164 | Nourish | O 
-EXPERT1 | EX1_165 | Druid of the Claw |  
+EXPERT1 | EX1_165 | Druid of the Claw | O 
 EXPERT1 | EX1_166 | Keeper of the Grove |  
 EXPERT1 | EX1_170 | Emperor Cobra | O
 EXPERT1 | EX1_178 | Ancient of War | O 
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 67% (158 of 237 Cards)
+- Progress: 67% (159 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -316,7 +316,7 @@ EXPERT1 | EX1_544 | Flare |
 EXPERT1 | EX1_549 | Bestial Wrath |  
 EXPERT1 | EX1_554 | Snake Trap |  
 EXPERT1 | EX1_556 | Harvest Golem | O
-EXPERT1 | EX1_557 | Nat Pagle |  
+EXPERT1 | EX1_557 | Nat Pagle | O 
 EXPERT1 | EX1_558 | Harrison Jones |  
 EXPERT1 | EX1_559 | Archmage Antonidas |  
 EXPERT1 | EX1_560 | Nozdormu |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 65% (155 of 237 Cards)
+- Progress: 66% (156 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Includes/Rosetta/Cards/Cards.hpp
+++ b/Includes/Rosetta/Cards/Cards.hpp
@@ -140,6 +140,11 @@ class Cards
     //! \return A default hero power card that matches condition.
     static Card* GetDefaultHeroPower(CardClass cardClass);
 
+    //! Returns whether this card is empty.
+    //! \param card Card to check
+    //! \return whether this card is empty.
+    static bool Cards::IsEmptyCard(Card* card);
+
  private:
     //! Constructor: Loads card data.
     Cards();

--- a/Includes/Rosetta/Cards/Cards.hpp
+++ b/Includes/Rosetta/Cards/Cards.hpp
@@ -143,7 +143,7 @@ class Cards
     //! Returns whether this card is empty.
     //! \param card Card to check
     //! \return whether this card is empty.
-    static bool Cards::IsEmptyCard(Card* card);
+    static bool IsEmptyCard(Card* card);
 
  private:
     //! Constructor: Loads card data.

--- a/Includes/Rosetta/Cards/Cards.hpp
+++ b/Includes/Rosetta/Cards/Cards.hpp
@@ -140,11 +140,6 @@ class Cards
     //! \return A default hero power card that matches condition.
     static Card* GetDefaultHeroPower(CardClass cardClass);
 
-    //! Returns whether this card is empty.
-    //! \param card Card to check
-    //! \return whether this card is empty.
-    static bool IsEmptyCard(Card* card);
-
  private:
     //! Constructor: Loads card data.
     Cards();

--- a/Includes/Rosetta/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/Conditions/SelfCondition.hpp
@@ -27,6 +27,11 @@ class SelfCondition
     //! \param func The function to check condition.
     explicit SelfCondition(std::function<bool(Entity*)> func);
 
+    //! SelfCondition wrapper for checking the hero power equals \p cardID.
+    //! \param cardID The card ID of hero power.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsHeroPowerCard(const std::string& cardID);
+
     //! SelfCondition wrapper for checking the entity is destroyed.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsDead();

--- a/Includes/Rosetta/Enchants/Trigger.hpp
+++ b/Includes/Rosetta/Enchants/Trigger.hpp
@@ -59,6 +59,7 @@ class Trigger
     std::vector<ITask*> tasks;
     SelfCondition* condition = nullptr;
 
+    float percentage = 1.0f;
     bool fastExecution = false;
     bool removeAfterTriggered = false;
 

--- a/Includes/Rosetta/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Enums/TaskEnums.hpp
@@ -22,6 +22,7 @@ enum class TaskID
 {
     INVALID,
     DRAW,
+    DRAW_NUMBER,
     DRAW_OP,
     DRAW_STACK,
     OVERDRAW,

--- a/Includes/Rosetta/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Enums/TaskEnums.hpp
@@ -73,6 +73,7 @@ enum class TaskID
     DAMAGE_NUMBER,
     SWAP_ATTACK_HEALTH,
     CHANCE,
+    CHANGE_HERO_POWER,
 
     NUM_TASK_ID
 };

--- a/Includes/Rosetta/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Enums/TaskEnums.hpp
@@ -95,6 +95,7 @@ enum class EntityType
     ENEMY_WEAPON,
     HAND,
     ENEMY_HAND,
+    DECK,
     ENEMY_DECK,
     ALL_MINIONS,
     ALL_MINIONS_NOSOURCE,

--- a/Includes/Rosetta/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Enums/TaskEnums.hpp
@@ -95,6 +95,7 @@ enum class EntityType
     ENEMY_WEAPON,
     HAND,
     ENEMY_HAND,
+    ENEMY_DECK,
     ALL_MINIONS,
     ALL_MINIONS_NOSOURCE,
     MINIONS,

--- a/Includes/Rosetta/Models/Entity.hpp
+++ b/Includes/Rosetta/Models/Entity.hpp
@@ -133,7 +133,7 @@ class Entity
     //! \param type The type of power.
     //! \param target The target.
     //! \param chooseOne The index of chosen card from two cards.
-    //! \parm chooseBase Choose One card.
+    //! \param chooseBase The base card to apply card effect.
     void ActivateTask(PowerType type, Entity* target = nullptr,
                       int chooseOne = 0, Entity* chooseBase = nullptr);
 

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -98,6 +98,7 @@
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DestroyTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DiscardTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/DrawNumberTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DrawOpTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DrawStackTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DrawTask.hpp>

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -89,6 +89,7 @@
 #include <Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ChanceTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/ChangeHeroPowerTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ControlTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/CopyTask.hpp>

--- a/Includes/Rosetta/Tasks/SimpleTasks/ChangeHeroPowerTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/ChangeHeroPowerTask.hpp
@@ -1,0 +1,43 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_CHANGE_HERO_POWER_TASK_HPP
+#define ROSETTASTONE_CHANGE_HERO_POWER_TASK_HPP
+
+#include <Rosetta/Tasks/ITask.hpp>
+
+namespace RosettaStone::SimpleTasks
+{
+//!
+//! \brief ChangeHeroPowerTask class.
+//!
+//! This class represents the task for changing hero power.
+//!
+class ChangeHeroPowerTask : public ITask
+{
+ public:
+    //! Constructs task with given \p cardID
+    //! \param cardID The card ID to be hero power.
+    explicit ChangeHeroPowerTask(const std::string& cardID);
+
+    //! Returns task ID.
+    //! \return Task ID.
+    TaskID GetTaskID() const override;
+
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player& player) override;
+
+    //! Internal method of Clone().
+    //! \return The cloned task.
+    ITask* CloneImpl() override;
+
+    Card* m_card = nullptr;
+};
+}  // namespace RosettaStone::SimpleTasks
+
+#endif  // ROSETTASTONE_CHANGE_HERO_POWER_TASK_HPP

--- a/Includes/Rosetta/Tasks/SimpleTasks/CountTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/CountTask.hpp
@@ -39,8 +39,8 @@ class CountTask : public ITask
     //! \return The cloned task.
     ITask* CloneImpl() override;
 
+    int m_numIndex;
     std::vector<SelfCondition> m_conditions;
-    int m_numIndex = 0;
 };
 }  // namespace RosettaStone::SimpleTasks
 

--- a/Includes/Rosetta/Tasks/SimpleTasks/CountTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/CountTask.hpp
@@ -19,16 +19,11 @@ namespace RosettaStone::SimpleTasks
 class CountTask : public ITask
 {
  public:
-    //! Constructs task with given \p entityType and \p numIndex.
-    //! \param entityType The type of entity.
-    //! \param numIndex An index of number.
-    CountTask(EntityType entityType, int numIndex = 0);
-    
     //! Constructs task with given \p entityType, \p numIndex and \p conditions.
     //! \param entityType The type of entity.
     //! \param numIndex An index of number.
     //! \param conditions SelfConditions to check.
-    CountTask(EntityType entityType, std::vector<SelfCondition> conditions, int numIndex = 0);
+    CountTask(EntityType entityType, int numIndex = 0, std::vector<SelfCondition> conditions = {});
 
     //! Returns task ID.
     //! \return Task ID.

--- a/Includes/Rosetta/Tasks/SimpleTasks/DrawNumberTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/DrawNumberTask.hpp
@@ -1,0 +1,37 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_DRAW_NUMBER_TASK_HPP
+#define ROSETTASTONE_DRAW_NUMBER_TASK_HPP
+
+#include <Rosetta/Tasks/ITask.hpp>
+
+namespace RosettaStone::SimpleTasks
+{
+//!
+//! \brief DrawNumberTask class.
+//!
+//! This class represents the task for drawing card(s) from task stack.
+//!
+class DrawNumberTask : public ITask
+{
+ public:
+    //! Returns task ID.
+    //! \return Task ID.
+    TaskID GetTaskID() const override;
+
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player& player) override;
+
+    //! Internal method of Clone().
+    //! \return The cloned task.
+    ITask* CloneImpl() override;
+};
+}  // namespace RosettaStone::SimpleTasks
+
+#endif  // ROSETTASTONE_DRAW_NUMBER_TASK_HPP

--- a/Includes/Rosetta/Tasks/SimpleTasks/DrawTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/DrawTask.hpp
@@ -23,10 +23,6 @@ class DrawTask : public ITask
     //! \param toStack A flag to store card to stack.
     explicit DrawTask(int amount, bool toStack = false);
 
-    //! Constructs task with given \p toStack.
-    //! \param toStack A flag to store card to stack.
-    explicit DrawTask(bool toStack = false);
-
     //! Returns task ID.
     //! \return Task ID.
     TaskID GetTaskID() const override;
@@ -43,7 +39,6 @@ class DrawTask : public ITask
 
     int m_amount = 0;
     bool m_toStack = false;
-    bool m_stackNum = false;
 };
 }  // namespace RosettaStone::SimpleTasks
 

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -2834,9 +2834,9 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_412] Raging Worgen - COST:3 [ATK:3/HP:3]
-    // - Set: Expert1, Rarity: Common
+    // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Taunt</b> Has +3 Attack while damaged.
+    // Text: Has +1 Attack and <b>Windfury</b> while damaged.
     // --------------------------------------------------------
     // GameTag:
     // - ENRAGED = 1

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -964,10 +964,7 @@ void Expert1CardsGen::AddPriest(std::map<std::string, Power>& cards)
     // - REQ_NUM_MINION_SLOTS = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(new FuncNumberTask([](Entity* entity) {
-        DeckZone& deck = entity->owner->opponent->GetDeckZone();
-        entity->owner->GetGame()->taskStack.entities = deck.GetAll();
-    }));
+    power.AddPowerTask(new IncludeTask(EntityType::ENEMY_DECK));
     power.AddPowerTask(new FilterStackTask(SelfCondition::IsMinion()));
     power.AddPowerTask(new CountTask(EntityType::STACK));
     power.AddPowerTask(new ConditionTask(

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1620,10 +1620,7 @@ void Expert1CardsGen::AddWarlock(std::map<std::string, Power>& cards)
     // Text: Draw 2 Demons from your deck.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(new FuncNumberTask([](Entity* entity) {
-        DeckZone& deck = entity->owner->GetDeckZone();
-        entity->owner->GetGame()->taskStack.entities = deck.GetAll();
-    }));
+    power.AddPowerTask(new IncludeTask(EntityType::DECK));
     power.AddPowerTask(new FilterStackTask(SelfCondition::IsRace(Race::DEMON)));
     power.AddPowerTask(new CountTask(EntityType::STACK));
     power.AddPowerTask(new ConditionTask(

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1620,15 +1620,20 @@ void Expert1CardsGen::AddWarlock(std::map<std::string, Power>& cards)
     // Text: Draw 2 Demons from your deck.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(new IncludeTask(EntityType::DECK));
-    power.AddPowerTask(new FilterStackTask(SelfCondition::IsRace(Race::DEMON)));
-    power.AddPowerTask(new CountTask(EntityType::STACK));
-    power.AddPowerTask(new ConditionTask(
-        EntityType::HERO, { SelfCondition::IsStackNum(1, RelaSign::GEQ) }));
-    power.AddPowerTask(new FlagTask(
-        true, { new RandomTask(EntityType::STACK, 2), new DrawStackTask(2) }));
-    power.AddPowerTask(
-        new FlagTask(false, { new AddCardTask(EntityType::HAND, "EX1_317t") }));
+    for (size_t i = 0; i < 2; ++i)
+    {
+        power.AddPowerTask(new IncludeTask(EntityType::DECK));
+        power.AddPowerTask(
+            new FilterStackTask(SelfCondition::IsRace(Race::DEMON)));
+        power.AddPowerTask(new CountTask(EntityType::STACK));
+        power.AddPowerTask(new ConditionTask(
+            EntityType::HERO, { SelfCondition::IsStackNum(1, RelaSign::GEQ) }));
+        power.AddPowerTask(new FlagTask(
+            true,
+            { new RandomTask(EntityType::STACK, 1), new DrawStackTask(1) }));
+        power.AddPowerTask(new FlagTask(
+            false, { new AddCardTask(EntityType::HAND, "EX1_317t") }));
+    }
     cards.emplace("EX1_317", power);
 
     // ---------------------------------------- SPELL - WARLOCK

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1588,9 +1588,9 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, Power>& cards)
     // - REQ_MINION_TARGET = 0
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(new CountTask(EntityType::FRIENDS,
+    power.AddPowerTask(new CountTask(EntityType::FRIENDS, 0,
                                      { SelfCondition::IsDamaged() }));
-    power.AddPowerTask(new DrawTask());
+    power.AddPowerTask(new DrawTask(0));
     cards.emplace("EX1_392", power);
 
     // --------------------------------------- MINION - WARRIOR

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -170,6 +170,19 @@ void Expert1CardsGen::AddDruid(std::map<std::string, Power>& cards)
     power.AddPowerTask(new AddEnchantmentTask("EX1_570e", EntityType::HERO));
     power.AddPowerTask(new ArmorTask(4));
     cards.emplace("EX1_570", power);
+
+    // ------------------------------------------ SPELL - DRUID
+    // [EX1_571] Force of Nature - COST:5
+    // - Faction: Neutral, Set: Expert1, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Summon three 2/2 Treants.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new EnqueueTask({ new SummonTask("EX1_tk9") }, 3));
+    cards.emplace("EX1_571", power);
 }
 
 void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
@@ -381,6 +394,14 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddEnchant(Enchants::GetEnchantFromText("EX1_570e"));
     cards.emplace("EX1_570e", power);
+
+    // ----------------------------------------- MINION - DRUID
+    // [EX1_tk9] Treant (*) - COST:2 [ATK:2/HP:2]
+    // - Faction: Neutral, Set: Expert1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("EX1_tk9", power);
 }
 
 void Expert1CardsGen::AddHunter(std::map<std::string, Power>& cards)

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -657,7 +657,7 @@ void Expert1CardsGen::AddMage(std::map<std::string, Power>& cards)
 
     // ------------------------------------------- SPELL - MAGE
     // [EX1_180] Tome of Intellect - COST:1
-    // - Faction: Neutral, Set: Expert1, Rarity: Common
+    // - Set: Expert1, Rarity: Common
     // --------------------------------------------------------
     // Text: Add a random Mage spell to your hand.
     // --------------------------------------------------------

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -65,7 +65,7 @@ void Expert1CardsGen::AddHeroPowers(std::map<std::string, Power>& cards)
 
     // ------------------------------------ HERO_POWER - PRIEST
     // [EX1_625t] Mind Spike (*) - COST:2
-    // - Faction: Neutral, Set: Expert1, Rarity: Free
+    // - Set: Expert1
     // --------------------------------------------------------
     // Text: <b>Hero Power</b>
     //       Deal $2 damage.
@@ -79,7 +79,7 @@ void Expert1CardsGen::AddHeroPowers(std::map<std::string, Power>& cards)
 
     // ------------------------------------ HERO_POWER - PRIEST
     // [EX1_625t2] Mind Shatter (*) - COST:2
-    // - Faction: Neutral, Set: Expert1, Rarity: Free
+    // - Set: Expert1
     // --------------------------------------------------------
     // Text: <b>Hero Power</b>
     //       Deal $3 damage.
@@ -1026,20 +1026,14 @@ void Expert1CardsGen::AddPriest(std::map<std::string, Power>& cards)
     //       If already in Shadowform: 3 damage.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(new FuncNumberTask([](Entity* entity) {
-        auto& stack = entity->owner->GetGame()->taskStack.entities;
-        stack.clear();
-        stack.emplace_back(
-            dynamic_cast<Entity*>(entity->owner->GetHero()->heroPower));
-    }));
     power.AddPowerTask(new ConditionTask(
-        EntityType::STACK, { SelfCondition::IsName("Mind Spike") }));
+        EntityType::SOURCE, { SelfCondition::IsHeroPowerCard("EX1_625t") }));
     power.AddPowerTask(
         new FlagTask(true, { new ChangeHeroPowerTask("EX1_625t2") }));
     power.AddPowerTask(new FlagTask(
         false,
-        { new ConditionTask(EntityType::STACK,
-                            { SelfCondition::IsName("Mind Shatter") }),
+        { new ConditionTask(EntityType::SOURCE,
+                            { SelfCondition::IsHeroPowerCard("EX1_625t2") }),
           new FlagTask(false, { new ChangeHeroPowerTask("EX1_625t") }) }));
     cards.emplace("EX1_625", power);
 

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -178,9 +178,9 @@ void Expert1CardsGen::AddDruid(std::map<std::string, Power>& cards)
 
     // ----------------------------------------- MINION - DRUID
     // [EX1_165] Druid of the Claw - COST:5 [ATK:4/HP:4]
-    // - Race: Beast, Faction: Neutral, Set: Expert1, Rarity: Common
+    // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
-    // Text: [x]<b>Choose One -</b> Transform into a 4/4 with <b>Charge</b>;
+    // Text: <b>Choose One -</b> Transform into a 4/4 with <b>Charge</b>;
     //       or a 4/6 with <b>Taunt</b>.
     // --------------------------------------------------------
     // GameTag:
@@ -398,7 +398,7 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
 
     // ----------------------------------------- MINION - DRUID
     // [EX1_165a] Cat Form (*) - COST:5 [ATK:4/HP:4]
-    // - Race: Beast, Faction: Neutral, Set: Expert1
+    // - Faction: Neutral, Set: Expert1
     // --------------------------------------------------------
     // Text: <b>Charge</b>
     // --------------------------------------------------------
@@ -408,7 +408,7 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
 
     // ----------------------------------------- MINION - DRUID
     // [EX1_165b] Bear Form (*) - COST:5 [ATK:4/HP:6]
-    // - Race: Beast, Faction: Neutral, Set: Expert1
+    // - Faction: Neutral, Set: Expert1
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------
@@ -418,7 +418,7 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
 
     // ----------------------------------------- MINION - DRUID
     // [EX1_165t1] Druid of the Claw (*) - COST:5 [ATK:4/HP:4]
-    // - Race: Beast, Faction: Neutral, Set: Expert1, Rarity: Common
+    // - Race: Beast, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Charge</b>
     // --------------------------------------------------------
@@ -431,7 +431,7 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
 
     // ----------------------------------------- MINION - DRUID
     // [EX1_165t2] Druid of the Claw (*) - COST:5 [ATK:4/HP:6]
-    // - Race: Beast, Faction: Neutral, Set: Expert1, Rarity: Common
+    // - Race: Beast, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -2794,7 +2794,7 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_390] Tauren Warrior - COST:3 [ATK:2/HP:3]
-    // - Set: Expert1, Rarity: Common
+    // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b> Has +3 Attack while damaged.
     // --------------------------------------------------------

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -231,7 +231,7 @@ void Expert1CardsGen::AddDruid(std::map<std::string, Power>& cards)
     // - REQ_NUM_MINION_SLOTS = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(new EnqueueTask({ new SummonTask("EX1_tk9") }, 3));
+    power.AddPowerTask(new SummonTask("EX1_tk9", 3));
     cards.emplace("EX1_571", power);
 }
 

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -179,6 +179,8 @@ void Expert1CardsGen::AddDruid(std::map<std::string, Power>& cards)
     // [EX1_178] Ancient of War - COST:7 [ATK:5/HP:5]
     // - Faction: Neutral, Set: Expert1, Rarity: Epic
     // --------------------------------------------------------
+    // Text: <b>Choose One -</b>+5 Attack; or +5 Health and <b>Taunt</b>.
+    // --------------------------------------------------------
     // GameTag:
     // - CHOOSE_ONE = 1
     // --------------------------------------------------------

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -14,8 +14,8 @@
 #include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ArmorTask.hpp>
-#include <Rosetta/Tasks/SimpleTasks/ChangeHeroPowerTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ChanceTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/ChangeHeroPowerTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ControlTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/CopyTask.hpp>
@@ -23,8 +23,8 @@
 #include <Rosetta/Tasks/SimpleTasks/DamageNumberTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DestroyTask.hpp>
-#include <Rosetta/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DrawStackTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FlagTask.hpp>
@@ -153,7 +153,8 @@ void Expert1CardsGen::AddDruid(std::map<std::string, Power>& cards)
     // [EX1_160] Power of the Wild - COST:2
     // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Choose One -</b> Give your minions +1/+1; or Summon a 3/2
+    // Text: <b>Choose One -</b> Give your minions +1/+1;
+    //       or Summon a 3/2 Panther.
     // --------------------------------------------------------
     // GameTag:
     // - CHOOSE_ONE = 1
@@ -179,7 +180,7 @@ void Expert1CardsGen::AddDruid(std::map<std::string, Power>& cards)
     // [EX1_165] Druid of the Claw - COST:5 [ATK:4/HP:4]
     // - Race: Beast, Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
-    // Text: [x]<b>Choose One -</b> Transform into a 4/4 with <b>Charge</b>; 
+    // Text: [x]<b>Choose One -</b> Transform into a 4/4 with <b>Charge</b>;
     //       or a 4/6 with <b>Taunt</b>.
     // --------------------------------------------------------
     // GameTag:
@@ -353,22 +354,23 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
     // Text: Give your minions +1/+1.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(new AddEnchantmentTask("EX1_160be", EntityType::MINIONS));
+    power.AddPowerTask(
+        new AddEnchantmentTask("EX1_160be", EntityType::MINIONS));
     cards.emplace("EX1_160b", power);
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [EX1_160be] Leader of the Pack (*) - COST:0
-    // - Faction: Neutral, Set: Expert1
+    // - Set: Expert1
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
     power.ClearData();
     power.AddEnchant(Enchants::GetEnchantFromText("EX1_160be"));
     cards.emplace("EX1_160be", power);
-    
+
     // ----------------------------------------- MINION - DRUID
     // [EX1_160t] Panther (*) - COST:2 [ATK:3/HP:2]
-    // - Race: Beast, Faction: Neutral, Set: Expert1
+    // - Race: Beast, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -966,15 +968,15 @@ void Expert1CardsGen::AddPriest(std::map<std::string, Power>& cards)
         DeckZone& deck = entity->owner->opponent->GetDeckZone();
         entity->owner->GetGame()->taskStack.entities = deck.GetAll();
     }));
-    power.AddPowerTask(
-        new FilterStackTask(SelfCondition::IsMinion()));
+    power.AddPowerTask(new FilterStackTask(SelfCondition::IsMinion()));
     power.AddPowerTask(new CountTask(EntityType::STACK));
-    power.AddPowerTask(new ConditionTask(EntityType::HERO,
-        { SelfCondition::IsStackNum(1, RelaSign::GEQ) }));
-    power.AddPowerTask(new FlagTask(true, { new RandomTask(EntityType::STACK, 1),
-        new CopyTask(EntityType::STACK, ZoneType::PLAY)}));
-    power.AddPowerTask(new FlagTask(false,
-        { new SummonTask("EX1_345t", SummonSide::SPELL) }));
+    power.AddPowerTask(new ConditionTask(
+        EntityType::HERO, { SelfCondition::IsStackNum(1, RelaSign::GEQ) }));
+    power.AddPowerTask(new FlagTask(
+        true, { new RandomTask(EntityType::STACK, 1),
+                new CopyTask(EntityType::STACK, ZoneType::PLAY) }));
+    power.AddPowerTask(
+        new FlagTask(false, { new SummonTask("EX1_345t", SummonSide::SPELL) }));
     cards.emplace("EX1_345", power);
 
     // ----------------------------------------- SPELL - PRIEST
@@ -1030,15 +1032,18 @@ void Expert1CardsGen::AddPriest(std::map<std::string, Power>& cards)
     power.AddPowerTask(new FuncNumberTask([](Entity* entity) {
         auto& stack = entity->owner->GetGame()->taskStack.entities;
         stack.clear();
-        stack.emplace_back(dynamic_cast<Entity*>(entity->owner->GetHero()->heroPower));
+        stack.emplace_back(
+            dynamic_cast<Entity*>(entity->owner->GetHero()->heroPower));
     }));
     power.AddPowerTask(new ConditionTask(
         EntityType::STACK, { SelfCondition::IsName("Mind Spike") }));
-    power.AddPowerTask(new FlagTask(true, { new ChangeHeroPowerTask("EX1_625t2") }));
-    power.AddPowerTask(new FlagTask(false, {
-        new ConditionTask(EntityType::STACK, { SelfCondition::IsName("Mind Shatter") }),
-        new FlagTask(false, { new ChangeHeroPowerTask("EX1_625t") })
-    }));
+    power.AddPowerTask(
+        new FlagTask(true, { new ChangeHeroPowerTask("EX1_625t2") }));
+    power.AddPowerTask(new FlagTask(
+        false,
+        { new ConditionTask(EntityType::STACK,
+                            { SelfCondition::IsName("Mind Shatter") }),
+          new FlagTask(false, { new ChangeHeroPowerTask("EX1_625t") }) }));
     cards.emplace("EX1_625", power);
 
     // ----------------------------------------- SPELL - PRIEST
@@ -1624,13 +1629,12 @@ void Expert1CardsGen::AddWarlock(std::map<std::string, Power>& cards)
     }));
     power.AddPowerTask(new FilterStackTask(SelfCondition::IsRace(Race::DEMON)));
     power.AddPowerTask(new CountTask(EntityType::STACK));
-    power.AddPowerTask(new ConditionTask(EntityType::HERO, {
-        SelfCondition::IsStackNum(1, RelaSign::GEQ)
-    }));
-    power.AddPowerTask(new FlagTask(true, { new RandomTask(EntityType::STACK, 2),
-        new DrawStackTask(2)}));
-    power.AddPowerTask(new FlagTask(false,
-        { new AddCardTask(EntityType::HAND, "EX1_317t")}));
+    power.AddPowerTask(new ConditionTask(
+        EntityType::HERO, { SelfCondition::IsStackNum(1, RelaSign::GEQ) }));
+    power.AddPowerTask(new FlagTask(
+        true, { new RandomTask(EntityType::STACK, 2), new DrawStackTask(2) }));
+    power.AddPowerTask(
+        new FlagTask(false, { new AddCardTask(EntityType::HAND, "EX1_317t") }));
     cards.emplace("EX1_317", power);
 
     // ---------------------------------------- SPELL - WARLOCK
@@ -1726,8 +1730,8 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, Power>& cards)
     // - REQ_MINION_TARGET = 0
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(new CountTask(EntityType::FRIENDS, 0,
-                                     { SelfCondition::IsDamaged() }));
+    power.AddPowerTask(
+        new CountTask(EntityType::FRIENDS, 0, { SelfCondition::IsDamaged() }));
     power.AddPowerTask(new DrawTask(0));
     cards.emplace("EX1_392", power);
 
@@ -1777,7 +1781,7 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, Power>& cards)
     power.AddPowerTask(
         new FlagTask(false, { new DamageTask(EntityType::TARGET, 4, true) }));
     cards.emplace("EX1_408", power);
-  
+
     // --------------------------------------- MINION - WARRIOR
     // [EX1_414] Grommash Hellscream - COST:8 [ATK:4/HP:9]
     // - Faction: Neutral, Set: Expert1, Rarity: Legendary
@@ -2874,8 +2878,8 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     power.GetTrigger()->triggerSource = TriggerSource::MINIONS_EXCEPT_SELF;
     power.GetTrigger()->condition =
         new SelfCondition(SelfCondition::IsRace(Race::MURLOC));
-    power.GetTrigger()->tasks =
-        { new AddEnchantmentTask("EX1_509e", EntityType::SOURCE) };
+    power.GetTrigger()->tasks = { new AddEnchantmentTask("EX1_509e",
+                                                         EntityType::SOURCE) };
     cards.emplace("EX1_509", power);
 
     // --------------------------------------- MINION - NEUTRAL
@@ -3047,7 +3051,7 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     power.AddPowerTask(new DestroyTask(EntityType::TARGET));
     power.AddPowerTask(new AddEnchantmentTask("NEW1_017e", EntityType::SOURCE));
     cards.emplace("NEW1_017", power);
-    
+
     // --------------------------------------- MINION - NEUTRAL
     // [NEW1_018] Bloodsail Raider - COST:2 [ATK:2/HP:3]
     // - Race: Pirate, Set: Expert1, Rarity: Common
@@ -3426,10 +3430,10 @@ void Expert1CardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
     // - ENRAGED = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddAura(new EnrageEffect(AuraType::SELF, {
-        Effects::AttackN(1), Effects::Windfury }));
+    power.AddAura(new EnrageEffect(AuraType::SELF,
+                                   { Effects::AttackN(1), Effects::Windfury }));
     cards.emplace("EX1_412e", power);
-    
+
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [EX1_507e] Mrgglaargl! (*) - COST:0
     // - Set: Expert1

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -23,13 +23,13 @@
 #include <Rosetta/Tasks/SimpleTasks/DamageNumberTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DestroyTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/DrawNumberTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DrawStackTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FlagTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FuncEntityTask.hpp>
-#include <Rosetta/Tasks/SimpleTasks/FuncNumberTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/GetGameTagTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/HealTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/IncludeTask.hpp>
@@ -1725,7 +1725,7 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddPowerTask(
         new CountTask(EntityType::FRIENDS, 0, { SelfCondition::IsDamaged() }));
-    power.AddPowerTask(new DrawTask(0));
+    power.AddPowerTask(new DrawNumberTask());
     cards.emplace("EX1_392", power);
 
     // --------------------------------------- MINION - WARRIOR

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -3437,7 +3437,7 @@ void Expert1CardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
     // [EX1_507e] Mrgglaargl! (*) - COST:0
     // - Set: Expert1
     // --------------------------------------------------------
-    // Text: +2 Attack fr Attack from Murloc Warleader.
+    // Text: +2 Attack from Murloc Warleader.
     // --------------------------------------------------------
     power.ClearData();
     power.AddEnchant(Enchants::GetEnchantFromText("EX1_507e"));

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -3047,8 +3047,11 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     // - REQ_TARGET_WITH_RACE = 14
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(new DestroyTask(EntityType::TARGET));
-    power.AddPowerTask(new AddEnchantmentTask("NEW1_017e", EntityType::SOURCE));
+    power.AddPowerTask(new ConditionTask(
+        EntityType::TARGET, { SelfCondition::IsRace(Race::MURLOC) }));
+    power.AddPowerTask(new FlagTask(
+        true, { new DestroyTask(EntityType::TARGET),
+                new AddEnchantmentTask("NEW1_017e", EntityType::SOURCE) }));
     cards.emplace("NEW1_017", power);
 
     // --------------------------------------- MINION - NEUTRAL

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -2705,6 +2705,24 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     cards.emplace("EX1_507", power);
 
     // --------------------------------------- MINION - NEUTRAL
+    // [EX1_509] Murloc Tidecaller - COST:1 [ATK:1/HP:2]
+    // - Race: Murloc, Faction: Neutral, Set: Expert1, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Whenever you summon a Murloc, gain +1 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(new Trigger(TriggerType::SUMMON));
+    power.GetTrigger()->triggerSource = TriggerSource::MINIONS_EXCEPT_SELF;
+    power.GetTrigger()->condition =
+        new SelfCondition(SelfCondition::IsRace(Race::MURLOC));
+    power.GetTrigger()->tasks =
+        { new AddEnchantmentTask("EX1_509e", EntityType::SOURCE) };
+    cards.emplace("EX1_509", power);
+
+    // --------------------------------------- MINION - NEUTRAL
     // [EX1_556] Harvest Golem - COST:3 [ATK:2/HP:3]
     // - Race: Mechanical, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
@@ -3248,6 +3266,16 @@ void Expert1CardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddEnchant(Enchants::GetEnchantFromText("EX1_507e"));
     cards.emplace("EX1_507e", power);
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [EX1_509e] Blarghghl (*) - COST:0
+    // - Set: Expert1
+    // --------------------------------------------------------
+    // Text: Increased Attack.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(new Enchant(Effects::AttackN(1)));
+    cards.emplace("EX1_509e", power);
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [EX1_584e] Teachings of the Kirin Tor (*) - COST:0

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -2901,7 +2901,6 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
-    // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(new Trigger(TriggerType::TURN_START));

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1736,7 +1736,7 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, Power>& cards)
 
     // --------------------------------------- MINION - WARRIOR
     // [EX1_393] Amani Berserker - COST:2 [ATK:2/HP:3]
-    // - Set: Expert1, Rarity: Common
+    // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
     // Text: Has +3 Attack while damaged.
     // --------------------------------------------------------

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -2869,12 +2869,9 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     // --------------------------------------------------------
     // Text: Whenever you summon a Murloc, gain +1 Attack.
     // --------------------------------------------------------
-    // GameTag:
-    // - TRIGGER_VISUAL = 1
-    // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(new Trigger(TriggerType::SUMMON));
-    power.GetTrigger()->triggerSource = TriggerSource::MINIONS_EXCEPT_SELF;
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
     power.GetTrigger()->condition =
         new SelfCondition(SelfCondition::IsRace(Race::MURLOC));
     power.GetTrigger()->tasks = { new AddEnchantmentTask("EX1_509e",

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1622,6 +1622,21 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, Power>& cards)
     power.AddPowerTask(new DestroyTask(EntityType::STACK));
     cards.emplace("EX1_407", power);
 
+    // --------------------------------------- MINION - WARRIOR
+    // [EX1_414] Grommash Hellscream - COST:8 [ATK:4/HP:9]
+    // - Faction: Neutral, Set: Expert1, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Charge</b> Has +6 Attack while damaged.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CHARGE = 1
+    // - ELITE = 1
+    // - ENRAGED = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(new Trigger(Triggers::EnrageTrigger("EX1_414e")));
+    cards.emplace("EX1_414", power);
+
     // ----------------------------------------- SPELL - WARRIOR
     // [EX1_607] Inner Rage - COST:0
     // - Set: Expert1, Rarity: Common
@@ -1664,6 +1679,16 @@ void Expert1CardsGen::AddWarriorNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddAura(new EnrageEffect(AuraType::SELF, { Effects::AttackN(3) }));
     cards.emplace("EX1_393e", power);
+
+    // ---------------------------------- ENCHANTMENT - WARRIOR
+    // [EX1_414e] Enraged (*) - COST:0
+    // - Set: Expert1
+    // --------------------------------------------------------
+    // Text: +6 Attack.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(new EnrageEffect(AuraType::SELF, { Effects::AttackN(6) }));
+    cards.emplace("EX1_414e", power);
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [EX1_607e] Inner Rage (*) - COST:0

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -176,6 +176,24 @@ void Expert1CardsGen::AddDruid(std::map<std::string, Power>& cards)
     cards.emplace("EX1_164", power);
 
     // ----------------------------------------- MINION - DRUID
+    // [EX1_165] Druid of the Claw - COST:5 [ATK:4/HP:4]
+    // - Race: Beast, Faction: Neutral, Set: Expert1, Rarity: Common
+    // --------------------------------------------------------
+    // Text: [x]<b>Choose One -</b> Transform into a 4/4 with <b>Charge</b>; 
+    //       or a 4/6 with <b>Taunt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CHOOSE_ONE = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - CHARGE = 1
+    // - TAUNT = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("EX1_165", power);
+
+    // ----------------------------------------- MINION - DRUID
     // [EX1_178] Ancient of War - COST:7 [ATK:5/HP:5]
     // - Faction: Neutral, Set: Expert1, Rarity: Epic
     // --------------------------------------------------------
@@ -375,6 +393,52 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddPowerTask(new DrawTask(3));
     cards.emplace("EX1_164b", power);
+
+    // ----------------------------------------- MINION - DRUID
+    // [EX1_165a] Cat Form (*) - COST:5 [ATK:4/HP:4]
+    // - Race: Beast, Faction: Neutral, Set: Expert1
+    // --------------------------------------------------------
+    // Text: <b>Charge</b>
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new TransformTask(EntityType::SOURCE, "EX1_165t1"));
+    cards.emplace("EX1_165a", power);
+
+    // ----------------------------------------- MINION - DRUID
+    // [EX1_165b] Bear Form (*) - COST:5 [ATK:4/HP:6]
+    // - Race: Beast, Faction: Neutral, Set: Expert1
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new TransformTask(EntityType::SOURCE, "EX1_165t2"));
+    cards.emplace("EX1_165b", power);
+
+    // ----------------------------------------- MINION - DRUID
+    // [EX1_165t1] Druid of the Claw (*) - COST:5 [ATK:4/HP:4]
+    // - Race: Beast, Faction: Neutral, Set: Expert1, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Charge</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - CHARGE = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("EX1_165t1", power);
+
+    // ----------------------------------------- MINION - DRUID
+    // [EX1_165t2] Druid of the Claw (*) - COST:5 [ATK:4/HP:6]
+    // - Race: Beast, Faction: Neutral, Set: Expert1, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("EX1_165t2", power);
 
     // ------------------------------------------ SPELL - DRUID
     // [EX1_178a] Rooted (*) - COST:7

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -2737,6 +2737,23 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, Power>& cards)
     cards.emplace("EX1_556", power);
 
     // --------------------------------------- MINION - NEUTRAL
+    // [EX1_557] Nat Pagle - COST:2 [ATK:0/HP:4]
+    // - Faction: Neutral, Set: Expert1, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: At the start of your turn, you have a 50% chance to
+    //       draw an extra card.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(new Trigger(TriggerType::TURN_START));
+    power.GetTrigger()->percentage = 0.5f;
+    power.GetTrigger()->tasks = { new DrawTask(1) };
+    cards.emplace("EX1_557", power);
+
+    // --------------------------------------- MINION - NEUTRAL
     // [EX1_563] Malygos - COST:9 [ATK:4/HP:12]
     // - Race: Dragon, Faction: Neutral, Set: Expert1, Rarity: Legendary
     // --------------------------------------------------------

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -454,7 +454,7 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [EX1_178ae] Rooted (*) - COST:0
-    // - Faction: Neutral, Set: Expert1
+    // - Set: Expert1
     // --------------------------------------------------------
     // Text: +5 Health and <b>Taunt</b>
     // --------------------------------------------------------
@@ -474,7 +474,7 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [EX1_178be] Uprooted (*) - COST:0
-    // - Faction: Neutral, Set: Expert1
+    // - Set: Expert1
     // --------------------------------------------------------
     // Text: +5 Attack.
     // --------------------------------------------------------

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -3401,7 +3401,7 @@ void Expert1CardsGen::AddNeutralNonCollect(std::map<std::string, Power>& cards)
     // [EX1_162o] Strength of the Pack (*) - COST:0
     // - Set: Expert1
     // --------------------------------------------------------
-    // Text: +1 Attack from {0}.
+    // Text: +1 Attack from Dire Wolf Alpha.
     // --------------------------------------------------------
     power.ClearData();
     power.AddEnchant(Enchants::GetEnchantFromText("EX1_162o"));

--- a/Sources/Rosetta/Cards/Cards.cpp
+++ b/Sources/Rosetta/Cards/Cards.cpp
@@ -36,11 +36,6 @@ Cards& Cards::GetInstance()
     return instance;
 }
 
-bool Cards::IsEmptyCard(Card* card)
-{
-    return card == &emptyCard;
-}
-
 const std::vector<Card*>& Cards::GetAllCards()
 {
     return m_cards;

--- a/Sources/Rosetta/Cards/Cards.cpp
+++ b/Sources/Rosetta/Cards/Cards.cpp
@@ -36,6 +36,11 @@ Cards& Cards::GetInstance()
     return instance;
 }
 
+bool Cards::IsEmptyCard(Card* card)
+{
+    return card == &emptyCard;
+}
+
 const std::vector<Card*>& Cards::GetAllCards()
 {
     return m_cards;

--- a/Sources/Rosetta/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/Conditions/SelfCondition.cpp
@@ -17,6 +17,13 @@ SelfCondition::SelfCondition(std::function<bool(Entity*)> func)
     // Do nothing
 }
 
+SelfCondition SelfCondition::IsHeroPowerCard(const std::string& cardID)
+{
+    return SelfCondition([=](Entity* entity) -> bool {
+        return entity->owner->GetHero()->heroPower->card->id == cardID;
+    });
+}
+
 SelfCondition SelfCondition::IsDead()
 {
     return SelfCondition(
@@ -161,7 +168,7 @@ SelfCondition SelfCondition::IsName(const std::string& name, bool isEqual)
 
 SelfCondition SelfCondition::IsStackNum(int value, RelaSign relaSign, int index)
 {
-    return SelfCondition([=](Entity* entity) -> bool{
+    return SelfCondition([=](Entity* entity) -> bool {
         auto& stack = entity->owner->GetGame()->taskStack;
         auto num = index == 0 ? stack.num : stack.num1;
 
@@ -170,7 +177,7 @@ SelfCondition SelfCondition::IsStackNum(int value, RelaSign relaSign, int index)
                (relaSign == RelaSign::LEQ && num <= value);
     });
 }
-      
+
 SelfCondition SelfCondition::IsHealth(int value, RelaSign relaSign)
 {
     return SelfCondition([=](Entity* entity) -> bool {

--- a/Sources/Rosetta/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/Conditions/SelfCondition.cpp
@@ -170,7 +170,7 @@ SelfCondition SelfCondition::IsStackNum(int value, RelaSign relaSign, int index)
 {
     return SelfCondition([=](Entity* entity) -> bool {
         auto& stack = entity->owner->GetGame()->taskStack;
-        auto num = index == 0 ? stack.num : stack.num1;
+        const auto num = index == 0 ? stack.num : stack.num1;
 
         return (relaSign == RelaSign::EQ && num == value) ||
                (relaSign == RelaSign::GEQ && num >= value) ||

--- a/Sources/Rosetta/Enchants/Trigger.cpp
+++ b/Sources/Rosetta/Enchants/Trigger.cpp
@@ -9,6 +9,10 @@
 #include <Rosetta/Models/Enchantment.hpp>
 #include <Rosetta/Tasks/ITask.hpp>
 
+#include <effolkronium/random.hpp>
+
+using Random = effolkronium::random_static;
+
 namespace RosettaStone
 {
 Trigger::Trigger(TriggerType type) : m_triggerType(type)
@@ -66,8 +70,11 @@ void Trigger::Activate(Entity* source, TriggerActivation activation,
 
     source->activatedTrigger = instance;
 
-    auto triggerFunc = [instance](Player* p, Entity* e) {
-        instance->Process(p, e);
+    auto triggerFunc = [this, instance](Player* p, Entity* e) { 
+        if (percentage == 1.0f || Random::get<float>(0.0f, 1.0f) < percentage)
+        {
+            instance->Process(p, e);
+        }
     };
 
     if (m_sequenceType != SequenceType::NONE)

--- a/Sources/Rosetta/Games/Game.cpp
+++ b/Sources/Rosetta/Games/Game.cpp
@@ -537,6 +537,7 @@ void Game::ProcessDestroyAndUpdateAura()
         {
             triggerManager.OnSummonTrigger(&GetCurrentPlayer(), minion);
         }
+        summonedMinions.clear();
         ProcessTasks();
         taskQueue.EndEvent();
     }

--- a/Sources/Rosetta/Models/Entity.cpp
+++ b/Sources/Rosetta/Models/Entity.cpp
@@ -174,14 +174,15 @@ void Entity::Destroy()
     isDestroyed = true;
 }
 
-void Entity::ActivateTask(PowerType type, Entity* target, int chooseOne, Entity* chooseBase)
+void Entity::ActivateTask(PowerType type, Entity* target, int chooseOne,
+                          Entity* chooseBase)
 {
     if (HasChooseOne())
     {
         if (chooseOne > 0)
         {
             chooseOneCard[chooseOne - 1]->ActivateTask(type, target, chooseOne,
-                chooseBase == nullptr ? this : chooseBase);
+                                                       this);
             return;
         }
     }

--- a/Sources/Rosetta/Models/Entity.cpp
+++ b/Sources/Rosetta/Models/Entity.cpp
@@ -110,16 +110,20 @@ void Entity::SetCost(int cost)
 
 bool Entity::IsExhausted() const
 {
+    // Consider windfury
     if (GetGameTag(GameTag::WINDFURY) == 1 &&
         GetGameTag(GameTag::NUM_ATTACKS_THIS_TURN) == 1)
     {
         return false;
     }
+
+    // Consider charge
     if (GetGameTag(GameTag::CHARGE) == 1 &&
         GetGameTag(GameTag::NUM_ATTACKS_THIS_TURN) == 0)
     {
         return false;
     }
+
     return GetGameTag(GameTag::EXHAUSTED) == 1;
 }
 

--- a/Sources/Rosetta/Tasks/SimpleTasks/ChangeHeroPowerTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/ChangeHeroPowerTask.cpp
@@ -21,16 +21,10 @@ TaskID ChangeHeroPowerTask::GetTaskID() const
 
 TaskStatus ChangeHeroPowerTask::Impl(Player& player)
 {
-    if (Cards::IsEmptyCard(m_card) ||
-        m_card->GetCardType() != CardType::HERO_POWER)
-    {
-        return TaskStatus::STOP;
-    }
-    
     delete player.GetHero()->heroPower;
-    player.GetHero()->heroPower = 
+    player.GetHero()->heroPower =
         dynamic_cast<HeroPower*>(Entity::GetFromCard(player, m_card));
-    
+
     return TaskStatus::COMPLETE;
 }
 

--- a/Sources/Rosetta/Tasks/SimpleTasks/ChangeHeroPowerTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/ChangeHeroPowerTask.cpp
@@ -1,0 +1,41 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/Cards/Cards.hpp>
+#include <Rosetta/Games/Game.hpp>
+#include <Rosetta/Tasks/SimpleTasks/ChangeHeroPowerTask.hpp>
+
+namespace RosettaStone::SimpleTasks
+{
+ChangeHeroPowerTask::ChangeHeroPowerTask(const std::string& cardID)
+{
+    m_card = Cards::FindCardByID(cardID);
+}
+
+TaskID ChangeHeroPowerTask::GetTaskID() const
+{
+    return TaskID::CHANGE_HERO_POWER;
+}
+
+TaskStatus ChangeHeroPowerTask::Impl(Player& player)
+{
+    if (Cards::IsEmptyCard(m_card) ||
+        m_card->GetCardType() != CardType::HERO_POWER)
+    {
+        return TaskStatus::STOP;
+    }
+    
+    delete player.GetHero()->heroPower;
+    player.GetHero()->heroPower = 
+        dynamic_cast<HeroPower*>(Entity::GetFromCard(player, m_card));
+    
+    return TaskStatus::COMPLETE;
+}
+
+ITask* ChangeHeroPowerTask::CloneImpl()
+{
+    return new ChangeHeroPowerTask(m_card->id);
+}
+}  // namespace RosettaStone::SimpleTasks

--- a/Sources/Rosetta/Tasks/SimpleTasks/CountTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/CountTask.cpp
@@ -9,14 +9,9 @@
 
 namespace RosettaStone::SimpleTasks
 {
-CountTask::CountTask(EntityType entityType, int numIndex)
-    : ITask(entityType), m_numIndex(numIndex)
-{
-    // Do nothing
-}
 
-CountTask::CountTask(EntityType entityType, std::vector<SelfCondition> conditions, int numIndex)
-    : ITask(entityType), m_conditions(std::move(conditions)), m_numIndex(numIndex)
+CountTask::CountTask(EntityType entityType, int numIndex, std::vector<SelfCondition> conditions)
+    : ITask(entityType), m_numIndex(numIndex), m_conditions(std::move(conditions))
 {
     // Do nothing
 }
@@ -76,6 +71,6 @@ TaskStatus CountTask::Impl(Player& player)
 
 ITask* CountTask::CloneImpl()
 {
-    return new CountTask(m_entityType, m_numIndex);
+    return new CountTask(m_entityType, m_numIndex, m_conditions);
 }
 }  // namespace RosettaStone::SimpleTasks

--- a/Sources/Rosetta/Tasks/SimpleTasks/DrawNumberTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/DrawNumberTask.cpp
@@ -1,0 +1,39 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/Actions/Draw.hpp>
+#include <Rosetta/Games/Game.hpp>
+#include <Rosetta/Tasks/SimpleTasks/DrawNumberTask.hpp>
+
+namespace RosettaStone::SimpleTasks
+{
+TaskID DrawNumberTask::GetTaskID() const
+{
+    return TaskID::DRAW_NUMBER;
+}
+
+TaskStatus DrawNumberTask::Impl(Player& player)
+{
+    std::vector<Entity*> cards;
+
+    for (int i = 0; i < player.GetGame()->taskStack.num; ++i)
+    {
+        Entity* card = Generic::Draw(player, nullptr);
+        cards.emplace_back(card);
+    }
+
+    if (cards.empty() || cards.at(0) == nullptr)
+    {
+        return TaskStatus::COMPLETE;
+    }
+
+    return TaskStatus::COMPLETE;
+}
+
+ITask* DrawNumberTask::CloneImpl()
+{
+    return new DrawNumberTask();
+}
+}  // namespace RosettaStone::SimpleTasks

--- a/Sources/Rosetta/Tasks/SimpleTasks/DrawStackTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/DrawStackTask.cpp
@@ -9,8 +9,7 @@
 
 namespace RosettaStone::SimpleTasks
 {
-DrawStackTask::DrawStackTask(std::size_t amount)
-    : m_amount(amount)
+DrawStackTask::DrawStackTask(std::size_t amount) : m_amount(amount)
 {
     // Do nothing
 }
@@ -23,13 +22,15 @@ TaskID DrawStackTask::GetTaskID() const
 TaskStatus DrawStackTask::Impl(Player& player)
 {
     auto& stack = player.GetGame()->taskStack.entities;
-    const std::size_t amount = (m_amount <= stack.size()) ? m_amount : stack.size();
+    const std::size_t amount =
+        (m_amount <= stack.size()) ? m_amount : stack.size();
 
     for (std::size_t i = 0; i < amount; ++i)
     {
         Entity* card = stack.at(i);
-        card = Generic::Draw(player, card);
+        Generic::Draw(player, card);
     }
+
     stack.clear();
 
     return TaskStatus::COMPLETE;

--- a/Sources/Rosetta/Tasks/SimpleTasks/DrawTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/DrawTask.cpp
@@ -24,9 +24,7 @@ TaskStatus DrawTask::Impl(Player& player)
 {
     std::vector<Entity*> cards;
 
-    const int amount = m_amount == 0 ? player.GetGame()->taskStack.num : m_amount;
-
-    for (int i = 0; i < amount; ++i)
+    for (int i = 0; i < m_amount; ++i)
     {
         Entity* card = Generic::Draw(player, nullptr);
         cards.emplace_back(card);

--- a/Sources/Rosetta/Tasks/SimpleTasks/DrawTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/DrawTask.cpp
@@ -15,12 +15,6 @@ DrawTask::DrawTask(int amount, bool toStack)
     // Do nothing
 }
 
-DrawTask::DrawTask(bool toStack)
-    : m_toStack(toStack), m_stackNum(true)
-{
-    // Do nothing
-}
-
 TaskID DrawTask::GetTaskID() const
 {
     return TaskID::DRAW;
@@ -30,7 +24,7 @@ TaskStatus DrawTask::Impl(Player& player)
 {
     std::vector<Entity*> cards;
 
-    const int amount = m_stackNum ? player.GetGame()->taskStack.num : m_amount;
+    const int amount = m_amount == 0 ? player.GetGame()->taskStack.num : m_amount;
 
     for (int i = 0; i < amount; ++i)
     {

--- a/Sources/Rosetta/Tasks/SimpleTasks/IncludeTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/IncludeTask.cpp
@@ -32,10 +32,16 @@ std::vector<Entity*> IncludeTask::GetEntities(EntityType entityType,
     switch (entityType)
     {
         case EntityType::SOURCE:
-            entities.emplace_back(source);
+            if (source != nullptr)
+            {
+                entities.emplace_back(source);
+            }
             break;
         case EntityType::TARGET:
-            entities.emplace_back(target);
+            if (target != nullptr)
+            {
+                entities.emplace_back(target);
+            }
             break;
         case EntityType::ALL:
             for (auto& minion : player.GetFieldZone().GetAll())

--- a/Sources/Rosetta/Tasks/SimpleTasks/IncludeTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/IncludeTask.cpp
@@ -136,6 +136,12 @@ std::vector<Entity*> IncludeTask::GetEntities(EntityType entityType,
                 entities.emplace_back(card);
             }
             break;
+        case EntityType::DECK:
+            for (auto& card : player.GetDeckZone().GetAll())
+            {
+                entities.emplace_back(card);
+            }
+            break;
         case EntityType::ENEMY_DECK:
             for (auto& card : player.opponent->GetDeckZone().GetAll())
             {

--- a/Sources/Rosetta/Tasks/SimpleTasks/IncludeTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/IncludeTask.cpp
@@ -136,6 +136,12 @@ std::vector<Entity*> IncludeTask::GetEntities(EntityType entityType,
                 entities.emplace_back(card);
             }
             break;
+        case EntityType::ENEMY_DECK:
+            for (auto& card : player.opponent->GetDeckZone().GetAll())
+            {
+                entities.emplace_back(card);
+            }
+            break;
         case EntityType::ALL_MINIONS:
             for (auto& minion : player.GetFieldZone().GetAll())
             {

--- a/Sources/Rosetta/Zones/FieldZone.cpp
+++ b/Sources/Rosetta/Zones/FieldZone.cpp
@@ -69,6 +69,12 @@ void FieldZone::Replace(Entity& oldEntity, Entity& newEntity)
     {
         aura->SetToBeUpdated(true);
     }
+
+    // Set exhausted by checking GameTag::CHARGE
+    if (newEntity.GetGameTag(GameTag::CHARGE) == 0)
+    {
+        newEntity.SetExhausted(true);
+    }
 }
 
 void FieldZone::ActivateAura(Entity& entity)

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -1886,16 +1886,16 @@ TEST(WarriorExpert1Test, EX1_414_GrommashHellscream)
         curPlayer, Cards::GetInstance().FindCardByName("Circle of Healing"));
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
-    EXPECT_EQ(curField[0]->GetDamage(), 0);
     EXPECT_EQ(curField[0]->GetAttack(), 4);
+    EXPECT_EQ(curField[0]->GetHealth(), 9);
 
-    game.Process(curPlayer, PlayerTasks::HeroPowerTask(card1));
-    EXPECT_EQ(curField[0]->GetDamage(), 1);
+    game.Process(curPlayer, HeroPowerTask(card1));
     EXPECT_EQ(curField[0]->GetAttack(), 10);
+    EXPECT_EQ(curField[0]->GetHealth(), 8);
 
     game.Process(curPlayer, PlayCardTask::Spell(card2));
-    EXPECT_EQ(curField[0]->GetDamage(), 0);
     EXPECT_EQ(curField[0]->GetAttack(), 4);
+    EXPECT_EQ(curField[0]->GetHealth(), 9);
 }
 
 // ----------------------------------------- SPELL - WARRIOR

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -323,6 +323,59 @@ TEST(DruidExpert1Test, EX1_164_Nourish)
 }
 
 // ----------------------------------------- MINION - DRUID
+// [EX1_165] Druid of the Claw - COST:5 [ATK:4/HP:4]
+// - Race: Beast, Faction: Neutral, Set: Expert1, Rarity: Common
+// --------------------------------------------------------
+// Text: [x]<b>Choose One -</b> Transform into a 4/4 with <b>Charge</b>; 
+//       or a 4/6 with <b>Taunt</b>.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// --------------------------------------------------------
+// RefTag:
+// - CHARGE = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST(DruidExpert1Test, EX1_165_DruidOfTheClaw)
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+    
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByID("EX1_165"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByID("EX1_165"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Silence"));
+    
+    game.Process(curPlayer, PlayCardTask::Minion(card1, 1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2, 2));
+    EXPECT_EQ(curField[0]->GetHealth(), 4);
+    EXPECT_EQ(curField[1]->GetHealth(), 6);
+    EXPECT_TRUE(curField[0]->CanAttack());
+    
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card2));
+    EXPECT_EQ(curField[1]->GetHealth(), 6);
+}
+
+// ----------------------------------------- MINION - DRUID
 // [EX1_178] Ancient of War - COST:7 [ATK:5/HP:5]
 // - Faction: Neutral, Set: Expert1, Rarity: Epic
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -6750,7 +6750,7 @@ TEST(WarlockExpert1Test, EX1_317_SenseDemons)
     config.skipMulligan = true;
     config.doShuffle = false;
 
-    for (int i = 0; i < 6; ++i)
+    for (int i = 0; i < 7; ++i)
     {
         config.player1Deck[i] =
             *Cards::GetInstance().FindCardByName("Blood Imp");
@@ -6775,16 +6775,15 @@ TEST(WarlockExpert1Test, EX1_317_SenseDemons)
     const auto card2 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Sense Demons"));
 
-    EXPECT_EQ(curDeck.GetCount(), 2);
-
     game.Process(curPlayer, PlayCardTask::Spell(card1));
-    EXPECT_EQ(curDeck.GetCount(), 0);
-    EXPECT_EQ(curHand.GetCount(), 7);
+    EXPECT_EQ(curDeck.GetCount(), 1);
+    EXPECT_EQ(curHand[5]->card->name, "Blood Imp");
+    EXPECT_EQ(curHand[6]->card->name, "Blood Imp");
 
     game.Process(curPlayer, PlayCardTask::Spell(card2));
     EXPECT_EQ(curDeck.GetCount(), 0);
-    EXPECT_EQ(curHand.GetCount(), 7);
-    EXPECT_EQ(curHand.GetAll().at(6)->card->name, "Worthless Imp");
+    EXPECT_EQ(curHand[6]->card->name, "Blood Imp");
+    EXPECT_EQ(curHand[7]->card->name, "Worthless Imp");
 }
 
 // ---------------------------------------- SPELL - WARLOCK

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -7710,7 +7710,7 @@ TEST(NeutralExpert1Test, NEW1_018_BloodsailRaider)
     auto& curField = curPlayer.GetFieldZone();
 
     const auto card1 = Generic::DrawCard(
-        curPlayer, Cards::GetInstance().FindCardByID("CS2_106"));
+        curPlayer, Cards::GetInstance().FindCardByName("Fiery War Axe"));
     const auto card2 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Bloodsail Raider"));
     const auto card3 = Generic::DrawCard(

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -1676,7 +1676,7 @@ TEST(WarriorExpert1Test, EX1_392_BattleRage)
 
 // --------------------------------------- MINION - WARRIOR
 // [EX1_393] Amani Berserker - COST:2 [ATK:2/HP:3]
-// - Set: Expert1, Rarity: Common
+// - Faction: Neutral, Set: Expert1, Rarity: Common
 // --------------------------------------------------------
 // Text: Has +3 Attack while damaged.
 // --------------------------------------------------------
@@ -1710,10 +1710,11 @@ TEST(Expert1Test, EX1_393_AmaniBerserker)
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     EXPECT_EQ(curField[0]->GetAttack(), 2);
+    EXPECT_EQ(curField[0]->GetHealth(), 3);
 
-    game.Process(curPlayer, PlayerTasks::HeroPowerTask(card1));
-    EXPECT_EQ(curField[0]->GetDamage(), 1);
+    game.Process(curPlayer, HeroPowerTask(card1));
     EXPECT_EQ(curField[0]->GetAttack(), 5);
+    EXPECT_EQ(curField[0]->GetHealth(), 2);
 }
 
 // ---------------------------------------- SPELL - WARRIOR

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -503,9 +503,9 @@ TEST(DruidExpert1Test, EX1_571_ForceOfNature)
     auto& curField = curPlayer.GetFieldZone();
 
     const auto card1 = Generic::DrawCard(
-        curPlayer, Cards::GetInstance().FindCardByID("EX1_571"));
+        curPlayer, Cards::GetInstance().FindCardByName("Force of Nature"));
     const auto card2 = Generic::DrawCard(
-        curPlayer, Cards::GetInstance().FindCardByID("EX1_571"));
+        curPlayer, Cards::GetInstance().FindCardByName("Force of Nature"));
     const auto card3 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
     const auto card4 = Generic::DrawCard(
@@ -516,6 +516,8 @@ TEST(DruidExpert1Test, EX1_571_ForceOfNature)
     game.Process(curPlayer, PlayCardTask::Minion(card3));
     game.Process(curPlayer, PlayCardTask::Minion(card4));
     game.Process(curPlayer, PlayCardTask::Minion(card5));
+    EXPECT_EQ(curField.GetCount(), 3);
+
     game.Process(curPlayer, PlayCardTask::Spell(card1));
     EXPECT_EQ(curField.GetCount(), 6);
     EXPECT_EQ(curField[3]->card->name, "Treant");
@@ -524,6 +526,7 @@ TEST(DruidExpert1Test, EX1_571_ForceOfNature)
 
     game.Process(curPlayer, PlayCardTask::Spell(card2));
     EXPECT_EQ(curField.GetCount(), 7);
+    EXPECT_EQ(curField[6]->card->name, "Treant");
 }
 
 // ---------------------------------------- WEAPON - HUNTER

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -1674,6 +1674,57 @@ TEST(WarriorExpert1Test, EX1_407_Brawl)
     EXPECT_EQ(curField.GetCount() + opField.GetCount(), 1);
 }
 
+// --------------------------------------- MINION - WARRIOR
+// [EX1_414] Grommash Hellscream - COST:8 [ATK:4/HP:9]
+// - Faction: Neutral, Set: Expert1, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Charge</b> Has +6 Attack while damaged.
+// --------------------------------------------------------
+// GameTag:
+// - CHARGE = 1
+// - ELITE = 1
+// - ENRAGED = 1
+// --------------------------------------------------------
+TEST(WarriorExpert1Test, EX1_414_GrommashHellscream)
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+    
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Grommash Hellscream"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Circle of Healing"));
+    
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    EXPECT_EQ(curField[0]->GetDamage(), 0);
+    EXPECT_EQ(curField[0]->GetAttack(), 4);
+    
+    game.Process(curPlayer, PlayerTasks::HeroPowerTask(card1));
+    EXPECT_EQ(curField[0]->GetDamage(), 1);
+    EXPECT_EQ(curField[0]->GetAttack(), 10);
+    
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    EXPECT_EQ(curField[0]->GetDamage(), 0);
+    EXPECT_EQ(curField[0]->GetAttack(), 4);
+}
+
 // ----------------------------------------- SPELL - WARRIOR
 // [EX1_607] Inner Rage - COST:0
 // - Set: Expert1, Rarity: Common

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -2231,7 +2231,6 @@ TEST(PriestExpert1Test, EX1_345_Mindgames)
     opPlayer.SetUsedMana(0);
 
     auto& curField = curPlayer.GetFieldZone();
-
     auto& opDeck = opPlayer.GetDeckZone();
 
     const auto card1 = Generic::DrawCard(
@@ -2250,6 +2249,7 @@ TEST(PriestExpert1Test, EX1_345_Mindgames)
 
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
+
     EXPECT_EQ(opDeck.GetCount(), 0);
 
     game.Process(curPlayer, PlayCardTask::Spell(card2));

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -6912,6 +6912,53 @@ TEST(NeutralExpert1Test, EX1_556_HarvestGolem)
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [EX1_557] Nat Pagle - COST:2 [ATK:0/HP:4]
+// - Faction: Neutral, Set: Expert1, Rarity: Legendary
+// --------------------------------------------------------
+// Text: At the start of your turn, you have a 50% chance to
+//       draw an extra card.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST(NeutralExpert1Test, EX1_557_NatPagle)
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curHand = curPlayer.GetHandZone();
+    
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Nat Pagle"));
+    
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+    
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+    
+    EXPECT_TRUE(curHand.GetCount() == 5 || curHand.GetCount() == 6 );
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [EX1_563] Malygos - COST:9 [ATK:4/HP:12]
 // - Race: Dragon, Faction: Neutral, Set: Expert1, Rarity: Legendary
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -415,6 +415,61 @@ TEST(DruidExpert1Test, EX1_570_Bite)
     EXPECT_EQ(curPlayer.GetHero()->GetArmor(), 5);
 }
 
+// ------------------------------------------ SPELL - DRUID
+// [EX1_571] Force of Nature - COST:5
+// - Faction: Neutral, Set: Expert1, Rarity: Epic
+// --------------------------------------------------------
+// Text: Summon three 2/2 Treants.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINIONSLOTS = 1
+// --------------------------------------------------------
+TEST(DruidExpert1Test, EX1_571_ForceOfNature)
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+    
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByID("EX1_571"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByID("EX1_571"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
+    const auto card5 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
+    
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    EXPECT_EQ(curField.GetCount(), 6);
+    EXPECT_EQ(curField[3]->card->name, "Treant");
+    EXPECT_EQ(curField[4]->card->name, "Treant");
+    EXPECT_EQ(curField[5]->card->name, "Treant");
+    
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    EXPECT_EQ(curField.GetCount(), 7);
+}
+
 // ---------------------------------------- WEAPON - HUNTER
 // [DS1_188] Gladiator's Longbow - COST:7 [ATK:5/HP:0]
 // - Faction: Neutral, Set: Expert1, Rarity: Epic

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -6922,9 +6922,9 @@ TEST(NeutralExpert1Test, EX1_405_Shieldbearer)
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_412] Raging Worgen - COST:3 [ATK:3/HP:3]
-// - Set: Expert1, Rarity: Common
+// - Faction: Neutral, Set: Expert1, Rarity: Common
 // --------------------------------------------------------
-// Text: <b>Taunt</b> Has +3 Attack while damaged.
+// Text: Has +1 Attack and <b>Windfury</b> while damaged.
 // --------------------------------------------------------
 // GameTag:
 // - ENRAGED = 1
@@ -6960,8 +6960,9 @@ TEST(NeutralExpert1Test, EX1_412_RagingWorgen)
         curPlayer, Cards::GetInstance().FindCardByName("Circle of Healing"));
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
-    EXPECT_EQ(curField[0]->GetAttack(), 3);
     EXPECT_EQ(curField[0]->GetGameTag(GameTag::WINDFURY), 0);
+    EXPECT_EQ(curField[0]->GetAttack(), 3);
+    EXPECT_EQ(curField[0]->GetHealth(), 3);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
@@ -6969,14 +6970,23 @@ TEST(NeutralExpert1Test, EX1_412_RagingWorgen)
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
-    game.Process(curPlayer, PlayerTasks::AttackTask(card1, opPlayer.GetHero()));
+    game.Process(curPlayer, AttackTask(card1, opPlayer.GetHero()));
     EXPECT_FALSE(curField[0]->CanAttack());
+    EXPECT_EQ(curField[0]->GetGameTag(GameTag::WINDFURY), 0);
+    EXPECT_EQ(curField[0]->GetAttack(), 3);
+    EXPECT_EQ(curField[0]->GetHealth(), 3);
 
-    game.Process(curPlayer, PlayerTasks::HeroPowerTask(card1));
+    game.Process(curPlayer, HeroPowerTask(card1));
     EXPECT_TRUE(curField[0]->CanAttack());
+    EXPECT_EQ(curField[0]->GetGameTag(GameTag::WINDFURY), 1);
+    EXPECT_EQ(curField[0]->GetAttack(), 4);
+    EXPECT_EQ(curField[0]->GetHealth(), 2);
 
     game.Process(curPlayer, PlayCardTask::Spell(card2));
     EXPECT_FALSE(curField[0]->CanAttack());
+    EXPECT_EQ(curField[0]->GetGameTag(GameTag::WINDFURY), 0);
+    EXPECT_EQ(curField[0]->GetAttack(), 3);
+    EXPECT_EQ(curField[0]->GetHealth(), 3);
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -2455,13 +2455,13 @@ TEST(PriestExpert1Test, EX1_625_Shadowform)
     const auto card3 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Shadowform"));
 
-    game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
+    game.Process(curPlayer, HeroPowerTask(opHero));
     EXPECT_EQ(opHero->GetHealth(), 29);
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
     EXPECT_EQ(curPlayer.GetHero()->heroPower->card->name, "Mind Spike");
 
-    game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
+    game.Process(curPlayer, HeroPowerTask(opHero));
     EXPECT_EQ(opHero->GetHealth(), 27);
 
     game.Process(curPlayer, EndTurnTask());
@@ -2470,13 +2470,13 @@ TEST(PriestExpert1Test, EX1_625_Shadowform)
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
-    game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
+    game.Process(curPlayer, HeroPowerTask(opHero));
     EXPECT_EQ(opHero->GetHealth(), 25);
 
     game.Process(curPlayer, PlayCardTask::Spell(card2));
     EXPECT_EQ(curPlayer.GetHero()->heroPower->card->name, "Mind Shatter");
 
-    game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
+    game.Process(curPlayer, HeroPowerTask(opHero));
     EXPECT_EQ(opHero->GetHealth(), 22);
 
     game.Process(curPlayer, EndTurnTask());
@@ -2485,15 +2485,13 @@ TEST(PriestExpert1Test, EX1_625_Shadowform)
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
-    game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
+    game.Process(curPlayer, HeroPowerTask(opHero));
     EXPECT_EQ(opHero->GetHealth(), 19);
 
-    const HeroPower* heroPower = curPlayer.GetHero()->heroPower;
-
     game.Process(curPlayer, PlayCardTask::Spell(card3));
-    EXPECT_EQ(curPlayer.GetHero()->heroPower, heroPower);
+    EXPECT_EQ(curPlayer.GetHero()->heroPower->card->name, "Mind Shatter");
 
-    game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
+    game.Process(curPlayer, HeroPowerTask(opHero));
     EXPECT_EQ(opHero->GetHealth(), 19);
 }
 

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -325,9 +325,9 @@ TEST(DruidExpert1Test, EX1_164_Nourish)
 
 // ----------------------------------------- MINION - DRUID
 // [EX1_165] Druid of the Claw - COST:5 [ATK:4/HP:4]
-// - Race: Beast, Faction: Neutral, Set: Expert1, Rarity: Common
+// - Faction: Neutral, Set: Expert1, Rarity: Common
 // --------------------------------------------------------
-// Text: [x]<b>Choose One -</b> Transform into a 4/4 with <b>Charge</b>;
+// Text: <b>Choose One -</b> Transform into a 4/4 with <b>Charge</b>;
 //       or a 4/6 with <b>Taunt</b>.
 // --------------------------------------------------------
 // GameTag:
@@ -360,20 +360,29 @@ TEST(DruidExpert1Test, EX1_165_DruidOfTheClaw)
     auto& curField = curPlayer.GetFieldZone();
 
     const auto card1 = Generic::DrawCard(
-        curPlayer, Cards::GetInstance().FindCardByID("EX1_165"));
+        curPlayer, Cards::GetInstance().FindCardByName("Druid of the Claw"));
     const auto card2 = Generic::DrawCard(
-        curPlayer, Cards::GetInstance().FindCardByID("EX1_165"));
+        curPlayer, Cards::GetInstance().FindCardByName("Druid of the Claw"));
     const auto card3 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Silence"));
 
     game.Process(curPlayer, PlayCardTask::Minion(card1, 1));
-    game.Process(curPlayer, PlayCardTask::Minion(card2, 2));
+    EXPECT_EQ(curField[0]->GetAttack(), 4);
     EXPECT_EQ(curField[0]->GetHealth(), 4);
-    EXPECT_EQ(curField[1]->GetHealth(), 6);
     EXPECT_TRUE(curField[0]->CanAttack());
+    EXPECT_EQ(curField[0]->GetGameTag(GameTag::TAUNT), 0);
 
-    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card2, 2));
+    EXPECT_EQ(curField[1]->GetAttack(), 4);
     EXPECT_EQ(curField[1]->GetHealth(), 6);
+    EXPECT_FALSE(curField[1]->CanAttack());
+    EXPECT_EQ(curField[1]->GetGameTag(GameTag::TAUNT), 1);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, curField[1]));
+    EXPECT_EQ(curField[1]->GetAttack(), 4);
+    EXPECT_EQ(curField[1]->GetHealth(), 6);
+    EXPECT_FALSE(curField[1]->CanAttack());
+    EXPECT_EQ(curField[1]->GetGameTag(GameTag::TAUNT), 0);
 }
 
 // ----------------------------------------- MINION - DRUID

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -1548,18 +1548,22 @@ TEST(WarriorExpert1Test, EX1_392_BattleRage)
         opPlayer, Cards::GetInstance().FindCardByName("Battle Rage"));
     const auto card3 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Chillwind Yeti"));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Wisp"));
     
+
     game.Process(curPlayer, PlayCardTask::Spell(card1));
-    EXPECT_EQ(curHand.GetCount(), 4);
+    EXPECT_EQ(curHand.GetCount(), 5);
     
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
     
     game.Process(opPlayer, PlayCardTask::Minion(card3));
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
     game.Process(opPlayer, PlayerTasks::HeroPowerTask(card3));
     game.Process(opPlayer, PlayCardTask::Spell(card2));
     EXPECT_EQ(opField[0]->GetDamage(), 1);
-    EXPECT_EQ(opHand.GetCount(), 6);
+    EXPECT_EQ(opHand.GetCount(), 8);
 }
 
 // --------------------------------------- MINION - WARRIOR

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -7065,9 +7065,6 @@ TEST(NeutralExpert1Test, EX1_507_MurlocWarleader)
 // --------------------------------------------------------
 // Text: Whenever you summon a Murloc, gain +1 Attack.
 // --------------------------------------------------------
-// GameTag:
-// - TRIGGER_VISUAL = 1
-// --------------------------------------------------------
 TEST(NeutralExpert1Test, EX1_509_MurlocTidecaller)
 {
     GameConfig config;
@@ -7098,6 +7095,8 @@ TEST(NeutralExpert1Test, EX1_509_MurlocTidecaller)
         curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
     const auto card4 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
+    const auto card5 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Murloc Tidehunter"));
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     EXPECT_EQ(curField[0]->GetAttack(), 1);
@@ -7106,11 +7105,15 @@ TEST(NeutralExpert1Test, EX1_509_MurlocTidecaller)
     EXPECT_EQ(curField[0]->GetAttack(), 3);
 
     game.Process(curPlayer, PlayCardTask::Minion(card3));
-    EXPECT_EQ(curField.GetCount(), 4);
     EXPECT_EQ(curField[0]->GetAttack(), 3);
 
     game.Process(curPlayer, PlayCardTask::Minion(card4));
-    EXPECT_EQ(curField.GetCount(), 5);
+    EXPECT_EQ(curField[0]->GetAttack(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
     EXPECT_EQ(curField[0]->GetAttack(), 3);
 }
 

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -7654,13 +7654,27 @@ TEST(NeutralExpert1Test, NEW1_017_HungryCrab)
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Murloc Raider"));
     const auto card2 = Generic::DrawCard(
-        curPlayer, Cards::GetInstance().FindCardByID("NEW1_017"));
+        curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Hungry Crab"));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Hungry Crab"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    EXPECT_EQ(curField.GetCount(), 1);
+    EXPECT_EQ(curField[0]->GetAttack(), 1);
+    EXPECT_EQ(curField[0]->GetHealth(), 2);
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
-    game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card1));
-    EXPECT_EQ(curField.GetCount(), 1);
-    EXPECT_EQ(curField[0]->GetAttack(), 3);
-    EXPECT_EQ(curField[0]->GetHealth(), 4);
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card3, card2));
+    EXPECT_EQ(curField.GetCount(), 3);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card3, card1));
+    EXPECT_EQ(curField.GetCount(), 3);
+    EXPECT_EQ(curField[2]->GetAttack(), 3);
+    EXPECT_EQ(curField[2]->GetHealth(), 4);
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -2298,6 +2298,84 @@ TEST(PriestExpert1Test, EX1_624_HolyFire)
 }
 
 // ----------------------------------------- SPELL - PRIEST
+// [EX1_625] Shadowform - COST:3
+// - Faction: Priest, Set: Expert1, Rarity: Epic
+// --------------------------------------------------------
+// Text: Your Hero Power becomes 'Deal 2 damage'.
+//       If already in Shadowform: 3 damage.
+// --------------------------------------------------------
+TEST(PriestExpert1Test, EX1_625_Shadowform)
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    Hero* opHero = opPlayer.GetHero();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Shadowform"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Shadowform"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Shadowform"));
+    
+    game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
+    EXPECT_EQ(opHero->GetHealth(), 29);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    EXPECT_EQ(curPlayer.GetHero()->heroPower->card->name, "Mind Spike");
+    
+    game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
+    EXPECT_EQ(opHero->GetHealth(), 27);
+    
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+    
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+    
+    game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
+    EXPECT_EQ(opHero->GetHealth(), 25);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    EXPECT_EQ(curPlayer.GetHero()->heroPower->card->name, "Mind Shatter");
+    
+    game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
+    EXPECT_EQ(opHero->GetHealth(), 22);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+    
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+    
+    game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
+    EXPECT_EQ(opHero->GetHealth(), 19);
+
+    const HeroPower* heroPower = curPlayer.GetHero()->heroPower;
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    EXPECT_EQ(curPlayer.GetHero()->heroPower, heroPower);
+    
+    game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
+    EXPECT_EQ(opHero->GetHealth(), 19);
+}
+
+// ----------------------------------------- SPELL - PRIEST
 // [EX1_626] Mass Dispel - COST:4
 // - Set: Expert1, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -214,7 +214,8 @@ TEST(DruidExpert1Test, EX1_158_SoulOfTheForest)
 // [EX1_160] Power of the Wild - COST:2
 // - Faction: Neutral, Set: Expert1, Rarity: Common
 // --------------------------------------------------------
-// Text: <b>Choose One -</b> Give your minions +1/+1; or Summon a 3/2
+// Text: <b>Choose One -</b> Give your minions +1/+1;
+//       or Summon a 3/2 Panther.
 // --------------------------------------------------------
 // GameTag:
 // - CHOOSE_ONE = 1
@@ -241,21 +242,21 @@ TEST(DruidExpert1Test, EX1_160_PowerOfTheWild)
 
     auto& curField = curPlayer.GetFieldZone();
     auto& opField = opPlayer.GetFieldZone();
-    
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Power of the Wild"));
     const auto card2 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Power of the Wild"));
     const auto card3 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Power of the Wild"));
-    
+
     game.Process(curPlayer, PlayCardTask::Spell(card1, 1));
     EXPECT_EQ(curField.GetCount(), 1);
     EXPECT_TRUE(opField.IsEmpty());
-    
+
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
-    
+
     game.Process(opPlayer, PlayCardTask::Spell(card2, 1));
     game.Process(opPlayer, PlayCardTask::Spell(card3, 2));
     EXPECT_EQ(curField.GetCount(), 1);
@@ -326,7 +327,7 @@ TEST(DruidExpert1Test, EX1_164_Nourish)
 // [EX1_165] Druid of the Claw - COST:5 [ATK:4/HP:4]
 // - Race: Beast, Faction: Neutral, Set: Expert1, Rarity: Common
 // --------------------------------------------------------
-// Text: [x]<b>Choose One -</b> Transform into a 4/4 with <b>Charge</b>; 
+// Text: [x]<b>Choose One -</b> Transform into a 4/4 with <b>Charge</b>;
 //       or a 4/6 with <b>Taunt</b>.
 // --------------------------------------------------------
 // GameTag:
@@ -357,20 +358,20 @@ TEST(DruidExpert1Test, EX1_165_DruidOfTheClaw)
     opPlayer.SetUsedMana(0);
 
     auto& curField = curPlayer.GetFieldZone();
-    
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByID("EX1_165"));
     const auto card2 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByID("EX1_165"));
     const auto card3 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Silence"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card1, 1));
     game.Process(curPlayer, PlayCardTask::Minion(card2, 2));
     EXPECT_EQ(curField[0]->GetHealth(), 4);
     EXPECT_EQ(curField[1]->GetHealth(), 6);
     EXPECT_TRUE(curField[0]->CanAttack());
-    
+
     game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card2));
     EXPECT_EQ(curField[1]->GetHealth(), 6);
 }
@@ -409,19 +410,19 @@ TEST(DruidExpert1Test, EX1_178_AncientOfWar)
 
     auto& curField = curPlayer.GetFieldZone();
     auto& opField = opPlayer.GetFieldZone();
-    
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Ancient of War"));
     const auto card2 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Ancient of War"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card1, 1));
     EXPECT_EQ(curField[0]->GetHealth(), 10);
     EXPECT_EQ(curField[0]->GetGameTag(GameTag::TAUNT), 1);
-    
+
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
-    
+
     game.Process(opPlayer, PlayCardTask::Minion(card2, 2));
     EXPECT_EQ(opField[0]->GetAttack(), 10);
 }
@@ -500,7 +501,7 @@ TEST(DruidExpert1Test, EX1_571_ForceOfNature)
     opPlayer.SetUsedMana(0);
 
     auto& curField = curPlayer.GetFieldZone();
-    
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByID("EX1_571"));
     const auto card2 = Generic::DrawCard(
@@ -511,7 +512,7 @@ TEST(DruidExpert1Test, EX1_571_ForceOfNature)
         curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
     const auto card5 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card3));
     game.Process(curPlayer, PlayCardTask::Minion(card4));
     game.Process(curPlayer, PlayCardTask::Minion(card5));
@@ -520,7 +521,7 @@ TEST(DruidExpert1Test, EX1_571_ForceOfNature)
     EXPECT_EQ(curField[3]->card->name, "Treant");
     EXPECT_EQ(curField[4]->card->name, "Treant");
     EXPECT_EQ(curField[5]->card->name, "Treant");
-    
+
     game.Process(curPlayer, PlayCardTask::Spell(card2));
     EXPECT_EQ(curField.GetCount(), 7);
 }
@@ -954,7 +955,7 @@ TEST(MageExpert1Test, EX1_180_TomeOfIntellect)
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = true;
     config.autoRun = false;
-    
+
     Game game(config);
     game.StartGame();
     game.ProcessUntil(Step::MAIN_START);
@@ -967,10 +968,10 @@ TEST(MageExpert1Test, EX1_180_TomeOfIntellect)
     opPlayer.SetUsedMana(0);
 
     auto& curHand = curPlayer.GetHandZone();
-    
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Tome of Intellect"));
-    
+
     game.Process(curPlayer, PlayCardTask::Spell(card1));
 
     EXPECT_EQ(curHand.GetAll().at(4)->card->GetCardClass(), CardClass::MAGE);
@@ -1651,7 +1652,7 @@ TEST(WarriorExpert1Test, EX1_392_BattleRage)
 
     auto& curHand = curPlayer.GetHandZone();
     auto& opHand = opPlayer.GetHandZone();
-    
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Battle Rage"));
     const auto card2 = Generic::DrawCard(
@@ -1660,14 +1661,13 @@ TEST(WarriorExpert1Test, EX1_392_BattleRage)
         opPlayer, Cards::GetInstance().FindCardByName("Chillwind Yeti"));
     const auto card4 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Wisp"));
-    
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
     EXPECT_EQ(curHand.GetCount(), 5);
-    
+
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
-    
+
     game.Process(opPlayer, PlayCardTask::Minion(card3));
     game.Process(opPlayer, PlayCardTask::Minion(card4));
     game.Process(opPlayer, PlayerTasks::HeroPowerTask(card3));
@@ -1706,13 +1706,13 @@ TEST(Expert1Test, EX1_393_AmaniBerserker)
     opPlayer.SetUsedMana(0);
 
     auto& curField = curPlayer.GetFieldZone();
-    
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Amani Berserker"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     EXPECT_EQ(curField[0]->GetAttack(), 2);
-    
+
     game.Process(curPlayer, PlayerTasks::HeroPowerTask(card1));
     EXPECT_EQ(curField[0]->GetDamage(), 1);
     EXPECT_EQ(curField[0]->GetAttack(), 5);
@@ -1880,20 +1880,20 @@ TEST(WarriorExpert1Test, EX1_414_GrommashHellscream)
     opPlayer.SetUsedMana(0);
 
     auto& curField = curPlayer.GetFieldZone();
-    
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Grommash Hellscream"));
     const auto card2 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Circle of Healing"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     EXPECT_EQ(curField[0]->GetDamage(), 0);
     EXPECT_EQ(curField[0]->GetAttack(), 4);
-    
+
     game.Process(curPlayer, PlayerTasks::HeroPowerTask(card1));
     EXPECT_EQ(curField[0]->GetDamage(), 1);
     EXPECT_EQ(curField[0]->GetAttack(), 10);
-    
+
     game.Process(curPlayer, PlayCardTask::Spell(card2));
     EXPECT_EQ(curField[0]->GetDamage(), 0);
     EXPECT_EQ(curField[0]->GetAttack(), 4);
@@ -2216,7 +2216,8 @@ TEST(PriestExpert1Test, EX1_345_Mindgames)
 
     for (int i = 0; i < 5; ++i)
     {
-        config.player2Deck[i] = *Cards::GetInstance().FindCardByName("Magma Rager");
+        config.player2Deck[i] =
+            *Cards::GetInstance().FindCardByName("Magma Rager");
     }
 
     Game game(config);
@@ -2233,21 +2234,21 @@ TEST(PriestExpert1Test, EX1_345_Mindgames)
     auto& curField = curPlayer.GetFieldZone();
 
     auto& opDeck = opPlayer.GetDeckZone();
-    
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Mindgames"));
     const auto card2 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Mindgames"));
-    
+
     EXPECT_EQ(opDeck.GetCount(), 1);
-    
+
     game.Process(curPlayer, PlayCardTask::Spell(card1));
     EXPECT_EQ(curField[0]->card->name, "Magma Rager");
     EXPECT_EQ(opDeck.GetCount(), 1);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
-    
+
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
     EXPECT_EQ(opDeck.GetCount(), 0);
@@ -2451,37 +2452,37 @@ TEST(PriestExpert1Test, EX1_625_Shadowform)
         curPlayer, Cards::GetInstance().FindCardByName("Shadowform"));
     const auto card3 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Shadowform"));
-    
+
     game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
     EXPECT_EQ(opHero->GetHealth(), 29);
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
     EXPECT_EQ(curPlayer.GetHero()->heroPower->card->name, "Mind Spike");
-    
+
     game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
     EXPECT_EQ(opHero->GetHealth(), 27);
-    
+
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
-    
+
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
-    
+
     game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
     EXPECT_EQ(opHero->GetHealth(), 25);
 
     game.Process(curPlayer, PlayCardTask::Spell(card2));
     EXPECT_EQ(curPlayer.GetHero()->heroPower->card->name, "Mind Shatter");
-    
+
     game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
     EXPECT_EQ(opHero->GetHealth(), 22);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
-    
+
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
-    
+
     game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
     EXPECT_EQ(opHero->GetHealth(), 19);
 
@@ -2489,7 +2490,7 @@ TEST(PriestExpert1Test, EX1_625_Shadowform)
 
     game.Process(curPlayer, PlayCardTask::Spell(card3));
     EXPECT_EQ(curPlayer.GetHero()->heroPower, heroPower);
-    
+
     game.Process(curPlayer, PlayerTasks::HeroPowerTask(opHero));
     EXPECT_EQ(opHero->GetHealth(), 19);
 }
@@ -6260,7 +6261,7 @@ TEST(NeutralExpert1Test, EX1_162_DireWolfAlpha)
     opPlayer.SetUsedMana(0);
 
     auto& curField = curPlayer.GetFieldZone();
-    
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Wisp"));
     const auto card2 = Generic::DrawCard(
@@ -6275,7 +6276,7 @@ TEST(NeutralExpert1Test, EX1_162_DireWolfAlpha)
         curPlayer, Cards::GetInstance().FindCardByName("Dire Wolf Alpha"));
     const auto card7 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Fireball"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     game.Process(curPlayer, PlayCardTask::Minion(card2));
     game.Process(curPlayer, PlayCardTask::Minion(card3));
@@ -6298,14 +6299,13 @@ TEST(NeutralExpert1Test, EX1_162_DireWolfAlpha)
     EXPECT_EQ(curField[4]->GetAttack(), 1);
     EXPECT_EQ(card5, curField[3]);
     EXPECT_EQ(card3, curField[4]);
-    
+
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
     EXPECT_EQ(curField[1]->GetAttack(), 2);
     EXPECT_EQ(curField[3]->GetAttack(), 2);
-    
-    
+
     game.Process(opPlayer, PlayCardTask::SpellTarget(card7, card6));
     EXPECT_EQ(curField[0]->GetAttack(), 1);
     EXPECT_EQ(curField[1]->GetAttack(), 1);
@@ -6753,7 +6753,8 @@ TEST(WarlockExpert1Test, EX1_317_SenseDemons)
 
     for (int i = 0; i < 6; ++i)
     {
-        config.player1Deck[i] = *Cards::GetInstance().FindCardByName("Blood Imp");
+        config.player1Deck[i] =
+            *Cards::GetInstance().FindCardByName("Blood Imp");
     }
 
     Game game(config);
@@ -6774,17 +6775,17 @@ TEST(WarlockExpert1Test, EX1_317_SenseDemons)
         curPlayer, Cards::GetInstance().FindCardByName("Sense Demons"));
     const auto card2 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Sense Demons"));
-    
+
     EXPECT_EQ(curDeck.GetCount(), 2);
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
     EXPECT_EQ(curDeck.GetCount(), 0);
     EXPECT_EQ(curHand.GetCount(), 7);
-    
+
     game.Process(curPlayer, PlayCardTask::Spell(card2));
     EXPECT_EQ(curDeck.GetCount(), 0);
     EXPECT_EQ(curHand.GetCount(), 7);
-    EXPECT_EQ(curHand.GetAll().at(6)->card->name, "Worthless Imp");   
+    EXPECT_EQ(curHand.GetAll().at(6)->card->name, "Worthless Imp");
 }
 
 // ---------------------------------------- SPELL - WARLOCK
@@ -6881,7 +6882,7 @@ TEST(NeutralExpert1Test, EX1_390_TaurenWarrior)
 
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Tauren Warrior"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     EXPECT_EQ(curField[0]->GetGameTag(GameTag::TAUNT), 1);
     EXPECT_EQ(curField[0]->GetAttack(), 2);
@@ -6952,23 +6953,22 @@ TEST(NeutralExpert1Test, EX1_412_RagingWorgen)
     opPlayer.SetUsedMana(0);
 
     auto& curField = curPlayer.GetFieldZone();
-    
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Raging Worgen"));
     const auto card2 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Circle of Healing"));
-    
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     EXPECT_EQ(curField[0]->GetAttack(), 3);
     EXPECT_EQ(curField[0]->GetGameTag(GameTag::WINDFURY), 0);
-    
+
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
-    
+
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
-    
+
     game.Process(curPlayer, PlayerTasks::AttackTask(card1, opPlayer.GetHero()));
     EXPECT_FALSE(curField[0]->CanAttack());
 
@@ -7010,7 +7010,7 @@ TEST(NeutralExpert1Test, EX1_507_MurlocWarleader)
 
     auto& curField = curPlayer.GetFieldZone();
     auto& opField = opPlayer.GetFieldZone();
-    
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Murloc Raider"));
     const auto card2 = Generic::DrawCard(
@@ -7023,13 +7023,13 @@ TEST(NeutralExpert1Test, EX1_507_MurlocWarleader)
         opPlayer, Cards::GetInstance().FindCardByName("Wisp"));
     const auto card6 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Murloc Warleader"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     game.Process(curPlayer, PlayCardTask::Minion(card2));
-    
+
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
-    
+
     game.Process(opPlayer, PlayCardTask::Minion(card4));
     game.Process(opPlayer, PlayCardTask::Minion(card5));
     game.Process(opPlayer, PlayCardTask::Minion(card6));
@@ -7038,10 +7038,10 @@ TEST(NeutralExpert1Test, EX1_507_MurlocWarleader)
     EXPECT_EQ(opField[0]->GetAttack(), 4);
     EXPECT_EQ(opField[1]->GetAttack(), 1);
     EXPECT_EQ(opField[2]->GetAttack(), 3);
-    
+
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
-    
+
     game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card6));
     EXPECT_EQ(curField[0]->GetAttack(), 2);
     EXPECT_EQ(curField[1]->GetAttack(), 1);
@@ -7088,11 +7088,10 @@ TEST(NeutralExpert1Test, EX1_509_MurlocTidecaller)
         curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
     const auto card4 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
-    
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     EXPECT_EQ(curField[0]->GetAttack(), 1);
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card2));
     EXPECT_EQ(curField[0]->GetAttack(), 3);
 
@@ -7195,19 +7194,19 @@ TEST(NeutralExpert1Test, EX1_557_NatPagle)
     opPlayer.SetUsedMana(0);
 
     auto& curHand = curPlayer.GetHandZone();
-    
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Nat Pagle"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card1));
-    
+
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
-    
+
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
-    
-    EXPECT_TRUE(curHand.GetCount() == 5 || curHand.GetCount() == 6 );
+
+    EXPECT_TRUE(curHand.GetCount() == 5 || curHand.GetCount() == 6);
 }
 
 // --------------------------------------- MINION - NEUTRAL
@@ -7653,17 +7652,17 @@ TEST(NeutralExpert1Test, NEW1_017_HungryCrab)
     opPlayer.SetUsedMana(0);
 
     auto& curField = curPlayer.GetFieldZone();
-    
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Murloc Raider"));
     const auto card2 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByID("NEW1_017"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card1));
     EXPECT_EQ(curField.GetCount(), 1);
     EXPECT_EQ(curField[0]->GetAttack(), 3);
-    EXPECT_EQ(curField[0]->GetHealth(), 4);    
+    EXPECT_EQ(curField[0]->GetHealth(), 4);
 }
 
 // --------------------------------------- MINION - NEUTRAL
@@ -7704,7 +7703,7 @@ TEST(NeutralExpert1Test, NEW1_018_BloodsailRaider)
         curPlayer, Cards::GetInstance().FindCardByName("Bloodsail Raider"));
     const auto card3 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Bloodsail Raider"));
-    
+
     game.Process(curPlayer, PlayCardTask::Minion(card2));
     EXPECT_EQ(curField[0]->GetAttack(), 2);
     EXPECT_EQ(curField[0]->GetHealth(), 3);

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -6798,6 +6798,62 @@ TEST(NeutralExpert1Test, EX1_507_MurlocWarleader)
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [EX1_509] Murloc Tidecaller - COST:1 [ATK:1/HP:2]
+// - Race: Murloc, Faction: Neutral, Set: Expert1, Rarity: Rare
+// --------------------------------------------------------
+// Text: Whenever you summon a Murloc, gain +1 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST(NeutralExpert1Test, EX1_509_MurlocTidecaller)
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto& curField = curPlayer.GetFieldZone();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Murloc Tidecaller"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Murloc Tidehunter"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Magma Rager"));
+    
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    EXPECT_EQ(curField[0]->GetAttack(), 1);
+    
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    EXPECT_EQ(curField[0]->GetAttack(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    EXPECT_EQ(curField.GetCount(), 4);
+    EXPECT_EQ(curField[0]->GetAttack(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    EXPECT_EQ(curField.GetCount(), 5);
+    EXPECT_EQ(curField[0]->GetAttack(), 3);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [EX1_556] Harvest Golem - COST:3 [ATK:2/HP:3]
 // - Race: Mechanical, Set: Expert1, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -1648,7 +1648,6 @@ TEST(WarriorExpert1Test, EX1_392_BattleRage)
     opPlayer.GetHero()->SetDamage(1);
 
     auto& opField = opPlayer.GetFieldZone();
-
     auto& curHand = curPlayer.GetHandZone();
     auto& opHand = opPlayer.GetHandZone();
 
@@ -1669,7 +1668,7 @@ TEST(WarriorExpert1Test, EX1_392_BattleRage)
 
     game.Process(opPlayer, PlayCardTask::Minion(card3));
     game.Process(opPlayer, PlayCardTask::Minion(card4));
-    game.Process(opPlayer, PlayerTasks::HeroPowerTask(card3));
+    game.Process(opPlayer, HeroPowerTask(card3));
     game.Process(opPlayer, PlayCardTask::Spell(card2));
     EXPECT_EQ(opField[0]->GetDamage(), 1);
     EXPECT_EQ(opHand.GetCount(), 8);

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -6848,7 +6848,7 @@ TEST(WarlockExpert1Test, EX1_320_BaneOfDoom)
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_390] Tauren Warrior - COST:3 [ATK:2/HP:3]
-// - Set: Expert1, Rarity: Common
+// - Faction: Neutral, Set: Expert1, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Taunt</b> Has +3 Attack while damaged.
 // --------------------------------------------------------
@@ -6884,10 +6884,12 @@ TEST(NeutralExpert1Test, EX1_390_TaurenWarrior)
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     EXPECT_EQ(curField[0]->GetGameTag(GameTag::TAUNT), 1);
     EXPECT_EQ(curField[0]->GetAttack(), 2);
+    EXPECT_EQ(curField[0]->GetHealth(), 3);
 
-    game.Process(curPlayer, PlayerTasks::HeroPowerTask(card1));
+    game.Process(curPlayer, HeroPowerTask(card1));
     EXPECT_EQ(curField[0]->GetGameTag(GameTag::TAUNT), 1);
     EXPECT_EQ(curField[0]->GetAttack(), 5);
+    EXPECT_EQ(curField[0]->GetHealth(), 2);
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -943,7 +943,7 @@ TEST(MageExpert1Test, EX1_179_Icicle)
 
 // ------------------------------------------- SPELL - MAGE
 // [EX1_180] Tome of Intellect - COST:1
-// - Faction: Neutral, Set: Expert1, Rarity: Common
+// - Set: Expert1, Rarity: Common
 // --------------------------------------------------------
 // Text: Add a random Mage spell to your hand.
 // --------------------------------------------------------
@@ -973,8 +973,7 @@ TEST(MageExpert1Test, EX1_180_TomeOfIntellect)
         curPlayer, Cards::GetInstance().FindCardByName("Tome of Intellect"));
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
-
-    EXPECT_EQ(curHand.GetAll().at(4)->card->GetCardClass(), CardClass::MAGE);
+    EXPECT_EQ(curHand[4]->card->GetCardClass(), CardClass::MAGE);
 }
 
 // ------------------------------------------- SPELL - MAGE

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -326,6 +326,8 @@ TEST(DruidExpert1Test, EX1_164_Nourish)
 // [EX1_178] Ancient of War - COST:7 [ATK:5/HP:5]
 // - Faction: Neutral, Set: Expert1, Rarity: Epic
 // --------------------------------------------------------
+// Text: <b>Choose One -</b>+5 Attack; or +5 Health and <b>Taunt</b>.
+// --------------------------------------------------------
 // GameTag:
 // - CHOOSE_ONE = 1
 // --------------------------------------------------------

--- a/Tests/UnitTests/Tasks/SimpleTasks/ChangeHeroPowerTaskTests.cpp
+++ b/Tests/UnitTests/Tasks/SimpleTasks/ChangeHeroPowerTaskTests.cpp
@@ -43,31 +43,3 @@ TEST(ChangeHeroPowerTask, Run)
         Cards::GetInstance().GetDefaultHeroPower(CardClass::MAGE)->id);
     EXPECT_FALSE(hero.heroPower->IsExhausted());
 }
-
-TEST(ChangeHeroPowerTask, InvalidCardID)
-{
-    GameConfig config;
-    config.startPlayer = PlayerType::PLAYER1;
-    config.player1Class = CardClass::PRIEST;
-    Game game(config);
-
-    ChangeHeroPowerTask change("");
-    change.SetPlayer(&game.GetPlayer1());
-
-    TaskStatus result = change.Run();
-    EXPECT_EQ(result, TaskStatus::STOP);
-}
-
-TEST(ChangeHeroPowerTask, InvalidCardType)
-{
-    GameConfig config;
-    config.startPlayer = PlayerType::PLAYER1;
-    config.player1Class = CardClass::PRIEST;
-    Game game(config);
-
-    ChangeHeroPowerTask change("CS2_118");  // Minion
-    change.SetPlayer(&game.GetPlayer1());
-
-    TaskStatus result = change.Run();
-    EXPECT_EQ(result, TaskStatus::STOP);
-}

--- a/Tests/UnitTests/Tasks/SimpleTasks/ChangeHeroPowerTaskTests.cpp
+++ b/Tests/UnitTests/Tasks/SimpleTasks/ChangeHeroPowerTaskTests.cpp
@@ -1,0 +1,73 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#include "gtest/gtest.h"
+
+#include <Rosetta/Cards/Cards.hpp>
+#include <Rosetta/Games/Game.hpp>
+#include <Rosetta/Tasks/SimpleTasks/ChangeHeroPowerTask.hpp>
+
+using namespace RosettaStone;
+using namespace SimpleTasks;
+
+TEST(ChangeHeroPowerTask, GetTaskID)
+{
+    const ChangeHeroPowerTask change("");
+    EXPECT_EQ(change.GetTaskID(), TaskID::CHANGE_HERO_POWER);
+}
+
+TEST(ChangeHeroPowerTask, Run)
+{
+    GameConfig config;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.player1Class = CardClass::PRIEST;
+    Game game(config);
+
+    Hero& hero = *game.GetPlayer1().GetHero();
+
+    hero.heroPower->SetExhausted(true);
+    EXPECT_EQ(hero.heroPower->card->id,
+        Cards::GetInstance().GetDefaultHeroPower(CardClass::PRIEST)->id);
+    EXPECT_TRUE(hero.heroPower->IsExhausted());
+
+    ChangeHeroPowerTask change(
+        Cards::GetInstance().GetDefaultHeroPower(CardClass::MAGE)->id);
+    change.SetPlayer(&game.GetPlayer1());
+    
+    TaskStatus result = change.Run();
+    EXPECT_EQ(result, TaskStatus::COMPLETE);
+    EXPECT_EQ(hero.heroPower->card->id,
+        Cards::GetInstance().GetDefaultHeroPower(CardClass::MAGE)->id);
+    EXPECT_FALSE(hero.heroPower->IsExhausted());
+}
+
+TEST(ChangeHeroPowerTask, InvalidCardID)
+{
+    GameConfig config;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.player1Class = CardClass::PRIEST;
+    Game game(config);
+
+    ChangeHeroPowerTask change("");
+    change.SetPlayer(&game.GetPlayer1());
+
+    TaskStatus result = change.Run();
+    EXPECT_EQ(result, TaskStatus::STOP);
+}
+
+TEST(ChangeHeroPowerTask, InvalidCardType)
+{
+    GameConfig config;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.player1Class = CardClass::PRIEST;
+    Game game(config);
+
+    ChangeHeroPowerTask change("CS2_118");  // Minion
+    change.SetPlayer(&game.GetPlayer1());
+
+    TaskStatus result = change.Run();
+    EXPECT_EQ(result, TaskStatus::STOP);
+}


### PR DESCRIPTION
This revision includes:  

- Implement 19 cards in the EXPERT1 card set
    - Power of the Wild (EX1_160)
    - Dire Wolf Alpha (EX1_162)
    - Ancient of War (EX1_178)
    - Tome of Intellect (EX1_180)
    - Mindgames (EX1_345)
    - Sense Demons (EX1_317)
    - Murloc Warleader (EX1_507)
    - Hungry Crab (NEW1_017)
    - Bloodsail Raider (NEW1_018)
    - Battle Rage (EX1_392)
    - Amani Berserker (EX1_393)
    - Tauren Warrior (EX1_390)
    - Raging Worgen (EX1_412)
    - Grommash Hellscream (EX1_414)
    - Murloc Tidecaller (EX1_509)
    - Nat Pagle (EX1_557)
    - Force of Nature (EX1_571)
    - Shadowform (EX1_625)  
    - Druid of the Claw (EX1_165)
- Fix #320
- Rework ActivateTask(fix #321)
- Implement `DrawStackTask`
- Implement `ChangeHeroPowerTask`
- Implement `IsStackNum`
- Implement `IsEmptyCard` to `Cards`
- Add case of `EntityType::HAND` to `AddCardTask`
- Implement `DrawTask` with taskStack.num
- Implement `CountTask` with conditions
- Implement trigger with percentage
- Fix logic of `IsExhausted`
- Fix issue of `SummonTrigger`