### PR TITLE
Implement 2 CORE and 5 EXPERT1 cards

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -115,8 +115,8 @@ CORE | EX1_084 | Warsong Commander | O
 CORE | EX1_129 | Fan of Knives | O
 CORE | EX1_169 | Innervate | O
 CORE | EX1_173 | Starfire | O
-CORE | EX1_191 | Plaguebringer |  
-CORE | EX1_192 | Radiance |  
+CORE | EX1_191 | Plaguebringer | O
+CORE | EX1_192 | Radiance | O
 CORE | EX1_244 | Totemic Might | O
 CORE | EX1_246 | Hex | O
 CORE | EX1_277 | Arcane Missiles | O
@@ -142,7 +142,7 @@ CORE | NEW1_003 | Sacrificial Pact | O
 CORE | NEW1_011 | Kor'kron Elite | O
 CORE | NEW1_031 | Animal Companion | O
 
-- Progress: 98% (131 of 133 Cards)
+- Progress: 100% (133 of 133 Cards)
 
 ## Classic
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -226,7 +226,7 @@ EXPERT1 | EX1_134 | SI:7 Agent | O
 EXPERT1 | EX1_136 | Redemption | O
 EXPERT1 | EX1_137 | Headcrack | O
 EXPERT1 | EX1_144 | Shadowstep | O
-EXPERT1 | EX1_145 | Preparation |  
+EXPERT1 | EX1_145 | Preparation | O
 EXPERT1 | EX1_154 | Wrath | O
 EXPERT1 | EX1_155 | Mark of Nature | O
 EXPERT1 | EX1_158 | Soul of the Forest | O
@@ -234,15 +234,15 @@ EXPERT1 | EX1_160 | Power of the Wild | O
 EXPERT1 | EX1_162 | Dire Wolf Alpha | O
 EXPERT1 | EX1_164 | Nourish | O
 EXPERT1 | EX1_165 | Druid of the Claw | O
-EXPERT1 | EX1_166 | Keeper of the Grove |  
+EXPERT1 | EX1_166 | Keeper of the Grove | O
 EXPERT1 | EX1_170 | Emperor Cobra | O
 EXPERT1 | EX1_178 | Ancient of War | O
 EXPERT1 | EX1_179 | Icicle | O
 EXPERT1 | EX1_180 | Tome of Intellect | O
 EXPERT1 | EX1_181 | Call of the Void | O
-EXPERT1 | EX1_182 | Pilfer |  
-EXPERT1 | EX1_183 | Gift of the Wild |  
-EXPERT1 | EX1_184 | Righteousness |  
+EXPERT1 | EX1_182 | Pilfer | O
+EXPERT1 | EX1_183 | Gift of the Wild | O
+EXPERT1 | EX1_184 | Righteousness | O
 EXPERT1 | EX1_185 | Siegebreaker |  
 EXPERT1 | EX1_186 | SI:7 Infiltrator |  
 EXPERT1 | EX1_187 | Arcane Devourer |  
@@ -394,7 +394,7 @@ EXPERT1 | NEW1_041 | Stampeding Kodo | O
 EXPERT1 | tt_004 | Flesheating Ghoul |  
 EXPERT1 | tt_010 | Spellbender |  
 
-- Progress: 73% (179 of 245 Cards)
+- Progress: 75% (184 of 245 Cards)
 
 ## Hall of Fame
 

--- a/Includes/Rosetta/Auras/Aura.hpp
+++ b/Includes/Rosetta/Auras/Aura.hpp
@@ -118,9 +118,6 @@ class Aura : public IAura
 
     //! Renews the condition of the applied entities.
     void RenewAll();
-
-    //!
-    void TriggeredRemove(Entity* source);
 };
 }  // namespace RosettaStone
 

--- a/Includes/Rosetta/Auras/Aura.hpp
+++ b/Includes/Rosetta/Auras/Aura.hpp
@@ -102,7 +102,7 @@ class Aura : public IAura
     PriorityQueue<AuraUpdateInstruction> m_auraUpdateInstQueue;
     std::vector<Playable*> m_appliedEntities;
 
-    std::function<void(Player*, Entity*)> m_removeHandler;
+    std::function<void(Entity*)> m_removeHandler;
 
     Card* m_enchantmentCard = nullptr;
     std::vector<IEffect*> m_effects;

--- a/Includes/Rosetta/Auras/Aura.hpp
+++ b/Includes/Rosetta/Auras/Aura.hpp
@@ -11,6 +11,7 @@
 #include <Rosetta/Commons/PriorityQueue.hpp>
 #include <Rosetta/Conditions/SelfCondition.hpp>
 #include <Rosetta/Enchants/Enchant.hpp>
+#include <Rosetta/Enchants/Trigger.hpp>
 #include <Rosetta/Enums/AuraEnums.hpp>
 
 #include <string>
@@ -81,6 +82,7 @@ class Aura : public IAura
     void NotifyEntityRemoved(Playable* entity);
 
     SelfCondition* condition = nullptr;
+    std::pair<TriggerType, SelfCondition*> removeTrigger;
     bool restless = false;
 
  protected:
@@ -100,6 +102,8 @@ class Aura : public IAura
     PriorityQueue<AuraUpdateInstruction> m_auraUpdateInstQueue;
     std::vector<Playable*> m_appliedEntities;
 
+    std::function<void(Player*, Entity*)> m_removeHandler;
+
     Card* m_enchantmentCard = nullptr;
     std::vector<IEffect*> m_effects;
 
@@ -114,6 +118,9 @@ class Aura : public IAura
 
     //! Renews the condition of the applied entities.
     void RenewAll();
+
+    //!
+    void TriggeredRemove(Entity* source);
 };
 }  // namespace RosettaStone
 

--- a/Includes/Rosetta/Auras/SwitchingAura.hpp
+++ b/Includes/Rosetta/Auras/SwitchingAura.hpp
@@ -46,12 +46,6 @@ class SwitchingAura : public Aura
     //! Internal method of Remove().
     void RemoveInternal() override;
 
-    //! Turns on switching aura.
-    void TurnOn(Entity*);
-
-    //! Turns off switching aura.
-    void TurnOff(Entity*);
-
     SelfCondition m_initCondition;
     TriggerType m_offTrigger;
 

--- a/Includes/Rosetta/Auras/SwitchingAura.hpp
+++ b/Includes/Rosetta/Auras/SwitchingAura.hpp
@@ -47,16 +47,16 @@ class SwitchingAura : public Aura
     void RemoveInternal() override;
 
     //! Turns on switching aura.
-    void TurnOn(Player*, Entity*);
+    void TurnOn(Entity*);
 
     //! Turns off switching aura.
-    void TurnOff(Player*, Entity*);
+    void TurnOff(Entity*);
 
     SelfCondition m_initCondition;
     TriggerType m_offTrigger;
 
-    std::function<void(Player*, Entity*)> m_onHandler;
-    std::function<void(Player*, Entity*)> m_offHandler;
+    std::function<void(Entity*)> m_onHandler;
+    std::function<void(Entity*)> m_offHandler;
 
     bool m_isRemoved = false;
 };

--- a/Includes/Rosetta/Cards/Card.hpp
+++ b/Includes/Rosetta/Cards/Card.hpp
@@ -91,6 +91,10 @@ class Card
     //! \return true if this card is in STANDARD set, and false otherwise.
     bool IsStandardSet() const;
 
+    //! Finds out if this card is in WILD set.
+    //! \return true if this card is in WILD set, and false otherwise.
+    bool IsWildSet() const;
+
     //! Returns the number of cards that can be inserted into the deck.
     //! \return The number of cards that can be inserted into the deck.
     std::size_t GetMaxAllowedInDeck() const;

--- a/Includes/Rosetta/Cards/Card.hpp
+++ b/Includes/Rosetta/Cards/Card.hpp
@@ -87,6 +87,10 @@ class Card
     //! \return The flag that indicates whether it is collectible.
     bool IsCollectible() const;
 
+    //! Finds out if this card is in STANDARD set.
+    //! \return true if this card is in STANDARD set, and false otherwise.
+    bool IsStandardSet() const;
+
     //! Returns the number of cards that can be inserted into the deck.
     //! \return The number of cards that can be inserted into the deck.
     std::size_t GetMaxAllowedInDeck() const;

--- a/Includes/Rosetta/Cards/Card.hpp
+++ b/Includes/Rosetta/Cards/Card.hpp
@@ -83,6 +83,10 @@ class Card
     //! \return The flag that indicates whether it is untouchable.
     bool IsUntouchable() const;
 
+    //! Returns the flag that indicates whether it is collectible.
+    //! \return The flag that indicates whether it is collectible.
+    bool IsCollectible() const;
+
     //! Returns the number of cards that can be inserted into the deck.
     //! \return The number of cards that can be inserted into the deck.
     std::size_t GetMaxAllowedInDeck() const;

--- a/Includes/Rosetta/Cards/Cards.hpp
+++ b/Includes/Rosetta/Cards/Cards.hpp
@@ -64,6 +64,10 @@ class Cards
     //! \return A list of all standard cards.
     static std::vector<Card*> GetAllStandardCards();
 
+    //! Returns a list of all wild cards.
+    //! \return A list of all wild cards.
+    static std::vector<Card*> GetAllWildCards();
+
     //! Returns a card that matches \p id.
     //! \param id The ID of the card.
     //! \return A card that matches \p id.

--- a/Includes/Rosetta/Cards/Cards.hpp
+++ b/Includes/Rosetta/Cards/Cards.hpp
@@ -60,6 +60,10 @@ class Cards
     //! \return A list of all cards.
     static const std::vector<Card*>& GetAllCards();
 
+    //! Returns a list of all standard cards.
+    //! \return A list of all standard cards.
+    static std::vector<Card*> GetAllStandardCards();
+
     //! Returns a card that matches \p id.
     //! \param id The ID of the card.
     //! \return A card that matches \p id.

--- a/Includes/Rosetta/Commons/Constants.hpp
+++ b/Includes/Rosetta/Commons/Constants.hpp
@@ -32,6 +32,32 @@ constexpr std::array<CardSet, 7> STANDARD_CARD_SETS = {
     CardSet::ULDUM,     // Saviors of Uldum, 2019
 };
 
+//! Specifies which card sets combine into the WILD set.
+constexpr std::array<CardSet, 19> WILD_CARD_SETS = {
+    // Standard
+    CardSet::CORE,      // Basic, 2014
+    CardSet::EXPERT1,   // Classic, 2014
+    CardSet::GILNEAS,   // The Witchwood, 2018
+    CardSet::BOOMSDAY,  // The Boomsday Project, 2018
+    CardSet::TROLL,     // Rastakhan's Rumble, 2018
+    CardSet::DALARAN,   // Rise of Shadows, 2019
+    CardSet::ULDUM,     // Saviors of Uldum, 2019
+
+    // Wild
+    CardSet::NAXX,          // Curse of Naxxramas, 2014
+    CardSet::GVG,           // Goblins vs Gnomes, 2014
+    CardSet::BRM,           // Blackrock Mountain, 2015
+    CardSet::TGT,           // The Grand Tournament, 2015
+    CardSet::LOE,           // The League of Explorers, 2015
+    CardSet::OG,            // Whispers of the Old Gods, 2016
+    CardSet::KARA,          // One Night in Karazhan, 2016
+    CardSet::GANGS,         // Mean Streets of Gadgetzan, 2016
+    CardSet::HOF,           // Hall of Fame, 2017
+    CardSet::UNGORO,        // Journey to Un'Goro, 2017
+    CardSet::ICECROWN,      // Knights of the Frozen Throne, 2017
+    CardSet::LOOTAPALOOZA,  // Kobolds & Catacombs, 2017
+};
+
 //! The number of player class.
 //! \note Druid, Hunter, Mage, Paladin, Priest, Rogue, Shaman, Warlock, Warrior
 constexpr int NUM_PLAYER_CLASS = 9;

