### PR TITLE
Implement 3 EXPERT1 cards

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -339,7 +339,7 @@ EXPERT1 | EX1_590 | Blood Knight |
 EXPERT1 | EX1_591 | Auchenai Soulpriest |  
 EXPERT1 | EX1_594 | Vaporize |  
 EXPERT1 | EX1_595 | Cult Master |  
-EXPERT1 | EX1_596 | Demonfire |  
+EXPERT1 | EX1_596 | Demonfire | O
 EXPERT1 | EX1_597 | Imp Master | O
 EXPERT1 | EX1_603 | Cruel Taskmaster |  
 EXPERT1 | EX1_604 | Frothing Berserker |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 60% (142 of 237 Cards)
+- Progress: 60% (143 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -329,7 +329,7 @@ EXPERT1 | EX1_570 | Bite | O
 EXPERT1 | EX1_571 | Force of Nature |  
 EXPERT1 | EX1_572 | Ysera | O
 EXPERT1 | EX1_573 | Cenarius |  
-EXPERT1 | EX1_575 | Mana Tide Totem |  
+EXPERT1 | EX1_575 | Mana Tide Totem | O 
 EXPERT1 | EX1_577 | The Beast | O
 EXPERT1 | EX1_578 | Savagery |  
 EXPERT1 | EX1_583 | Priestess of Elune | O
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 60% (143 of 237 Cards)
+- Progress: 61% (144 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -298,7 +298,7 @@ EXPERT1 | EX1_405 | Shieldbearer | O
 EXPERT1 | EX1_407 | Brawl | O
 EXPERT1 | EX1_408 | Mortal Strike | O
 EXPERT1 | EX1_409 | Upgrade! |  
-EXPERT1 | EX1_410 | Shield Slam |  
+EXPERT1 | EX1_410 | Shield Slam | O
 EXPERT1 | EX1_411 | Gorehowl |  
 EXPERT1 | EX1_412 | Raging Worgen |  
 EXPERT1 | EX1_414 | Grommash Hellscream |  
@@ -386,7 +386,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 59% (141 of 237 Cards)
+- Progress: 60% (142 of 237 Cards)
 
 ## Hall of Fame
 

--- a/Includes/Rosetta/Tasks/SimpleTasks/ConditionTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/ConditionTask.hpp
@@ -32,6 +32,14 @@ class ConditionTask : public ITask
     explicit ConditionTask(EntityType entityType,
                            std::vector<RelaCondition> relaConditions);
 
+    //! Constructs task with given \p entityType and \p selfConditions and \p relaConditions.
+    //! \param entityType The entity type to check condition.
+    //! \param selfConditions A container of self condition.
+    //! \param relaConditions A container of relation condition.
+    explicit ConditionTask(EntityType entityType,
+                           std::vector<SelfCondition> selfConditions,
+                           std::vector<RelaCondition> relaConditions);                           
+
     //! Returns task ID.
     //! \return Task ID.
     TaskID GetTaskID() const override;

--- a/Includes/Rosetta/Tasks/SimpleTasks/ConditionTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/ConditionTask.hpp
@@ -38,7 +38,7 @@ class ConditionTask : public ITask
     //! \param relaConditions A container of relation condition.
     explicit ConditionTask(EntityType entityType,
                            std::vector<SelfCondition> selfConditions,
-                           std::vector<RelaCondition> relaConditions);                           
+                           std::vector<RelaCondition> relaConditions);
 
     //! Returns task ID.
     //! \return Task ID.

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1715,7 +1715,7 @@ void Expert1CardsGen::AddWarlockNonCollect(std::map<std::string, Power>& cards)
     // Text: This Demon has +2/+2.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddEnchant(new Enchant(Effects::AttackHealthN(2)));
+    power.AddEnchant(Enchants::GetEnchantFromText("EX1_596e"));
     cards.emplace("EX1_596e", power);
 }
 

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1421,6 +1421,21 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, Power>& cards)
         new FlagTask(false, { new DamageTask(EntityType::TARGET, 4, true) }));
     cards.emplace("EX1_408", power);
 
+    // ---------------------------------------- SPELL - WARRIOR
+    // [EX1_410] Shield Slam - COST:1
+    // - Faction: Neutral, Set: Expert1, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Deal 1 damage to a minion for each Armor you have.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new GetGameTagTask(EntityType::HERO, GameTag::ARMOR));
+    power.AddPowerTask(new DamageNumberTask(EntityType::TARGET, true));
+    cards.emplace("EX1_410", power);
+
     // ----------------------------------------- SPELL - WARRIOR
     // [EX1_607] Inner Rage - COST:0
     // - Set: Expert1, Rarity: Common

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1459,7 +1459,7 @@ void Expert1CardsGen::AddShaman(std::map<std::string, Power>& cards)
 
     // ---------------------------------------- MINION - SHAMAN
     // [EX1_575] Mana Tide Totem - COST:3 [ATK:0/HP:3]
