### PR TITLE
Improve code reliability of SonarCloud

### DIFF
--- a/Sources/Rosetta/Enchants/Trigger.cpp
+++ b/Sources/Rosetta/Enchants/Trigger.cpp
@@ -407,7 +407,7 @@ void Trigger::Validate(Player* player, Entity* source)
         case TriggerSource::ENCHANTMENT_TARGET:
         {
             const auto enchantment = dynamic_cast<Enchantment*>(m_owner);
-            if (enchantment == nullptr ||
+            if (enchantment == nullptr || source == nullptr ||
                 enchantment->GetTarget()->id != source->id)
             {
                 return;
@@ -425,7 +425,7 @@ void Trigger::Validate(Player* player, Entity* source)
         }
         case TriggerSource::FRIENDLY:
         {
-            if (source->owner != m_owner->owner)
+            if (source == nullptr || source->owner != m_owner->owner)
             {
                 return;
             }
@@ -439,7 +439,7 @@ void Trigger::Validate(Player* player, Entity* source)
     {
         case TriggerType::TURN_START:
         case TriggerType::TURN_END:
-            if (player != m_owner->owner)
+            if (m_owner == nullptr || player != m_owner->owner)
             {
                 return;
             }


### PR DESCRIPTION
This revision includes:
- Improve code reliability of SonarCloud (#336)
    - Access to field 'id' results in a dereference of a null pointer (loaded from variable 'source')
    - Access to field 'owner' results in a dereference of a null pointer (loaded from variable 'source')
    - Access to field 'owner' results in a dereference of a null pointer (loaded from field 'm_owner')