--- a/Includes/Rosetta/Commons/Constants.hpp
+++ b/Includes/Rosetta/Commons/Constants.hpp
@@ -7,6 +7,7 @@
 #ifndef ROSETTASTONE_CONSTANTS_HPP
 #define ROSETTASTONE_CONSTANTS_HPP
 
+#include <array>
 #include <string>
 
 namespace RosettaStone
@@ -19,6 +20,17 @@ constexpr int DECK_CODE_VERSION = 1;
 
 //! Invalid card ID.
 const std::string INVALID_CARD_ID = "INVALID";
+
+//! Specifies which card sets combine into the STANDARD set.
+constexpr std::array<CardSet, 7> STANDARD_CARD_SETS = {
+    CardSet::CORE,      // Basic, 2014
+    CardSet::EXPERT1,   // Classic, 2014
+    CardSet::GILNEAS,   // The Witchwood, 2018
+    CardSet::BOOMSDAY,  // The Boomsday Project, 2018
+    CardSet::TROLL,     // Rastakhan's Rumble, 2018
+    CardSet::DALARAN,   // Rise of Shadows, 2019
+    CardSet::ULDUM,     // Saviors of Uldum, 2019
+};
 
 //! The number of player class.
 //! \note Druid, Hunter, Mage, Paladin, Priest, Rogue, Shaman, Warlock, Warrior

--- a/Includes/Rosetta/Commons/Constants.hpp
+++ b/Includes/Rosetta/Commons/Constants.hpp
@@ -7,6 +7,8 @@
 #ifndef ROSETTASTONE_CONSTANTS_HPP
 #define ROSETTASTONE_CONSTANTS_HPP
 
+#include <Rosetta/Enums/CardEnums.hpp>
+
 #include <array>
 #include <string>
 

--- a/Includes/Rosetta/Enchants/Trigger.hpp
+++ b/Includes/Rosetta/Enchants/Trigger.hpp
@@ -60,6 +60,7 @@ class Trigger
     SelfCondition* condition = nullptr;
 
     float percentage = 1.0f;
+    bool eitherTurn = false;
     bool fastExecution = false;
     bool removeAfterTriggered = false;
 

--- a/Includes/Rosetta/Enchants/Trigger.hpp
+++ b/Includes/Rosetta/Enchants/Trigger.hpp
@@ -65,9 +65,8 @@ class Trigger
 
  private:
     //! Processes trigger to apply the effect.
-    //! \param player The player.
     //! \param source The source of trigger.
-    void Process(Player* player, Entity* source);
+    void Process(Entity* source);
 
     //! Internal method of Process().
     //! \param source The source of trigger.
@@ -75,9 +74,8 @@ class Trigger
 
     //! Validates triggers related to the current sequence at once before the
     //! sequence starts.
-    //! \param player The player.
     //! \param source The source of trigger.
-    void Validate(Player* player, Entity* source);
+    void Validate(Entity* source);
 
     Playable* m_owner = nullptr;
 

--- a/Includes/Rosetta/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Enums/TaskEnums.hpp
@@ -20,7 +20,7 @@ enum class PowerType
 //! \brief An enumerator for identifying entity type.
 enum class EntityType
 {
-    EMPTY,
+    INVALID,
     SOURCE,
     TARGET,
     ALL,

--- a/Includes/Rosetta/Games/Game.hpp
+++ b/Includes/Rosetta/Games/Game.hpp
@@ -59,6 +59,10 @@ class Game
     //! \param rhs The source to copy the content.
     void RefCopyFrom(const Game& rhs);
 
+    //! Returns the format type of the game.
+    //! \return The format type of the game.
+    FormatType GetFormatType() const;
+
     //! Returns the first player.
     //! \return The first player.
     Player* GetPlayer1();

--- a/Includes/Rosetta/Games/GameConfig.hpp
+++ b/Includes/Rosetta/Games/GameConfig.hpp
@@ -21,10 +21,12 @@ namespace RosettaStone
 //!
 struct GameConfig
 {
+    FormatType formatType = FormatType::STANDARD;
+
     PlayerType startPlayer = PlayerType::RANDOM;
 
-    CardClass player1Class = CardClass::MAGE;
-    CardClass player2Class = CardClass::WARLOCK;
+    CardClass player1Class = CardClass::INVALID;
+    CardClass player2Class = CardClass::INVALID;
 
     std::array<Card, START_DECK_SIZE> player1Deck;
     std::array<Card, START_DECK_SIZE> player2Deck;

--- a/Includes/Rosetta/Games/TriggerManager.hpp
+++ b/Includes/Rosetta/Games/TriggerManager.hpp
@@ -12,7 +12,6 @@
 namespace RosettaStone
 {
 class Entity;
-class Player;
 
 //!
 //! \brief TriggerManager class.
@@ -23,95 +22,80 @@ class TriggerManager
 {
  public:
     //! Callback for trigger when player's turn is started.
-    //! \param player A player to execute trigger.
     //! \param sender An entity that is the source of trigger.
-    void OnStartTurnTrigger(Player* player, Entity* sender) const;
+    void OnStartTurnTrigger(Entity* sender) const;
 
     //! Callback for trigger when player's turn is ended.
-    //! \param player A player to execute trigger.
     //! \param sender An entity that is the source of trigger.
-    void OnEndTurnTrigger(Player* player, Entity* sender) const;
+    void OnEndTurnTrigger(Entity* sender) const;
 
     //! Callback for trigger when player plays a card.
-    //! \param player A player to execute trigger.
     //! \param sender An entity that is the source of trigger.
-    void OnPlayCardTrigger(Player* player, Entity* sender) const;
+    void OnPlayCardTrigger(Entity* sender) const;
 
     //! Callback for trigger when player plays a minion.
-    //! \param player A player to execute trigger.
     //! \param sender An entity that is the source of trigger.
-    void OnPlayMinionTrigger(Player* player, Entity* sender) const;
+    void OnPlayMinionTrigger(Entity* sender) const;
 
     //! Callback for trigger after player plays a minion.
-    //! \param player A player to execute trigger.
     //! \param sender An entity that is the source of trigger.
-    void OnAfterPlayMinionTrigger(Player* player, Entity* sender) const;
+    void OnAfterPlayMinionTrigger(Entity* sender) const;
 
     //! Callback for trigger when player plays a spell card.
-    //! \param player A player to execute trigger.
     //! \param sender An entity that is the source of trigger.
-    void OnCastSpellTrigger(Player* player, Entity* sender) const;
+    void OnCastSpellTrigger(Entity* sender) const;
 
     //! Callback for trigger after player plays a spell card.
-    //! \param player A player to execute trigger.
     //! \param sender An entity that is the source of trigger.
-    void OnAfterCastTrigger(Player* player, Entity* sender) const;
+    void OnAfterCastTrigger(Entity* sender) const;
 
     //! Callback for trigger when entity is healed.
-    //! \param player A player to execute trigger.
     //! \param sender An entity that is the source of trigger.
-    void OnHealTrigger(Player* player, Entity* sender) const;
+    void OnHealTrigger(Entity* sender) const;
 
     //! Callback for trigger when entity attacks target.
-    //! \param player A player to execute trigger.
     //! \param sender An entity that is the source of trigger.
-    void OnAttackTrigger(Player* player, Entity* sender) const;
+    void OnAttackTrigger(Entity* sender) const;
 
     //! Callback for trigger when entity is summoned.
-    //! \param player A player to execute trigger.
     //! \param sender An entity that is the source of trigger.
-    void OnSummonTrigger(Player* player, Entity* sender) const;
+    void OnSummonTrigger(Entity* sender) const;
 
     //! Callback for trigger after entity is summoned.
-    //! \param player A player to execute trigger.
     //! \param sender An entity that is the source of trigger.
-    void OnAfterSummonTrigger(Player* player, Entity* sender) const;
+    void OnAfterSummonTrigger(Entity* sender) const;
 
     //! Callback for trigger when entity deals damage.
-    //! \param player A player to execute trigger.
     //! \param sender An entity that is the source of trigger.
-    void OnDealDamageTrigger(Player* player, Entity* sender) const;
+    void OnDealDamageTrigger(Entity* sender) const;
 
     //! Callback for trigger when entity is taken damage.
-    //! \param player A player to execute trigger.
     //! \param sender An entity that is the source of trigger.
-    void OnTakeDamageTrigger(Player* player, Entity* sender) const;
+    void OnTakeDamageTrigger(Entity* sender) const;
 
     //! Callback for trigger when entity is targeted.
-    //! \param player A player to execute trigger.
     //! \param sender An entity that is the source of trigger.
-    void OnTargetTrigger(Player* player, Entity* sender) const;
+    void OnTargetTrigger(Entity* sender) const;
 
     //! Callback for trigger when minion is dead.
-    //! \param player A player to execute trigger.
     //! \param sender An entity that is the source of trigger.
-    void OnDeathTrigger(Player* player, Entity* sender) const;
+    void OnDeathTrigger(Entity* sender) const;
 
-    std::function<void(Player*, Entity*)> startTurnTrigger;
-    std::function<void(Player*, Entity*)> endTurnTrigger;
-    std::function<void(Player*, Entity*)> playCardTrigger;
-    std::function<void(Player*, Entity*)> playMinionTrigger;
-    std::function<void(Player*, Entity*)> afterPlayMinionTrigger;
-    std::function<void(Player*, Entity*)> castSpellTrigger;
-    std::function<void(Player*, Entity*)> afterCastTrigger;
-    std::function<void(Player*, Entity*)> healTrigger;
-    std::function<void(Player*, Entity*)> attackTrigger;
-    std::function<void(Player*, Entity*)> summonTrigger;
-    std::function<void(Player*, Entity*)> afterSummonTrigger;
-    std::function<void(Player*, Entity*)> dealDamageTrigger;
-    std::function<void(Player*, Entity*)> takeDamageTrigger;
-    std::function<void(Player*, Entity*)> targetTrigger;
-    std::function<void(Player*, Entity*)> deathTrigger;
+    std::function<void(Entity*)> startTurnTrigger;
+    std::function<void(Entity*)> endTurnTrigger;
+    std::function<void(Entity*)> playCardTrigger;
+    std::function<void(Entity*)> playMinionTrigger;
+    std::function<void(Entity*)> afterPlayMinionTrigger;
+    std::function<void(Entity*)> castSpellTrigger;
+    std::function<void(Entity*)> afterCastTrigger;
+    std::function<void(Entity*)> healTrigger;
+    std::function<void(Entity*)> attackTrigger;
+    std::function<void(Entity*)> summonTrigger;
+    std::function<void(Entity*)> afterSummonTrigger;
+    std::function<void(Entity*)> dealDamageTrigger;
+    std::function<void(Entity*)> takeDamageTrigger;
+    std::function<void(Entity*)> targetTrigger;
+    std::function<void(Entity*)> deathTrigger;
 };
 }  // namespace RosettaStone
 

--- a/Includes/Rosetta/Models/Character.hpp
+++ b/Includes/Rosetta/Models/Character.hpp
@@ -98,22 +98,26 @@ class Character : public Playable
     //! \param amount The number of attacks at this turn.
     void SetNumAttacksThisTurn(int amount);
 
-    //! Returns the flag that indicates whether this character is \p race.
+    //! Returns the flag that indicates whether it is \p race.
     //! \param race The value of race.
-    //! \return The flag that indicates whether this character is \p race.
+    //! \return The flag that indicates whether it is \p race.
     bool IsRace(Race race) const;
 
-    //! Returns the flag that indicates whether this character is immune.
-    //! \return The flag that indicates whether this character is immune.
+    //! Returns the flag that indicates whether it is immune.
+    //! \return The flag that indicates whether it is immune.
     bool IsImmune() const;
 
-    //! Returns the flag that indicates whether this character has taunt.
-    //! \return The flag that indicates whether this character has taunt.
+    //! Returns the flag that indicates whether it has taunt.
+    //! \return The flag that indicates whether it has taunt.
     bool HasTaunt() const;
 
-    //! Returns the flag that indicates whether this character has stealth.
-    //! \return The flag that indicates whether this character has stealth.
+    //! Returns the flag that indicates whether it has stealth.
+    //! \return The flag that indicates whether it has stealth.
     bool HasStealth() const;
+
+    //! Returns the flag that indicates whether it has divine shield.
+    //! \return The flag that indicates whether it has divine shield.
+    bool HasDivineShield() const;
 
     //! Returns whether attack is possible.
     //! \return Whether attack is possible.

--- a/Includes/Rosetta/Models/Character.hpp
+++ b/Includes/Rosetta/Models/Character.hpp
@@ -145,9 +145,9 @@ class Character : public Playable
     //! \param heal The value of heal.
     void TakeHeal(Playable* source, int heal);
 
-    std::function<void(Player*, Entity*)> preDamageTrigger;
-    std::function<void(Player*, Entity*)> takeDamageTrigger;
-    std::function<void(Player*, Entity*)> afterAttackTrigger;
+    std::function<void(Entity*)> preDamageTrigger;
+    std::function<void(Entity*)> takeDamageTrigger;
+    std::function<void(Entity*)> afterAttackTrigger;
 };
 }  // namespace RosettaStone
 