-    // - Faction: Neutral, Set: Expert1, Rarity: Rare
+    // - Race: Totem, Faction: Neutral, Set: Expert1, Rarity: Rare
     // --------------------------------------------------------
     // Text: At the end of your turn, draw a card.
     // --------------------------------------------------------
@@ -1669,17 +1669,17 @@ void Expert1CardsGen::AddWarlock(std::map<std::string, Power>& cards)
     //       give it +2/+2 instead.
     // --------------------------------------------------------
     // PlayReq:
-    // - EQ_MINION_TARGET = 0
+    // - REQ_MINION_TARGET = 0
     // - REQ_TARGET_TO_PLAY = 0
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(new ConditionTask(EntityType::TARGET, 
-        { SelfCondition::IsRace(Race::DEMON)}, 
-        { RelaCondition::IsFriendly()}));
-    power.AddPowerTask(new FlagTask(true,
-        { new AddEnchantmentTask("EX1_596e", EntityType::TARGET) }));
-    power.AddPowerTask(new FlagTask(false,
-        { new DamageTask(EntityType::TARGET, 2, true) }));
+    power.AddPowerTask(new ConditionTask(EntityType::TARGET,
+                                         { SelfCondition::IsRace(Race::DEMON) },
+                                         { RelaCondition::IsFriendly() }));
+    power.AddPowerTask(new FlagTask(
+        true, { new AddEnchantmentTask("EX1_596e", EntityType::TARGET) }));
+    power.AddPowerTask(
+        new FlagTask(false, { new DamageTask(EntityType::TARGET, 2, true) }));
     cards.emplace("EX1_596", power);
 }
 
@@ -1710,7 +1710,7 @@ void Expert1CardsGen::AddWarlockNonCollect(std::map<std::string, Power>& cards)
 
     // ---------------------------------- ENCHANTMENT - WARLOCK
     // [EX1_596e] Demonfire (*) - COST:0
-    // - Set: Expert1
+    // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
     // Text: This Demon has +2/+2.
     // --------------------------------------------------------
@@ -1822,6 +1822,9 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, Power>& cards)
     // - Faction: Neutral, Set: Expert1, Rarity: Epic
     // --------------------------------------------------------
     // Text: Deal 1 damage to a minion for each Armor you have.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AFFECTED_BY_SPELL_POWER = 1
     // --------------------------------------------------------
     // PlayReq:
     // - REQ_MINION_TARGET = 0

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1349,6 +1349,16 @@ void Expert1CardsGen::AddWarlockNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddEnchant(new Enchant(Effects::HealthN(1)));
     cards.emplace("CS2_059o", power);
+
+    // ---------------------------------- ENCHANTMENT - WARLOCK
+    // [EX1_596e] Demonfire (*) - COST:0
+    // - Set: Expert1
+    // --------------------------------------------------------
+    // Text: This Demon has +2/+2.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(new Enchant(Effects::AttackHealthN(2)));
+    cards.emplace("EX1_596e", power);
 }
 
 void Expert1CardsGen::AddWarrior(std::map<std::string, Power>& cards)
@@ -1435,6 +1445,27 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, Power>& cards)
     power.AddPowerTask(new GetGameTagTask(EntityType::HERO, GameTag::ARMOR));
     power.AddPowerTask(new DamageNumberTask(EntityType::TARGET, true));
     cards.emplace("EX1_410", power);
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [EX1_596] Demonfire - COST:2
+    // - Faction: Neutral, Set: Expert1, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Deal $2 damage to a minion. If it’s a friendly Demon,
+    //       give it +2/+2 instead.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - EQ_MINION_TARGET = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new ConditionTask(EntityType::TARGET, 
+        { SelfCondition::IsRace(Race::DEMON)}, 
+        { RelaCondition::IsFriendly()}));
+    power.AddPowerTask(new FlagTask(true,
+        { new AddEnchantmentTask("EX1_596e", EntityType::TARGET) }));
+    power.AddPowerTask(new FlagTask(false,
+        { new DamageTask(EntityType::TARGET, 2, true) }));
+    cards.emplace("EX1_596", power);
 
     // ----------------------------------------- SPELL - WARRIOR
     // [EX1_607] Inner Rage - COST:0

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1166,6 +1166,17 @@ void Expert1CardsGen::AddShaman(std::map<std::string, Power>& cards)
     cards.emplace("EX1_567", power);
 
     // ---------------------------------------- MINION - SHAMAN