--- a/Includes/Rosetta/Tasks/ITask.hpp
+++ b/Includes/Rosetta/Tasks/ITask.hpp
@@ -94,7 +94,7 @@ class ITask
     void EnableFreeable();
 
  protected:
-    EntityType m_entityType = EntityType::EMPTY;
+    EntityType m_entityType = EntityType::INVALID;
     Player* m_player = nullptr;
     Entity* m_source = nullptr;
     Playable* m_target = nullptr;

--- a/Includes/Rosetta/Tasks/SimpleTasks/RandomCardTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/RandomCardTask.hpp
@@ -13,18 +13,24 @@ namespace RosettaStone::SimpleTasks
 class RandomCardTask : public ITask
 {
  public:
+    //! Constructs task with given \p entityType and \p opposite.
+    //! \param entityType The entity type to choose the random card from.
+    //! \param opposite The flag that indicates the card is for the opponent.
+    RandomCardTask(EntityType entityType, bool opposite = false);
+
     //! Constructs task with given \p cardType, \p cardClass and \p race.
-    //! \param cardType The type of card.
-    //! \param cardClass The class of card.
-    //! \param race The race of card.
+    //! \param cardType The type of card to filter.
+    //! \param cardClass The class of card to filter.
+    //! \param race The race of card to filter.
+    //! \param opposite The flag that indicates the card is for the opponent.
     RandomCardTask(CardType cardType, CardClass cardClass,
-                   Race race = Race::INVALID);
+                   Race race = Race::INVALID, bool opposite = false);
 
  private:
     //! Returns card list that fits the criteria.
-    //! \param cardType The type of card.
-    //! \param cardClass The class of card.
-    //! \param race The race of card.
+    //! \param cardType The type of card to filter.
+    //! \param cardClass The class of card to filter.
+    //! \param race The race of card to filter.
     //! \return Card list that fits the criteria.
     std::vector<Card*> GetCardList(CardType cardType = CardType::INVALID,
                                    CardClass cardClass = CardClass::INVALID,
@@ -42,6 +48,7 @@ class RandomCardTask : public ITask
     CardType m_cardType;
     CardClass m_cardClass;
     Race m_race;
+    bool m_opposite;
 };
 }  // namespace RosettaStone::SimpleTasks
 

--- a/Includes/Rosetta/Tasks/SimpleTasks/RandomCardTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/RandomCardTask.hpp
@@ -34,7 +34,7 @@ class RandomCardTask : public ITask
     //! \return Card list that fits the criteria.
     std::vector<Card*> GetCardList(CardType cardType = CardType::INVALID,
                                    CardClass cardClass = CardClass::INVALID,
-                                   Race race = Race::INVALID);
+                                   Race race = Race::INVALID) const;
 
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/Tasks/SimpleTasks/RandomCardTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/RandomCardTask.hpp
@@ -20,10 +20,6 @@ class RandomCardTask : public ITask
     RandomCardTask(CardType cardType, CardClass cardClass,
                    Race race = Race::INVALID);
 
-    CardType m_cardType;
-    CardClass m_cardClass;
-    Race m_race;
-
  private:
     //! Returns card list that fits the criteria.
     //! \param cardType The type of card.
@@ -31,8 +27,8 @@ class RandomCardTask : public ITask
     //! \param race The race of card.
     //! \return Card list that fits the criteria.
     std::vector<Card*> GetCardList(CardType cardType = CardType::INVALID,
-                                  CardClass cardClass = CardClass::INVALID,
-                                  Race race = Race::INVALID);
+                                   CardClass cardClass = CardClass::INVALID,
+                                   Race race = Race::INVALID);
 
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.
@@ -42,6 +38,10 @@ class RandomCardTask : public ITask
     //! Internal method of Clone().
     //! \return The cloned task.
     ITask* CloneImpl() override;
+
+    CardType m_cardType;
+    CardClass m_cardClass;
+    Race m_race;
 };
 }  // namespace RosettaStone::SimpleTasks
 

--- a/Includes/Rosetta/Tasks/SimpleTasks/RandomCardTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/RandomCardTask.hpp
@@ -16,15 +16,15 @@ class RandomCardTask : public ITask
     //! Constructs task with given \p entityType and \p opposite.
     //! \param entityType The entity type to choose the random card from.
     //! \param opposite The flag that indicates the card is for the opponent.
-    RandomCardTask(EntityType entityType, bool opposite = false);
+    explicit RandomCardTask(EntityType entityType, bool opposite = false);
 
     //! Constructs task with given \p cardType, \p cardClass and \p race.
     //! \param cardType The type of card to filter.
     //! \param cardClass The class of card to filter.
     //! \param race The race of card to filter.
     //! \param opposite The flag that indicates the card is for the opponent.
-    RandomCardTask(CardType cardType, CardClass cardClass,
-                   Race race = Race::INVALID, bool opposite = false);
+    explicit RandomCardTask(CardType cardType, CardClass cardClass,
+                            Race race = Race::INVALID, bool opposite = false);
 
  private:
     //! Returns card list that fits the criteria.

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Basic & Classic
 
-  * 98% Basic (131 of 133 Cards)
-  * 73% Classic (179 of 245 Cards)
+  * **100% Basic (133 of 133 Cards)**
+  * 75% Classic (184 of 245 Cards)
   * 37% Hall of Fame (9 of 24 Cards)
 
 ### Adventures

--- a/Sources/Rosetta/Actions/Attack.cpp
+++ b/Sources/Rosetta/Actions/Attack.cpp
@@ -22,7 +22,7 @@ void Attack(Player* player, Character* source, Character* target)
 
     // Process attack trigger
     player->game->taskQueue.StartEvent();
-    player->game->triggerManager.OnAttackTrigger(player, source);
+    player->game->triggerManager.OnAttackTrigger(source);
     player->game->ProcessTasks();
     player->game->taskQueue.EndEvent();
 
@@ -31,7 +31,7 @@ void Attack(Player* player, Character* source, Character* target)
 
     // Process target trigger
     player->game->taskQueue.StartEvent();
-    player->game->triggerManager.OnTargetTrigger(player, source);
+    player->game->triggerManager.OnTargetTrigger(source);
     player->game->ProcessTasks();
     player->game->taskQueue.EndEvent();
 
@@ -110,7 +110,7 @@ void Attack(Player* player, Character* source, Character* target)
     player->game->taskQueue.StartEvent();
     if (source->afterAttackTrigger != nullptr)
     {
-        source->afterAttackTrigger(player, source);
+        source->afterAttackTrigger(source);
     }
     player->game->ProcessTasks();
     player->game->taskQueue.EndEvent();

--- a/Sources/Rosetta/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/Actions/PlayCard.cpp
@@ -118,15 +118,15 @@ void PlayMinion(Player* player, Minion* minion, Character* target, int fieldPos,
 
     // Process play card trigger
     player->game->taskQueue.StartEvent();
-    player->game->triggerManager.OnPlayMinionTrigger(player, minion);
-    player->game->triggerManager.OnPlayCardTrigger(player, minion);
+    player->game->triggerManager.OnPlayMinionTrigger(minion);
+    player->game->triggerManager.OnPlayCardTrigger(minion);
     player->game->ProcessTasks();
     player->game->taskQueue.EndEvent();
     player->game->ProcessDestroyAndUpdateAura();
 
     // Process summon trigger
     player->game->taskQueue.StartEvent();
-    player->game->triggerManager.OnSummonTrigger(player, minion);
+    player->game->triggerManager.OnSummonTrigger(minion);
     player->game->ProcessTasks();
     player->game->taskQueue.EndEvent();
 
@@ -134,7 +134,7 @@ void PlayMinion(Player* player, Minion* minion, Character* target, int fieldPos,
     if (target != nullptr)
     {
         player->game->taskQueue.StartEvent();
-        player->game->triggerManager.OnTargetTrigger(player, minion);
+        player->game->triggerManager.OnTargetTrigger(minion);
         player->game->ProcessTasks();
         player->game->taskQueue.EndEvent();
     }
@@ -156,13 +156,13 @@ void PlayMinion(Player* player, Minion* minion, Character* target, int fieldPos,
 
     // Process after play minion trigger
     player->game->taskQueue.StartEvent();
-    player->game->triggerManager.OnAfterPlayMinionTrigger(player, minion);
+    player->game->triggerManager.OnAfterPlayMinionTrigger(minion);
     player->game->ProcessTasks();
     player->game->taskQueue.EndEvent();
 
     // Process after summon trigger
     player->game->taskQueue.StartEvent();
-    player->game->triggerManager.OnAfterSummonTrigger(player, minion);
+    player->game->triggerManager.OnAfterSummonTrigger(minion);
     player->game->ProcessTasks();
     player->game->taskQueue.EndEvent();
 }
@@ -174,10 +174,10 @@ void PlaySpell(Player* player, Spell* spell, Character* target, int chooseOne)
 
     // Process cast spell trigger
     player->game->taskQueue.StartEvent();
-    player->game->triggerManager.OnCastSpellTrigger(player, spell);
+    player->game->triggerManager.OnCastSpellTrigger(spell);
 
     // Process play card trigger
-    player->game->triggerManager.OnPlayCardTrigger(player, spell);
+    player->game->triggerManager.OnPlayCardTrigger(spell);
     player->game->ProcessTasks();
     player->game->taskQueue.EndEvent();
     player->game->ProcessDestroyAndUpdateAura();
@@ -193,7 +193,7 @@ void PlaySpell(Player* player, Spell* spell, Character* target, int chooseOne)
         if (target != nullptr)
         {
             player->game->taskQueue.StartEvent();
-            player->game->triggerManager.OnTargetTrigger(player, spell);
+            player->game->triggerManager.OnTargetTrigger(spell);
             player->game->ProcessTasks();
             player->game->taskQueue.EndEvent();
         }
@@ -204,7 +204,7 @@ void PlaySpell(Player* player, Spell* spell, Character* target, int chooseOne)
 
     // Process after cast trigger
     player->game->taskQueue.StartEvent();
-    player->game->triggerManager.OnAfterCastTrigger(player, spell);
+    player->game->triggerManager.OnAfterCastTrigger(spell);
     player->game->ProcessTasks();
     player->game->taskQueue.EndEvent();
 
@@ -214,7 +214,7 @@ void PlaySpell(Player* player, Spell* spell, Character* target, int chooseOne)
 void PlayWeapon(Player* player, Weapon* weapon, Character* target)
 {
     // Process play card trigger
-    player->game->triggerManager.OnPlayCardTrigger(player, weapon);
+    player->game->triggerManager.OnPlayCardTrigger(weapon);
 
     // Process trigger
     if (weapon->card->power.GetTrigger())
@@ -232,7 +232,7 @@ void PlayWeapon(Player* player, Weapon* weapon, Character* target)
     if (target != nullptr)
     {
         player->game->taskQueue.StartEvent();
-        player->game->triggerManager.OnTargetTrigger(player, weapon);
+        player->game->triggerManager.OnTargetTrigger(weapon);
         player->game->ProcessTasks();
         player->game->taskQueue.EndEvent();
     }

--- a/Sources/Rosetta/Actions/Summon.cpp
+++ b/Sources/Rosetta/Actions/Summon.cpp
@@ -19,7 +19,7 @@ void Summon(Player* player, Minion* minion, int fieldPos)
 
     // Process after summon trigger
     player->game->taskQueue.StartEvent();
-    player->game->triggerManager.OnAfterSummonTrigger(player, minion);
+    player->game->triggerManager.OnAfterSummonTrigger(minion);
     player->game->ProcessTasks();
     player->game->taskQueue.EndEvent();
 }

--- a/Sources/Rosetta/Auras/Aura.cpp
+++ b/Sources/Rosetta/Auras/Aura.cpp
@@ -43,7 +43,11 @@ void Aura::Activate(Playable* owner, bool cloning)
     {
         switch (removeTrigger.first)
         {
-            case TriggerType::PLAY_MINION:
+            case TriggerType::CAST_SPELL:
+                owner->game->triggerManager.castSpellTrigger =
+                    std::move(instance->m_removeHandler);
+                break;
+            default:
                 break;
         }
     }
@@ -143,6 +147,17 @@ void Aura::Remove()
         {
             // Do nothing
         }
+    }
+
+    switch (removeTrigger.first)
+    {
+        case TriggerType::NONE:
+            break;
+        case TriggerType::CAST_SPELL:
+            m_owner->game->triggerManager.castSpellTrigger = nullptr;
+            break;
+        default:
+            break;
     }
 
     if (auto enchantment = dynamic_cast<Enchantment*>(m_owner))

--- a/Sources/Rosetta/Auras/Aura.cpp
+++ b/Sources/Rosetta/Auras/Aura.cpp
@@ -284,6 +284,9 @@ Aura::Aura(Aura& prototype, Playable& owner)
     {
         m_auraUpdateInstQueue = prototype.m_auraUpdateInstQueue;
     }
+
+    m_removeHandler =
+        std::bind(&Aura::TriggeredRemove, this, std::placeholders::_1);
 }
 
 void Aura::AddToGame(Playable& owner, Aura& aura)