+    // [EX1_575] Mana Tide Totem - COST:3 [ATK:0/HP:3]
+    // - Faction: Neutral, Set: Expert1, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: At the end of your turn, draw a card.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(new Trigger(TriggerType::TURN_END));
+    power.GetTrigger()->tasks = { new DrawTask(1) };
+    cards.emplace("EX1_575", power);
+
+    // ---------------------------------------- MINION - SHAMAN
     // [NEW1_010] Al'Akir the Windlord - COST:8 [ATK:3/HP:5]
     // - Race: Elemental, Set: Expert1, Rarity: Legendary
     // --------------------------------------------------------

--- a/Sources/Rosetta/Tasks/SimpleTasks/ConditionTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/ConditionTask.cpp
@@ -25,6 +25,16 @@ ConditionTask::ConditionTask(EntityType entityType,
     // Do nothing
 }
 
+ConditionTask::ConditionTask(EntityType entityType,
+                             std::vector<SelfCondition> selfConditions,
+                             std::vector<RelaCondition> relaConditions)
+    : ITask(entityType),
+      m_selfConditions(std::move(selfConditions)),
+      m_relaConditions(std::move(relaConditions))
+{
+        // Do nothing
+}
+
 TaskID ConditionTask::GetTaskID() const
 {
     return TaskID::CONDITION;
@@ -63,6 +73,6 @@ TaskStatus ConditionTask::Impl(Player& player)
 
 ITask* ConditionTask::CloneImpl()
 {
-    return new ConditionTask(m_entityType, m_selfConditions);
+    return new ConditionTask(m_entityType, m_selfConditions, m_relaConditions);
 }
 }  // namespace RosettaStone::SimpleTasks

--- a/Sources/Rosetta/Tasks/SimpleTasks/ConditionTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/ConditionTask.cpp
@@ -32,7 +32,7 @@ ConditionTask::ConditionTask(EntityType entityType,
       m_selfConditions(std::move(selfConditions)),
       m_relaConditions(std::move(relaConditions))
 {
-        // Do nothing
+    // Do nothing
 }
 
 TaskID ConditionTask::GetTaskID() const

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -6591,6 +6591,69 @@ TEST(NeutralExpert1Test, EX1_584_AncientMage)
     EXPECT_EQ(curField[3]->GetSpellPower(), 0);
 }
 
+// ---------------------------------------- SPELL - WARLOCK
+// [EX1_596] Demonfire - COST:2
+// - Faction: Neutral, Set: Expert1, Rarity: Common
+// --------------------------------------------------------
+// Text: Deal $2 damage to a minion. If it’s a friendly Demon,
+//       give it +2/+2 instead.
+// --------------------------------------------------------
+// PlayReq:
+// - EQ_MINION_TARGET = 0
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST(WarlockExpert1Test, EX1_596_Demonfire) {
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player &curPlayer = game.GetCurrentPlayer();
+    Player &opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    auto &curField = curPlayer.GetFieldZone();
+    auto &opField = opPlayer.GetFieldZone();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Demonfire"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Demonfire"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Felguard"));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Felguard"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    EXPECT_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    EXPECT_EQ(opField.GetCount(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3));
+    EXPECT_EQ(curField[0]->GetAttack(), 5);
+    EXPECT_EQ(curField[0]->GetHealth(), 7);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card4));
+    EXPECT_EQ(opField[0]->GetAttack(), 3);
+    EXPECT_EQ(opField[0]->GetHealth(), 3);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_597] Imp Master - COST:3 [ATK:1/HP:5]
 // - Faction: Neutral, Set: Expert1, Rarity: Rare

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -1898,19 +1898,27 @@ TEST(WarriorExpert1Test, EX1_410_ShieldSlam)
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Shield Slam"));
     const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Shield Slam"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Bloodmage Thalnos"));
+    const auto card4 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Ironbark Protector"));
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
-    game.Process(opPlayer, PlayCardTask::Minion(card2));
-    EXPECT_EQ(opField.GetCount(), 1);
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    EXPECT_EQ(opField[0]->GetHealth(), 8);
 
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
-    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card4));
     EXPECT_EQ(opField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card4));
+    EXPECT_EQ(opField[0]->GetHealth(), 1);
 }
 
 // --------------------------------------- MINION - WARRIOR
@@ -6949,29 +6957,39 @@ TEST(WarlockExpert1Test, EX1_596_Demonfire)
     const auto card2 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Demonfire"));
     const auto card3 = Generic::DrawCard(
-        curPlayer, Cards::GetInstance().FindCardByName("Felguard"));
+        curPlayer, Cards::GetInstance().FindCardByName("Demonfire"));
     const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Bloodmage Thalnos"));
+    const auto card5 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Felguard"));
+    const auto card6 = Generic::DrawCard(
         opPlayer, Cards::GetInstance().FindCardByName("Felguard"));
 
-    game.Process(curPlayer, PlayCardTask::Minion(card3));
-    EXPECT_EQ(curField.GetCount(), 1);
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+    EXPECT_EQ(curField[0]->GetAttack(), 3);
+    EXPECT_EQ(curField[0]->GetHealth(), 5);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
-    game.Process(opPlayer, PlayCardTask::Minion(card4));
-    EXPECT_EQ(opField.GetCount(), 1);
+    game.Process(opPlayer, PlayCardTask::Minion(card6));
+    EXPECT_EQ(opField[0]->GetAttack(), 3);
+    EXPECT_EQ(opField[0]->GetHealth(), 5);
 
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
-    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3));
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card5));
     EXPECT_EQ(curField[0]->GetAttack(), 5);
     EXPECT_EQ(curField[0]->GetHealth(), 7);
 
-    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card4));
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card6));
     EXPECT_EQ(opField[0]->GetAttack(), 3);
     EXPECT_EQ(opField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card6));
+    EXPECT_TRUE(opField.IsEmpty());
 }
 
 // --------------------------------------- MINION - NEUTRAL
@@ -7516,7 +7534,6 @@ TEST(ShamanExpert1Test, EX1_575_ManaTideTotem)
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::GetInstance().FindCardByName("Mana Tide Totem"));
 
-    EXPECT_EQ(curPlayer.GetHandZone().GetCount(), 5);
     game.Process(curPlayer, PlayCardTask::Weapon(card1));
     EXPECT_EQ(curPlayer.GetHandZone().GetCount(), 4);
 

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -1495,6 +1495,57 @@ TEST(WarriorExpert1Test, EX1_408_MortalStrike)
     EXPECT_EQ(opPlayer.GetHero()->GetHealth(), 20);
 }
 
+// ---------------------------------------- SPELL - WARRIOR
+// [EX1_410] Shield Slam - COST:1
+// - Faction: Neutral, Set: Expert1, Rarity: Epic
+// --------------------------------------------------------
+// Text: Deal 1 damage to a minion for each Armor you have.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINION_TARGET = 0
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST(WarriorExpert1Test, EX1_410_ShieldSlam)
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+    curPlayer.GetHero()->SetArmor(3);
+
+    auto& opField = opPlayer.GetFieldZone();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Shield Slam"));
+    const auto card2 = Generic::DrawCard(
+        opPlayer, Cards::GetInstance().FindCardByName("Ironbark Protector"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    EXPECT_EQ(opField.GetCount(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1,card2));
+    EXPECT_EQ(opField[0]->GetHealth(), 5);
+}
+
 // ----------------------------------------- SPELL - WARRIOR
 // [EX1_607] Inner Rage - COST:0
 // - Set: Expert1, Rarity: Common

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -6437,6 +6437,45 @@ TEST(NeutralExpert1Test, EX1_572_Ysera)
                           dreamCard->id) != entourages.end());
 }
 
+// ---------------------------------------- MINION - SHAMAN
+// [EX1_575] Mana Tide Totem - COST:3 [ATK:0/HP:3]
+// - Faction: Neutral, Set: Expert1, Rarity: Rare
+// --------------------------------------------------------
+// Text: At the end of your turn, draw a card.
+// --------------------------------------------------------
+TEST(ShamanExpert1Test, EX1_575_ManaTideTotem)
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.StartGame();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player& curPlayer = game.GetCurrentPlayer();
+    Player& opPlayer = game.GetOpponentPlayer();
+    curPlayer.SetTotalMana(10);
+    curPlayer.SetUsedMana(0);
+    opPlayer.SetTotalMana(10);
+    opPlayer.SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::GetInstance().FindCardByName("Mana Tide Totem"));
+
+    EXPECT_EQ(curPlayer.GetHandZone().GetCount(), 5);
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    EXPECT_EQ(curPlayer.GetHandZone().GetCount(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    EXPECT_EQ(curPlayer.GetHandZone().GetCount(), 5);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_577] The Beast - COST:6 [ATK:9/HP:7]
 // - Race: Beast, Faction: Neutral, Set: Expert1, Rarity: Legendary


### PR DESCRIPTION
This revision includes:
- Implement 3 card in the EXPERT1 card set
    - Shield Slam (EX1_410)
    - Demonfire (EX1_596)
    - Mana Tide totem (EX1_575)
- Add parameter in `ConditionTask`