--- a/Sources/Rosetta/Auras/Aura.cpp
+++ b/Sources/Rosetta/Auras/Aura.cpp
@@ -39,6 +39,15 @@ void Aura::Activate(Playable* owner, bool cloning)
 
     AddToGame(*owner, *instance);
 
+    if (removeTrigger.first != TriggerType::NONE)
+    {
+        switch (removeTrigger.first)
+        {
+            case TriggerType::PLAY_MINION:
+                break;
+        }
+    }
+
     if (!cloning && !restless)
     {
         instance->m_auraUpdateInstQueue.Push(
@@ -248,6 +257,7 @@ void Aura::NotifyEntityRemoved(Playable* entity)
 
 Aura::Aura(Aura& prototype, Playable& owner)
     : condition(prototype.condition),
+      removeTrigger(prototype.removeTrigger),
       restless(prototype.restless),
       m_type(prototype.m_type),
       m_owner(&owner),
@@ -429,5 +439,23 @@ void Aura::RenewAll()
             throw std::invalid_argument(
                 "Aura::RenewAll() - Invalid aura type!");
     }
+}
+
+void Aura::TriggeredRemove(Entity* source)
+{
+    if (removeTrigger.second != nullptr)
+    {
+        if (dynamic_cast<Player*>(source))
+        {
+            source = m_owner;
+        }
+
+        if (!removeTrigger.second->Evaluate(dynamic_cast<Playable*>(source)))
+        {
+            return;
+        }
+    }
+
+    Remove();
 }
 }  // namespace RosettaStone

--- a/Sources/Rosetta/Auras/SwitchingAura.cpp
+++ b/Sources/Rosetta/Auras/SwitchingAura.cpp
@@ -107,41 +107,33 @@ void SwitchingAura::RemoveInternal()
     }
 }
 
-void SwitchingAura::TurnOn(Entity*)
-{
-    if (m_turnOn)
-    {
-        return;
-    }
-
-    m_turnOn = true;
-
-    m_auraUpdateInstQueue.Push(AuraUpdateInstruction(AuraInstruction::ADD_ALL),
-                               1);
-}
-
-void SwitchingAura::TurnOff(Entity*)
-{
-    if (!m_turnOn)
-    {
-        return;
-    }
-
-    m_turnOn = false;
-
-    m_auraUpdateInstQueue.Push(
-        AuraUpdateInstruction(AuraInstruction::REMOVE_ALL), 0);
-}
-
 SwitchingAura::SwitchingAura(SwitchingAura& prototype, Playable& owner)
     : Aura(prototype, owner),
       m_initCondition(prototype.m_initCondition),
-      m_offTrigger(prototype.m_offTrigger),
-      m_onHandler(
-          std::bind(&SwitchingAura::TurnOn, this, std::placeholders::_1)),
-      m_offHandler(
-          std::bind(&SwitchingAura::TurnOff, this, std::placeholders::_1))
+      m_offTrigger(prototype.m_offTrigger)
 {
-    // Do nothing
+    m_onHandler = [this](Entity*) {
+        if (m_turnOn)
+        {
+            return;
+        }
+
+        m_turnOn = true;
+
+        m_auraUpdateInstQueue.Push(
+            AuraUpdateInstruction(AuraInstruction::ADD_ALL), 1);
+    };
+
+    m_offHandler = [this](Entity*) {
+        if (!m_turnOn)
+        {
+            return;
+        }
+
+        m_turnOn = false;
+
+        m_auraUpdateInstQueue.Push(
+            AuraUpdateInstruction(AuraInstruction::REMOVE_ALL), 0);
+    };
 }
 }  // namespace RosettaStone

--- a/Sources/Rosetta/Auras/SwitchingAura.cpp
+++ b/Sources/Rosetta/Auras/SwitchingAura.cpp
@@ -7,7 +7,6 @@
 #include <Rosetta/Cards/Card.hpp>
 #include <Rosetta/Games/Game.hpp>
 #include <Rosetta/Models/Entity.hpp>
-#include <Rosetta/Models/Player.hpp>
 
 #include <utility>
 
@@ -108,7 +107,7 @@ void SwitchingAura::RemoveInternal()
     }
 }
 
-void SwitchingAura::TurnOn(Player*, Entity*)
+void SwitchingAura::TurnOn(Entity*)
 {
     if (m_turnOn)
     {
@@ -121,7 +120,7 @@ void SwitchingAura::TurnOn(Player*, Entity*)
                                1);
 }
 
-void SwitchingAura::TurnOff(Player*, Entity*)
+void SwitchingAura::TurnOff(Entity*)
 {
     if (!m_turnOn)
     {
@@ -138,10 +137,10 @@ SwitchingAura::SwitchingAura(SwitchingAura& prototype, Playable& owner)
     : Aura(prototype, owner),
       m_initCondition(prototype.m_initCondition),
       m_offTrigger(prototype.m_offTrigger),
-      m_onHandler(std::bind(&SwitchingAura::TurnOn, this, std::placeholders::_1,
-                            std::placeholders::_2)),
-      m_offHandler(std::bind(&SwitchingAura::TurnOff, this,
-                             std::placeholders::_1, std::placeholders::_2))
+      m_onHandler(
+          std::bind(&SwitchingAura::TurnOn, this, std::placeholders::_1)),
+      m_offHandler(
+          std::bind(&SwitchingAura::TurnOff, this, std::placeholders::_1))
 {
     // Do nothing
 }

--- a/Sources/Rosetta/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/CoreCardsGen.cpp
@@ -1356,6 +1356,27 @@ void CoreCardsGen::AddRogue(std::map<std::string, Power>& cards)
     power.AddPowerTask(new DrawTask(1));
     cards.emplace("EX1_129", power);
 
+    // ----------------------------------------- MINION - ROGUE
+    // [EX1_191] Plaguebringer - COST:4 [ATK:3/HP:3]
+    // - Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a friendly minion <b>Poisonous</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - POISONOUS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new AddEnchantmentTask("EX1_191e", EntityType::TARGET));
+    cards.emplace("EX1_191", power);
+
     // ------------------------------------------ SPELL - ROGUE
     // [EX1_278] Shiv - COST:2
     // - Faction: Neutral, Set: Core, Rarity: Free
@@ -1401,6 +1422,19 @@ void CoreCardsGen::AddRogueNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddPowerTask(nullptr);
     cards.emplace("CS2_082", power);
+
+    // ------------------------------------ ENCHANTMENT - ROGUE
+    // [EX1_191e] Plaguetouched (*) - COST:0
+    // - Set: Core
+    // --------------------------------------------------------
+    // Text: <b>Poisonous</b>
+    // --------------------------------------------------------
+    // RefTag:
+    // - POISONOUS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("EX1_191e"));
+    cards.emplace("EX1_191e", power);
 }
 
 void CoreCardsGen::AddShaman(std::map<std::string, Power>& cards)

--- a/Sources/Rosetta/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/CoreCardsGen.cpp
@@ -1226,6 +1226,16 @@ void CoreCardsGen::AddPriest(std::map<std::string, Power>& cards)
     cards.emplace("CS2_236", power);
 
     // ----------------------------------------- SPELL - PRIEST
+    // [EX1_192] Radiance - COST:1
+    // - Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: Restore 5 Health to your hero.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new HealTask(EntityType::HERO, 5));
+    cards.emplace("EX1_192", power);
+
+    // ----------------------------------------- SPELL - PRIEST
     // [EX1_622] Shadow Word: Death - COST:3
     // - Set: Core, Rarity: Free
     // --------------------------------------------------------

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1505,9 +1505,9 @@ void Expert1CardsGen::AddRogue(std::map<std::string, Power>& cards)
     //       <i>(from your opponent's class)</i>.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(new RandomCardTask(EntityType::ENEMY_HAND));
+    power.AddPowerTask(new RandomCardTask(EntityType::ENEMY_HERO));
     power.AddPowerTask(new AddStackToTask(EntityType::HAND));
-    cards.emplace("EX1_145", power);
+    cards.emplace("EX1_182", power);
 
     // ----------------------------------------- MINION - ROGUE
     // [EX1_522] Patient Assassin - COST:2 [ATK:1/HP:1]

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -940,6 +940,20 @@ void Expert1CardsGen::AddPaladin(std::map<std::string, Power>& cards)
     cards.emplace("EX1_136", power);
 
     // ---------------------------------------- SPELL - PALADIN
+    // [EX1_184] Righteousness - COST:5
+    // - Set: Expert1, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Give your minions <b>Divine Shield</b>.
+    // --------------------------------------------------------
+    // RefTag:
+    // - DIVINE_SHIELD = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        new SetGameTagTask(EntityType::MINIONS, GameTag::DIVINE_SHIELD, 1));
+    cards.emplace("EX1_184", power);
+
+    // ---------------------------------------- SPELL - PALADIN
     // [EX1_354] Lay on Hands - COST:8
     // - Faction: Neutral, Set: Expert1, Rarity: Epic
     // --------------------------------------------------------

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1438,6 +1438,16 @@ void Expert1CardsGen::AddRogue(std::map<std::string, Power>& cards)
         new AddAuraEffectTask(Effects::ReduceCost(2), EntityType::TARGET));
     cards.emplace("EX1_144", power);
 
+    // ------------------------------------------ SPELL - ROGUE
+    // [EX1_145] Preparation - COST:0
+    // - Faction: Neutral, Set: Expert1, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: The next spell you cast this turn costs (3) less.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new AddEnchantmentTask("EX1_145o", EntityType::PLAYER));
+    cards.emplace("EX1_145", power);
+
     // ----------------------------------------- MINION - ROGUE
     // [EX1_522] Patient Assassin - COST:2 [ATK:1/HP:1]
     // - Faction: Neutral, Set: Expert1, Rarity: Epic
@@ -1502,6 +1512,24 @@ void Expert1CardsGen::AddRogueNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddPowerTask(nullptr);
     cards.emplace("EX1_131t", power);
+
+    // ------------------------------------ ENCHANTMENT - ROGUE
+    // [EX1_145o] Preparation (*) - COST:0
+    // - Set: Expert1
+    // --------------------------------------------------------
+    // Text: The next spell you cast this turn costs (3) less.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(new Aura(AuraType::HAND, { Effects::ReduceCost(3) }));
+    {
+        const auto aura = dynamic_cast<Aura*>(power.GetAura());
+        aura->condition = new SelfCondition(SelfCondition::IsSpell());
+        //
+    }
+    cards.emplace("EX1_145o", power);
 }
 
 void Expert1CardsGen::AddShaman(std::map<std::string, Power>& cards)

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1497,6 +1497,18 @@ void Expert1CardsGen::AddRogue(std::map<std::string, Power>& cards)
     power.AddPowerTask(new AddEnchantmentTask("EX1_145o", EntityType::PLAYER));
     cards.emplace("EX1_145", power);
 
+    // ------------------------------------------ SPELL - ROGUE
+    // [EX1_182] Pilfer - COST:1
+    // - Set: Expert1, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Add a random card from another class to your hand
+    //       <i>(from your opponent's class)</i>.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new RandomCardTask(EntityType::ENEMY_HAND));
+    power.AddPowerTask(new AddStackToTask(EntityType::HAND));
+    cards.emplace("EX1_145", power);
+
     // ----------------------------------------- MINION - ROGUE
     // [EX1_522] Patient Assassin - COST:2 [ATK:1/HP:1]
     // - Faction: Neutral, Set: Expert1, Rarity: Epic

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -206,6 +206,25 @@ void Expert1CardsGen::AddDruid(std::map<std::string, Power>& cards)
     cards.emplace("EX1_165", power);
 
     // ----------------------------------------- MINION - DRUID
+    // [EX1_166] Keeper of the Grove - COST:4 [ATK:2/HP:2]
+    // - Faction: Neutral, Set: Expert1, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Choose One -</b> Deal 2 damage; or <b>Silence</b> a minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CHOOSE_ONE = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - SILENCE = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("EX1_166", power);
+
+    // ----------------------------------------- MINION - DRUID
     // [EX1_178] Ancient of War - COST:7 [ATK:5/HP:5]
     // - Faction: Neutral, Set: Expert1, Rarity: Epic
     // --------------------------------------------------------
@@ -326,6 +345,36 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddEnchant(Enchants::GetEnchantFromText("EX1_155be"));
     cards.emplace("EX1_155be", power);
+
+    // ------------------------------------------ SPELL - DRUID
+    // [EX1_166a] Moonfire (*) - COST:0
+    // - Faction: Neutral, Set: Expert1
+    // --------------------------------------------------------
+    // Text: Deal 2 damage.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new DamageTask(EntityType::TARGET, 2));
+    cards.emplace("EX1_166a", power);
+
+    // ------------------------------------------ SPELL - DRUID
+    // [EX1_166b] Dispel (*) - COST:0
+    // - Faction: Neutral, Set: Expert1
+    // --------------------------------------------------------
+    // Text: <b>Silence</b> a minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SILENCE = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new SilenceTask(EntityType::TARGET));
+    cards.emplace("EX1_166b", power);
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [EX1_158e] Soul of the Forest (*) - COST:0

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -1442,7 +1442,7 @@ void Expert1CardsGen::AddRogue(std::map<std::string, Power>& cards)
     // [EX1_145] Preparation - COST:0
     // - Faction: Neutral, Set: Expert1, Rarity: Epic
     // --------------------------------------------------------
-    // Text: The next spell you cast this turn costs (3) less.
+    // Text: The next spell you cast this turn costs (2) less.
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(new AddEnchantmentTask("EX1_145o", EntityType::PLAYER));
@@ -1517,17 +1517,17 @@ void Expert1CardsGen::AddRogueNonCollect(std::map<std::string, Power>& cards)
     // [EX1_145o] Preparation (*) - COST:0
     // - Set: Expert1
     // --------------------------------------------------------
-    // Text: The next spell you cast this turn costs (3) less.
+    // Text: The next spell you cast this turn costs (2) less.
     // --------------------------------------------------------
     // GameTag:
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddAura(new Aura(AuraType::HAND, { Effects::ReduceCost(3) }));
+    power.AddAura(new Aura(AuraType::HAND, { Effects::ReduceCost(2) }));
     {
         const auto aura = dynamic_cast<Aura*>(power.GetAura());
         aura->condition = new SelfCondition(SelfCondition::IsSpell());
-        //
+        aura->removeTrigger = { TriggerType::CAST_SPELL, nullptr };
     }
     cards.emplace("EX1_145o", power);
 }

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -240,6 +240,19 @@ void Expert1CardsGen::AddDruid(std::map<std::string, Power>& cards)
     power.AddPowerTask(nullptr);
     cards.emplace("EX1_178", power);
 
+    // ------------------------------------------ SPELL - DRUID
+    // [EX1_183] Gift of the Wild - COST:8
+    // - Set: Expert1, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Give your minions +2/+2 and <b>Taunt</b>.
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(new AddEnchantmentTask("EX1_183e", EntityType::MINIONS));
+    cards.emplace("EX1_183", power);
+
     // ------------------------------------------- SPELL - DRUID
     // [EX1_570] Bite - COST:4
     // - Faction: Neutral, Set: Expert1, Rarity: Rare
@@ -541,6 +554,16 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, Power>& cards)
     power.ClearData();
     power.AddEnchant(Enchants::GetEnchantFromText("EX1_178be"));
     cards.emplace("EX1_178be", power);
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [EX1_183e] Gift of the Wild (*) - COST:0
+    // - Set: Expert1
+    // --------------------------------------------------------
+    // Text: +2/+2 and <b>Taunt</b>.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("EX1_183e"));
+    cards.emplace("EX1_183e", power);
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [EX1_570e] Bite - COST:0

--- a/Sources/Rosetta/Cards/Card.cpp
+++ b/Sources/Rosetta/Cards/Card.cpp
@@ -173,6 +173,11 @@ bool Card::IsUntouchable() const
     return static_cast<bool>(gameTags.at(GameTag::UNTOUCHABLE));
 }
 
+bool Card::IsCollectible() const
+{
+    return static_cast<bool>(gameTags.at(GameTag::COLLECTIBLE));
+}
+
 std::size_t Card::GetMaxAllowedInDeck() const
 {
     return maxAllowedInDeck;

--- a/Sources/Rosetta/Cards/Card.cpp
+++ b/Sources/Rosetta/Cards/Card.cpp
@@ -192,6 +192,19 @@ bool Card::IsStandardSet() const
     return false;
 }
 
+bool Card::IsWildSet() const
+{
+    for (auto& cardSet : WILD_CARD_SETS)
+    {
+        if (GetCardSet() == cardSet)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 std::size_t Card::GetMaxAllowedInDeck() const
 {
     return maxAllowedInDeck;

--- a/Sources/Rosetta/Cards/Card.cpp
+++ b/Sources/Rosetta/Cards/Card.cpp
@@ -5,6 +5,7 @@
 // property of any third parties.
 
 #include <Rosetta/Cards/Card.hpp>
+#include <Rosetta/Commons/Constants.hpp>
 #include <Rosetta/Models/Player.hpp>
 #include <Rosetta/Zones/FieldZone.hpp>
 
@@ -176,6 +177,19 @@ bool Card::IsUntouchable() const
 bool Card::IsCollectible() const
 {
     return static_cast<bool>(gameTags.at(GameTag::COLLECTIBLE));
+}
+
+bool Card::IsStandardSet() const
+{
+    for (auto& cardSet : STANDARD_CARD_SETS)
+    {
+        if (GetCardSet() == cardSet)
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 std::size_t Card::GetMaxAllowedInDeck() const

--- a/Sources/Rosetta/Cards/Cards.cpp
+++ b/Sources/Rosetta/Cards/Cards.cpp
@@ -41,6 +41,22 @@ const std::vector<Card*>& Cards::GetAllCards()
     return m_cards;
 }
 
+std::vector<Card*> Cards::GetAllStandardCards()
+{
+    std::vector<Card*> result;
+
+    for (Card* card : m_cards)
+    {
+        if (card->IsCollectible() && card->IsStandardSet() &&
+            card->GetCardType() != CardType::HERO)
+        {
+            result.emplace_back(card);
+        }
+    }
+
+    return result;
+}
+
 Card* Cards::FindCardByID(const std::string& id)
 {
     for (Card* card : m_cards)

--- a/Sources/Rosetta/Cards/Cards.cpp
+++ b/Sources/Rosetta/Cards/Cards.cpp
@@ -57,6 +57,22 @@ std::vector<Card*> Cards::GetAllStandardCards()
     return result;
 }
 
+std::vector<Card*> Cards::GetAllWildCards()
+{
+    std::vector<Card*> result;
+
+    for (Card* card : m_cards)
+    {
+        if (card->IsCollectible() && card->IsWildSet() &&
+            card->GetCardType() != CardType::HERO)
+        {
+            result.emplace_back(card);
+        }
+    }
+
+    return result;
+}
+
 Card* Cards::FindCardByID(const std::string& id)
 {
     for (Card* card : m_cards)

--- a/Sources/Rosetta/Enchants/Enchants.cpp
+++ b/Sources/Rosetta/Enchants/Enchants.cpp
@@ -43,6 +43,11 @@ Enchant* Enchants::GetEnchantFromText(const std::string& cardID)
         effects.emplace_back(Effects::Taunt);
     }
 
+    if (text.find("<b>Poisonous</b>") != std::string::npos)
+    {
+        effects.emplace_back(Effects::Poisonous);
+    }
+
     if (text.find("<b>Charge</b>") != std::string::npos)
     {
         effects.emplace_back(Effects::Charge);

--- a/Sources/Rosetta/Enchants/Trigger.cpp
+++ b/Sources/Rosetta/Enchants/Trigger.cpp
@@ -490,10 +490,9 @@ void Trigger::Validate(Entity* source)
 
     if (condition != nullptr)
     {
-        const bool res =
-            (source != nullptr)
-                ? condition->Evaluate(dynamic_cast<Playable*>(source))
-                : condition->Evaluate(m_owner);
+        const auto playable = dynamic_cast<Playable*>(source);
+        const bool res = (playable != nullptr) ? condition->Evaluate(playable)
+                                               : condition->Evaluate(m_owner);
 
         if (!res)
         {

--- a/Sources/Rosetta/Enchants/Trigger.cpp
+++ b/Sources/Rosetta/Enchants/Trigger.cpp
@@ -350,17 +350,27 @@ void Trigger::ProcessInternal(Entity* source)
         clonedTask->SetPlayer(m_owner->player);
         clonedTask->SetSource(m_owner);
 
-        if (source != nullptr)
+        if (const auto playable = dynamic_cast<Playable*>(source); playable)
         {
-            clonedTask->SetTarget(dynamic_cast<Playable*>(source));
+            clonedTask->SetTarget(playable);
         }
         else
         {
             const auto enchantment = dynamic_cast<Enchantment*>(m_owner);
-            if (enchantment != nullptr && enchantment->GetTarget() != nullptr)
+
+            if (enchantment != nullptr)
             {
-                clonedTask->SetTarget(
-                    dynamic_cast<Playable*>(enchantment->GetTarget()));
+                const auto enchantPlayable =
+                    dynamic_cast<Playable*>(enchantment->GetTarget());
+
+                if (enchantPlayable != nullptr)
+                {
+                    clonedTask->SetTarget(enchantPlayable);
+                }
+                else
+                {
+                    clonedTask->SetTarget(nullptr);
+                }
             }
             else
             {

--- a/Sources/Rosetta/Enchants/Trigger.cpp
+++ b/Sources/Rosetta/Enchants/Trigger.cpp
@@ -72,10 +72,10 @@ void Trigger::Activate(Playable* source, TriggerActivation activation,
 
     source->activatedTrigger = instance;
 
-    auto triggerFunc = [this, instance](Player* p, Entity* e) {
+    auto triggerFunc = [this, instance](Entity* e) {
         if (percentage == 1.0f || Random::get<float>(0.0f, 1.0f) < percentage)
         {
-            instance->Process(p, e);
+            instance->Process(e);
         }
     };
 
@@ -313,16 +313,16 @@ void Trigger::ValidateTriggers(Game* game, Entity* source, SequenceType type)
     {
         if (trigger->m_sequenceType == type)
         {
-            trigger->Validate(game->GetCurrentPlayer(), source);
+            trigger->Validate(source);
         }
     }
 }
 
-void Trigger::Process(Player* player, Entity* source)
+void Trigger::Process(Entity* source)
 {
     if (m_sequenceType == SequenceType::NONE)
     {
-        Validate(player, source);
+        Validate(source);
     }
 
     if (!m_isValidated)
@@ -380,7 +380,7 @@ void Trigger::ProcessInternal(Entity* source)
     m_isValidated = false;
 }
 
-void Trigger::Validate(Player* player, Entity* source)
+void Trigger::Validate(Entity* source)
 {
     switch (triggerSource)
     {
@@ -469,7 +469,7 @@ void Trigger::Validate(Player* player, Entity* source)
     {
         case TriggerType::TURN_START:
         case TriggerType::TURN_END:
-            if (m_owner == nullptr || player != m_owner->player)
+            if (m_owner == nullptr || source != m_owner->player)
             {
                 return;
             }

--- a/Sources/Rosetta/Enchants/Trigger.cpp
+++ b/Sources/Rosetta/Enchants/Trigger.cpp
@@ -46,6 +46,7 @@ Trigger::Trigger(Trigger& prototype, Entity& owner)
     : triggerSource(prototype.triggerSource),
       tasks(prototype.tasks),
       condition(prototype.condition),
+      eitherTurn(prototype.eitherTurn),
       fastExecution(prototype.fastExecution),
       removeAfterTriggered(prototype.removeAfterTriggered),
       m_owner(dynamic_cast<Playable*>(&owner)),
@@ -469,7 +470,8 @@ void Trigger::Validate(Entity* source)
     {
         case TriggerType::TURN_START:
         case TriggerType::TURN_END:
-            if (m_owner == nullptr || source != m_owner->player)
+            if (!eitherTurn &&
+                (m_owner == nullptr || source != m_owner->player))
             {
                 return;
             }

--- a/Sources/Rosetta/Games/Game.cpp
+++ b/Sources/Rosetta/Games/Game.cpp
@@ -394,7 +394,7 @@ void Game::MainReady()
 
 void Game::MainStartTriggers()
 {
-    triggerManager.OnStartTurnTrigger(nullptr);
+    triggerManager.OnStartTurnTrigger(GetCurrentPlayer());
     ProcessTasks();
     ProcessDestroyAndUpdateAura();
 
@@ -461,7 +461,7 @@ void Game::MainAction()
 void Game::MainEnd()
 {
     taskQueue.StartEvent();
-    triggerManager.OnEndTurnTrigger(nullptr);
+    triggerManager.OnEndTurnTrigger(GetCurrentPlayer());
     ProcessTasks();
     taskQueue.EndEvent();
     ProcessDestroyAndUpdateAura();

--- a/Sources/Rosetta/Games/Game.cpp
+++ b/Sources/Rosetta/Games/Game.cpp
@@ -168,6 +168,11 @@ void Game::RefCopyFrom(const Game& rhs)
     m_oopIndex = rhs.m_oopIndex;
 }
 
+FormatType Game::GetFormatType() const
+{
+    return m_gameConfig.formatType;
+}
+
 Player* Game::GetPlayer1()
 {
     return &m_players[0];

--- a/Sources/Rosetta/Games/Game.cpp
+++ b/Sources/Rosetta/Games/Game.cpp
@@ -394,7 +394,7 @@ void Game::MainReady()
 
 void Game::MainStartTriggers()
 {
-    triggerManager.OnStartTurnTrigger(GetCurrentPlayer(), nullptr);
+    triggerManager.OnStartTurnTrigger(nullptr);
     ProcessTasks();
     ProcessDestroyAndUpdateAura();
 
@@ -461,7 +461,7 @@ void Game::MainAction()
 void Game::MainEnd()
 {
     taskQueue.StartEvent();
-    triggerManager.OnEndTurnTrigger(GetCurrentPlayer(), nullptr);
+    triggerManager.OnEndTurnTrigger(nullptr);
     ProcessTasks();
     taskQueue.EndEvent();
     ProcessDestroyAndUpdateAura();
@@ -593,7 +593,7 @@ void Game::ProcessDestroyAndUpdateAura()
         taskQueue.StartEvent();
         for (auto& minion : summonedMinions)
         {
-            triggerManager.OnSummonTrigger(GetCurrentPlayer(), minion);
+            triggerManager.OnSummonTrigger(minion);
         }
         summonedMinions.clear();
         ProcessTasks();
@@ -633,7 +633,7 @@ void Game::ProcessGraveyard()
             Minion* minion = deadMinion.second;
 
             // Death event created
-            triggerManager.OnDeathTrigger(minion->player, minion);
+            triggerManager.OnDeathTrigger(minion);
 
             // Remove minion from battlefield
             minion->SetLastBoardPos(minion->GetZonePosition());

--- a/Sources/Rosetta/Games/TriggerManager.cpp
+++ b/Sources/Rosetta/Games/TriggerManager.cpp
@@ -8,124 +8,123 @@
 
 namespace RosettaStone
 {
-void TriggerManager::OnStartTurnTrigger(Player* player, Entity* sender) const
+void TriggerManager::OnStartTurnTrigger(Entity* sender) const
 {
     if (startTurnTrigger != nullptr)
     {
-        startTurnTrigger(player, sender);
+        startTurnTrigger(sender);
     }
 }
 
-void TriggerManager::OnEndTurnTrigger(Player* player, Entity* sender) const
+void TriggerManager::OnEndTurnTrigger(Entity* sender) const
 {
     if (endTurnTrigger != nullptr)
     {
-        endTurnTrigger(player, sender);
+        endTurnTrigger(sender);
     }
 }
 
-void TriggerManager::OnPlayCardTrigger(Player* player, Entity* sender) const
+void TriggerManager::OnPlayCardTrigger(Entity* sender) const
 {
     if (playCardTrigger != nullptr)
     {
-        playCardTrigger(player, sender);
+        playCardTrigger(sender);
     }
 }
 
-void TriggerManager::OnPlayMinionTrigger(Player* player, Entity* sender) const
+void TriggerManager::OnPlayMinionTrigger(Entity* sender) const
 {
     if (playMinionTrigger != nullptr)
     {
-        playMinionTrigger(player, sender);
+        playMinionTrigger(sender);
     }
 }
 
-void TriggerManager::OnAfterPlayMinionTrigger(Player* player,
-                                              Entity* sender) const
+void TriggerManager::OnAfterPlayMinionTrigger(Entity* sender) const
 {
     if (afterPlayMinionTrigger != nullptr)
     {
-        afterPlayMinionTrigger(player, sender);
+        afterPlayMinionTrigger(sender);
     }
 }
 
-void TriggerManager::OnCastSpellTrigger(Player* player, Entity* sender) const
+void TriggerManager::OnCastSpellTrigger(Entity* sender) const
 {
     if (castSpellTrigger != nullptr)
     {
-        castSpellTrigger(player, sender);
+        castSpellTrigger(sender);
     }
 }
 
-void TriggerManager::OnAfterCastTrigger(Player* player, Entity* sender) const
+void TriggerManager::OnAfterCastTrigger(Entity* sender) const
 {
     if (afterCastTrigger != nullptr)
     {
-        afterCastTrigger(player, sender);
+        afterCastTrigger(sender);
     }
 }
 
-void TriggerManager::OnHealTrigger(Player* player, Entity* sender) const
+void TriggerManager::OnHealTrigger(Entity* sender) const
 {
     if (healTrigger != nullptr)
     {
-        healTrigger(player, sender);
+        healTrigger(sender);
     }
 }
 
-void TriggerManager::OnAttackTrigger(Player* player, Entity* sender) const
+void TriggerManager::OnAttackTrigger(Entity* sender) const
 {
     if (attackTrigger != nullptr)
     {
-        attackTrigger(player, sender);
+        attackTrigger(sender);
     }
 }
 
-void TriggerManager::OnSummonTrigger(Player* player, Entity* sender) const
+void TriggerManager::OnSummonTrigger(Entity* sender) const
 {
     if (summonTrigger != nullptr)
     {
-        summonTrigger(player, sender);
+        summonTrigger(sender);
     }
 }
 
-void TriggerManager::OnAfterSummonTrigger(Player* player, Entity* sender) const
+void TriggerManager::OnAfterSummonTrigger(Entity* sender) const
 {
     if (afterSummonTrigger != nullptr)
     {
-        afterSummonTrigger(player, sender);
+        afterSummonTrigger(sender);
     }
 }
 
-void TriggerManager::OnDealDamageTrigger(Player* player, Entity* sender) const
+void TriggerManager::OnDealDamageTrigger(Entity* sender) const
 {
     if (dealDamageTrigger != nullptr)
     {
-        dealDamageTrigger(player, sender);
+        dealDamageTrigger(sender);
     }
 }
 
-void TriggerManager::OnTakeDamageTrigger(Player* player, Entity* sender) const
+void TriggerManager::OnTakeDamageTrigger(Entity* sender) const
 {
     if (takeDamageTrigger != nullptr)
     {
-        takeDamageTrigger(player, sender);
+        takeDamageTrigger(sender);
     }
 }
 
-void TriggerManager::OnTargetTrigger(Player* player, Entity* sender) const
+void TriggerManager::OnTargetTrigger(Entity* sender) const
 {
     if (targetTrigger != nullptr)
     {
-        targetTrigger(player, sender);
+        targetTrigger(sender);
     }
 }
 
-void TriggerManager::OnDeathTrigger(Player* player, Entity* sender) const
+void TriggerManager::OnDeathTrigger(Entity* sender) const
 {
     if (deathTrigger != nullptr)
     {
-        deathTrigger(player, sender);
+        deathTrigger(sender);
     }
 }
 }  // namespace RosettaStone

--- a/Sources/Rosetta/Models/Character.cpp
+++ b/Sources/Rosetta/Models/Character.cpp
@@ -127,6 +127,11 @@ bool Character::HasStealth() const
     return static_cast<bool>(GetGameTag(GameTag::STEALTH));
 }
 
+bool Character::HasDivineShield() const
+{
+    return static_cast<bool>(GetGameTag(GameTag::DIVINE_SHIELD));
+}
+
 bool Character::CanAttack() const
 {
     // If the value of attack is 0, returns false

--- a/Sources/Rosetta/Models/Character.cpp
+++ b/Sources/Rosetta/Models/Character.cpp
@@ -235,7 +235,7 @@ int Character::TakeDamage(Playable* source, int damage)
 
     if (preDamageTrigger != nullptr)
     {
-        preDamageTrigger(player, this);
+        preDamageTrigger(this);
         game->ProcessTasks();
         amount = game->currentEventData->eventNumber;
 
@@ -270,10 +270,10 @@ int Character::TakeDamage(Playable* source, int damage)
     // Process damage triggers
     if (takeDamageTrigger != nullptr)
     {
-        takeDamageTrigger(player, this);
+        takeDamageTrigger(this);
     }
-    game->triggerManager.OnTakeDamageTrigger(player, this);
-    game->triggerManager.OnDealDamageTrigger(player->opponent, source);
+    game->triggerManager.OnTakeDamageTrigger(this);
+    game->triggerManager.OnDealDamageTrigger(source);
 
     game->ProcessTasks();
     game->taskQueue.EndEvent();
@@ -300,7 +300,7 @@ void Character::TakeHeal(Playable* source, int heal)
     SetDamage(GetDamage() - amount);
 
     game->taskQueue.StartEvent();
-    game->triggerManager.OnHealTrigger(player, this);
+    game->triggerManager.OnHealTrigger(this);
     game->ProcessTasks();
     game->taskQueue.EndEvent();
 }

--- a/Sources/Rosetta/Models/Hero.cpp
+++ b/Sources/Rosetta/Models/Hero.cpp
@@ -64,7 +64,7 @@ void Hero::RemoveWeapon()
         return;
     }
 
-    game->triggerManager.OnDeathTrigger(player, weapon);
+    game->triggerManager.OnDeathTrigger(weapon);
 
     player->GetGraveyardZone()->Add(weapon);
 

--- a/Sources/Rosetta/Tasks/PlayerTasks/HeroPowerTask.cpp
+++ b/Sources/Rosetta/Tasks/PlayerTasks/HeroPowerTask.cpp
@@ -43,7 +43,7 @@ TaskStatus HeroPowerTask::Impl(Player* player)
     {
         Trigger::ValidateTriggers(player->game, &power, SequenceType::TARGET);
         player->game->taskQueue.StartEvent();
-        player->game->triggerManager.OnTargetTrigger(player, &power);
+        player->game->triggerManager.OnTargetTrigger(&power);
         player->game->ProcessTasks();
         player->game->taskQueue.EndEvent();
     }

--- a/Sources/Rosetta/Tasks/SimpleTasks/RandomCardTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/RandomCardTask.cpp
@@ -29,10 +29,13 @@ RandomCardTask::RandomCardTask(CardType cardType, CardClass cardClass,
 }
 
 std::vector<Card*> RandomCardTask::GetCardList(CardType cardType,
-                                               CardClass cardClass, Race race)
+                                               CardClass cardClass,
+                                               Race race) const
 {
     std::vector<Card*> result;
-    const auto cards = Cards::GetAllCards();
+    const auto cards = m_source->game->GetFormatType() == FormatType::STANDARD
+                           ? Cards::GetAllStandardCards()
+                           : Cards::GetAllWildCards();
 
     for (const auto& card : cards)
     {

--- a/Sources/Rosetta/Tasks/SimpleTasks/RandomCardTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/RandomCardTask.cpp
@@ -51,7 +51,25 @@ std::vector<Card*> RandomCardTask::GetCardList(CardType cardType,
 
 TaskStatus RandomCardTask::Impl(Player* player)
 {
-    auto cardsList = GetCardList(m_cardType, m_cardClass, m_race);
+    CardClass cardClass;
+
+    switch (m_entityType)
+    {
+        case EntityType::HERO:
+            cardClass = player->GetHero()->card->GetCardClass();
+            break;
+        case EntityType::ENEMY_HERO:
+            cardClass = player->opponent->GetHero()->card->GetCardClass();
+            break;
+        case EntityType::INVALID:
+            cardClass = m_cardClass;
+            break;
+        default:
+            throw std::invalid_argument(
+                "RandomCardTask::Impl() - Invalid entity type");
+    }
+
+    auto cardsList = GetCardList(m_cardType, cardClass, m_race);
     if (cardsList.empty())
     {
         return TaskStatus::STOP;

--- a/Sources/Rosetta/Tasks/SimpleTasks/RandomCardTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/RandomCardTask.cpp
@@ -8,9 +8,22 @@ using Random = effolkronium::random_static;
 
 namespace RosettaStone::SimpleTasks
 {
+RandomCardTask::RandomCardTask(EntityType entityType, bool opposite)
+    : ITask(entityType),
+      m_cardType(CardType::INVALID),
+      m_cardClass(CardClass::INVALID),
+      m_race(Race::INVALID),
+      m_opposite(opposite)
+{
+    // Do nothing
+}
+
 RandomCardTask::RandomCardTask(CardType cardType, CardClass cardClass,
-                               Race race)
-    : m_cardType(cardType), m_cardClass(cardClass), m_race(race)
+                               Race race, bool opposite)
+    : m_cardType(cardType),
+      m_cardClass(cardClass),
+      m_race(race),
+      m_opposite(opposite)
 {
     // Do nothing
 }
@@ -45,7 +58,8 @@ TaskStatus RandomCardTask::Impl(Player* player)
     }
 
     const auto idx = Random::get<std::size_t>(0, cardsList.size() - 1);
-    auto randomCard = Entity::GetFromCard(player, cardsList.at(idx));
+    auto randomCard = Entity::GetFromCard(
+        m_opposite ? player->opponent : player, cardsList.at(idx));
     player->game->taskStack.playables.emplace_back(randomCard);
 
     return TaskStatus::COMPLETE;

--- a/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
@@ -3413,6 +3413,63 @@ TEST(RogueCoreTest, EX1_129_FanOfKnives)
     EXPECT_EQ(opPlayer->GetHero()->GetHealth(), 30);
 }
 
+// ----------------------------------------- MINION - ROGUE
+// [EX1_191] Plaguebringer - COST:4 [ATK:3/HP:3]
+// - Set: Core, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give a friendly minion <b>Poisonous</b>.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINION_TARGET = 0
+// - REQ_FRIENDLY_TARGET = 0
+// - REQ_TARGET_IF_AVAILABLE = 0
+// --------------------------------------------------------
+// RefTag:
+// - POISONOUS = 1
+// --------------------------------------------------------
+TEST(RogueCoreTest, EX1_191_Plaguebringer)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::ROGUE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Plaguebringer"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    game.Process(opPlayer, PlayCardTask::MinionTarget(card2, card3));
+
+    game.Process(opPlayer, AttackTask(card3, card1));
+    EXPECT_EQ(curPlayer->GetFieldZone()->GetCount(), 0);
+    EXPECT_EQ(opPlayer->GetFieldZone()->GetCount(), 1);
+}
+
 // ------------------------------------------ SPELL - ROGUE
 // [EX1_278] Shiv - COST:2
 // - Faction: Neutral, Set: Core, Rarity: Free

--- a/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/CoreCardsGenTests.cpp
@@ -3044,6 +3044,47 @@ TEST(PriestCoreTest, CS2_236_DivineSpirit)
 }
 
 // ----------------------------------------- SPELL - PRIEST
+// [EX1_192] Radiance - COST:1
+// - Set: Core, Rarity: Free
+// --------------------------------------------------------
+// Text: Restore 5 Health to your hero.
+// --------------------------------------------------------
+TEST(PriestCoreTest, EX1_192_Radiance)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(8);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Radiance"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Radiance"));
+
+    EXPECT_EQ(curPlayer->GetHero()->GetHealth(), 22);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    EXPECT_EQ(curPlayer->GetHero()->GetHealth(), 27);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    EXPECT_EQ(curPlayer->GetHero()->GetHealth(), 30);
+}
+
+// ----------------------------------------- SPELL - PRIEST
 // [EX1_622] Shadow Word: Death - COST:3
 // - Set: Core, Rarity: Free
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -499,6 +499,77 @@ TEST(DruidExpert1Test, EX1_178_AncientOfWar)
     EXPECT_EQ(opField[0]->GetAttack(), 10);
 }
 
+// ------------------------------------------ SPELL - DRUID
+// [EX1_183] Gift of the Wild - COST:8
+// - Set: Expert1, Rarity: Common
+// --------------------------------------------------------
+// Text: Give your minions +2/+2 and <b>Taunt</b>.
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST(DruidExpert1Test, EX1_183_GiftOfTheWild)
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Gift of the Wild"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    EXPECT_EQ(curField[0]->GetAttack(), 1);
+    EXPECT_EQ(curField[0]->GetHealth(), 1);
+    EXPECT_EQ(curField[0]->HasTaunt(), false);
+    EXPECT_EQ(curField[1]->GetAttack(), 3);
+    EXPECT_EQ(curField[1]->GetHealth(), 1);
+    EXPECT_EQ(curField[1]->HasTaunt(), false);
+    EXPECT_EQ(curField[2]->GetAttack(), 3);
+    EXPECT_EQ(curField[2]->GetHealth(), 2);
+    EXPECT_EQ(curField[2]->HasTaunt(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    EXPECT_EQ(curField[0]->GetAttack(), 3);
+    EXPECT_EQ(curField[0]->GetHealth(), 3);
+    EXPECT_EQ(curField[0]->HasTaunt(), true);
+    EXPECT_EQ(curField[1]->GetAttack(), 5);
+    EXPECT_EQ(curField[1]->GetHealth(), 3);
+    EXPECT_EQ(curField[1]->HasTaunt(), true);
+    EXPECT_EQ(curField[2]->GetAttack(), 5);
+    EXPECT_EQ(curField[2]->GetHealth(), 4);
+    EXPECT_EQ(curField[2]->HasTaunt(), true);
+}
+
 // ------------------------------------------- SPELL - DRUID
 // [EX1_570] Bite - COST:4
 // - Faction: Neutral, Set: Expert1, Rarity: Rare

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -3755,6 +3755,69 @@ TEST(RogueExpert1Test, EX1_144_Shadowstep)
     EXPECT_EQ(opPlayer->GetHero()->GetHealth(), 22);
 }
 
+// ------------------------------------------ SPELL - ROGUE
+// [EX1_145] Preparation - COST:0
+// - Faction: Neutral, Set: Expert1, Rarity: Epic
+// --------------------------------------------------------
+// Text: The next spell you cast this turn costs (2) less.
+// --------------------------------------------------------
+TEST(RogueExpert1Test, EX1_145_Preparation)
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Preparation"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Preparation"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Preparation"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Eviscerate"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Vanish"));
+
+    EXPECT_EQ(card1->GetCost(), 0);
+    EXPECT_EQ(card2->GetCost(), 0);
+    EXPECT_EQ(card3->GetCost(), 0);
+    EXPECT_EQ(card4->GetCost(), 2);
+    EXPECT_EQ(card5->GetCost(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    EXPECT_EQ(card2->GetCost(), 0);
+    EXPECT_EQ(card3->GetCost(), 0);
+    EXPECT_EQ(card4->GetCost(), 0);
+    EXPECT_EQ(card5->GetCost(), 4);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    EXPECT_EQ(card3->GetCost(), 0);
+    EXPECT_EQ(card4->GetCost(), 0);
+    EXPECT_EQ(card5->GetCost(), 4);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card4, opPlayer->GetHero()));
+    EXPECT_EQ(card3->GetCost(), 0);
+    EXPECT_EQ(card5->GetCost(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    EXPECT_EQ(card5->GetCost(), 4);
+}
+
 // ----------------------------------------- MINION - ROGUE
 // [EX1_522] Patient Assassin - COST:2 [ATK:1/HP:1]
 // - Faction: Neutral, Set: Expert1, Rarity: Epic

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -1674,6 +1674,65 @@ TEST(PaladinExpert1Test, EX1_136_Redemption)
 }
 
 // ---------------------------------------- SPELL - PALADIN
+// [EX1_184] Righteousness - COST:5
+// - Set: Expert1, Rarity: Rare
+// --------------------------------------------------------
+// Text: Give your minions <b>Divine Shield</b>.
+// --------------------------------------------------------
+// RefTag:
+// - DIVINE_SHIELD = 1
+// --------------------------------------------------------
+TEST(DruidExpert1Test, EX1_184_Righteousness)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Righteousness"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    EXPECT_EQ(curField[0]->HasDivineShield(), false);
+    EXPECT_EQ(curField[1]->HasDivineShield(), false);
+    EXPECT_EQ(curField[2]->HasDivineShield(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    EXPECT_EQ(curField[0]->HasDivineShield(), true);
+    EXPECT_EQ(curField[1]->HasDivineShield(), true);
+    EXPECT_EQ(curField[2]->HasDivineShield(), true);
+}
+
+// ---------------------------------------- SPELL - PALADIN
 // [EX1_354] Lay on Hands - COST:8
 // - Faction: Neutral, Set: Expert1, Rarity: Epic
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -344,7 +344,7 @@ TEST(DruidExpert1Test, EX1_164_Nourish)
 TEST(DruidExpert1Test, EX1_165_DruidOfTheClaw)
 {
     GameConfig config;
-    config.player1Class = CardClass::MAGE;
+    config.player1Class = CardClass::DRUID;
     config.player2Class = CardClass::MAGE;
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = true;
@@ -387,6 +387,65 @@ TEST(DruidExpert1Test, EX1_165_DruidOfTheClaw)
     EXPECT_EQ(curField[1]->GetHealth(), 6);
     EXPECT_FALSE(curField[1]->CanAttack());
     EXPECT_EQ(curField[1]->GetGameTag(GameTag::TAUNT), 0);
+}
+
+// ----------------------------------------- MINION - DRUID
+// [EX1_166] Keeper of the Grove - COST:4 [ATK:2/HP:2]
+// - Faction: Neutral, Set: Expert1, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Choose One -</b> Deal 2 damage; or <b>Silence</b> a minion.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// --------------------------------------------------------
+// RefTag:
+// - SILENCE = 1
+// --------------------------------------------------------
+TEST(DruidExpert1Test, EX1_166_KeeperOfTheGrove)
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Keeper of the Grove"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Keeper of the Grove"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Archmage"));
+
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card1, opPlayer->GetHero(), 1));
+    EXPECT_EQ(opPlayer->GetHero()->GetHealth(), 28);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    EXPECT_EQ(opPlayer->currentSpellPower, 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card3, 2));
+    EXPECT_EQ(opPlayer->currentSpellPower, 0);
 }
 
 // ----------------------------------------- MINION - DRUID

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -3877,6 +3877,47 @@ TEST(RogueExpert1Test, EX1_145_Preparation)
     EXPECT_EQ(card5->GetCost(), 4);
 }
 
+// ------------------------------------------ SPELL - ROGUE
+// [EX1_182] Pilfer - COST:1
+// - Set: Expert1, Rarity: Common
+// --------------------------------------------------------
+// Text: Add a random card from another class to your hand
+//       <i>(from your opponent's class)</i>.
+// --------------------------------------------------------
+TEST(RogueExpert1Test, EX1_182_Pilfer)
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Pilfer"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Pilfer"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    EXPECT_EQ(curHand[5]->card->GetCardClass(), CardClass::PALADIN);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    EXPECT_EQ(curHand[5]->card->GetCardClass(), CardClass::PALADIN);
+}
+
 // ----------------------------------------- MINION - ROGUE
 // [EX1_522] Patient Assassin - COST:2 [ATK:1/HP:1]
 // - Faction: Neutral, Set: Expert1, Rarity: Epic

--- a/Tests/UnitTests/Cards/CardsTests.cpp
+++ b/Tests/UnitTests/Cards/CardsTests.cpp
@@ -19,6 +19,28 @@ TEST(Cards, GetAllCards)
     EXPECT_EQ(cards.size(), 7735u);
 }
 
+TEST(Cards, GetAllStandardCards)
+{
+    const std::vector<Card*> cards = Cards::GetInstance().GetAllStandardCards();
+
+    ASSERT_FALSE(cards.empty());
+    for (auto& card : cards)
+    {
+        EXPECT_EQ(card->IsStandardSet(), true);
+    }
+}
+
+TEST(Cards, GetAllWildCards)
+{
+    const std::vector<Card*> cards = Cards::GetInstance().GetAllWildCards();
+
+    ASSERT_FALSE(cards.empty());
+    for (auto& card : cards)
+    {
+        EXPECT_EQ(card->IsWildSet(), true);
+    }
+}
+
 TEST(Cards, FindCardByID)
 {
     const Card* card1 = Cards::GetInstance().FindCardByID("AT_001");
@@ -168,9 +190,11 @@ TEST(Cards, FindCardByName)
 {
     Cards& instance = Cards::GetInstance();
 
-    const Card* card = instance.FindCardByName("Flame Lance");
+    const Card* card1 = instance.FindCardByName("Flame Lance");
+    EXPECT_EQ(card1->name, "Flame Lance");
 
-    EXPECT_EQ("Flame Lance", card->name);
+    const Card* card2 = instance.FindCardByName("INVALID");
+    EXPECT_EQ(card2->name.empty(), true);
 }
 
 TEST(Cards, FindCardByCost)

--- a/Tests/UnitTests/Tasks/SimpleTasks/ChangeHeroPowerTaskTests.cpp
+++ b/Tests/UnitTests/Tasks/SimpleTasks/ChangeHeroPowerTaskTests.cpp
@@ -18,6 +18,7 @@ TEST(ChangeHeroPowerTask, Run)
     GameConfig config;
     config.startPlayer = PlayerType::PLAYER1;
     config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
     Game game(config);
 
     Hero& hero = *game.GetPlayer1()->GetHero();

--- a/Tests/UnitTests/Tasks/SimpleTasks/ControlTaskTests.cpp
+++ b/Tests/UnitTests/Tasks/SimpleTasks/ControlTaskTests.cpp
@@ -19,6 +19,8 @@ TEST(ControlTask, Run)
 {
     GameConfig config;
     config.startPlayer = PlayerType::PLAYER1;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
     Game game(config);
 
     Player* player1 = game.GetPlayer1();

--- a/Tests/UnitTests/Tasks/SimpleTasks/DrawTaskTests.cpp
+++ b/Tests/UnitTests/Tasks/SimpleTasks/DrawTaskTests.cpp
@@ -23,6 +23,8 @@ TEST(DrawTask, Run)
 
     GameConfig config;
     config.startPlayer = PlayerType::PLAYER1;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
     Game game(config);
 
     Player* player = game.GetPlayer1();
@@ -70,6 +72,8 @@ TEST(DrawTask, RunExhaust)
 {
     GameConfig config;
     config.startPlayer = PlayerType::PLAYER1;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
     Game game(config);
 
     Player* player = game.GetPlayer1();
@@ -111,6 +115,8 @@ TEST(DrawTask, RunOverDraw)
 
     GameConfig config;
     config.startPlayer = PlayerType::PLAYER1;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
     Game game(config);
 
     Player* player = game.GetPlayer1();
@@ -160,6 +166,8 @@ TEST(DrawTask, RunExhaustOverdraw)
 
     GameConfig config;
     config.startPlayer = PlayerType::PLAYER1;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
     Game game(config);
 
     Player* player = game.GetPlayer1();

--- a/Tests/UnitTests/Tasks/SimpleTasks/IncludeTaskTests.cpp
+++ b/Tests/UnitTests/Tasks/SimpleTasks/IncludeTaskTests.cpp
@@ -153,7 +153,7 @@ TEST(IncludeTask, Run_NonConst)
         IncludeTask::GetEntities(EntityType::STACK, player1);
     EXPECT_EQ(entities21.size(), 0u);
 
-    EXPECT_THROW(IncludeTask::GetEntities(EntityType::EMPTY, player1),
+    EXPECT_THROW(IncludeTask::GetEntities(EntityType::INVALID, player1),
                  std::invalid_argument);
 }
 
@@ -300,6 +300,6 @@ TEST(IncludeTask, Run_Const)
         IncludeTask::GetEntities(EntityType::STACK, player1);
     EXPECT_EQ(entities21.size(), 0u);
 
-    EXPECT_THROW(IncludeTask::GetEntities(EntityType::EMPTY, player1),
+    EXPECT_THROW(IncludeTask::GetEntities(EntityType::INVALID, player1),
                  std::invalid_argument);
 }

--- a/Tests/UnitTests/Tasks/SimpleTasks/MathNumberIndexTaskTests.cpp
+++ b/Tests/UnitTests/Tasks/SimpleTasks/MathNumberIndexTaskTests.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <Utils/TestUtils.hpp>
+#include "gtest/gtest.h"
+
+#include <Rosetta/Games/Game.hpp>
+#include <Rosetta/Tasks/SimpleTasks/MathNumberIndexTask.hpp>
+
+using namespace RosettaStone;
+using namespace SimpleTasks;
+using namespace TestUtils;
+
+TEST(MathNumberIndexTask, Run_Add)
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+
+    Player* player1 = game.GetPlayer1();
+
+    game.taskStack.num = 1;
+    game.taskStack.num1 = 2;
+
+    MathNumberIndexTask task(0, 1, MathOperation::ADD, 0);
+    task.SetPlayer(player1);
+
+    TaskStatus result = task.Run();
+    EXPECT_EQ(result, TaskStatus::COMPLETE);
+    EXPECT_EQ(game.taskStack.num, 3);
+}
+
+TEST(MathNumberIndexTask, Run_Sub)
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+
+    Player* player1 = game.GetPlayer1();
+
+    game.taskStack.num = 5;
+    game.taskStack.num1 = 3;
+
+    MathNumberIndexTask task(0, 1, MathOperation::SUB, 1);
+    task.SetPlayer(player1);
+
+    TaskStatus result = task.Run();
+    EXPECT_EQ(result, TaskStatus::COMPLETE);
+    EXPECT_EQ(game.taskStack.num1, 2);
+}
+
+TEST(MathNumberIndexTask, Run_Mul)
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+
+    Player* player1 = game.GetPlayer1();
+
+    game.taskStack.num = 2;
+    game.taskStack.num1 = 4;
+
+    MathNumberIndexTask task(0, 1, MathOperation::MUL, 0);
+    task.SetPlayer(player1);
+
+    TaskStatus result = task.Run();
+    EXPECT_EQ(result, TaskStatus::COMPLETE);
+    EXPECT_EQ(game.taskStack.num, 8);
+}
+
+TEST(MathNumberIndexTask, Run_Div)
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+
+    Player* player1 = game.GetPlayer1();
+
+    game.taskStack.num = 9;
+    game.taskStack.num1 = 3;
+
+    MathNumberIndexTask task(0, 1, MathOperation::DIV, 1);
+    task.SetPlayer(player1);
+
+    TaskStatus result = task.Run();
+    EXPECT_EQ(result, TaskStatus::COMPLETE);
+    EXPECT_EQ(game.taskStack.num1, 3);
+}


### PR DESCRIPTION
This revision includes:
- Implement 2 cards in the CORE card set
    - Plaguebringer (EX1_191)
    - Radiance (EX1_192)
- Implement 5 cards in the EXPERT1 card set
    - Preparation (EX1_145)
    - Keeper of the Grove (EX1_166)
    - Pilfer (EX1_182)
    - Gift of the Wild (EX1_183)
    - Righteousness (EX1_184)
- Add code to parse `Effects::Poisonous` from text in `Enchants::GetEnchantFromText()`
- Refactor trigger and aura system
    - Remove argument `player` from trigger handler
    - Add `removeTrigger` and `eitherTurn` and code to process them
    - Change parameter of start/end turn trigger
    - Add code to process trigger type `CAST_SPELL`
    - Add code to assign `m_removeHandler`
- Change the name of entity type `EMPTY` to `INVALID`
- Refactor `RandomCardTask`
    - Add code to process card class by checking entity type
    - Add code to get a list of cards by checking format type
- Add constants
    - `STANDARD_CARD_SETS`: Specifies which card sets combine into the STANDARD set
    - `WILD_CARD_SETS`: Specifies which card sets combine into the WILD set
- Add some methods
    - `HasDivineShield()`: Returns the flag that indicates whether it has divine shield
    - `IsCollectible()`: Returns the flag that indicates whether it is collectible
    - `IsStandardSet()`: Finds out if this card is in STANDARD set
    - `IsWildSet()`: Finds out if this card is in WILD set
    - `GetAllStandardCards()`: Returns a list of all standard cards
    - `GetAllWildCards()`: Returns a list of all wild cards
    - `GetFormatType()`: Returns the format type of the game