### PR TITLE
Prepare RosettaStone 2020 roadmap

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -404,17 +404,17 @@ HOF | CS2_031 | Ice Lance | O
 HOF | DS1_233 | Mind Blast | O
 HOF | EX1_016 | Sylvanas Windrunner | O
 HOF | EX1_050 | Coldlight Oracle | O
-HOF | EX1_062 | Old Murk-Eye |  
+HOF | EX1_062 | Old Murk-Eye | O
 HOF | EX1_112 | Gelbin Mekkatorque |  
-HOF | EX1_128 | Conceal |  
+HOF | EX1_128 | Conceal | O
 HOF | EX1_161 | Naturalize | O
 HOF | EX1_284 | Azure Drake | O
 HOF | EX1_295 | Ice Block |  
 HOF | EX1_298 | Ragnaros the Firelord |  
 HOF | EX1_310 | Doomguard | O
 HOF | EX1_316 | Power Overwhelming | O
-HOF | EX1_349 | Divine Favor |  
-HOF | EX1_620 | Molten Giant |  
+HOF | EX1_349 | Divine Favor | O
+HOF | EX1_620 | Molten Giant | O
 HOF | GIL_130 | Gloom Stag |  
 HOF | GIL_530 | Murkspark Eel |  
 HOF | GIL_692 | Genn Greymane |  
@@ -425,4 +425,4 @@ HOF | NEW1_004 | Vanish | O
 HOF | NEW1_016 | Captain's Parrot |  
 HOF | PRO_001 | Elite Tauren Chieftain |  
 
-- Progress: 37% (9 of 24 Cards)
+- Progress: 54% (13 of 24 Cards)

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -1,8 +1,11 @@
 # RosettaStone card list
 
-* [Basic card list](#basic)
-* [Classic card list](#classic)
-* [Hall of Fame card list](#hall-of-fame)
+* [Basic](#basic)
+* [Classic](#classic)
+* [Hall of Fame](#hall-of-fame)
+* [Descent of Dragons](#descent-of-dragons)
+* [Saviors of Uldum](#saviors-of-uldum)
+* [Rise of Shadows](#rise-of-shadows)
 
 ## Basic
 
@@ -426,3 +429,434 @@ HOF | NEW1_016 | Captain's Parrot |
 HOF | PRO_001 | Elite Tauren Chieftain |  
 
 - Progress: 54% (13 of 24 Cards)
+
+## Descent of Dragons
+
+Set | ID | Name | Implemented
+:---: | :---: | :---: | :---:
+DRAGONS | DRG_006 | Corrosive Breath |  
+DRAGONS | DRG_007 | Stormhammer |  
+DRAGONS | DRG_008 | Righteous Cause |  
+DRAGONS | DRG_010 | Diving Gryphon |  
+DRAGONS | DRG_019 | Scion of Ruin |  
+DRAGONS | DRG_020 | EVIL Quartermaster |  
+DRAGONS | DRG_021 | Ritual Chopper |  
+DRAGONS | DRG_022 | Ramming Speed |  
+DRAGONS | DRG_023 | Skybarge |  
+DRAGONS | DRG_024 | Sky Raider |  
+DRAGONS | DRG_025 | Ancharrr |  
+DRAGONS | DRG_026 | Deathwing, Mad Aspect |  
+DRAGONS | DRG_027 | Umbral Skulker |  
+DRAGONS | DRG_028 | Dragon's Hoard |  
+DRAGONS | DRG_030 | Praise Galakrond! |  
+DRAGONS | DRG_031 | Necrium Apothecary |  
+DRAGONS | DRG_033 | Candle Breath |  
+DRAGONS | DRG_034 | Stowaway |  
+DRAGONS | DRG_035 | Bloodsail Flybooter |  
+DRAGONS | DRG_036 | Waxadred |  
+DRAGONS | DRG_037 | Flik Skyshiv |  
+DRAGONS | DRG_049 | Tasty Flyfish |  
+DRAGONS | DRG_050 | Devoted Maniac |  
+DRAGONS | DRG_051 | Strength in Numbers |  
+DRAGONS | DRG_054 | Big Ol' Whelp |  
+DRAGONS | DRG_055 | Hoard Pillager |  
+DRAGONS | DRG_056 | Parachute Brigand |  
+DRAGONS | DRG_057 | Hot Air Balloon |  
+DRAGONS | DRG_058 | Wing Commander |  
+DRAGONS | DRG_059 | Goboglide Tech |  
+DRAGONS | DRG_060 | Fire Hawk |  
+DRAGONS | DRG_061 | Gyrocopter |  
+DRAGONS | DRG_062 | Wyrmrest Purifier |  
+DRAGONS | DRG_063 | Dragonmaw Poacher |  
+DRAGONS | DRG_064 | Zul'Drak Ritualist |  
+DRAGONS | DRG_065 | Hippogryph |  
+DRAGONS | DRG_066 | Evasive Chimaera |  
+DRAGONS | DRG_067 | Troll Batrider |  
+DRAGONS | DRG_068 | Living Dragonbreath |  
+DRAGONS | DRG_069 | Platebreaker |  
+DRAGONS | DRG_070 | Dragon Breeder |  
+DRAGONS | DRG_071 | Bad Luck Albatross |  
+DRAGONS | DRG_072 | Skyfin |  
+DRAGONS | DRG_073 | Evasive Feywing |  
+DRAGONS | DRG_074 | Camouflaged Dirigible |  
+DRAGONS | DRG_075 | Cobalt Spellkin |  
+DRAGONS | DRG_076 | Faceless Corruptor |  
+DRAGONS | DRG_077 | Utgarde Grapplesniper |  
+DRAGONS | DRG_078 | Depth Charge |  
+DRAGONS | DRG_079 | Evasive Wyrm |  
+DRAGONS | DRG_081 | Scalerider |  
+DRAGONS | DRG_082 | Kobold Stickyfinger |  
+DRAGONS | DRG_084 | Tentacled Menace |  
+DRAGONS | DRG_086 | Chromatic Egg |  
+DRAGONS | DRG_088 | Dread Raven |  
+DRAGONS | DRG_089 | Dragonqueen Alexstrasza |  
+DRAGONS | DRG_090 | Murozond the Infinite |  
+DRAGONS | DRG_091 | Shu'ma |  
+DRAGONS | DRG_092 | Transmogrifier |  
+DRAGONS | DRG_095 | Veranus |  
+DRAGONS | DRG_096 | Bandersmosh |  
+DRAGONS | DRG_099 | Kronx Dragonhoof |  
+DRAGONS | DRG_102 | Azure Explorer |  
+DRAGONS | DRG_104 | Chenvaala |  
+DRAGONS | DRG_106 | Arcane Breath |  
+DRAGONS | DRG_107 | Violet Spellwing |  
+DRAGONS | DRG_109 | Mana Giant |  
+DRAGONS | DRG_201 | Crazed Netherwing |  
+DRAGONS | DRG_202 | Dragonblight Cultist |  
+DRAGONS | DRG_203 | Veiled Worshipper |  
+DRAGONS | DRG_204 | Dark Skies |  
+DRAGONS | DRG_205 | Nether Breath |  
+DRAGONS | DRG_206 | Rain of Fire |  
+DRAGONS | DRG_207 | Abyssal Summoner |  
+DRAGONS | DRG_208 | Valdris Felgorge |  
+DRAGONS | DRG_209 | Zzeraku the Warped |  
+DRAGONS | DRG_211 | Squallhunter |  
+DRAGONS | DRG_213 | Twin Tyrant |  
+DRAGONS | DRG_215 | Storm's Wrath |  
+DRAGONS | DRG_216 | Surging Tempest |  
+DRAGONS | DRG_217 | Dragon's Pack |  
+DRAGONS | DRG_218 | Corrupt Elementalist |  
+DRAGONS | DRG_219 | Lightning Breath |  
+DRAGONS | DRG_223 | Cumulo-Maximus |  
+DRAGONS | DRG_224 | Nithogg |  
+DRAGONS | DRG_225 | Sky Claw |  
+DRAGONS | DRG_226 | Amber Watcher |  
+DRAGONS | DRG_229 | Bronze Explorer |  
+DRAGONS | DRG_231 | Lightforged Crusader |  
+DRAGONS | DRG_232 | Lightforged Zealot |  
+DRAGONS | DRG_233 | Sand Breath |  
+DRAGONS | DRG_235 | Dragonrider Talritha |  
+DRAGONS | DRG_239 | Blazing Battlemage |  
+DRAGONS | DRG_242 | Shield of Galakrond |  
+DRAGONS | DRG_246 | Time Rip |  
+DRAGONS | DRG_247 | Seal Fate |  
+DRAGONS | DRG_248 | Invocation of Frost |  
+DRAGONS | DRG_249 | Awaken! |  
+DRAGONS | DRG_250 | Fiendish Rites |  
+DRAGONS | DRG_251 | Clear the Way |  
+DRAGONS | DRG_252 | Phase Stalker |  
+DRAGONS | DRG_253 | Dwarven Sharpshooter |  
+DRAGONS | DRG_254 | Primordial Explorer |  
+DRAGONS | DRG_255 | Toxic Reinforcements |  
+DRAGONS | DRG_256 | Dragonbane |  
+DRAGONS | DRG_257 | Frizz Kindleroost |  
+DRAGONS | DRG_258 | Sanctuary |  
+DRAGONS | DRG_270 | Malygos, Aspect of Magic |  
+DRAGONS | DRG_300 | Fate Weaver |  
+DRAGONS | DRG_301 | Whispers of EVIL |  
+DRAGONS | DRG_302 | Grave Rune |  
+DRAGONS | DRG_303 | Disciple of Galakrond |  
+DRAGONS | DRG_304 | Chronobreaker |  
+DRAGONS | DRG_306 | Envoy of Lazul |  
+DRAGONS | DRG_307 | Breath of the Infinite |  
+DRAGONS | DRG_308 | Mindflayer Kaahrj |  
+DRAGONS | DRG_309 | Nozdormu the Timeless |  
+DRAGONS | DRG_310 | Evasive Drakonid |  
+DRAGONS | DRG_311 | Treenforcements |  
+DRAGONS | DRG_312 | Shrubadier |  
+DRAGONS | DRG_313 | Emerald Explorer |  
+DRAGONS | DRG_314 | Aeroponics |  
+DRAGONS | DRG_315 | Embiggen |  
+DRAGONS | DRG_317 | Secure the Deck |  
+DRAGONS | DRG_318 | Breath of Dreams |  
+DRAGONS | DRG_319 | Goru the Mightree |  
+DRAGONS | DRG_320 | Ysera, Unleashed |  
+DRAGONS | DRG_321 | Rolling Fireball |  
+DRAGONS | DRG_322 | Dragoncaster |  
+DRAGONS | DRG_323 | Learn Draconic |  
+DRAGONS | DRG_324 | Elemental Allies |  
+DRAGONS | DRG_401 | Grizzled Wizard |  
+DRAGONS | DRG_402 | Sathrovarr |  
+DRAGONS | DRG_403 | Blowtorch Saboteur |  
+DRAGONS | DRG_500 | Molten Breath |  
+DRAGONS | DRG_600 | Galakrond, the Wretched |  
+DRAGONS | DRG_610 | Galakrond, the Nightmare |  
+DRAGONS | DRG_620 | Galakrond, the Tempest |  
+DRAGONS | DRG_650 | Galakrond, the Unbreakable |  
+DRAGONS | DRG_660 | Galakrond, the Unspeakable |  
+
+- Progress: 0% (0 of 140 Cards)
+
+## Saviors of Uldum
+
+Set | ID | Name | Implemented
+:---: | :---: | :---: | :---:
+ULDUM | ULD_003 | Zephrys the Great |  
+ULDUM | ULD_131 | Untapped Potential |  
+ULDUM | ULD_133 | Crystal Merchant |  
+ULDUM | ULD_134 | BEEEES!!! |  
+ULDUM | ULD_135 | Hidden Oasis |  
+ULDUM | ULD_136 | Worthy Expedition |  
+ULDUM | ULD_137 | Garden Gnome |  
+ULDUM | ULD_138 | Anubisath Defender |  
+ULDUM | ULD_139 | Elise the Enlightened |  
+ULDUM | ULD_140 | Supreme Archaeology |  
+ULDUM | ULD_143 | Pharaoh's Blessing |  
+ULDUM | ULD_145 | Brazen Zealot |  
+ULDUM | ULD_151 | Ramkahen Wildtamer |  
+ULDUM | ULD_152 | Pressure Plate |  
+ULDUM | ULD_154 | Hyena Alpha |  
+ULDUM | ULD_155 | Unseal the Vault |  
+ULDUM | ULD_156 | Dinotamer Brann |  
+ULDUM | ULD_157 | Questing Explorer |  
+ULDUM | ULD_158 | Sandstorm Elemental |  
+ULDUM | ULD_160 | Sinister Deal |  
+ULDUM | ULD_161 | Neferset Thrasher |  
+ULDUM | ULD_162 | EVIL Recruiter |  
+ULDUM | ULD_163 | Expired Merchant |  
+ULDUM | ULD_165 | Riftcleaver |  
+ULDUM | ULD_167 | Diseased Vulture |  
+ULDUM | ULD_168 | Dark Pharaoh Tekahn |  
+ULDUM | ULD_169 | Mogu Fleshshaper |  
+ULDUM | ULD_170 | Weaponized Wasp |  
+ULDUM | ULD_171 | Totemic Surge |  
+ULDUM | ULD_172 | Plague of Murlocs |  
+ULDUM | ULD_173 | Vessina |  
+ULDUM | ULD_174 | Serpent Egg |  
+ULDUM | ULD_177 | Octosari |  
+ULDUM | ULD_178 | Siamat |  
+ULDUM | ULD_179 | Phalanx Commander |  
+ULDUM | ULD_180 | Sunstruck Henchman |  
+ULDUM | ULD_181 | Earthquake |  
+ULDUM | ULD_182 | Spitting Camel |  
+ULDUM | ULD_183 | Anubisath Warbringer |  
+ULDUM | ULD_184 | Kobold Sandtrooper |  
+ULDUM | ULD_185 | Temple Berserker |  
+ULDUM | ULD_186 | Pharaoh Cat |  
+ULDUM | ULD_188 | Golden Scarab |  
+ULDUM | ULD_189 | Faceless Lurker |  
+ULDUM | ULD_190 | Pit Crocolisk |  
+ULDUM | ULD_191 | Beaming Sidekick |  
+ULDUM | ULD_193 | Living Monument |  
+ULDUM | ULD_194 | Wasteland Scorpid |  
+ULDUM | ULD_195 | Frightened Flunky |  
+ULDUM | ULD_196 | Neferset Ritualist |  
+ULDUM | ULD_197 | Quicksand Elemental |  
+ULDUM | ULD_198 | Conjured Mirage |  
+ULDUM | ULD_205 | Candletaker |  
+ULDUM | ULD_206 | Restless Mummy |  
+ULDUM | ULD_207 | Ancestral Guardian |  
+ULDUM | ULD_208 | Khartut Defender |  
+ULDUM | ULD_209 | Vulpera Scoundrel |  
+ULDUM | ULD_212 | Wild Bloodstinger |  
+ULDUM | ULD_214 | Generous Mummy |  
+ULDUM | ULD_215 | Wrapped Golem |  
+ULDUM | ULD_216 | Puzzle Box of Yogg-Saron |  
+ULDUM | ULD_217 | Micro Mummy |  
+ULDUM | ULD_229 | Mischief Maker |  
+ULDUM | ULD_231 | Whirlkick Master |  
+ULDUM | ULD_236 | Tortollan Pilgrim |  
+ULDUM | ULD_238 | Reno the Relicologist |  
+ULDUM | ULD_239 | Flame Ward |  
+ULDUM | ULD_240 | Arcane Flakmage |  
+ULDUM | ULD_250 | Infested Goblin |  
+ULDUM | ULD_253 | Tomb Warden |  
+ULDUM | ULD_256 | Into the Fray |  
+ULDUM | ULD_258 | Armagedillo |  
+ULDUM | ULD_262 | High Priest Amet |  
+ULDUM | ULD_265 | Embalming Ritual |  
+ULDUM | ULD_266 | Grandmummy |  
+ULDUM | ULD_268 | Psychopomp |  
+ULDUM | ULD_269 | Wretched Reclaimer |  
+ULDUM | ULD_270 | Sandhoof Waterbearer |  
+ULDUM | ULD_271 | Injured Tol'vir |  
+ULDUM | ULD_272 | Holy Ripple |  
+ULDUM | ULD_273 | Overflow |  
+ULDUM | ULD_274 | Wasteland Assassin |  
+ULDUM | ULD_275 | Bone Wraith |  
+ULDUM | ULD_276 | EVIL Totem |  
+ULDUM | ULD_280 | Sahket Sapper |  
+ULDUM | ULD_282 | Jar Dealer |  
+ULDUM | ULD_285 | Hooked Scimitar |  
+ULDUM | ULD_286 | Shadow of Death |  
+ULDUM | ULD_288 | Anka, the Buried |  
+ULDUM | ULD_289 | Fishflinger |  
+ULDUM | ULD_290 | History Buff |  
+ULDUM | ULD_291 | Corrupt the Waters |  
+ULDUM | ULD_292 | Oasis Surger |  
+ULDUM | ULD_293 | Cloud Prince |  
+ULDUM | ULD_304 | King Phaoris |  
+ULDUM | ULD_309 | Dwarven Archaeologist |  
+ULDUM | ULD_324 | Impbalming |  
+ULDUM | ULD_326 | Bazaar Burglary |  
+ULDUM | ULD_327 | Bazaar Mugger |  
+ULDUM | ULD_328 | Clever Disguise |  
+ULDUM | ULD_329 | Dune Sculptor |  
+ULDUM | ULD_410 | Scarlet Webweaver |  
+ULDUM | ULD_413 | Splitting Axe |  
+ULDUM | ULD_429 | Hunter's Pack |  
+ULDUM | ULD_430 | Desert Spear |  
+ULDUM | ULD_431 | Making Mummies |  
+ULDUM | ULD_433 | Raid the Sky Temple |  
+ULDUM | ULD_435 | Naga Sand Witch |  
+ULDUM | ULD_438 | Salhet's Pride |  
+ULDUM | ULD_439 | Sandwasp Queen |  
+ULDUM | ULD_450 | Vilefiend |  
+ULDUM | ULD_500 | Sir Finley of the Sands |  
+ULDUM | ULD_702 | Mortuary Machine |  
+ULDUM | ULD_703 | Desert Obelisk |  
+ULDUM | ULD_705 | Mogu Cultist |  
+ULDUM | ULD_706 | Blatant Decoy |  
+ULDUM | ULD_707 | Plague of Wrath |  
+ULDUM | ULD_708 | Livewire Lance |  
+ULDUM | ULD_709 | Armored Goon |  
+ULDUM | ULD_711 | Hack the System |  
+ULDUM | ULD_712 | Bug Collector |  
+ULDUM | ULD_713 | Swarm of Locusts |  
+ULDUM | ULD_714 | Penance |  
+ULDUM | ULD_715 | Plague of Madness |  
+ULDUM | ULD_716 | Tip the Scales |  
+ULDUM | ULD_717 | Plague of Flames |  
+ULDUM | ULD_718 | Plague of Death |  
+ULDUM | ULD_719 | Desert Hare |  
+ULDUM | ULD_720 | Bloodsworn Mercenary |  
+ULDUM | ULD_721 | Colossus of the Moon |  
+ULDUM | ULD_723 | Murmy |  
+ULDUM | ULD_724 | Activate the Obelisk |  
+ULDUM | ULD_726 | Ancient Mysteries |  
+ULDUM | ULD_727 | Body Wrapper |  
+ULDUM | ULD_728 | Subdue |  
+
+- Progress: 0% (0 of 135 Cards)
+
+## Rise of Shadows
+
+Set | ID | Name | Implemented
+:---: | :---: | :---: | :---:
+DALARAN | DAL_007 | Rafaam's Scheme |  
+DALARAN | DAL_008 | Dr. Boom's Scheme |  
+DALARAN | DAL_009 | Hagatha's Scheme |  
+DALARAN | DAL_010 | Togwaggle's Scheme |  
+DALARAN | DAL_011 | Lazul's Scheme |  
+DALARAN | DAL_030 | Shadowy Figure |  
+DALARAN | DAL_039 | Convincing Infiltrator |  
+DALARAN | DAL_040 | Hench-Clan Shadequill |  
+DALARAN | DAL_047 | Walking Fountain |  
+DALARAN | DAL_049 | Underbelly Angler |  
+DALARAN | DAL_052 | Muckmorpher |  
+DALARAN | DAL_058 | Hecklebot |  
+DALARAN | DAL_059 | Dimensional Ripper |  
+DALARAN | DAL_060 | Clockwork Goblin |  
+DALARAN | DAL_062 | Sweeping Strikes |  
+DALARAN | DAL_063 | Wrenchcalibur |  
+DALARAN | DAL_064 | Blastmaster Boom |  
+DALARAN | DAL_065 | Unsleeping Soul |  
+DALARAN | DAL_070 | The Boom Reaver |  
+DALARAN | DAL_071 | Mutate |  
+DALARAN | DAL_077 | Toxfin |  
+DALARAN | DAL_078 | Traveling Healer |  
+DALARAN | DAL_081 | Spellward Jeweler |  
+DALARAN | DAL_085 | Dalaran Crusader |  
+DALARAN | DAL_086 | Sunreaver Spy |  
+DALARAN | DAL_087 | Hench-Clan Hag |  
+DALARAN | DAL_088 | Safeguard |  
+DALARAN | DAL_089 | Spellbook Binder |  
+DALARAN | DAL_090 | Hench-Clan Sneak |  
+DALARAN | DAL_092 | Arcane Servant |  
+DALARAN | DAL_095 | Violet Spellsword |  
+DALARAN | DAL_096 | Violet Warden |  
+DALARAN | DAL_141 | Desperate Measures |  
+DALARAN | DAL_146 | Bronze Herald |  
+DALARAN | DAL_147 | Dragon Speaker |  
+DALARAN | DAL_163 | Messenger Raven |  
+DALARAN | DAL_173 | Darkest Hour |  
+DALARAN | DAL_177 | Conjurer's Calling |  
+DALARAN | DAL_182 | Magic Dart Frog |  
+DALARAN | DAL_185 | Aranasi Broodmother |  
+DALARAN | DAL_256 | The Forest's Aid |  
+DALARAN | DAL_350 | Crystal Power |  
+DALARAN | DAL_351 | Blessing of the Ancients |  
+DALARAN | DAL_352 | Crystalsong Portal |  
+DALARAN | DAL_354 | Acornbearer |  
+DALARAN | DAL_355 | Lifeweaver |  
+DALARAN | DAL_357 | Lucentbark |  
+DALARAN | DAL_366 | Unidentified Contract |  
+DALARAN | DAL_371 | Marked Shot |  
+DALARAN | DAL_372 | Arcane Fletcher |  
+DALARAN | DAL_373 | Rapid Fire |  
+DALARAN | DAL_376 | Oblivitron |  
+DALARAN | DAL_377 | Nine Lives |  
+DALARAN | DAL_378 | Unleash the Beast |  
+DALARAN | DAL_379 | Vereesa Windrunner |  
+DALARAN | DAL_400 | EVIL Cable Rat |  
+DALARAN | DAL_413 | EVIL Conscripter |  
+DALARAN | DAL_415 | EVIL Miscreant |  
+DALARAN | DAL_416 | Hench-Clan Burglar |  
+DALARAN | DAL_417 | Heistbaron Togwaggle |  
+DALARAN | DAL_422 | Arch-Villain Rafaam |  
+DALARAN | DAL_431 | Swampqueen Hagatha |  
+DALARAN | DAL_432 | Witch's Brew |  
+DALARAN | DAL_433 | Sludge Slurper |  
+DALARAN | DAL_434 | Arcane Watcher |  
+DALARAN | DAL_538 | Unseen Saboteur |  
+DALARAN | DAL_539 | Sunreaver Warmage |  
+DALARAN | DAL_544 | Potion Vendor |  
+DALARAN | DAL_546 | Barista Lynchen |  
+DALARAN | DAL_548 | Azerite Elemental |  
+DALARAN | DAL_550 | Underbelly Ooze |  
+DALARAN | DAL_551 | Proud Defender |  
+DALARAN | DAL_553 | Big Bad Archmage |  
+DALARAN | DAL_554 | Chef Nomi |  
+DALARAN | DAL_558 | Archmage Vargoth |  
+DALARAN | DAL_560 | Heroic Innkeeper |  
+DALARAN | DAL_561 | Jumbo Imp |  
+DALARAN | DAL_563 | Eager Underling |  
+DALARAN | DAL_565 | Portal Overfiend |  
+DALARAN | DAL_566 | Eccentric Scribe |  
+DALARAN | DAL_568 | Lightforged Blessing |  
+DALARAN | DAL_570 | Never Surrender! |  
+DALARAN | DAL_571 | Mysterious Blade |  
+DALARAN | DAL_573 | Commander Rhyssa |  
+DALARAN | DAL_575 | Khadgar |  
+DALARAN | DAL_576 | Kirin Tor Tricaster |  
+DALARAN | DAL_577 | Ray of Frost |  
+DALARAN | DAL_578 | Power of Creation |  
+DALARAN | DAL_581 | Nozari |  
+DALARAN | DAL_582 | Portal Keeper |  
+DALARAN | DAL_587 | Shimmerfly |  
+DALARAN | DAL_589 | Hunting Party |  
+DALARAN | DAL_592 | Batterhead |  
+DALARAN | DAL_602 | Plot Twist |  
+DALARAN | DAL_603 | Mana Cyclone |  
+DALARAN | DAL_604 | Ursatron |  
+DALARAN | DAL_605 | Impferno |  
+DALARAN | DAL_606 | EVIL Genius |  
+DALARAN | DAL_607 | Fel Lord Betrug |  
+DALARAN | DAL_608 | Magic Trick |  
+DALARAN | DAL_609 | Kalecgos |  
+DALARAN | DAL_710 | Soul of the Murloc |  
+DALARAN | DAL_714 | Underbelly Fence |  
+DALARAN | DAL_716 | Vendetta |  
+DALARAN | DAL_719 | Tak Nozwhisker |  
+DALARAN | DAL_720 | Waggle Pick |  
+DALARAN | DAL_721 | Catrina Muerte |  
+DALARAN | DAL_723 | Forbidden Words |  
+DALARAN | DAL_724 | Mass Resurrection |  
+DALARAN | DAL_726 | Scargil |  
+DALARAN | DAL_727 | Call to Adventure |  
+DALARAN | DAL_728 | Daring Escape |  
+DALARAN | DAL_729 | Madame Lazul |  
+DALARAN | DAL_731 | Duel! |  
+DALARAN | DAL_732 | Keeper Stalladris |  
+DALARAN | DAL_733 | Dreamway Guardians |  
+DALARAN | DAL_735 | Dalaran Librarian |  
+DALARAN | DAL_736 | Archivist Elysiana |  
+DALARAN | DAL_742 | Whirlwind Tempest |  
+DALARAN | DAL_743 | Hench-Clan Hogsteed |  
+DALARAN | DAL_744 | Faceless Rager |  
+DALARAN | DAL_747 | Flight Master |  
+DALARAN | DAL_748 | Mana Reservoir |  
+DALARAN | DAL_749 | Recurring Villain |  
+DALARAN | DAL_751 | Mad Summoner |  
+DALARAN | DAL_752 | Jepetto Joybuzz |  
+DALARAN | DAL_759 | Vicious Scraphound |  
+DALARAN | DAL_760 | Burly Shovelfist |  
+DALARAN | DAL_769 | Improve Morale |  
+DALARAN | DAL_770 | Omega Devastator |  
+DALARAN | DAL_771 | Soldier of Fortune |  
+DALARAN | DAL_773 | Magic Carpet |  
+DALARAN | DAL_774 | Exotic Mountseller |  
+DALARAN | DAL_775 | Tunnel Blaster |  
+DALARAN | DAL_799 | Crystal Stag |  
+
+- Progress: 0% (0 of 135 Cards)

--- a/Extensions/RosettaTool/main.cpp
+++ b/Extensions/RosettaTool/main.cpp
@@ -45,7 +45,7 @@ inline std::string ToString(const clara::Parser& p)
 inline bool CheckCardImpl(const std::string& path, const std::string& id)
 {
 #if defined(ROSETTASTONE_WINDOWS) || defined(ROSETTASTONE_LINUX)
-    const filesystem::path p(path + "/Sources/Rosetta/CardSets");
+    const filesystem::path p(path + "/Tests/UnitTests/CardSets");
 
     if (!filesystem::exists(p))
     {

--- a/Includes/Rosetta/CardSets/DalaranCardsGen.hpp
+++ b/Includes/Rosetta/CardSets/DalaranCardsGen.hpp
@@ -1,0 +1,236 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_DALARAN_CARDS_GEN_HPP
+#define ROSETTASTONE_DALARAN_CARDS_GEN_HPP
+
+#include <Rosetta/Enchants/Power.hpp>
+
+#include <map>
+#include <string>
+
+namespace RosettaStone
+{
+using PowersType = std::map<std::string, Power>;
+using PlayReqs = std::map<PlayReq, int>;
+using PlayReqsType = std::map<std::string, PlayReqs>;
+using Entourages = std::vector<std::string>;
+using EntouragesType = std::map<std::string, Entourages>;
+
+//!
+//! \brief DalaranCardsGen class.
+//!
+//! This structure adds DALARAN cards to the data storage with powers,
+//! play requirements and entourages.
+//!
+class DalaranCardsGen
+{
+ public:
+    //! Adds hero cards to \p powers, \p playReqs and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddHeroes(PowersType& powers, PlayReqsType& playReqs,
+                          EntouragesType& entourages);
+
+    //! Adds hero power cards to \p powers, \p playReqs and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddHeroPowers(PowersType& powers, PlayReqsType& playReqs,
+                              EntouragesType& entourages);
+
+    //! Adds druid cards that are collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddDruid(PowersType& powers, PlayReqsType& playReqs,
+                         EntouragesType& entourages);
+
+    //! Adds druid cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddDruidNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                   EntouragesType& entourages);
+
+    //! Adds hunter cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddHunter(PowersType& powers, PlayReqsType& playReqs,
+                          EntouragesType& entourages);
+
+    //! Adds hunter cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddHunterNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                    EntouragesType& entourages);
+
+    //! Adds mage cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddMage(PowersType& powers, PlayReqsType& playReqs,
+                        EntouragesType& entourages);
+
+    //! Adds mage cards that are not collectible to \p powers and \p playReqs.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddMageNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                  EntouragesType& entourages);
+
+    //! Adds paladin cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddPaladin(PowersType& powers, PlayReqsType& playReqs,
+                           EntouragesType& entourages);
+
+    //! Adds paladin cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddPaladinNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                     EntouragesType& entourages);
+
+    //! Adds priest cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddPriest(PowersType& powers, PlayReqsType& playReqs,
+                          EntouragesType& entourages);
+
+    //! Adds priest cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddPriestNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                    EntouragesType& entourages);
+
+    //! Adds rogue cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddRogue(PowersType& powers, PlayReqsType& playReqs,
+                         EntouragesType& entourages);
+
+    //! Adds rogue cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddRogueNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                   EntouragesType& entourages);
+
+    //! Adds shaman cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddShaman(PowersType& powers, PlayReqsType& playReqs,
+                          EntouragesType& entourages);
+
+    //! Adds shaman cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddShamanNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                    EntouragesType& entourages);
+
+    //! Adds warlock cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddWarlock(PowersType& powers, PlayReqsType& playReqs,
+                           EntouragesType& entourages);
+
+    //! Adds warlock cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddWarlockNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                     EntouragesType& entourages);
+
+    //! Adds warrior cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddWarrior(PowersType& powers, PlayReqsType& playReqs,
+                           EntouragesType& entourages);
+
+    //! Adds warrior cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddWarriorNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                     EntouragesType& entourages);
+
+    //! Adds neutral cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddNeutral(PowersType& powers, PlayReqsType& playReqs,
+                           EntouragesType& entourages);
+
+    //! Adds neutral cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddNeutralNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                     EntouragesType& entourages);
+
+    //! Adds all cards to \p powers, \p playReqs and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddAll(PowersType& powers, PlayReqsType& playReqs,
+                       EntouragesType& entourages);
+};
+}  // namespace RosettaStone
+
+#endif  // ROSETTASTONE_DALARAN_CARDS_GEN_HPP

--- a/Includes/Rosetta/CardSets/DragonsCardsGen.hpp
+++ b/Includes/Rosetta/CardSets/DragonsCardsGen.hpp
@@ -1,0 +1,236 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_DRAGONS_CARDS_GEN_HPP
+#define ROSETTASTONE_DRAGONS_CARDS_GEN_HPP
+
+#include <Rosetta/Enchants/Power.hpp>
+
+#include <map>
+#include <string>
+
+namespace RosettaStone
+{
+using PowersType = std::map<std::string, Power>;
+using PlayReqs = std::map<PlayReq, int>;
+using PlayReqsType = std::map<std::string, PlayReqs>;
+using Entourages = std::vector<std::string>;
+using EntouragesType = std::map<std::string, Entourages>;
+
+//!
+//! \brief DragonsCardsGen class.
+//!
+//! This structure adds DRAGONS cards to the data storage with powers,
+//! play requirements and entourages.
+//!
+class DragonsCardsGen
+{
+ public:
+    //! Adds hero cards to \p powers, \p playReqs and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddHeroes(PowersType& powers, PlayReqsType& playReqs,
+                          EntouragesType& entourages);
+
+    //! Adds hero power cards to \p powers, \p playReqs and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddHeroPowers(PowersType& powers, PlayReqsType& playReqs,
+                              EntouragesType& entourages);
+
+    //! Adds druid cards that are collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddDruid(PowersType& powers, PlayReqsType& playReqs,
+                         EntouragesType& entourages);
+
+    //! Adds druid cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddDruidNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                   EntouragesType& entourages);
+
+    //! Adds hunter cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddHunter(PowersType& powers, PlayReqsType& playReqs,
+                          EntouragesType& entourages);
+
+    //! Adds hunter cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddHunterNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                    EntouragesType& entourages);
+
+    //! Adds mage cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddMage(PowersType& powers, PlayReqsType& playReqs,
+                        EntouragesType& entourages);
+
+    //! Adds mage cards that are not collectible to \p powers and \p playReqs.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddMageNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                  EntouragesType& entourages);
+
+    //! Adds paladin cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddPaladin(PowersType& powers, PlayReqsType& playReqs,
+                           EntouragesType& entourages);
+
+    //! Adds paladin cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddPaladinNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                     EntouragesType& entourages);
+
+    //! Adds priest cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddPriest(PowersType& powers, PlayReqsType& playReqs,
+                          EntouragesType& entourages);
+
+    //! Adds priest cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddPriestNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                    EntouragesType& entourages);
+
+    //! Adds rogue cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddRogue(PowersType& powers, PlayReqsType& playReqs,
+                         EntouragesType& entourages);
+
+    //! Adds rogue cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddRogueNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                   EntouragesType& entourages);
+
+    //! Adds shaman cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddShaman(PowersType& powers, PlayReqsType& playReqs,
+                          EntouragesType& entourages);
+
+    //! Adds shaman cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddShamanNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                    EntouragesType& entourages);
+
+    //! Adds warlock cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddWarlock(PowersType& powers, PlayReqsType& playReqs,
+                           EntouragesType& entourages);
+
+    //! Adds warlock cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddWarlockNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                     EntouragesType& entourages);
+
+    //! Adds warrior cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddWarrior(PowersType& powers, PlayReqsType& playReqs,
+                           EntouragesType& entourages);
+
+    //! Adds warrior cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddWarriorNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                     EntouragesType& entourages);
+
+    //! Adds neutral cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddNeutral(PowersType& powers, PlayReqsType& playReqs,
+                           EntouragesType& entourages);
+
+    //! Adds neutral cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddNeutralNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                     EntouragesType& entourages);
+
+    //! Adds all cards to \p powers, \p playReqs and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddAll(PowersType& powers, PlayReqsType& playReqs,
+                       EntouragesType& entourages);
+};
+}  // namespace RosettaStone
+
+#endif  // ROSETTASTONE_DRAGONS_CARDS_GEN_HPP

--- a/Includes/Rosetta/CardSets/UldumCardsGen.hpp
+++ b/Includes/Rosetta/CardSets/UldumCardsGen.hpp
@@ -1,0 +1,236 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_ULDUM_CARDS_GEN_HPP
+#define ROSETTASTONE_ULDUM_CARDS_GEN_HPP
+
+#include <Rosetta/Enchants/Power.hpp>
+
+#include <map>
+#include <string>
+
+namespace RosettaStone
+{
+using PowersType = std::map<std::string, Power>;
+using PlayReqs = std::map<PlayReq, int>;
+using PlayReqsType = std::map<std::string, PlayReqs>;
+using Entourages = std::vector<std::string>;
+using EntouragesType = std::map<std::string, Entourages>;
+
+//!
+//! \brief UldumCardsGen class.
+//!
+//! This structure adds ULDUM cards to the data storage with powers,
+//! play requirements and entourages.
+//!
+class UldumCardsGen
+{
+ public:
+    //! Adds hero cards to \p powers, \p playReqs and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddHeroes(PowersType& powers, PlayReqsType& playReqs,
+                          EntouragesType& entourages);
+
+    //! Adds hero power cards to \p powers, \p playReqs and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddHeroPowers(PowersType& powers, PlayReqsType& playReqs,
+                              EntouragesType& entourages);
+
+    //! Adds druid cards that are collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddDruid(PowersType& powers, PlayReqsType& playReqs,
+                         EntouragesType& entourages);
+
+    //! Adds druid cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddDruidNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                   EntouragesType& entourages);
+
+    //! Adds hunter cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddHunter(PowersType& powers, PlayReqsType& playReqs,
+                          EntouragesType& entourages);
+
+    //! Adds hunter cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddHunterNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                    EntouragesType& entourages);
+
+    //! Adds mage cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddMage(PowersType& powers, PlayReqsType& playReqs,
+                        EntouragesType& entourages);
+
+    //! Adds mage cards that are not collectible to \p powers and \p playReqs.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddMageNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                  EntouragesType& entourages);
+
+    //! Adds paladin cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddPaladin(PowersType& powers, PlayReqsType& playReqs,
+                           EntouragesType& entourages);
+
+    //! Adds paladin cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddPaladinNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                     EntouragesType& entourages);
+
+    //! Adds priest cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddPriest(PowersType& powers, PlayReqsType& playReqs,
+                          EntouragesType& entourages);
+
+    //! Adds priest cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddPriestNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                    EntouragesType& entourages);
+
+    //! Adds rogue cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddRogue(PowersType& powers, PlayReqsType& playReqs,
+                         EntouragesType& entourages);
+
+    //! Adds rogue cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddRogueNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                   EntouragesType& entourages);
+
+    //! Adds shaman cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddShaman(PowersType& powers, PlayReqsType& playReqs,
+                          EntouragesType& entourages);
+
+    //! Adds shaman cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddShamanNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                    EntouragesType& entourages);
+
+    //! Adds warlock cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddWarlock(PowersType& powers, PlayReqsType& playReqs,
+                           EntouragesType& entourages);
+
+    //! Adds warlock cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddWarlockNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                     EntouragesType& entourages);
+
+    //! Adds warrior cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddWarrior(PowersType& powers, PlayReqsType& playReqs,
+                           EntouragesType& entourages);
+
+    //! Adds warrior cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddWarriorNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                     EntouragesType& entourages);
+
+    //! Adds neutral cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddNeutral(PowersType& powers, PlayReqsType& playReqs,
+                           EntouragesType& entourages);
+
+    //! Adds neutral cards that are not collectible to \p powers, \p playReqs
+    //! and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddNeutralNonCollect(PowersType& powers, PlayReqsType& playReqs,
+                                     EntouragesType& entourages);
+
+    //! Adds all cards to \p powers, \p playReqs and \p entourages.
+    //! \param powers The data storage to store added cards with powers.
+    //! \param playReqs The data storage to store added cards with
+    //! play requirements.
+    //! \param entourages The data storage to store added cards with entourages.
+    static void AddAll(PowersType& powers, PlayReqsType& playReqs,
+                       EntouragesType& entourages);
+};
+}  // namespace RosettaStone
+
+#endif  // ROSETTASTONE_ULDUM_CARDS_GEN_HPP

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -36,8 +36,11 @@
 #include <Rosetta/Auras/SummoningPortalAura.hpp>
 #include <Rosetta/Auras/SwitchingAura.hpp>
 #include <Rosetta/CardSets/CoreCardsGen.hpp>
+#include <Rosetta/CardSets/DalaranCardsGen.hpp>
+#include <Rosetta/CardSets/DragonsCardsGen.hpp>
 #include <Rosetta/CardSets/Expert1CardsGen.hpp>
 #include <Rosetta/CardSets/HoFCardsGen.hpp>
+#include <Rosetta/CardSets/UldumCardsGen.hpp>
 #include <Rosetta/Cards/Card.hpp>
 #include <Rosetta/Cards/Cards.hpp>
 #include <Rosetta/Commons/Constants.hpp>

--- a/README.md
+++ b/README.md
@@ -33,13 +33,32 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ## Roadmap
 
+### 2020
+
+  * Implement all standard cards
+    * Rise of Shadows
+    * Saviors of Uldum
+    * Descent of Dragons
+  * Implement programs for playing game
+    * Console-based
+    * GUI-based
+    * Web-based
+  * Prepare "Hearthstone pro gamer" vs AI match-up
+  * Implement "Hearthstone Battlegrounds"
+  * Support various deep-learning framework for RL environment
+    * Tensorflow
+    * PyTorch
+  * Fully support Python API
+  * Write a paper on Hearthstone's RL environment
+  * Make architecture documents for contributors
+  * Make tutorials for programs
+
 ### 2019
 
-  * Implement all original + some expansion cards
-  * Fully support console and GUI program
+  * Implement all original cards
+  * Implement console and GUI program
   * Provide RL environment using PyTorch C++ API
   * Support API for another language such as Python
-  * Integrate with RealStone, "Real" Hearthstone hardware using Arduino
 
 ### 2018
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
   * **100% Basic (133 of 133 Cards)**
   * **100% Classic (245 of 245 Cards)**
-  * 37% Hall of Fame (9 of 24 Cards)
+  * 54% Hall of Fame (13 of 24 Cards)
 
 ### Adventures
 

--- a/Sources/Rosetta/CardSets/DalaranCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DalaranCardsGen.cpp
@@ -1,0 +1,188 @@
+﻿// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/CardSets/DalaranCardsGen.hpp>
+
+namespace RosettaStone
+{
+void DalaranCardsGen::AddHeroes(PowersType& powers, PlayReqsType& playReqs,
+                                EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddHeroPowers(PowersType& powers, PlayReqsType& playReqs,
+                                    EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddDruid(PowersType& powers, PlayReqsType& playReqs,
+                               EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddDruidNonCollect(PowersType& powers,
+                                         PlayReqsType& playReqs,
+                                         EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddHunter(PowersType& powers, PlayReqsType& playReqs,
+                                EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddHunterNonCollect(PowersType& powers,
+                                          PlayReqsType& playReqs,
+                                          EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddMage(PowersType& powers, PlayReqsType& playReqs,
+                              EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddMageNonCollect(PowersType& powers,
+                                        PlayReqsType& playReqs,
+                                        EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddPaladin(PowersType& powers, PlayReqsType& playReqs,
+                                 EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddPaladinNonCollect(PowersType& powers,
+                                           PlayReqsType& playReqs,
+                                           EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddPriest(PowersType& powers, PlayReqsType& playReqs,
+                                EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddPriestNonCollect(PowersType& powers,
+                                          PlayReqsType& playReqs,
+                                          EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddRogue(PowersType& powers, PlayReqsType& playReqs,
+                               EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddRogueNonCollect(PowersType& powers,
+                                         PlayReqsType& playReqs,
+                                         EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddShaman(PowersType& powers, PlayReqsType& playReqs,
+                                EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddShamanNonCollect(PowersType& powers,
+                                          PlayReqsType& playReqs,
+                                          EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddWarlock(PowersType& powers, PlayReqsType& playReqs,
+                                 EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddWarlockNonCollect(PowersType& powers,
+                                           PlayReqsType& playReqs,
+                                           EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddWarrior(PowersType& powers, PlayReqsType& playReqs,
+                                 EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddWarriorNonCollect(PowersType& powers,
+                                           PlayReqsType& playReqs,
+                                           EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddNeutral(PowersType& powers, PlayReqsType& playReqs,
+                                 EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddNeutralNonCollect(PowersType& powers,
+                                           PlayReqsType& playReqs,
+                                           EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DalaranCardsGen::AddAll(PowersType& powers, PlayReqsType& playReqs,
+                             EntouragesType& entourages)
+{
+    AddHeroes(powers, playReqs, entourages);
+    AddHeroPowers(powers, playReqs, entourages);
+
+    AddDruid(powers, playReqs, entourages);
+    AddDruidNonCollect(powers, playReqs, entourages);
+
+    AddHunter(powers, playReqs, entourages);
+    AddHunterNonCollect(powers, playReqs, entourages);
+
+    AddMage(powers, playReqs, entourages);
+    AddMageNonCollect(powers, playReqs, entourages);
+
+    AddPaladin(powers, playReqs, entourages);
+    AddPaladinNonCollect(powers, playReqs, entourages);
+
+    AddPriest(powers, playReqs, entourages);
+    AddPriestNonCollect(powers, playReqs, entourages);
+
+    AddRogue(powers, playReqs, entourages);
+    AddRogueNonCollect(powers, playReqs, entourages);
+
+    AddShaman(powers, playReqs, entourages);
+    AddShamanNonCollect(powers, playReqs, entourages);
+
+    AddWarlock(powers, playReqs, entourages);
+    AddWarlockNonCollect(powers, playReqs, entourages);
+
+    AddWarrior(powers, playReqs, entourages);
+    AddWarriorNonCollect(powers, playReqs, entourages);
+
+    AddNeutral(powers, playReqs, entourages);
+    AddNeutralNonCollect(powers, playReqs, entourages);
+}
+}  // namespace RosettaStone

--- a/Sources/Rosetta/CardSets/DalaranCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DalaranCardsGen.cpp
@@ -22,131 +22,2319 @@ void DalaranCardsGen::AddHeroPowers(PowersType& powers, PlayReqsType& playReqs,
 void DalaranCardsGen::AddDruid(PowersType& powers, PlayReqsType& playReqs,
                                EntouragesType& entourages)
 {
-    (void)powers;
+    // ------------------------------------------ SPELL - DRUID
+    // [DAL_256] The Forest's Aid - COST:8
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Twinspell</b> Summon five 2/2 Treants.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TWINSPELL_COPY = 52821
+    // - TWINSPELL = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [DAL_350] Crystal Power - COST:1
+    // - Faction: Neutral, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Choose One -</b> Deal 2 damage to a minion;
+    //       or Restore 5 Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CHOOSE_ONE = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [DAL_351] Blessing of the Ancients - COST:3
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Twinspell</b> Give your minions +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TWINSPELL_COPY = 54128
+    // - TWINSPELL = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [DAL_352] Crystalsong Portal - COST:2
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Discover</b> a Druid minion.
+    //       If your hand has no minions, keep all 3.
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [DAL_354] Acornbearer - COST:1 [ATK:2/HP:1]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Add two 1/1 Squirrels to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [DAL_355] Lifeweaver - COST:3 [ATK:2/HP:5]
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Whenever you restore Health,
+    //       add a random Druid spell to your hand.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [DAL_357] Lucentbark - COST:8 [ATK:4/HP:8]
+    // - Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Deathrattle:</b> Go dormant.
+    //       Restore 5 Health to awaken this minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - TAUNT = 1
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [DAL_732] Keeper Stalladris - COST:2 [ATK:2/HP:3]
+    // - Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: After you cast a <b>Choose One</b> spell,
+    //       add copies of both choices to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [DAL_733] Dreamway Guardians - COST:2
+    // - Faction: Neutral, Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Summon two 1/2 Dryads with <b>Lifesteal</b>.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - LIFESTEAL = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [DAL_799] Crystal Stag - COST:5 [ATK:4/HP:4]
+    // - Race: Beast, Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>. <b>Battlecry:</b> If you've restored
+    //       5 Health this game, summon a copy of this.
+    //       @ <i>({0} left!)</i>@ <i>(Ready!)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - RUSH = 1
+    // - PLAYER_TAG_THRESHOLD_TAG_ID = 958
+    // - PLAYER_TAG_THRESHOLD_VALUE = 5
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddDruidNonCollect(PowersType& powers,
                                          PlayReqsType& playReqs,
                                          EntouragesType& entourages)
 {
-    (void)powers;
+    // ----------------------------------------- MINION - DRUID
+    // [DAL_256t2] Treant (*) - COST:2 [ATK:2/HP:2]
+    // - Set: Dalaran
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [DAL_256ts] The Forest's Aid (*) - COST:8
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Summon five 2/2 Treants.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [DAL_350a] Piercing Thorns (*) - COST:1
+    // - Faction: Neutral, Set: Dalaran
+    // --------------------------------------------------------
+    // Text: Deal 2 damage to a minion.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [DAL_350b] Healing Blossom (*) - COST:1
+    // - Faction: Neutral, Set: Dalaran,
+    // --------------------------------------------------------
+    // Text: Restore 5 Health.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [DAL_351ts] Blessing of the Ancients (*) - COST:3
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Give your minions +1/+1.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [DAL_354t] Squirrel (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Beast, Set: Dalaran
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [DAL_357t] Spirit of Lucentbark (*) - COST:11 [ATK:0/HP:1]
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: When you restore 5 Health, awaken this minion.
+    //       <i>(@ left!)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_SCRIPT_DATA_NUM_1 = 5
+    // - HIDE_STATS = 1
+    // - UNTOUCHABLE = 1
+    // - SCORE_VALUE_1 = 5
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [DAL_733t] Crystal Dryad (*) - COST:1 [ATK:1/HP:2]
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: <b>Lifesteal</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - LIFESTEAL = 1
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddHunter(PowersType& powers, PlayReqsType& playReqs,
                                 EntouragesType& entourages)
 {
-    (void)powers;
+    // ----------------------------------------- SPELL - HUNTER
+    // [DAL_371] Marked Shot - COST:4
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Deal 4 damage to a minion. <b>Discover</b> a spell.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [DAL_372] Arcane Fletcher - COST:4 [ATK:3/HP:3]
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Whenever you play a 1-Cost minion,
+    //       draw a spell from your deck.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [DAL_373] Rapid Fire - COST:1
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Twinspell</b> Deal 1 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TWINSPELL_COPY = 54143
+    // - TWINSPELL = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [DAL_376] Oblivitron - COST:6 [ATK:3/HP:4]
+    // - Race: Mechanical, Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon a Mech from your hand
+    //       and trigger its <b>Deathrattle</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [DAL_377] Nine Lives - COST:3
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Discover</b> a friendly <b>Deathrattle</b> minion that
+    //       died this game. Also trigger its <b>Deathrattle</b>.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_FRIENDLY_DEATHRATTLE_MINION_DIED_THIS_GAME = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [DAL_378] Unleash the Beast - COST:6
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Twinspell</b> Summon a 5/5 Wyvern with <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TWINSPELL_COPY = 54145
+    // - TWINSPELL = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [DAL_379] Vereesa Windrunner - COST:7 [ATK:5/HP:6]
+    // - Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Equip Thori'dal, the Stars' Fury.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [DAL_587] Shimmerfly - COST:1 [ATK:1/HP:1]
+    // - Race: Beast, Set: Dalaran, Rarity: rare
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Add a random Hunter spell to your hand.
+    // --------------------------------------------------------
+    // Entourage: NEW1_032, NEW1_033, NEW1_034
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [DAL_589] Hunting Party - COST:5
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Copy all Beasts in your hand.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [DAL_604] Ursatron - COST:3 [ATK:3/HP:3]
+    // - Race: Mechanical, Faction: Neutral, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Draw a Mech from your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddHunterNonCollect(PowersType& powers,
                                           PlayReqsType& playReqs,
                                           EntouragesType& entourages)
 {
-    (void)powers;
+    // ----------------------------------------- SPELL - HUNTER
+    // [DAL_373ts] Rapid Fire (*) - COST:1
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Deal 1 damage.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [DAL_378t1] Wyvern (*) - COST:5 [ATK:5/HP:5]
+    // - Race: Beast, Set: Dalaran
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [DAL_378ts] Unleash the Beast (*) - COST:6
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Summon a 5/5 Wyvern with <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - HIDE_ATTACK = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - HUNTER
+    // [DAL_379e] Stars' Fury (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: You have <b>Spell Damage +2</b> this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- WEAPON - HUNTER
+    // [DAL_379t] Thori'dal, the Stars' Fury (*) - COST:3 [ATK:2/HP:0]
+    // - Set: Dalaran,
+    // --------------------------------------------------------
+    // Text: After your hero attacks, gain <b>Spell Damage +2</b> this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DURABILITY = 3
+    // --------------------------------------------------------
+    // RefTag:
+    // - SPELLPOWER = 1
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddMage(PowersType& powers, PlayReqsType& playReqs,
                               EntouragesType& entourages)
 {
-    (void)powers;
+    // ------------------------------------------ MINION - MAGE
+    // [DAL_163] Messenger Raven - COST:3 [ATK:3/HP:2]
+    // - Race: Beast, Faction: Neutral, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Discover</b> a Mage minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DAL_177] Conjurer's Calling - COST:3
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Twinspell</b> Destroy a minion.
+    //       Summon 2 minions of the same Cost to replace it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TWINSPELL_COPY = 52637
+    // - TWINSPELL = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [DAL_182] Magic Dart Frog - COST:2 [ATK:1/HP:3]
+    // - Race: Beast, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: After you cast a spell, deal 1 damage to a random enemy minion.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [DAL_575] Khadgar - COST:2 [ATK:2/HP:2]
+    // - Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Your cards that summon minions summon twice as many.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [DAL_576] Kirin Tor Tricaster - COST:4 [ATK:3/HP:3]
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Spell Damage +3</b> Your spells cost (1) more.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPELLPOWER = 3
+    // - AURA = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DAL_577] Ray of Frost - COST:1
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Twinspell</b> <b>Freeze</b> a minion.
+    //       If it's already <b>Frozen</b>, deal 2 damage to it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TWINSPELL_COPY = 54193
+    // - TWINSPELL = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - FREEZE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DAL_578] Power of Creation - COST:8
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Discover</b> a 6-Cost minion. Summon two copies of it.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [DAL_603] Mana Cyclone - COST:2 [ATK:2/HP:2]
+    // - Race: Elemental, Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> For each spell you've cast this turn,
+    //       add a random Mage spell to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DAL_608] Magic Trick - COST:1
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Discover</b> a spell that costs (3) or less.
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [DAL_609] Kalecgos - COST:10 [ATK:4/HP:12]
+    // - Race: Dragon, Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Your first spell each turn costs (0).
+    //       <b>Battlecry:</b> <b>Discover</b> a spell.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - AURA = 1
+    // - DISCOVER = 1
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddMageNonCollect(PowersType& powers,
                                         PlayReqsType& playReqs,
                                         EntouragesType& entourages)
 {
-    (void)powers;
+    // ------------------------------------------- SPELL - MAGE
+    // [DAL_177ts] Conjurer's Calling (*) - COST:3
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Destroy a minion. Summon 2 minions of the same Cost to replace it.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DAL_577ts] Ray of Frost (*) - COST:1
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Freeze</b> a minion.
+    //       If it's already <b>Frozen</b>, deal 2 damage to it.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - FREEZE = 1
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddPaladin(PowersType& powers, PlayReqsType& playReqs,
                                  EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------------- SPELL - PALADIN
+    // [DAL_141] Desperate Measures - COST:1
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Twinspell</b> Cast a random Paladin <b>Secret</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TWINSPELL_COPY = 54129
+    // - TWINSPELL = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_SECRET_ZONE_CAP_FOR_NON_SECRET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [DAL_146] Bronze Herald - COST:3 [ATK:3/HP:2]
+    // - Race: Dragon, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Add two 4/4 Dragons to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [DAL_147] Dragon Speaker - COST:5 [ATK:3/HP:5]
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give all Dragons in your hand +3/+3.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [DAL_568] Lightforged Blessing - COST:2
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Twinspell</b> Give a friendly minion <b>Lifesteal</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TWINSPELL_COPY = 54189
+    // - TWINSPELL = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - LIFESTEAL = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [DAL_570] Never Surrender! - COST:1
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Secret:</b> When your opponent casts a spell,
+    //       give your minions +2 Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- WEAPON - PALADIN
+    // [DAL_571] Mysterious Blade - COST:2 [ATK:2/HP:0]
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you control a
+    //       <b>Secret</b>, gain +1 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 2
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [DAL_573] Commander Rhyssa - COST:3 [ATK:4/HP:3]
+    // - Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Your <b>Secrets</b> trigger twice.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - AURA = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [DAL_581] Nozari - COST:10 [ATK:4/HP:12]
+    // - Race: Dragon, Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Restore both heroes to full Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - AFFECTED_BY_HEALING_DOES_DAMAGE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [DAL_727] Call to Adventure - COST:3
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Draw the lowest Cost minion from your deck. Give it +2/+2.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [DAL_731] Duel! - COST:5
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Summon a minion from each player's deck. They fight!
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddPaladinNonCollect(PowersType& powers,
                                            PlayReqsType& playReqs,
                                            EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------------- SPELL - PALADIN
+    // [DAL_141ts] Desperate Measures (*) - COST:1
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Cast a random Paladin <b>Secret</b>.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_SECRET_ZONE_CAP_FOR_NON_SECRET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [DAL_146t] Bronze Dragon (*) - COST:4 [ATK:4/HP:4]
+    // - Race: Dragon, Set: Dalaran
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [DAL_568e] Lightforged Blessing (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: <b>Lifesteal</b>
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [DAL_568ts] Lightforged Blessing (*) - COST:2
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Give a friendly minion <b>Lifesteal</b>.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - LIFESTEAL = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [DAL_571e] Mysterious (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: +1 Attack.
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddPriest(PowersType& powers, PlayReqsType& playReqs,
                                 EntouragesType& entourages)
 {
-    (void)powers;
+    // ----------------------------------------- SPELL - PRIEST
+    // [DAL_011] Lazul's Scheme - COST:0
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Reduce the Attack of an enemy minion by
+    //       @ until your next turn. <i>(Upgrades each turn!)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_SCRIPT_DATA_NUM_1 = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_ENEMY_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [DAL_030] Shadowy Figure - COST:2 [ATK:2/HP:2]
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Transform into a 2/2 copy of
+    //       a friendly <b>Deathrattle</b> minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_TARGET_WITH_DEATHRATTLE = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [DAL_039] Convincing Infiltrator - COST:5 [ATK:2/HP:6]
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Deathrattle:</b> Destroy a random enemy minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [DAL_040] Hench-Clan Shadequill - COST:4 [ATK:4/HP:7]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Restore 5 Health to the enemy hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // - AFFECTED_BY_HEALING_DOES_DAMAGE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [DAL_065] Unsleeping Soul - COST:4
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Silence</b> a friendly minion, then summon a copy of it.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - SILENCE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [DAL_413] EVIL Conscripter - COST:2 [ATK:2/HP:2]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Add a <b>Lackey</b> to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [DAL_721] Catrina Muerte - COST:8 [ATK:6/HP:8]
+    // - Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: At the end of your turn, summon a friendly minion
+    //       that died this game.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [DAL_723] Forbidden Words - COST:0
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Spend all your Mana. Destroy a minion with that
+    //       much Attack or less.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ85 = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [DAL_724] Mass Resurrection - COST:9
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Summon 3 friendly minions that died this game.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // - REQ_FRIENDLY_MINION_DIED_THIS_GAME = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [DAL_729] Madame Lazul - COST:3 [ATK:3/HP:2]
+    // - Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Discover</b> a
+    //       copy of a card in your opponent's hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddPriestNonCollect(PowersType& powers,
                                           PlayReqsType& playReqs,
                                           EntouragesType& entourages)
 {
-    (void)powers;
+    // ----------------------------------- ENCHANTMENT - PRIEST
+    // [DAL_030e] Shade (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: 2/2.
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddRogue(PowersType& powers, PlayReqsType& playReqs,
                                EntouragesType& entourages)
 {
-    (void)powers;
+    // ------------------------------------------ SPELL - ROGUE
+    // [DAL_010] Togwaggle's Scheme - COST:1
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Choose a minion. Shuffle @ (copy, copies) of it into your deck.
+    //       <i>(Upgrades each turn!)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_SCRIPT_DATA_NUM_1 = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [DAL_366] Unidentified Contract - COST:6
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Destroy a minion. Gains a bonus effect in your hand.
+    // --------------------------------------------------------
+    // Entourage: DAL_366t1, DAL_366t2, DAL_366t3, DAL_366t4
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [DAL_415] EVIL Miscreant - COST:3 [ATK:1/HP:5]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Combo:</b> Add two random <b>Lackeys</b> to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - COMBO = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [DAL_416] Hench-Clan Burglar - COST:4 [ATK:4/HP:3]
+    // - Race: Pirate, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Discover</b> a spell from another class.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [DAL_417] Heistbaron Togwaggle - COST:6 [ATK:5/HP:5]
+    // - Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you control a_<b>Lackey</b>,
+    //       choose a fantastic treasure.
+    // --------------------------------------------------------
+    // Entourage: LOOT_998h, LOOT_998j, LOOT_998l, LOOT_998k
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - MULTIPLY_BUFF_VALUE = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [DAL_714] Underbelly Fence - COST:2 [ATK:2/HP:3]
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you're holding a card from
+    //       another class, gain +1/+1 and <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [DAL_716] Vendetta - COST:4
+    // - Faction: Neutral, Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Deal 4 damage to a minion. Costs (0) if you're
+    //       holding a card from another class.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [DAL_719] Tak Nozwhisker - COST:7 [ATK:6/HP:6]
+    // - Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Whenever you shuffle a card into your deck,
+    //       add a copy to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- WEAPON - ROGUE
+    // [DAL_720] Waggle Pick - COST:4 [ATK:4/HP:0]
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Return a random friendly
+    //       minion to your hand. It costs (2) less.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 2
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [DAL_728] Daring Escape - COST:1
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Return all friendly minions to your hand.
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddRogueNonCollect(PowersType& powers,
                                          PlayReqsType& playReqs,
                                          EntouragesType& entourages)
 {
-    (void)powers;
+    // ------------------------------------------ SPELL - ROGUE
+    // [DAL_366t1] Assassin's Contract (*) - COST:6
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Destroy a minion. Summon a 1/1 Patient Assassin.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [DAL_366t2] Recruitment Contract (*) - COST:6
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Destroy a minion. Add a copy of it to your hand.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [DAL_366t3] Lucrative Contract (*) - COST:6
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Destroy a minion. Add 2 Coins to your hand.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [DAL_366t4] Turncoat Contract (*) - COST:6
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Destroy a minion. It deals its damage to adjacent minions.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddShaman(PowersType& powers, PlayReqsType& playReqs,
                                 EntouragesType& entourages)
 {
-    (void)powers;
+    // ----------------------------------------- SPELL - SHAMAN
+    // [DAL_009] Hagatha's Scheme - COST:5
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Deal @ damage to all minions.
+    //       <i>(Upgrades each turn!)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_SCRIPT_DATA_NUM_1 = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DAL_047] Walking Fountain - COST:8 [ATK:4/HP:8]
+    // - Race: Elemental, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Lifesteal</b>, <b>Rush</b>, <b>Windfury</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - WINDFURY = 1
+    // - LIFESTEAL = 1
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DAL_049] Underbelly Angler - COST:2 [ATK:2/HP:3]
+    // - Race: Murloc, Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: After you play a Murloc, add a random Murloc to your hand.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DAL_052] Muckmorpher - COST:5 [ATK:4/HP:4]
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Transform into a 4/4 copy of
+    //       a different minion in your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [DAL_071] Mutate - COST:0
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Transform a friendly minion into a random one
+    //       that costs (1) more.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DAL_431] Swampqueen Hagatha - COST:7 [ATK:5/HP:5]
+    // - Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Add a 5/5 Horror to your hand.
+    //       Teach it two Shaman spells.
+    // --------------------------------------------------------
+    // Entourage: DAL_431t
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [DAL_432] Witch's Brew - COST:2
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Restore 4 Health. Repeatable this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - NON_KEYWORD_ECHO = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DAL_433] Sludge Slurper - COST:1 [ATK:2/HP:1]
+    // - Race: Murloc, Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Add a <b>Lackey</b> to your hand.
+    //       <b>Overload:</b> (1)
+    // --------------------------------------------------------
+    // GameTag:
+    // - OVERLOAD = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [DAL_710] Soul of the Murloc - COST:2
+    // - Faction: Neutral, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Give your minions "<b>Deathrattle:</b> Summon a 1/1 Murloc."
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DAL_726] Scargil - COST:4 [ATK:4/HP:4]
+    // - Race: Murloc, Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Your Murlocs cost (1).
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - AURA = 1
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddShamanNonCollect(PowersType& powers,
                                           PlayReqsType& playReqs,
                                           EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------------- MINION - SHAMAN
+    // [DAL_431t] Drustvar Horror (*) - COST:5 [ATK:5/HP:5]
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Cast {0} and {1}.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - SHAMAN
+    // [DAL_710e] Soul of the Murloc (*) - COST:0
+    // - Faction: Neutral, Set: Dalaran
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon a 1/1 Murloc.
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddWarlock(PowersType& powers, PlayReqsType& playReqs,
                                  EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------------- SPELL - WARLOCK
+    // [DAL_007] Rafaam's Scheme - COST:3
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Summon @ 1/1 (Imp, Imps). <i>(Upgrades each turn!)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_SCRIPT_DATA_NUM_1 = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [DAL_173] Darkest Hour - COST:6
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Destroy all friendly minions.
+    //       For each one, summon a random minion from your deck.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [DAL_185] Aranasi Broodmother - COST:6 [ATK:4/HP:6]
+    // - Race: Demon, Faction: Neutral, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b> When you draw this,
+    //       restore 4 Health to your hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - TOPDECK = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [DAL_422] Arch-Villain Rafaam - COST:7 [ATK:7/HP:8]
+    // - Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b> <b>Battlecry:</b> Replace your hand
+    //       and deck with <b>Legendary</b> minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [DAL_561] Jumbo Imp - COST:10 [ATK:8/HP:8]
+    // - Race: Demon, Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Costs (1) less whenever a friendly Demon dies
+    //       while this is in your hand.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [DAL_563] Eager Underling - COST:4 [ATK:2/HP:2]
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Give two random friendly minions +2/+2.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [DAL_602] Plot Twist - COST:2
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Shuffle your hand into your deck. Draw that many cards.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [DAL_605] Impferno - COST:3
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Give your Demons +1 Attack.
+    //       Deal 1 damage to all enemy minions.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_WITH_RACE = 15
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [DAL_606] EVIL Genius - COST:2 [ATK:2/HP:2]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Destroy a friendly minion
+    //       to add 2 random <b>Lackeys</b> to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [DAL_607] Fel Lord Betrug - COST:8 [ATK:5/HP:7]
+    // - Race: Demon, Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Whenever you draw a minion, summon a copy
+    //       with <b>Rush</b> that dies at end of turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddWarlockNonCollect(PowersType& powers,
                                            PlayReqsType& playReqs,
                                            EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------- ENCHANTMENT - WARLOCK
+    // [DAL_605e] Imptastic (*) - COST:2
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: +1 Attack.
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddWarrior(PowersType& powers, PlayReqsType& playReqs,
                                  EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------------- SPELL - WARRIOR
+    // [DAL_008] Dr. Boom's Scheme - COST:4
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Gain @ Armor. <i>(Upgrades each turn!)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_SCRIPT_DATA_NUM_1 = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [DAL_059] Dimensional Ripper - COST:10
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Summon 2 copies of a minion in your deck.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [DAL_060] Clockwork Goblin - COST:3 [ATK:3/HP:3]
+    // - Race: Mechanical, Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Shuffle a Bomb into your opponent's deck.
+    //       When drawn, it explodes for 5 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [DAL_062] Sweeping Strikes - COST:2
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Give a minion "Also damages minions next to whomever this attacks."
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- WEAPON - WARRIOR
+    // [DAL_063] Wrenchcalibur - COST:4 [ATK:3/HP:0]
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: After your hero attacks, shuffle a Bomb
+    //       into your opponent's deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 2
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [DAL_064] Blastmaster Boom - COST:7 [ATK:7/HP:7]
+    // - Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon two 1/1 Boom Bots
+    //       for each Bomb in your opponent's deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [DAL_070] The Boom Reaver - COST:10 [ATK:7/HP:9]
+    // - Race: Mechanical, Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon a copy of a minion in your deck.
+    //       Give it <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [DAL_759] Vicious Scraphound - COST:2 [ATK:2/HP:2]
+    // - Race: Mechanical, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Whenever this minion deals damage, gain that much Armor.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [DAL_769] Improve Morale - COST:1
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Deal 1 damage to a minion.
+    //       If it survives, add a <b>Lackey</b> to your hand.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [DAL_770] Omega Devastator - COST:4 [ATK:4/HP:5]
+    // - Race: Mechanical, Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you have 10 Mana Crystals,
+    //       deal 10 damage to a minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_MANA_CRYSTAL = 10
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddWarriorNonCollect(PowersType& powers,
                                            PlayReqsType& playReqs,
                                            EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------- ENCHANTMENT - WARRIOR
+    // [DAL_062e] Sweeping Strikes (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: Damages minions adjacent to defender.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARRIOR
+    // [DAL_070e] Reaving (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: Has <b>Rush</b>.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARRIOR
+    // [DAL_742e] Whirling (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: <b>Mega-Windfury</b>
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddNeutral(PowersType& powers, PlayReqsType& playReqs,
                                  EntouragesType& entourages)
 {
-    (void)powers;
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_058] Hecklebot - COST:4 [ATK:3/HP:8]
+    // - Race: Mechanical, Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b> <b>Battlecry:</b> Your opponent
+    //       summons a minion from their deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_077] Toxfin - COST:1 [ATK:1/HP:2]
+    // - Race: Murloc, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a friendly Murloc <b>Poisonous</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_TARGET_WITH_RACE = 14
+    // --------------------------------------------------------
+    // RefTag:
+    // - POISONOUS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_078] Travelling Healer - COST:4 [ATK:3/HP:2]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Divine Shield</b> <b>Battlecry:</b> Restore 3 Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DIVINE_SHIELD = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_081] Spellward Jeweler - COST:3 [ATK:3/HP:4]
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Your hero can't be targeted by
+    //       spells or Hero Powers until your next turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_085] Dalaran Crusader - COST:5 [ATK:5/HP:4]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Divine Shield</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - DIVINE_SHIELD = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_086] Sunreaver Spy - COST:2 [ATK:2/HP:3]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you control a <b>Secret</b>, gain +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_087] Hench-Clan Hag - COST:4 [ATK:3/HP:3]
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon two 1/1 Amalgams
+    //       with all minion types.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_088] Safeguard - COST:6 [ATK:4/HP:5]
+    // - Race: Mechanical, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b> <b>Deathrattle:</b> Summon a 0/5
+    //       Vault Safe with <b>Taunt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_089] Spellbook Binder - COST:2 [ATK:3/HP:2]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you have <b>Spell Damage</b>,
+    //       draw a card.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SPELLPOWER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_090] Hench-Clan Sneak - COST:3 [ATK:3/HP:3]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - STEALTH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_092] Arcane Servant - COST:2 [ATK:2/HP:3]
+    // - Race: Elemental, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_095] Violet Spellsword - COST:4 [ATK:1/HP:6]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Gain +1 Attack
+    //       for each spell in your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_096] Violet Warden - COST:6 [ATK:4/HP:7]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b> <b>Spell Damage +1</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - SPELLPOWER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_400] EVIL Cable Rat - COST:2 [ATK:1/HP:1]
+    // - Race: Beast, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Add a <b>Lackey</b> to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_434] Arcane Watcher - COST:3 [ATK:5/HP:6]
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Can't attack unless you have <b>Spell Damage</b>.
+    // --------------------------------------------------------
+    // RefTag:
+    // - SPELLPOWER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_538] Unseen Saboteur - COST:6 [ATK:5/HP:6]
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Your opponent casts a random spell
+    //       from their hand <i>(targets chosen randomly)</i>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_539] Sunreaver Warmage - COST:5 [ATK:4/HP:4]
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you're holding a spell that
+    //       costs (5) or more, deal 4 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_DRAG_TO_PLAY = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_544] Potion Vendor - COST:1 [ATK:1/HP:1]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Restore 2 Health to all friendly characters.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_546] Barista Lynchen - COST:5 [ATK:4/HP:5]
+    // - Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Add a copy of each of your other
+    //       <b>Battlecry</b> minions to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_548] Azerite Elemental - COST:5 [ATK:2/HP:7]
+    // - Race: Elemental, Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: At the start of your turn, gain <b>Spell Damage +2</b>.
+    // --------------------------------------------------------
+    // RefTag:
+    // - SPELLPOWER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_550] Underbelly Ooze - COST:7 [ATK:3/HP:5]
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: After this minion survives damage, summon a copy of it.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_551] Proud Defender - COST:4 [ATK:2/HP:6]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       Has +2 Attack while you have no other minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_553] Big Bad Archmage - COST:10 [ATK:6/HP:6]
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: At the end of your turn, summon a random
+    //       6-Cost minion.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_554] Chef Nomi - COST:7 [ATK:6/HP:6]
+    // - Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your deck is empty,
+    //       summon six 6/6 Greasefire Elementals.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_558] Archmage Vargoth - COST:4 [ATK:2/HP:6]
+    // - Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: At the end of your turn, cast a spell
+    //       you've cast this turn <i>(targets are random)</i>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_560] Heroic Innkeeper - COST:8 [ATK:4/HP:4]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt.</b> <b>Battlecry:</b> Gain +2/+2
+    //       for each other friendly minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_565] Portal Overfiend - COST:6 [ATK:5/HP:6]
+    // - Race: Demon, Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Shuffle 3 Portals into your deck.
+    //       When drawn, summon a 2/2 Demon with <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_566] Eccentric Scribe - COST:6 [ATK:6/HP:4]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon four 1/1 Vengeful Scrolls.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_582] Portal Keeper - COST:4 [ATK:5/HP:2]
+    // - Race: Demon, Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Shuffle 3 Portals into your deck.
+    //       When drawn, summon a 2/2 Demon with <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_592] Batterhead - COST:8 [ATK:3/HP:12]
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>. After this attacks and kills a minion,
+    //       it may attack again.
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_735] Dalaran Librarian - COST:2 [ATK:2/HP:3]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Silence</b> adjacent minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SILENCE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_736] Archivist Elysiana - COST:8 [ATK:7/HP:7]
+    // - Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Discover</b> 5 cards.
+    //       Replace your deck with 2 copies of each.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_742] Whirlwind Tempest - COST:8 [ATK:6/HP:6]
+    // - Race: Elemental, Faction: Neutral, Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Your minions with <b>Windfury</b> have <b>Mega-Windfury</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AURA = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - WINDFURY = 1
+    // - MEGA_WINDFURY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_743] Hench-Clan Hogsteed - COST:2 [ATK:2/HP:1]
+    // - Race: Beast, Faction: Neutral, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Rush</b> <b>Deathrattle:</b> Summon a 1/1 Murloc.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_744] Faceless Rager - COST:3 [ATK:5/HP:1]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Copy a friendly minion's Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_747] Flight Master - COST:3 [ATK:3/HP:4]
+    // - Faction: Alliance, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon a 2/2 Gryphon for each player.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_748] Mana Reservoir - COST:2 [ATK:0/HP:6]
+    // - Race: Elemental, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Spell Damage +1</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPELLPOWER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_749] Recurring Villain - COST:5 [ATK:3/HP:6]
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> If this minion has 4 or more Attack,
+    //       resummon it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_751] Mad Summoner - COST:6 [ATK:4/HP:4]
+    // - Race: Demon, Faction: Alliance, Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Fill each player's board with 1/1 Imps.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_752] Jepetto Joybuzz - COST:8 [ATK:6/HP:6]
+    // - Set: Dalaran, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Draw 2 minions from your deck.
+    //       Set their Attack, Health, and Cost to 1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_760] Burly Shovelfist - COST:9 [ATK:9/HP:9]
+    // - Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_771] Soldier of Fortune - COST:4 [ATK:5/HP:6]
+    // - Race: Elemental, Set: Dalaran, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Whenever this minion attacks, give your opponent a Coin.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_773] Magic Carpet - COST:3 [ATK:1/HP:6]
+    // - Set: Dalaran, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: After you play a 1-Cost minion,
+    //       give it +1 Attack and <b>Rush</b>.
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_774] Exotic Mountseller - COST:7 [ATK:5/HP:8]
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Whenever you cast a spell, summon a random 3-Cost Beast.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_775] Tunnel Blaster - COST:7 [ATK:3/HP:7]
+    // - Set: Dalaran, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b> <b>Deathrattle:</b> Deal 3 damage
+    //       to all minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddNeutralNonCollect(PowersType& powers,
                                            PlayReqsType& playReqs,
                                            EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_011e] Lazul's Curse (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: Reduced Attack.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_052e] Muckmorphing (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: 4/4.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_077e] Toxic Fin (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: <b>Poisonous</b>
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_081e] Sparkly (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: Can't be targeted by spells or Hero Powers.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CANT_BE_TARGETED_BY_SPELLS = 1
+    // - CANT_BE_TARGETED_BY_HERO_POWERS = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_086e] Stolen Secrets (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: +1/+1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_087t] Amalgam (*) - COST:1 [ATK:1/HP:1]
+    // - Race: All, Set: Dalaran
+    // --------------------------------------------------------
+    // Text: <i>This is an Elemental, Mech, Demon, Murloc, Dragon,
+    //       Beast, Pirate and Totem.</i>
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_088t2] Vault Safe (*) - COST:2 [ATK:0/HP:5]
+    // - Race: Mechanical, Set: Dalaran
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_095e] Pizzazz (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: Increased Attack.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_147e] Dragon Shout (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: +3/+3.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_351e] Ancient Blessings (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: +1/+1.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_548e] Arcane Expansion (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: Increased <b>Spell Damage</b>.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_554t] Greasefire Elemental (*) - COST:6 [ATK:6/HP:6]
+    // - Race: Elemental, Faction: Neutral, Set: Dalaran
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_566t] Vengeful Scroll (*) - COST:1 [ATK:1/HP:1]
+    // - Set: Dalaran
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_560e2] Protect the Brews! (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: Increased stats.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_561e] Imp-onomical (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: Costs (1) less.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_563e] Power of EVIL (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: +2/+2.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_570e] Never Surrender! (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: +2 Health.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_576e] Kirin Tor's Curse (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: Costs (1) more.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [DAL_582t] Felhound Portal (*) - COST:2
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: <b>Casts When Drawn</b>
+    //       Summon a 2/2 Felhound with <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TOPDECK = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // - CASTSWHENDRAWN = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_582t2] Felhound (*) - COST:2 [ATK:2/HP:2]
+    // - Race: Demon, Set: Dalaran
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_589e] Hunting Party (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: +3/+3.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_607e] Fleeting Fel (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>. Dies at end of turn.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_613] Faceless Lackey (*) - COST:1 [ATK:1/HP:1]
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon a random 2-Cost minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_614] Kobold Lackey (*) - COST:1 [ATK:1/HP:1]
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Deal 2 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_615] Witchy Lackey (*) - COST:1 [ATK:1/HP:1]
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Transform a friendly minion into one
+    //       that costs (1) more.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_714e] Street Smarts (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: +1/+1.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_726e] Scargil's Blessing (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: Costs (1).
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_727e] Heroic (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: +2/+2.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_739] Goblin Lackey (*) - COST:1 [ATK:1/HP:1]
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a friendly minion +1 Attack
+    //       and <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_739e] Short Fuse (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: +1 Attack and <b>Rush</b>.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_741] Ethereal Lackey (*) - COST:1 [ATK:1/HP:1]
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Discover</b> a spell.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_743t] Hench-Clan Squire (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Murloc, Set: Dalaran
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_744e] Familiar Faces (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: Copied health.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_747t] Gryphon (*) - COST:2 [ATK:2/HP:2]
+    // - Race: Beast, Faction: Alliance, Set: Dalaran
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DAL_751t] Imp (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Demon, Faction: Neutral, Set: Dalaran
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_752e] Toy-sized (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: Jepetto Joybuzz made this 1/1.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_752e2] On Sale (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: Costs (1).
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DAL_773e] Flying High (*) - COST:0
+    // - Set: Dalaran
+    // --------------------------------------------------------
+    // Text: +1 Attack and <b>Rush</b>.
+    // --------------------------------------------------------
 }
 
 void DalaranCardsGen::AddAll(PowersType& powers, PlayReqsType& playReqs,

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -1,0 +1,188 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/CardSets/DragonsCardsGen.hpp>
+
+namespace RosettaStone
+{
+void DragonsCardsGen::AddHeroes(PowersType& powers, PlayReqsType& playReqs,
+                                EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddHeroPowers(PowersType& powers, PlayReqsType& playReqs,
+                                    EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddDruid(PowersType& powers, PlayReqsType& playReqs,
+                               EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddDruidNonCollect(PowersType& powers,
+                                         PlayReqsType& playReqs,
+                                         EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddHunter(PowersType& powers, PlayReqsType& playReqs,
+                                EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddHunterNonCollect(PowersType& powers,
+                                          PlayReqsType& playReqs,
+                                          EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddMage(PowersType& powers, PlayReqsType& playReqs,
+                              EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddMageNonCollect(PowersType& powers,
+                                        PlayReqsType& playReqs,
+                                        EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddPaladin(PowersType& powers, PlayReqsType& playReqs,
+                                 EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddPaladinNonCollect(PowersType& powers,
+                                           PlayReqsType& playReqs,
+                                           EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddPriest(PowersType& powers, PlayReqsType& playReqs,
+                                EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddPriestNonCollect(PowersType& powers,
+                                          PlayReqsType& playReqs,
+                                          EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddRogue(PowersType& powers, PlayReqsType& playReqs,
+                               EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddRogueNonCollect(PowersType& powers,
+                                         PlayReqsType& playReqs,
+                                         EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddShaman(PowersType& powers, PlayReqsType& playReqs,
+                                EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddShamanNonCollect(PowersType& powers,
+                                          PlayReqsType& playReqs,
+                                          EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddWarlock(PowersType& powers, PlayReqsType& playReqs,
+                                 EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddWarlockNonCollect(PowersType& powers,
+                                           PlayReqsType& playReqs,
+                                           EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddWarrior(PowersType& powers, PlayReqsType& playReqs,
+                                 EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddWarriorNonCollect(PowersType& powers,
+                                           PlayReqsType& playReqs,
+                                           EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddNeutral(PowersType& powers, PlayReqsType& playReqs,
+                                 EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddNeutralNonCollect(PowersType& powers,
+                                           PlayReqsType& playReqs,
+                                           EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void DragonsCardsGen::AddAll(PowersType& powers, PlayReqsType& playReqs,
+                             EntouragesType& entourages)
+{
+    AddHeroes(powers, playReqs, entourages);
+    AddHeroPowers(powers, playReqs, entourages);
+
+    AddDruid(powers, playReqs, entourages);
+    AddDruidNonCollect(powers, playReqs, entourages);
+
+    AddHunter(powers, playReqs, entourages);
+    AddHunterNonCollect(powers, playReqs, entourages);
+
+    AddMage(powers, playReqs, entourages);
+    AddMageNonCollect(powers, playReqs, entourages);
+
+    AddPaladin(powers, playReqs, entourages);
+    AddPaladinNonCollect(powers, playReqs, entourages);
+
+    AddPriest(powers, playReqs, entourages);
+    AddPriestNonCollect(powers, playReqs, entourages);
+
+    AddRogue(powers, playReqs, entourages);
+    AddRogueNonCollect(powers, playReqs, entourages);
+
+    AddShaman(powers, playReqs, entourages);
+    AddShamanNonCollect(powers, playReqs, entourages);
+
+    AddWarlock(powers, playReqs, entourages);
+    AddWarlockNonCollect(powers, playReqs, entourages);
+
+    AddWarrior(powers, playReqs, entourages);
+    AddWarriorNonCollect(powers, playReqs, entourages);
+
+    AddNeutral(powers, playReqs, entourages);
+    AddNeutralNonCollect(powers, playReqs, entourages);
+}
+}  // namespace RosettaStone

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -10,143 +10,2597 @@ namespace RosettaStone
 void DragonsCardsGen::AddHeroes(PowersType& powers, PlayReqsType& playReqs,
                                 EntouragesType& entourages)
 {
-    (void)powers;
+    // ----------------------------------------- HERO - WARLOCK
+    // [DRG_600] Galakrond, the Wretched - COST:7 [ATK:0/HP:30]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon 1 random Demon. <i>(@)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_SCRIPT_DATA_NUM_2 = 2
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - ARMOR = 5
+    // - HERO_POWER = 55807
+    // - 676 = 1
+    // - GALAKROND_HERO_CARD = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- HERO - WARLOCK
+    // [DRG_600t2] Galakrond, the Apocalypse (*) - COST:7 [ATK:0/HP:30]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon 2 random Demons. <i>(@)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_SCRIPT_DATA_NUM_2 = 2
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - ARMOR = 5
+    // - HERO_POWER = 55807
+    // - GALAKROND_HERO_CARD = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- HERO - WARLOCK
+    // [DRG_600t3] Galakrond, Azeroth's End (*) - COST:7 [ATK:0/HP:30]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon 4 random Demons.
+    //       Equip a 5/2 Claw.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - ARMOR = 5
+    // - HERO_POWER = 55807
+    // - GALAKROND_HERO_CARD = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- HERO - ROGUE
+    // [DRG_610] Galakrond, the Nightmare - COST:7 [ATK:0/HP:30]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Draw 1 card. It costs (0).
+    //       <i>(@)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_SCRIPT_DATA_NUM_2 = 2
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - ARMOR = 5
+    // - HERO_POWER = 55806
+    // - 676 = 1
+    // - GALAKROND_HERO_CARD = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- HERO - ROGUE
+    // [DRG_610t2] Galakrond, the Apocalypse (*) - COST:7 [ATK:0/HP:30]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Draw 2 cards. They cost (0).
+    //       <i>(@)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_SCRIPT_DATA_NUM_2 = 2
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - ARMOR = 5
+    // - HERO_POWER = 55806
+    // - GALAKROND_HERO_CARD = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- HERO - ROGUE
+    // [DRG_610t3] Galakrond, Azeroth's End (*) - COST:7 [ATK:0/HP:30]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Draw 4 cards. They cost (0).
+    //       Equip a 5/2 Claw.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - ARMOR = 5
+    // - HERO_POWER = 55806
+    // - GALAKROND_HERO_CARD = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ HERO - SHAMAN
+    // [DRG_620] Galakrond, the Tempest - COST:7 [ATK:0/HP:30]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon two 2/2 Storms with <b>Rush</b>.
+    //       <i>(@)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_SCRIPT_DATA_NUM_2 = 2
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - ARMOR = 5
+    // - HERO_POWER = 55808
+    // - 676 = 1
+    // - GALAKROND_HERO_CARD = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ HERO - SHAMAN
+    // [DRG_620t2] Galakrond, the Apocalypse (*) - COST:7 [ATK:0/HP:30]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon two 4/4 Storms with <b>Rush</b>.
+    //       <i>(@)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_SCRIPT_DATA_NUM_2 = 2
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - ARMOR = 5
+    // - HERO_POWER = 55808
+    // - GALAKROND_HERO_CARD = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ HERO - SHAMAN
+    // [DRG_620t3] Galakrond, Azeroth's End (*) - COST:7 [ATK:0/HP:30]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon two 8/8 Storms with <b>Rush</b>.
+    //       Equip a 5/2 Claw.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - ARMOR = 5
+    // - HERO_POWER = 55808
+    // - GALAKROND_HERO_CARD = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- HERO - WARRIOR
+    // [DRG_650] Galakrond, the Unbreakable - COST:7 [ATK:0/HP:30]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Draw 1 minion. Give it +4/+4.
+    //       <i>(@)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_SCRIPT_DATA_NUM_2 = 2
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - ARMOR = 5
+    // - HERO_POWER = 55805
+    // - 676 = 1
+    // - GALAKROND_HERO_CARD = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- HERO - WARRIOR
+    // [DRG_650t2] Galakrond, the Apocalypse (*) - COST:7 [ATK:0/HP:30]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Draw 2 minions. Give them +4/+4.
+    //       <i>(@)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_SCRIPT_DATA_NUM_2 = 2
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - ARMOR = 5
+    // - HERO_POWER = 55805
+    // - GALAKROND_HERO_CARD = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- HERO - WARRIOR
+    // [DRG_650t3] Galakrond, Azeroth's End (*) - COST:7 [ATK:0/HP:30]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Draw 4 minions. Give them +4/+4.
+    //       Equip a 5/2 Claw.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - ARMOR = 5
+    // - HERO_POWER = 55805
+    // - GALAKROND_HERO_CARD = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ HERO - PRIEST
+    // [DRG_660] Galakrond, the Unspeakable - COST:7 [ATK:0/HP:30]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Destroy 1 random enemy minion.
+    //       <i>(@)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_SCRIPT_DATA_NUM_2 = 2
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - ARMOR = 5
+    // - HERO_POWER = 55810
+    // - 676 = 1
+    // - GALAKROND_HERO_CARD = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ HERO - PRIEST
+    // [DRG_660t2] Galakrond, the Apocalypse (*) - COST:7 [ATK:0/HP:30]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Destroy 2 random enemy minions.
+    //       <i>(@)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_SCRIPT_DATA_NUM_2 = 2
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - ARMOR = 5
+    // - HERO_POWER = 55810
+    // - GALAKROND_HERO_CARD = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ HERO - PRIEST
+    // [DRG_660t3] Galakrond, Azeroth's End (*) - COST:7 [ATK:0/HP:30]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Destroy 4 random enemy minions.
+    //       Equip a 5/2 Claw.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - ARMOR = 5
+    // - HERO_POWER = 55810
+    // - GALAKROND_HERO_CARD = 1
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddHeroPowers(PowersType& powers, PlayReqsType& playReqs,
                                     EntouragesType& entourages)
 {
-    (void)powers;
+    // ----------------------------------- HERO_POWER - WARRIOR
+    // [DRG_238p] Galakrond's Might (*) - COST:2
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b> Give your hero +3 Attack this turn.
+    // --------------------------------------------------------
+
+    // ------------------------------------- HERO_POWER - ROGUE
+    // [DRG_238p2] Galakrond's Guile (*) - COST:2
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b> Add a <b>Lackey</b> to your hand.
+    // --------------------------------------------------------
+
+    // ----------------------------------- HERO_POWER - WARLOCK
+    // [DRG_238p3] Galakrond's Malice (*) - COST:2
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b> Summon two 1/1 Imps.
+    // --------------------------------------------------------
+
+    // ------------------------------------ HERO_POWER - SHAMAN
+    // [DRG_238p4] Galakrond's Fury (*) - COST:2
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b> Summon a 2/1 Elemental with <b>Rush</b>.
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------ HERO_POWER - PRIEST
+    // [DRG_238p5] Galakrond's Wit (*) - COST:2
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b> Add a random Priest minion to your hand.
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddDruid(PowersType& powers, PlayReqsType& playReqs,
                                EntouragesType& entourages)
 {
-    (void)powers;
+    // ------------------------------------------ SPELL - DRUID
+    // [DRG_051] Strength in Numbers - COST:1
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Sidequest:</b> Spend 10 Mana on minions.
+    //       <b>Reward:</b> Summon a minion from your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - QUEST_PROGRESS_TOTAL = 10
+    // - SIDEQUEST = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [DRG_311] Treenforcements - COST:1
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Choose One -</b> Give a minion +2 Health and
+    //       <b>Taunt</b>; or Summon a 2/2 Treant.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CHOOSE_ONE = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [DRG_312] Shrubadier - COST:2 [ATK:1/HP:1]
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon a 2/2 Treant.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [DRG_313] Emerald Explorer - COST:6 [ATK:4/HP:8]
+    // - Race: Dragon, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> <b>Discover</b> a Dragon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [DRG_314] Aeroponics - COST:5
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Draw 2 cards.
+    //       Costs (2) less for each Treant you control.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [DRG_315] Embiggen - COST:0
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Give all minions in your deck +2/+2.
+    //       They cost (1) more <i>(up to 10)</i>.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [DRG_317] Secure the Deck - COST:1
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Sidequest:</b> Attack twice with your hero.
+    //       <b>Reward:</b> Add 3 'Claw' spells to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - QUEST_PROGRESS_TOTAL = 2
+    // - SIDEQUEST = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [DRG_318] Breath of Dreams - COST:2
+    // - Faction: Neutral, Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Draw a card. If you're holding a Dragon,
+    //       gain an empty Mana Crystal.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [DRG_319] Goru the Mightree - COST:7 [ATK:5/HP:10]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b> <b>Battlecry:</b> For the rest of
+    //       the game, your Treants have +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [DRG_320] Ysera, Unleashed - COST:9 [ATK:4/HP:12]
+    // - Race: Dragon, Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Shuffle 7 Dream Portals into your deck.
+    //       When drawn, summon a random Dragon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddDruidNonCollect(PowersType& powers,
                                          PlayReqsType& playReqs,
                                          EntouragesType& entourages)
 {
-    (void)powers;
+    // ------------------------------------------ SPELL - DRUID
+    // [DRG_311a] Spin 'em Up (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Summon a 2/2 Treant.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [DRG_311b] Small Repairs (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Give a minion +2 Health and <b>Taunt</b>.
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [DRG_311t] Treant (*) - COST:2 [ATK:2/HP:2]
+    // - Faction: Neutral, Set: Dragons
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [DRG_315e] Embiggened (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +2/+2.
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [DRG_315e2] Costly Embiggening (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Costs (1) more.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [DRG_320t] Dream Portal (*) - COST:9
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Casts When Drawn</b> Summon a random Dragon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TOPDECK = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - CASTSWHENDRAWN = 1
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddHunter(PowersType& powers, PlayReqsType& playReqs,
                                 EntouragesType& entourages)
 {
-    (void)powers;
+    // ----------------------------------------- SPELL - HUNTER
+    // [DRG_006] Corrosive Breath - COST:2
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Deal 3 damage to a minion. If you're holding
+    //       a Dragon, it also hits the enemy hero.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- WEAPON - HUNTER
+    // [DRG_007] Stormhammer - COST:3 [ATK:3/HP:0]
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Doesn't lose Durability while you control a Dragon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 2
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [DRG_010] Diving Gryphon - COST:3 [ATK:4/HP:1]
+    // - Race: Beast, Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Rush</b> <b>Battlecry:</b> Draw a
+    //       <b>Rush</b> minion from your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [DRG_095] Veranus - COST:6 [ATK:7/HP:6]
+    // - Race: Dragon, Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Change the Health of all enemy minions to 1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [DRG_251] Clear the Way - COST:1
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Sidequest:</b> Summon 3 <b>Rush</b> minions.
+    //       <b>Reward:</b> Summon a 4/4 Gryphon with <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - QUEST_PROGRESS_TOTAL = 3
+    // - SIDEQUEST = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [DRG_252] Phase Stalker - COST:2 [ATK:2/HP:3]
+    // - Race: Beast, Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: After you use your Hero Power,
+    //       cast a <b>Secret</b> from your deck.
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [DRG_253] Dwarven Sharpshooter - COST:1 [ATK:1/HP:3]
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Your Hero Power can target minions.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [DRG_254] Primordial Explorer - COST:3 [ATK:2/HP:3]
+    // - Race: Dragon, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Poisonous</b>
+    //       <b>Battlecry:</b> <b>Discover</b> a Dragon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - POISONOUS = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [DRG_255] Toxic Reinforcements - COST:1
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Sidequest:</b> Use your Hero Power three times.
+    //       <b>Reward:</b> Summon three 1/1 Leper Gnomes.
+    // --------------------------------------------------------
+    // GameTag:
+    // - QUEST_PROGRESS_TOTAL = 3
+    // - QUEST_REWARD_DATABASE_ID = 41127
+    // - SIDEQUEST = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [DRG_256] Dragonbane - COST:4 [ATK:3/HP:5]
+    // - Race: Mechanical, Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: After you use your Hero Power,
+    //       deal 5 damage to a random enemy.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddHunterNonCollect(PowersType& powers,
                                           PlayReqsType& playReqs,
                                           EntouragesType& entourages)
 {
-    (void)powers;
+    // ----------------------------------- ENCHANTMENT - HUNTER
+    // [DRG_095e] Intimidated (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Health changed to 1.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [DRG_251t] Gryphon (*) - COST:4 [ATK:4/HP:4]
+    // - Race: Beast, Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddMage(PowersType& powers, PlayReqsType& playReqs,
                               EntouragesType& entourages)
 {
-    (void)powers;
+    // ------------------------------------------ MINION - MAGE
+    // [DRG_102] Azure Explorer - COST:4 [ATK:2/HP:3]
+    // - Race: Dragon, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Spell Damage +2</b>
+    //       <b>Battlecry:</b> <b>Discover</b> a Dragon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPELLPOWER = 2
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [DRG_104] Chenvaala - COST:3 [ATK:2/HP:5]
+    // - Race: Elemental, Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: After you cast three spells in a turn,
+    //       summon a 5/5 Elemental.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DRG_106] Arcane Breath - COST:1
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Deal 2 damage to a minion. If you're holding a Dragon,
+    //       <b>Discover</b> a spell.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [DRG_107] Violet Spellwing - COST:1 [ATK:1/HP:1]
+    // - Race: Elemental, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Add an 'Arcane Missiles' spell
+    //       to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [DRG_109] Mana Giant - COST:8 [ATK:8/HP:8]
+    // - Race: Elemental, Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Costs (1) less for each card you've played this
+    //       game that didn't start in your deck.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [DRG_270] Malygos, Aspect of Magic - COST:5 [ATK:2/HP:8]
+    // - Race: Dragon, Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you're holding a Dragon,
+    //       <b>Discover</b> an upgraded Mage spell.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DRG_321] Rolling Fireball - COST:5
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Deal 8 damage to a minion. Any excess damage
+    //       continues to the left or right.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ImmuneToSpellpower = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [DRG_322] Dragoncaster - COST:6 [ATK:4/HP:4]
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you're holding a Dragon,
+    //       your next spell this turn costs (0).
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DRG_323] Learn Draconic - COST:1
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Sidequest:</b> Spend 8 Mana on spells.
+    //       <b>Reward:</b> Summon a 6/6 Dragon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - QUEST_PROGRESS_TOTAL = 8
+    // - QUEST_REWARD_DATABASE_ID = 55282
+    // - SIDEQUEST = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DRG_324] Elemental Allies - COST:1
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Sidequest:</b> Play an Elemental 2 turns in a row.
+    //       <b>Reward:</b> Draw 3 spells from your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - QUEST_PROGRESS_TOTAL = 2
+    // - QUEST_REWARD_DATABASE_ID = 395
+    // - SIDEQUEST = 1
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddMageNonCollect(PowersType& powers,
                                         PlayReqsType& playReqs,
                                         EntouragesType& entourages)
 {
-    (void)powers;
+    // ------------------------------------------ MINION - MAGE
+    // [DRG_104t2] Snow Elemental (*) - COST:5 [ATK:5/HP:5]
+    // - Race: Elemental, Set: Dragons
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DRG_270t1] Malygos's Intellect (*) - COST:3
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Draw 4 cards.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DRG_270t2] Malygos's Tome (*) - COST:1
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Add 3 random Mage spells to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DRG_270t4] Malygos's Explosion (*) - COST:2
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Deal 2 damage to all enemy minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DRG_270t5] Malygos's Nova (*) - COST:1
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Freeze</b> all enemy minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DRG_270t6] Malygos's Polymorph (*) - COST:1
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Transform a minion into a 1/1 Sheep.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [DRG_270t6t] Malygos's Sheep (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Beast, Faction: Neutral, Set: Dragons
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DRG_270t7] Malygos's Flamestrike (*) - COST:7
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Deal 8 damage to all enemy minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DRG_270t8] Malygos's Frostbolt (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Deal 3 damage to a character and <b>Freeze</b> it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DRG_270t9] Malygos's Fireball (*) - COST:4
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Deal 8 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [DRG_270t11] Malygos's Missiles (*) - COST:1
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Deal 6 damage randomly split among all enemies.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - ImmuneToSpellpower = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------- ENCHANTMENT - MAGE
+    // [DRG_322e] Draconic Magic (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: The next spell you cast this turn costs (0).
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [DRG_323t] Draconic Emissary (*) - COST:6 [ATK:6/HP:6]
+    // - Race: Dragon, Set: Dragons
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddPaladin(PowersType& powers, PlayReqsType& playReqs,
                                  EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------------- SPELL - PALADIN
+    // [DRG_008] Righteous Cause - COST:1
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Sidequest:</b> Summon 5 minions.
+    //       <b>Reward:</b> Give your minions +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - QUEST_PROGRESS_TOTAL = 5
+    // - SIDEQUEST = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [DRG_225] Sky Claw - COST:3 [ATK:1/HP:2]
+    // - Race: Mechanical, Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Your other Mechs have +1 Attack.
+    //       <b>Battlecry:</b> Summon two 1/1 Microcopters.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - AURA = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [DRG_226] Amber Watcher - COST:5 [ATK:4/HP:6]
+    // - Race: Dragon, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Restore 8 Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [DRG_229] Bronze Explorer - COST:3 [ATK:2/HP:3]
+    // - Race: Dragon, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Lifesteal</b>
+    //       <b>Battlecry:</b> <b>Discover</b> a Dragon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - LIFESTEAL = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [DRG_231] Lightforged Crusader - COST:7 [ATK:7/HP:7]
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your deck has no Neutral cards,
+    //       add 5 random Paladin cards to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [DRG_232] Lightforged Zealot - COST:4 [ATK:4/HP:2]
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your deck has no Neutral cards,
+    //       equip a 4/2 Truesilver_Champion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [DRG_233] Sand Breath - COST:1
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Give a minion +1/+2. Give it <b>Divine Shield</b>
+    //       if you're holding a Dragon.
+    // --------------------------------------------------------
+    // RefTag:
+    // - DIVINE_SHIELD = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [DRG_235] Dragonrider Talritha - COST:3 [ATK:3/HP:3]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Give a Dragon in your hand +3/+3
+    //       and this <b>Deathrattle</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [DRG_258] Sanctuary - COST:2
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Sidequest:</b> Take no damage for a turn.
+    //       <b>Reward:</b> Summon a 3/6 minion with <b>Taunt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - QUEST_PROGRESS_TOTAL = 1
+    // - QUEST_REWARD_DATABASE_ID = 57723
+    // - SIDEQUEST = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [DRG_309] Nozdormu the Timeless - COST:4 [ATK:8/HP:8]
+    // - Race: Dragon, Faction: Neutral, Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Set each player to 10 Mana Crystals.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddPaladinNonCollect(PowersType& powers,
                                            PlayReqsType& playReqs,
                                            EntouragesType& entourages)
 {
-    (void)powers;
+    // --------------------------------------- MINION - PALADIN
+    // [DRG_225t] Microcopter (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Mechanical, Set: Dragons
+    // --------------------------------------------------------
+
+    // --------------------------------------- WEAPON - PALADIN
+    // [DRG_232t] Truesilver Champion (*) - COST:4 [ATK:4/HP:0]
+    // - Faction: Neutral, Set: Dragons, Rarity: Free
+    // --------------------------------------------------------
+    // Text: Whenever your hero attacks, restore 2 Health to it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 2
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [DRG_258t] Indomitable Champion (*) - COST:4 [ATK:3/HP:6]
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddPriest(PowersType& powers, PlayReqsType& playReqs,
                                 EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------------- MINION - PRIEST
+    // [DRG_090] Murozond the Infinite - COST:8 [ATK:8/HP:8]
+    // - Race: Dragon, Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Play all cards your opponent
+    //       played last turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [DRG_246] Time Rip - COST:5
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Destroy a minion. <b>Invoke</b> Galakrond.
+    // --------------------------------------------------------
+    // GameTag:
+    // - 676 = 1
+    // - EMPOWER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [DRG_300] Fate Weaver - COST:4 [ATK:3/HP:6]
+    // - Race: Dragon, Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you've <b>Invoked</b> twice,
+    //       reduce the Cost of cards in your hand by (1).
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - 676 = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - EMPOWER = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [DRG_301] Whispers of EVIL - COST:0
+    // - Faction: Neutral, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Add a <b>Lackey</b> to your hand.
+    // --------------------------------------------------------
+    // RefTag:
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [DRG_302] Grave Rune - COST:4
+    // - Faction: Neutral, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Give a minion "<b>Deathrattle:</b> Summon 2 copies of this."
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [DRG_303] Disciple of Galakrond - COST:1 [ATK:1/HP:2]
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Invoke</b> Galakrond.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - 676 = 1
+    // - EMPOWER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [DRG_304] Chronobreaker - COST:5 [ATK:4/HP:5]
+    // - Race: Dragon, Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> If you're holding a Dragon,
+    //       deal 3 damage to all enemy minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [DRG_306] Envoy of Lazul - COST:2 [ATK:2/HP:2]
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Look at 3 cards.
+    //       Guess which one is in your opponent's hand
+    //       to get a copy of it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [DRG_307] Breath of the Infinite - COST:3
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Deal 2 damage to all minions.
+    //       If you're holding a Dragon, only damage enemies.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [DRG_308] Mindflayer Kaahrj - COST:3 [ATK:3/HP:3]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Choose an enemy minion.
+    //       <b>Deathrattle:</b> Summon a new copy of it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DEATHRATTLE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddPriestNonCollect(PowersType& powers,
                                           PlayReqsType& playReqs,
                                           EntouragesType& entourages)
 {
-    (void)powers;
+    // ----------------------------------- ENCHANTMENT - PRIEST
+    // [DRG_300e] Draconic Fate (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Costs (1) less.
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddRogue(PowersType& powers, PlayReqsType& playReqs,
                                EntouragesType& entourages)
 {
-    (void)powers;
+    // ----------------------------------------- MINION - ROGUE
+    // [DRG_027] Umbral Skulker - COST:4 [ATK:3/HP:3]
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you've <b>Invoked</b> twice,
+    //       add 3 Coins to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - 676 = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - EMPOWER = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [DRG_028] Dragon's Hoard - COST:1
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Discover</b> a <b>Legendary</b> minion
+    //       from another class.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [DRG_030] Praise Galakrond! - COST:1
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Give a minion +1 Attack. <b>Invoke</b> Galakrond.
+    // --------------------------------------------------------
+    // GameTag:
+    // - 676 = 1
+    // - EMPOWER = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [DRG_031] Necrium Apothecary - COST:4 [ATK:2/HP:5]
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Combo:</b> Draw a <b>Deathrattle</b> minion
+    //       from your deck and gain its <b>Deathrattle</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - COMBO = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [DRG_033] Candle Breath - COST:6
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Draw 3 cards.
+    //       Costs (3) less while you're holding a Dragon.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [DRG_034] Stowaway - COST:5 [ATK:4/HP:4]
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If there are cards in your deck
+    //       that didn't start there, draw 2 of them.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [DRG_035] Bloodsail Flybooter - COST:1 [ATK:1/HP:1]
+    // - Race: Pirate, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Add two 1/1 Pirates to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [DRG_036] Waxadred - COST:5 [ATK:7/HP:5]
+    // - Race: Dragon, Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Shuffle a Candle into your deck
+    //       that resummons Waxadred when drawn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [DRG_037] Flik Skyshiv - COST:6 [ATK:4/HP:4]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Destroy a minion and all copies
+    //       of it <i>(wherever they are)</i>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [DRG_247] Seal Fate - COST:3
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Deal 3 damage to an undamaged character.
+    //       <b>Invoke</b> Galakrond.
+    // --------------------------------------------------------
+    // GameTag:
+    // - 676 = 1
+    // - EMPOWER = 1
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddRogueNonCollect(PowersType& powers,
                                          PlayReqsType& playReqs,
                                          EntouragesType& entourages)
 {
-    (void)powers;
+    // ------------------------------------ ENCHANTMENT - ROGUE
+    // [DRG_030e] Praise Galakrond! (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +1 Attack.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [DRG_035t] Sky Pirate (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Pirate, Set: Dragons
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [DRG_036t] Waxadred's Candle (*) - COST:5
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Casts When Drawn</b> Summon Waxadred.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TOPDECK = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - CASTSWHENDRAWN = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - ROGUE
+    // [DRG_074e] Camouflaged (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Stealthed until your next turn.
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - ROGUE
+    // [DRG_610e] Galakrond's Wonder (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Costs (0).
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddShaman(PowersType& powers, PlayReqsType& playReqs,
                                 EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------------- MINION - SHAMAN
+    // [DRG_096] Bandersmosh - COST:5 [ATK:5/HP:5]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Each turn this is in your hand, transform it into a
+    //       5/5 copy of a random <b>Legendary</b> minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DRG_211] Squallhunter - COST:4 [ATK:5/HP:7]
+    // - Race: Dragon, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Spell Damage +2</b> <b>Overload:</b> (2)
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPELLPOWER = 2
+    // - OVERLOAD = 2
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [DRG_215] Storm's Wrath - COST:1
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Give your minions +1/+1. <b>Overload:</b> (1)
+    // --------------------------------------------------------
+    // GameTag:
+    // - OVERLOAD = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DRG_216] Surging Tempest - COST:1 [ATK:1/HP:3]
+    // - Race: Elemental, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Has +1 Attack while you have <b>Overloaded</b>
+    //       Mana Crystals.
+    // --------------------------------------------------------
+    // RefTag:
+    // - OVERLOAD = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [DRG_217] Dragon's Pack - COST:5
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Summon two 2/3 Spirit Wolves with <b>Taunt</b>.
+    //       If you've <b>Invoked</b> twice, give them +3/+3.
+    // --------------------------------------------------------
+    // GameTag:
+    // - 676 = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // - EMPOWER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DRG_218] Corrupt Elementalist - COST:5 [ATK:3/HP:3]
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Invoke</b> Galakrond twice.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - 676 = 1
+    // - EMPOWER = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [DRG_219] Lightning Breath - COST:3
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Deal 4 damage to a minion. If you're holding
+    //       a Dragon, also damage its neighbors.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DRG_223] Cumulo-Maximus - COST:5 [ATK:5/HP:5]
+    // - Race: Elemental, Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you have <b>Overloaded</b>
+    //       Mana Crystals, deal 5 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - OVERLOAD = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DRG_224] Nithogg - COST:6 [ATK:5/HP:5]
+    // - Race: Dragon, Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon two 0/3 Eggs.
+    //       Next turn they hatch into 4/4 Drakes with <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [DRG_248] Invocation of Frost - COST:1
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Freeze</b> an enemy. <b>Invoke</b> Galakrond.
+    // --------------------------------------------------------
+    // GameTag:
+    // - 676 = 1
+    // - EMPOWER = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - FREEZE = 1
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddShamanNonCollect(PowersType& powers,
                                           PlayReqsType& playReqs,
                                           EntouragesType& entourages)
 {
-    (void)powers;
+    // ----------------------------------- ENCHANTMENT - SHAMAN
+    // [DRG_068e] Toasty (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Can't be <b>Frozen</b>.
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - SHAMAN
+    // [DRG_096e2] Smoshing (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: 5/5.
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - SHAMAN
+    // [DRG_216e] Surging (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +1 Attack.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DRG_217t] Spirit Wolf (*) - COST:2 [ATK:2/HP:3]
+    // - Faction: Neutral, Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DRG_224t] Storm Egg (*) - COST:1 [ATK:0/HP:3]
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: At the start of your turn, transform into
+    //       a 4/4 Storm Drake with <b>Rush</b>.
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DRG_224t2] Storm Drake (*) - COST:4 [ATK:4/HP:4]
+    // - Race: Dragon, Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DRG_238t14t3] Windswept Elemental (*) - COST:2 [ATK:2/HP:1]
+    // - Race: Elemental, Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DRG_620t4] Brewing Storm (*) - COST:2 [ATK:2/HP:2]
+    // - Race: Elemental, Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DRG_620t5] Living Storm (*) - COST:4 [ATK:4/HP:4]
+    // - Race: Elemental, Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [DRG_620t6] Raging Storm (*) - COST:8 [ATK:8/HP:8]
+    // - Race: Elemental, Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddWarlock(PowersType& powers, PlayReqsType& playReqs,
                                  EntouragesType& entourages)
 {
-    (void)powers;
+    // --------------------------------------- MINION - WARLOCK
+    // [DRG_201] Crazed Netherwing - COST:5 [ATK:5/HP:5]
+    // - Race: Dragon, Faction: Neutral, Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you're holding a Dragon,
+    //       deal 3 damage to all other characters.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [DRG_202] Dragonblight Cultist - COST:3 [ATK:1/HP:1]
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Invoke</b> Galakrond.
+    //       Gain +1 Attack for each other friendly minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - 676 = 1
+    // - EMPOWER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [DRG_203] Veiled Worshipper - COST:4 [ATK:5/HP:4]
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you've <b>Invoked</b> twice,
+    //       draw 3 cards.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - 676 = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - EMPOWER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [DRG_204] Dark Skies - COST:3
+    // - Faction: Neutral, Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Deal 1 damage to a random minion.
+    //       Repeat for each card in your hand.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [DRG_205] Nether Breath - COST:2
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Deal 2 damage. If you're holding a Dragon,
+    //       deal 4 damage with <b>Lifesteal</b> instead.
+    // --------------------------------------------------------
+    // RefTag:
+    // - LIFESTEAL = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [DRG_206] Rain of Fire - COST:1
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Deal 1 damage to all characters.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [DRG_207] Abyssal Summoner - COST:6 [ATK:2/HP:2]
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon a Demon with <b>Taunt</b>
+    //       and stats equal to your hand size.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [DRG_208] Valdris Felgorge - COST:7 [ATK:4/HP:4]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Increase your maximum hand size
+    //       to 12. Draw 4 cards.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [DRG_209] Zzeraku the Warped - COST:8 [ATK:4/HP:12]
+    // - Race: Dragon, Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Whenever your hero takes damage,
+    //       summon a 6/6 Nether Drake.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [DRG_250] Fiendish Rites - COST:3
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Invoke</b> Galakrond.
+    //       Give your minions +1 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - 676 = 1
+    // - EMPOWER = 1
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddWarlockNonCollect(PowersType& powers,
                                            PlayReqsType& playReqs,
                                            EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------- ENCHANTMENT - WARLOCK
+    // [DRG_202e] Power of the Cult (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Increased Attack.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [DRG_207t] Abyssal Destroyer (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Demon, Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [DRG_209t] Nether Drake (*) - COST:6 [ATK:6/HP:6]
+    // - Race: Dragon, Set: Dragons
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [DRG_238t12t2] Draconic Imp (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Demon, Set: Dragons
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddWarrior(PowersType& powers, PlayReqsType& playReqs,
                                  EntouragesType& entourages)
 {
-    (void)powers;
+    // --------------------------------------- MINION - WARRIOR
+    // [DRG_019] Scion of Ruin - COST:3 [ATK:3/HP:2]
+    // - Race: Dragon, Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>. <b>Battlecry:</b> If you've
+    //       <b>Invoked</b> twice, summon 2 copies of this.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - 676 = 1
+    // - RUSH = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - EMPOWER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [DRG_020] EVIL Quartermaster - COST:3 [ATK:2/HP:3]
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Add a <b>Lackey</b> to your hand.
+    //       Gain 3 Armor.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- WEAPON - WARRIOR
+    // [DRG_021] Ritual Chopper - COST:2 [ATK:1/HP:0]
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Invoke</b> Galakrond.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 2
+    // - BATTLECRY = 1
+    // - 676 = 1
+    // - EMPOWER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [DRG_022] Ramming Speed - COST:3
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Force a minion to attack one of its neighbors.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [DRG_023] Skybarge - COST:3 [ATK:2/HP:5]
+    // - Race: Mechanical, Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: After you summon a Pirate,
+    //       deal 2 damage to a random enemy.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [DRG_024] Sky Raider - COST:1 [ATK:1/HP:2]
+    // - Race: Pirate, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Add a random Pirate to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- WEAPON - WARRIOR
+    // [DRG_025] Ancharrr - COST:3 [ATK:2/HP:0]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: After your hero attacks, draw a Pirate from your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DURABILITY = 3
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [DRG_026] Deathwing, Mad Aspect - COST:8 [ATK:12/HP:12]
+    // - Race: Dragon, Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Attack ALL other minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [DRG_249] Awaken! - COST:3
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Invoke</b> Galakrond. Deal 1 damage to all minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - 676 = 1
+    // - EMPOWER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [DRG_500] Molten Breath - COST:4
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Deal 5 damage to a minion.
+    //       If you're holding a Dragon, gain 5 Armor.
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddWarriorNonCollect(PowersType& powers,
                                            PlayReqsType& playReqs,
                                            EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------- ENCHANTMENT - WARRIOR
+    // [DRG_238t10e] Galakrond's Might (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +3 Attack this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddNeutral(PowersType& powers, PlayReqsType& playReqs,
                                  EntouragesType& entourages)
 {
-    (void)powers;
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_049] Tasty Flyfish - COST:2 [ATK:2/HP:2]
+    // - Race: Murloc, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Give a Dragon in your hand +2/+2.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_050] Devoted Maniac - COST:4 [ATK:2/HP:2]
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>
+    //       <b>Battlecry:</b> <b>Invoke</b> Galakrond.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - 676 = 1
+    // - RUSH = 1
+    // - EMPOWER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_054] Big Ol' Whelp - COST:5 [ATK:5/HP:5]
+    // - Race: Dragon, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Draw a card.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_055] Hoard Pillager - COST:4 [ATK:4/HP:2]
+    // - Race: Pirate, Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Equip one of your destroyed weapons.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_056] Parachute Brigand - COST:2 [ATK:2/HP:2]
+    // - Race: Pirate, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: After you play a Pirate,
+    //       summon this minion from your hand.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_057] Hot Air Balloon - COST:1 [ATK:1/HP:2]
+    // - Race: Mechanical, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: At the start of your turn, gain +1 Health.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_058] Wing Commander - COST:4 [ATK:2/HP:5]
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Has +2 Attack for each Dragon in your hand.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_059] Goboglide Tech - COST:3 [ATK:3/HP:3]
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you control a Mech,
+    //       gain +1/+1 and <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_060] Fire Hawk - COST:3 [ATK:1/HP:3]
+    // - Race: Elemental, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Gain +1 Attack for each card
+    //       in your opponent's hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_061] Gyrocopter - COST:6 [ATK:4/HP:5]
+    // - Race: Mechanical, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Rush</b> <b>Windfury</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - WINDFURY = 1
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_062] Wyrmrest Purifier - COST:2 [ATK:3/HP:2]
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Transform all Neutral cards
+    //       in your deck into random cards from your class.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_063] Dragonmaw Poacher - COST:4 [ATK:4/HP:4]
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your opponent controls a Dragon,
+    //       gain +4/+4 and <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_064] Zul'Drak Ritualist - COST:4 [ATK:3/HP:9]
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b> <b>Battlecry:</b> Summon three
+    //       random 1-Cost minions for your opponent.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_065] Hippogryph - COST:4 [ATK:2/HP:6]
+    // - Race: Beast, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Rush</b> <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_066] Evasive Chimaera - COST:2 [ATK:2/HP:1]
+    // - Race: Beast, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Poisonous</b>
+    //       Can't be targeted by spells or Hero Powers.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CANT_BE_TARGETED_BY_SPELLS = 1
+    // - CANT_BE_TARGETED_BY_HERO_POWERS = 1
+    // - POISONOUS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_067] Troll Batrider - COST:4 [ATK:3/HP:3]
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Deal 3 damage to a random enemy minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_068] Living Dragonbreath - COST:3 [ATK:3/HP:4]
+    // - Race: Elemental, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Your minions can't be <b>Frozen</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AURA = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - FREEZE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_069] Platebreaker - COST:5 [ATK:5/HP:5]
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Destroy your opponent's Armor.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_070] Dragon Breeder - COST:2 [ATK:2/HP:3]
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Choose a friendly Dragon.
+    //       Add a copy of it to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_071] Bad Luck Albatross - COST:3 [ATK:4/HP:3]
+    // - Race: Beast, Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Shuffle two 1/1 Albatross
+    //       into your opponent's deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_072] Skyfin - COST:5 [ATK:3/HP:3]
+    // - Race: Murloc, Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you're holding a Dragon,
+    //       summon 2 random Murlocs.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_073] Evasive Feywing - COST:4 [ATK:5/HP:4]
+    // - Race: Dragon, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Can't be targeted by spells or Hero Powers.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CANT_BE_TARGETED_BY_SPELLS = 1
+    // - CANT_BE_TARGETED_BY_HERO_POWERS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_074] Camouflaged Dirigible - COST:6 [ATK:6/HP:6]
+    // - Race: Mechanical, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give your other Mechs
+    //       <b>Stealth</b> until your next turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - STEALTH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_075] Cobalt Spellkin - COST:5 [ATK:3/HP:5]
+    // - Race: Dragon, Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Add two 1-Cost spells from
+    //       your class to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_076] Faceless Corruptor - COST:5 [ATK:5/HP:4]
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>. <b>Battlecry:</b> Transform
+    //       one of your minions into a copy of this.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_077] Utgarde Grapplesniper - COST:6 [ATK:5/HP:5]
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Both players draw a card.
+    //       If it's a Dragon, summon it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_078] Depth Charge - COST:1 [ATK:0/HP:5]
+    // - Set: Dragons, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: At the start of your turn,
+    //       deal 5 damage to ALL minions.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_079] Evasive Wyrm - COST:6 [ATK:5/HP:3]
+    // - Race: Dragon, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Divine Shield</b>. <b>Rush</b>.
+    //       Can't be targeted by spells or Hero Powers.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DIVINE_SHIELD = 1
+    // - CANT_BE_TARGETED_BY_SPELLS = 1
+    // - CANT_BE_TARGETED_BY_HERO_POWERS = 1
+    // - RUSH = 1
+    // - 1211 = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_081] Scalerider - COST:3 [ATK:3/HP:3]
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you're holding a Dragon,
+    //       deal 2 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_082] Kobold Stickyfinger - COST:5 [ATK:4/HP:4]
+    // - Race: Pirate, Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Steal your opponent's weapon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_084] Tentacled Menace - COST:5 [ATK:6/HP:5]
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Each player draws a card.
+    //       Swap their Costs.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_086] Chromatic Egg - COST:5 [ATK:0/HP:3]
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Secretly <b>Discover</b>
+    //       a Dragon to hatch into. <b>Deathrattle:</b> Hatch!
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_088] Dread Raven - COST:3 [ATK:3/HP:4]
+    // - Race: Beast, Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Has +3 Attack for each other Dread Raven you control.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AURA = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_089] Dragonqueen Alexstrasza - COST:9 [ATK:8/HP:8]
+    // - Race: Dragon, Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your deck has no duplicates,
+    //       add 2 random Dragons to your hand. They cost (0).
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_091] Shu'ma - COST:7 [ATK:1/HP:7]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: At the end of your turn,
+    //       fill your board with 1/1 Tentacles.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_092] Transmogrifier - COST:2 [ATK:2/HP:3]
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Whenever you draw a card,
+    //       transform it into a random <b>Legendary</b> minion.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_099] Kronx Dragonhoof - COST:6 [ATK:6/HP:6]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Draw Galakrond.
+    //       If you're already Galakrond, unleash a Devastation.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - 676 = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_213] Twin Tyrant - COST:8 [ATK:4/HP:10]
+    // - Race: Dragon, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Deal 4 damage to two random enemy minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_239] Blazing Battlemage - COST:1 [ATK:2/HP:2]
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_242] Shield of Galakrond - COST:5 [ATK:4/HP:5]
+    // - Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> <b>Invoke</b> Galakrond.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // - 676 = 1
+    // - EMPOWER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_257] Frizz Kindleroost - COST:4 [ATK:5/HP:4]
+    // - Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Reduce the Cost of Dragons
+    //       in your deck by (2).
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_310] Evasive Drakonid - COST:7 [ATK:7/HP:7]
+    // - Race: Dragon, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       Can't be targeted by spells or Hero Powers.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - CANT_BE_TARGETED_BY_SPELLS = 1
+    // - CANT_BE_TARGETED_BY_HERO_POWERS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_401] Grizzled Wizard - COST:2 [ATK:3/HP:2]
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Swap Hero Powers with your opponent
+    //       until your next turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_402] Sathrovarr - COST:9 [ATK:5/HP:5]
+    // - Race: Demon, Set: Dragons, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Choose a friendly minion.
+    //       Add a copy of it to your hand, deck, and battlefield.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_403] Blowtorch Saboteur - COST:3 [ATK:3/HP:4]
+    // - Set: Dragons, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Your opponent's next
+    //       Hero Power costs (3).
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddNeutralNonCollect(PowersType& powers,
                                            PlayReqsType& playReqs,
                                            EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_008e] Righteous Cause (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +1/+1.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_049e] Well Fed (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +2/+2.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_052] Draconic Lackey (*) - COST:1 [ATK:1/HP:1]
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Discover</b> a Dragon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - MARK_OF_EVIL = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_058e] Commanding (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Increased Attack.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_059e] Gobogliding (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +1/+1.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_063e] Poaching (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +4/+4 and <b>Rush</b>.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_084e] Tentacle Confusion (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Cost swapped by Tentacled Menace.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_086e] What's in the Egg? (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: It's a mystery...@{0} is inside!
+    //       <i>(Only you can see this.)</i>
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_088e] Conspiracy of Ravens (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +3 Attack for each other Dread Raven.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_089e] A Queen's Discount (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Costs (0).
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_091t] Tentacle (*) - COST:1 [ATK:1/HP:1]
+    // - Set: Dragons
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [DRG_099t1] Decimation (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Deal 5 damage to the enemy hero.
+    //       Restore 5 Health to your hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ImmuneToSpellpower = 1
+    // - 1200 = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [DRG_099t2] Reanimation (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Summon an 8/8 Dragon with <b>Taunt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - 1200 = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [DRG_099t3] Domination (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Give your other minions +2/+2.
+    // --------------------------------------------------------
+    // GameTag:
+    // - 1200 = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [DRG_099t4] Annihilation (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Deal 5 damage to all other minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ImmuneToSpellpower = 1
+    // - 1200 = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_096e] Smoshing (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Transforming into random <b>Legendary</b> minions.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_099t2t] Reanimated Dragon (*) - COST:8 [ATK:8/HP:8]
+    // - Race: Dragon, Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_099t3e] Dominating (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +2/+2.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_215e] Storm's Wrath (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +1/+1.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_217e] Galakrond's Power (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +3/+3.
+    // --------------------------------------------------------
+    // GameTag:
+    // - HIDE_WATERMARK = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_225e] Mechanical Might (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +1 Attack from Sky Claw.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_233e] Sand Breath (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +1/+2.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [DRG_235d] Dragonrider Talritha Effect Dummy (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // GameTag:
+    // - HIDE_WATERMARK = 1
+    // - 1200 = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_235e] Rider Talritha (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +3/+3 and <b>Deathrattle:</b> Give a Dragon in your hand this
+    // enchant.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_250e] Fiendish Rites (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +1 Attack.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [DRG_255t2] Leper Gnome (*) - COST:1 [ATK:1/HP:1]
+    // - Faction: Neutral, Set: Dragons, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Deal 2 damage to the enemy hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_257e3] Ready to Hatch! (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Reduced Cost.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_308e] Shadowborn (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon {0}.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_311e] Spore Hardened (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +2 Health and <b>Taunt</b>.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_319e4] Treant Powerup (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Your Treants have +1/+1.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [DRG_401d] Grizzled Power Dummy (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Dummy Hook Up for DRG_401e
+    // --------------------------------------------------------
+    // GameTag:
+    // - HIDE_WATERMARK = 1
+    // - 1200 = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_401e] Grizzled Power (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Swap Hero Powers with your opponent next turn.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_403e] Hot Hot Hot! (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: Costs (3).
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_650e] Galakrond's Strength (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +4/+4.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_650e2] Galakrond's Strength (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +4/+4.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [DRG_650e3] Galakrond's Strength (*) - COST:0
+    // - Set: Dragons
+    // --------------------------------------------------------
+    // Text: +4/+4.
+    // --------------------------------------------------------
 }
 
 void DragonsCardsGen::AddAll(PowersType& powers, PlayReqsType& playReqs,

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -16,137 +16,2367 @@ void UldumCardsGen::AddHeroes(PowersType& powers, PlayReqsType& playReqs,
 void UldumCardsGen::AddHeroPowers(PowersType& powers, PlayReqsType& playReqs,
                                   EntouragesType& entourages)
 {
-    (void)powers;
+    // ------------------------------------- HERO_POWER - DRUID
+    // [ULD_131p] Ossirian Tear (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Passive Hero Power</b>
+    //       Your <b>Choose One</b> cards have both effects combined.
+    // --------------------------------------------------------
+    // GameTag:
+    // - HIDE_STATS = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------- HERO_POWER - WARLOCK
+    // [ULD_140p] Tome of Origination (*) - COST:2
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b> Draw a card. It costs (0).
+    // --------------------------------------------------------
+
+    // ------------------------------------ HERO_POWER - HUNTER
+    // [ULD_155p] Ramkahen Roar (*) - COST:2
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b> Give your minions +2 Attack.
+    // --------------------------------------------------------
+
+    // ------------------------------------ HERO_POWER - SHAMAN
+    // [ULD_291p] Heart of Vir'naal (*) - COST:2
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b>
+    //       Your <b>Battlecries</b> trigger twice this turn.
+    // --------------------------------------------------------
+    // RefTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------- HERO_POWER - ROGUE
+    // [ULD_326p] Ancient Blades (*) - COST:2
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b> Equip a 3/2 Blade with
+    //       <b>Immune</b> while attacking.
+    // --------------------------------------------------------
+    // RefTag:
+    // - IMMUNE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------- HERO_POWER - PALADIN
+    // [ULD_431p] Emperor Wraps (*) - COST:2
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b> Summon a 2/2 copy of a friendly minion.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+
+    // -------------------------------------- HERO_POWER - MAGE
+    // [ULD_433p] Ascendant Scroll (*) - COST:2
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b> Add a random Mage spell to your hand.
+    //       It costs (2) less.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_HAND_NOT_FULL = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------- HERO_POWER - WARRIOR
+    // [ULD_711p3] Anraphet's Core (*) - COST:2
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b> Summon a 4/3 Golem.
+    //       After your hero attacks, refresh this.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------ HERO_POWER - PRIEST
+    // [ULD_724p] Obelisk's Eye (*) - COST:2
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b> Restore 3 Health.
+    //       If you target a minion, also give it +3/+3.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddDruid(PowersType& powers, PlayReqsType& playReqs,
                              EntouragesType& entourages)
 {
-    (void)powers;
+    // ------------------------------------------ SPELL - DRUID
+    // [ULD_131] Untapped Potential - COST:1
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> End 4 turns with any unspent Mana.
+    //       <b>Reward:</b> Ossirian Tear.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 4
+    // - 676 = 1
+    // - 839 = 1
+    // - QUEST_REWARD_DATABASE_ID = 53499
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [ULD_133] Crystal Merchant - COST:2 [ATK:1/HP:4]
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: If you have any unspent Mana at the end of your turn,
+    //       draw a card.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [ULD_134] BEEEES!!! - COST:3 [ATK:1/HP:4]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Choose a minion. Summon four 1/1 Bees that attack it.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [ULD_135] Hidden Oasis - COST:6
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Choose One</b> - Summon a 6/6 Ancient with <b>Taunt</b>;
+    //       or Restore 12 Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CHOOSE_ONE = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [ULD_136] Worthy Expedition - COST:1
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Discover</b> a <b>Choose One</b> card.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [ULD_137] Garden Gnome - COST:4 [ATK:2/HP:3]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you're holding a spell that
+    //       costs (5) or more, summon two 2/2 Treants.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [ULD_138] Anubisath Defender - COST:5 [ATK:3/HP:5]
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>. Costs (0) if you've cast a spell that
+    //       costs (5) or more this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [ULD_139] Elise the Enlightened - COST:5 [ATK:5/HP:5]
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your deck has no duplicates,
+    //       duplicate your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [ULD_273] Overflow - COST:7
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Restore 5 Health to all characters. Draw 5 cards.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [ULD_292] Oasis Surger - COST:5 [ATK:3/HP:3]
+    // - Race: Elemental, Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Rush</b> <b>Choose One -</b> Gain +2/+2;
+    //       or Summon a copy of this minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CHOOSE_ONE = 1
+    // - RUSH = 1
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddDruidNonCollect(PowersType& powers,
                                        PlayReqsType& playReqs,
                                        EntouragesType& entourages)
 {
-    (void)powers;
+    // ----------------------------------------- MINION - DRUID
+    // [ULD_134t] Bee (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Beast, Set: Uldum
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [ULD_135a] Befriend the Ancient (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Summon a 6/6 Ancient with <b>Taunt</b>.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [ULD_135at] Vir'naal Ancient (*) - COST:6 [ATK:6/HP:6]
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [ULD_135b] Drink the Water (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Restore 12 Health.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [ULD_137t] Treant (*) - COST:2 [ATK:2/HP:2]
+    // - Set: Uldum
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [ULD_288e] Buried (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Anka, the Buried made this 1/1.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [ULD_292a] Focused Burst (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Gain +2/+2.
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [ULD_292ae] Focused (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: +2/+2.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [ULD_292b] Divide and Conquer (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Summon a copy of this minion.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 2
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddHunter(PowersType& powers, PlayReqsType& playReqs,
                               EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------------- MINION - HUNTER
+    // [ULD_151] Ramkahen Wildtamer - COST:3 [ATK:4/HP:3]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Copy a random Beast in your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [ULD_152] Pressure Plate - COST:2
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Secret:</b> After your opponent casts a spell,
+    //       destroy a random enemy minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [ULD_154] Hyena Alpha - COST:4 [ATK:3/HP:3]
+    // - Race: Beast, Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you control a <b>Secret</b>,
+    //       summon two 2/2 Hyenas.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [ULD_155] Unseal the Vault - COST:1
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> Summon 20 minions.
+    //       <b>Reward:</b> Ramkahen Roar.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 20
+    // - 676 = 1
+    // - 839 = 1
+    // - QUEST_REWARD_DATABASE_ID = 53925
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [ULD_156] Dinotamer Brann - COST:7 [ATK:2/HP:4]
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your deck has no duplicates,
+    //       summon King Krush.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [ULD_212] Wild Bloodstinger - COST:6 [ATK:6/HP:9]
+    // - Race: Beast, Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon a minion from
+    //       your opponent's hand. Attack it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [ULD_410] Scarlet Webweaver - COST:6 [ATK:5/HP:5]
+    // - Race: Beast, Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Reduce the Cost of a random Beast
+    //       in your hand by (5).
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [ULD_429] Hunter's Pack - COST:3
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Add a random Hunter Beast, <b>Secret</b>,
+    //       and weapon to your hand.
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- WEAPON - HUNTER
+    // [ULD_430] Desert Spear - COST:3 [ATK:1/HP:0]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: After your hero attacks,
+    //       summon a 1/1 Locust with <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 3
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [ULD_713] Swarm of Locusts - COST:6
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Summon seven 1/1 Locusts with <b>Rush</b>.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddHunterNonCollect(PowersType& powers,
                                         PlayReqsType& playReqs,
                                         EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------------- MINION - HUNTER
+    // [ULD_154t] Hyena (*) - COST:2 [ATK:2/HP:2]
+    // - Race: Beast, Set: Uldum
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - HUNTER
+    // [ULD_155e] Roar! (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: +2 Attack.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [ULD_156t] Duke (*) - COST:5 [ATK:5/HP:5]
+    // - Race: Beast, Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [ULD_156t2] Duchess (*) - COST:5 [ATK:5/HP:5]
+    // - Race: Beast, Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [ULD_156t3] King Krush (*) - COST:9 [ATK:8/HP:8]
+    // - Race: Beast, Faction: Neutral, Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Charge</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - CHARGE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - HUNTER
+    // [ULD_410e] Weaved (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Costs (5) less.
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddMage(PowersType& powers, PlayReqsType& playReqs,
                             EntouragesType& entourages)
 {
-    (void)powers;
+    // ------------------------------------------- SPELL - MAGE
+    // [ULD_216] Puzzle Box of Yogg-Saron - COST:10
+    // - Faction: Neutral, Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Cast 10 random spells <i>(targets chosen randomly).</i>
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [ULD_236] Tortollan Pilgrim - COST:8 [ATK:5/HP:5]
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry</b>: <b>Discover</b> a copy of
+    //       a spell in your deck and cast it with random targets.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [ULD_238] Reno the Relicologist - COST:6 [ATK:4/HP:6]
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your deck has no duplicates,
+    //       deal 10 damage randomly split among all enemy minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [ULD_239] Flame Ward - COST:3
+    // - Faction: Neutral, Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Secret:</b> After a minion attacks your hero,
+    //       deal 3 damage to all enemy minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [ULD_240] Arcane Flakmage - COST:2 [ATK:3/HP:2]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: After you play a <b>Secret</b>,
+    //       deal 2 damage to all enemy minions.
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [ULD_293] Cloud Prince - COST:5 [ATK:4/HP:4]
+    // - Race: Elemental, Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you control a <b>Secret</b>,
+    //       deal 6 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE_AND_MINIMUM_FRIENDLY_SECRETS = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [ULD_329] Dune Sculptor - COST:3 [ATK:3/HP:3]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: After you cast a spell, add a random Mage
+    //       minion to your hand.
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [ULD_433] Raid the Sky Temple - COST:1
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> Cast 10 spells.
+    //       <b>Reward: </b>Ascendant Scroll.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 10
+    // - 676 = 1
+    // - 839 = 1
+    // - QUEST_REWARD_DATABASE_ID = 53946
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [ULD_435] Naga Sand Witch - COST:5 [ATK:5/HP:5]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Change the Cost of spells
+    //       in your hand to (5).
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [ULD_726] Ancient Mysteries - COST:2
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Draw a <b>Secret</b> from your deck. It costs (0).
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddMageNonCollect(PowersType& powers,
                                       PlayReqsType& playReqs,
                                       EntouragesType& entourages)
 {
-    (void)powers;
+    // ------------------------------------- ENCHANTMENT - MAGE
+    // [ULD_435e] Sandwitched (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Costs (5).
+    // --------------------------------------------------------
+
+    // ------------------------------------- ENCHANTMENT - MAGE
+    // [ULD_726e] Translated (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Costs (0).
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddPaladin(PowersType& powers, PlayReqsType& playReqs,
                                EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------------- SPELL - PALADIN
+    // [ULD_143] Pharaoh's Blessing - COST:6
+    // - Faction: Neutral, Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Give a minion +4/+4, <b>Divine Shield</b>,
+    //       and <b>Taunt</b>.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // - DIVINE_SHIELD = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [ULD_145] Brazen Zealot - COST:1 [ATK:2/HP:1]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Whenever you summon a minion, gain +1 Attack.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [ULD_207] Ancestral Guardian - COST:4 [ATK:4/HP:2]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Lifesteal</b> <b>Reborn</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - LIFESTEAL = 1
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [ULD_217] Micro Mummy - COST:2 [ATK:1/HP:2]
+    // - Race: Mechanical, Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Reborn</b> At the end of your turn, give
+    //       another random friendly minion +1 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [ULD_431] Making Mummies - COST:1
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> Play 5 <b>Reborn</b> minions.
+    //       <b>Reward:</b> Emperor Wraps.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 5
+    // - 676 = 1
+    // - 839 = 1
+    // - QUEST_REWARD_DATABASE_ID = 53908
+    // --------------------------------------------------------
+    // RefTag:
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [ULD_438] Salhet's Pride - COST:3 [ATK:3/HP:1]
+    // - Race: Beast, Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Draw two 1-Health minions
+    //       from your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [ULD_439] Sandwasp Queen - COST:2 [ATK:3/HP:1]
+    // - Race: Beast, Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Add two 2/1 Sandwasps to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [ULD_500] Sir Finley of the Sands - COST:2 [ATK:2/HP:3]
+    // - Race: Murloc, Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your deck has no duplicates,
+    //       <b>Discover</b> an upgraded Hero Power.
+    // --------------------------------------------------------
+    // Entourage: AT_132_DRUID, AT_132_HUNTER, AT_132_MAGE, AT_132_PALADIN,
+    //            AT_132_PRIEST, AT_132_SHAMAN, AT_132_ROGUE, AT_132_WARLOCK,
+    //            AT_132_WARRIOR
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [ULD_716] Tip the Scales - COST:8
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Summon 7 Murlocs from your deck.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [ULD_728] Subdue - COST:2
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Set a minion's Attack and Health to 1.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddPaladinNonCollect(PowersType& powers,
                                          PlayReqsType& playReqs,
                                          EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [ULD_143e] Pharaoh's Blessing (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: +4/+4, <b>Divine Shield</b>, and <b>Taunt</b>.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [ULD_145e] Zeal (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Increased Attack.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [ULD_431e] Emperor Wrapped (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: 2/2.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [ULD_439t] Sandwasp (*) - COST:1 [ATK:2/HP:1]
+    // - Race: Beast, Set: Uldum
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [ULD_716e2] Watched (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Stats changed to 3/3.
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddPriest(PowersType& powers, PlayReqsType& playReqs,
                               EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------------- MINION - PRIEST
+    // [ULD_262] High Priest Amet - COST:4 [ATK:2/HP:7]
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Whenever you summon a minion,
+    //       set its Health equal to this minion's.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [ULD_265] Embalming Ritual - COST:1
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Give a minion <b>Reborn</b>.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [ULD_266] Grandmummy - COST:2 [ATK:1/HP:2]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Reborn</b> <b>Deathrattle:</b> Give a random
+    //       friendly minion +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [ULD_268] Psychopomp - COST:4 [ATK:3/HP:1]
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon a random friendly minion
+    //       that died this game. Give it <b>Reborn</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [ULD_269] Wretched Reclaimer - COST:3 [ATK:3/HP:3]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Destroy a friendly minion,
+    //       then return it to life with full Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [ULD_270] Sandhoof Waterbearer - COST:5 [ATK:5/HP:5]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: At the end of your turn, restore 5 Health
+    //       to a damaged friendly character.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [ULD_272] Holy Ripple - COST:2
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Deal $1 damage to all enemies. Restore 1 Health
+    //       to all friendly characters.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [ULD_714] Penance - COST:2
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Lifesteal</b> Deal 3 damage to a_minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - LIFESTEAL = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [ULD_718] Plague of Death - COST:9
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Silence</b> and destroy all minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SILENCE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [ULD_724] Activate the Obelisk - COST:1
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> Restore 15 Health.
+    //       <b>Reward:</b> Obelisk's Eye.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 15
+    // - 676 = 1
+    // - 839 = 1
+    // - QUEST_REWARD_DATABASE_ID = 54750
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddPriestNonCollect(PowersType& powers,
                                         PlayReqsType& playReqs,
                                         EntouragesType& entourages)
 {
-    (void)powers;
+    // ----------------------------------- ENCHANTMENT - PRIEST
+    // [ULD_262e] Amet's Blessing (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Health changed.
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - PRIEST
+    // [ULD_266e] Grandmummy's Blessing (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - PRIEST
+    // [ULD_724e] Obelisk's Gaze (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Increased stats.
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddRogue(PowersType& powers, PlayReqsType& playReqs,
                              EntouragesType& entourages)
 {
-    (void)powers;
+    // ----------------------------------------- MINION - ROGUE
+    // [ULD_186] Pharaoh Cat - COST:1 [ATK:1/HP:2]
+    // - Race: Beast, Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Add a random <b>Reborn</b> minion
+    //       to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [ULD_231] Whirlkick Master - COST:2 [ATK:1/HP:2]
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Whenever you play a <b>Combo</b> card,
+    //       add a random <b>Combo</b> card to your hand.
+    // --------------------------------------------------------
+    // RefTag:
+    // - COMBO = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [ULD_280] Sahket Sapper - COST:4 [ATK:4/HP:4]
+    // - Race: Pirate, Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Return a random enemy minion
+    //       to your opponent's hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- WEAPON - ROGUE
+    // [ULD_285] Hooked Scimitar - COST:3 [ATK:2/HP:0]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Combo:</b> Gain +2 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 2
+    // - COMBO = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [ULD_286] Shadow of Death - COST:4
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Choose a minion. Shuffle 3 'Shadows' into your deck
+    //       that summon a copy when drawn.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [ULD_288] Anka, the Buried - COST:5 [ATK:5/HP:5]
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Change each <b>Deathrattle</b>
+    //       minion in your hand into a 1/1 that costs (1).
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [ULD_326] Bazaar Burglary - COST:1
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> Add 4 cards from other classes to your hand.
+    //       <b>Reward: </b>Ancient Blades.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 4
+    // - 676 = 1
+    // - 839 = 1
+    // - QUEST_REWARD_DATABASE_ID = 54312
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [ULD_327] Bazaar Mugger - COST:5 [ATK:3/HP:5]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Rush</b> <b>Battlecry:</b> Add a random minion
+    //       from another class to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [ULD_328] Clever Disguise - COST:2
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Add 2 random spells from another class to your hand.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [ULD_715] Plague of Madness - COST:1
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Each player equips a 2/2 Knife with <b>Poisonous</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - 858 = 2451
+    // --------------------------------------------------------
+    // RefTag:
+    // - POISONOUS = 1
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddRogueNonCollect(PowersType& powers,
                                        PlayReqsType& playReqs,
                                        EntouragesType& entourages)
 {
-    (void)powers;
+    // ------------------------------------ ENCHANTMENT - ROGUE
+    // [ULD_285e] Polished (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: +2 Attack.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [ULD_286t] Shadow (*) - COST:4
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Casts When Drawn</b> Summon a {0}.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TOPDECK = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - CASTSWHENDRAWN = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- WEAPON - ROGUE
+    // [ULD_326t] Mirage Blade (*) - COST:2 [ATK:3/HP:0]
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Your hero is <b>Immune</b> while attacking.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 2
+    // --------------------------------------------------------
+    // RefTag:
+    // - IMMUNE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- WEAPON - ROGUE
+    // [ULD_715t] Plagued Knife (*) - COST:1 [ATK:2/HP:0]
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Poisonous</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 2
+    // - POISONOUS = 1
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddShaman(PowersType& powers, PlayReqsType& playReqs,
                               EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------------- MINION - SHAMAN
+    // [ULD_158] Sandstorm Elemental - COST:2 [ATK:2/HP:2]
+    // - Race: Elemental, Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Deal 1 damage to all enemy minions.
+    // <b>Overload:</b> (1)
+    // --------------------------------------------------------
+    // GameTag:
+    // - OVERLOAD = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [ULD_169] Mogu Fleshshaper - COST:7 [ATK:3/HP:4]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>. Costs (1) less for each minion
+    //       on the battlefield.
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [ULD_170] Weaponized Wasp - COST:3 [ATK:3/HP:3]
+    // - Race: Beast, Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you control a <b>Lackey</b>,
+    //       deal 3 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ88 = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [ULD_171] Totemic Surge - COST:0
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Give your Totems +2 Attack.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [ULD_172] Plague of Murlocs - COST:3
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Transform all minions into random Murlocs.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [ULD_173] Vessina - COST:4 [ATK:2/HP:6]
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: While you're <b>Overloaded</b>,
+    //       your other minions have +2 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - AURA = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - OVERLOAD = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [ULD_181] Earthquake - COST:7
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Deal 5 damage to all minions,
+    //       then deal 2 damage to all minions.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [ULD_276] EVIL Totem - COST:2 [ATK:0/HP:2]
+    // - Race: Totem, Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: At the end of your turn,
+    //       add a <b>Lackey</b> to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - 1359 = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [ULD_291] Corrupt the Waters - COST:1
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> Play 6 <b>Battlecry</b> cards.
+    //       <b>Reward:</b> Heart of Vir'naal.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 6
+    // - 676 = 1
+    // - 839 = 1
+    // - QUEST_REWARD_DATABASE_ID = 54370
+    // --------------------------------------------------------
+    // RefTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- WEAPON - SHAMAN
+    // [ULD_413] Splitting Axe - COST:4 [ATK:3/HP:0]
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon copies of your Totems.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 2
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddShamanNonCollect(PowersType& powers,
                                         PlayReqsType& playReqs,
                                         EntouragesType& entourages)
 {
-    (void)powers;
+    // ----------------------------------- ENCHANTMENT - SHAMAN
+    // [ULD_171e] Big Surge (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: +2 Attack.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - SHAMAN
+    // [ULD_173e] Vessina's Devotion (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Vessina is granting this minion +2_Attack.
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - SHAMAN
+    // [ULD_433e] Cheat Sheet (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Costs (2) less.
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddWarlock(PowersType& powers, PlayReqsType& playReqs,
                                EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------------- SPELL - WARLOCK
+    // [ULD_140] Supreme Archaeology - COST:1
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> Draw 20 cards.
+    //       <b>Reward:</b> Tome of Origination.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 20
+    // - 676 = 1
+    // - 839 = 1
+    // - QUEST_REWARD_DATABASE_ID = 53740
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [ULD_160] Sinister Deal - COST:1
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Discover</b> a <b>Lackey</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // - 1359 = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [ULD_161] Neferset Thrasher - COST:3 [ATK:4/HP:5]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Whenever this attacks, deal 3 damage to your hero.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [ULD_162] EVIL Recruiter - COST:3 [ATK:3/HP:3]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Destroy a friendly <b>Lackey</b>
+    //       to summon a 5/5 Demon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - 1359 = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ87 = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [ULD_163] Expired Merchant - COST:2 [ATK:2/HP:1]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Discard your highest Cost card.
+    //       <b>Deathrattle:</b> Add 2 copies of it to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [ULD_165] Riftcleaver - COST:6 [ATK:7/HP:5]
+    // - Race: Demon, Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Destroy a minion.
+    //       Your hero takes damage equal to its Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [ULD_167] Diseased Vulture - COST:4 [ATK:3/HP:5]
+    // - Race: Beast, Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: After your hero takes damage on your turn,
+    //       summon a random 3-Cost minion.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [ULD_168] Dark Pharaoh Tekahn - COST:5 [ATK:4/HP:4]
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> For the rest of the game,
+    //       your <b>Lackeys</b> are 4/4.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [ULD_324] Impbalming - COST:4
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Destroy a minion. Shuffle 3 Worthless Imps into your deck.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [ULD_717] Plague of Flames - COST:1
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Destroy all your minions.
+    //       For each one, destroy a random enemy minion.
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddWarlockNonCollect(PowersType& powers,
                                          PlayReqsType& playReqs,
                                          EntouragesType& entourages)
 {
-    (void)powers;
+    // ---------------------------------- ENCHANTMENT - WARLOCK
+    // [ULD_140e] Origination (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Costs (0).
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [ULD_162t] EVIL Demon (*) - COST:5 [ATK:5/HP:5]
+    // - Race: Demon, Set: Uldum
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARLOCK
+    // [ULD_163e] Expired Goods (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Discarded {0}.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARLOCK
+    // [ULD_168e] Lackey Empowerment (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Your <b>Lackeys</b> are 4/4.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARLOCK
+    // [ULD_168e2] Lackey Empowerment (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Your <b>Lackeys</b> are 4/4.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARLOCK
+    // [ULD_168e3] Lackey Empowerment (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: 4/4.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ENCHANTMENT_INVISIBLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [ULD_324t] Worthless Imp (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Demon, Set: Uldum
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddWarrior(PowersType& powers, PlayReqsType& playReqs,
                                EntouragesType& entourages)
 {
-    (void)powers;
+    // --------------------------------------- MINION - WARRIOR
+    // [ULD_195] Frightened Flunky - COST:2 [ATK:2/HP:2]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> <b>Discover</b> a <b>Taunt</b> minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [ULD_206] Restless Mummy - COST:4 [ATK:3/HP:2]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Rush</b> <b>Reborn</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [ULD_253] Tomb Warden - COST:8 [ATK:3/HP:6]
+    // - Race: Mechanical, Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> Summon a copy of this minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [ULD_256] Into the Fray - COST:1
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Give all <b>Taunt</b> minions in your hand +2/+2.
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [ULD_258] Armagedillo - COST:6 [ATK:4/HP:7]
+    // - Race: Beast, Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b> At the end of your turn,
+    //       give all <b>Taunt</b> minions in your hand +2/+2.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [ULD_707] Plague of Wrath - COST:5
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Destroy all damaged minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - 858 = 41425
+    // --------------------------------------------------------
+
+    // --------------------------------------- WEAPON - WARRIOR
+    // [ULD_708] Livewire Lance - COST:3 [ATK:2/HP:0]
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: After your Hero attacks,
+    //       add a <b>Lackey</b> to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 2
+    // - 1359 = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [ULD_709] Armored Goon - COST:6 [ATK:6/HP:7]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Whenever your hero attacks, gain 5 Armor.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [ULD_711] Hack the System - COST:1
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> Attack 5 times with your hero.
+    //       <b>Reward:</b> Anraphet's Core.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 5
+    // - 676 = 1
+    // - 839 = 1
+    // - QUEST_REWARD_DATABASE_ID = 54416
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [ULD_720] Bloodsworn Mercenary - COST:3 [ATK:3/HP:3]
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry</b>: Choose a damaged friendly minion.
+    //       Summon a copy of it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_DAMAGED_TARGET = 0
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddWarriorNonCollect(PowersType& powers,
                                          PlayReqsType& playReqs,
                                          EntouragesType& entourages)
 {
-    (void)powers;
+    // --------------------------------------- MINION - WARRIOR
+    // [ULD_711t] Stone Golem (*) - COST:3 [ATK:4/HP:3]
+    // - Set: Uldum
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddNeutral(PowersType& powers, PlayReqsType& playReqs,
                                EntouragesType& entourages)
 {
-    (void)powers;
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_003] Zephrys the Great - COST:2 [ATK:3/HP:2]
+    // - Race: Elemental, Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your deck has no duplicates,
+    //       wish for the perfect card.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_157] Questing Explorer - COST:2 [ATK:2/HP:3]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you control a <b>Quest</b>,
+    //       draw a card.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - QUEST = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_174] Serpent Egg - COST:2 [ATK:0/HP:3]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon a 3/4 Sea Serpent.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_177] Octosari - COST:8 [ATK:8/HP:8]
+    // - Race: Beast, Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Draw 8 cards.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_178] Siamat - COST:7 [ATK:6/HP:6]
+    // - Race: Elemental, Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Gain 2 of <b>Rush</b>,
+    //       <b>Taunt</b>, <b>Divine Shield</b>, or
+    //       <b>Windfury</b> <i>(your choice).</i>
+    // --------------------------------------------------------
+    // Entourage: ULD_178a2, ULD_178a, ULD_178a3, ULD_178a4
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - WINDFURY = 1
+    // - TAUNT = 1
+    // - DIVINE_SHIELD = 1
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_179] Phalanx Commander - COST:5 [ATK:4/HP:5]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Your <b>Taunt</b> minions have +2 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AURA = 1
+    // - 1429 = 58385
+    // - TECH_LEVEL = 3
+    // - 1456 = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_180] Sunstruck Henchman - COST:4 [ATK:6/HP:5]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: At the start of your turn,
+    //       this has a 50% chance to fall asleep.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_182] Spitting Camel - COST:2 [ATK:2/HP:4]
+    // - Race: Beast, Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: At the end of your turn, deal 1 damage
+    //       to another random friendly minion.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_183] Anubisath Warbringer - COST:9 [ATK:9/HP:6]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Give all minions in your hand +3/+3.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_184] Kobold Sandtrooper - COST:2 [ATK:2/HP:1]
+    // - Faction: Alliance, Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Deal 3 damage to the enemy hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_185] Temple Berserker - COST:2 [ATK:1/HP:2]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Reborn</b> Has +2 Attack while damaged.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ENRAGED = 1
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_188] Golden Scarab - COST:3 [ATK:2/HP:2]
+    // - Race: Beast, Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b><b>Battlecry:</b> Discover</b> a 4-Cost card.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_189] Faceless Lurker - COST:5 [ATK:3/HP:3]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> Double this minion's Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_190] Pit Crocolisk - COST:8 [ATK:5/HP:6]
+    // - Race: Beast, Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Deal 5 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_191] Beaming Sidekick - COST:1 [ATK:1/HP:2]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a friendly minion +2 Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_193] Living Monument - COST:10 [ATK:10/HP:10]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_194] Wasteland Scorpid - COST:7 [ATK:3/HP:9]
+    // - Race: Beast, Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Poisonous</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - POISONOUS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_196] Neferset Ritualist - COST:2 [ATK:2/HP:3]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Restore adjacent minions
+    //       to full Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_197] Quicksand Elemental - COST:2 [ATK:3/HP:2]
+    // - Race: Elemental, Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give all enemy minions -2 Attack
+    //       this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_198] Conjured Mirage - COST:4 [ATK:3/HP:10]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b> At the start of your turn,
+    //       shuffle this minion into your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_205] Candletaker - COST:3 [ATK:3/HP:2]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Reborn</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_208] Khartut Defender - COST:6 [ATK:3/HP:4]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>, <b>Reborn</b> <b>Deathrattle:</b>
+    //       Restore 3 Health to your hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - DEATHRATTLE = 1
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_209] Vulpera Scoundrel - COST:3 [ATK:2/HP:3]
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry</b>: <b>Discover</b> a spell or
+    //       pick a mystery choice.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_214] Generous Mummy - COST:3 [ATK:5/HP:4]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Reborn</b> Your opponent's cards cost (1) less.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AURA = 1
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_215] Wrapped Golem - COST:7 [ATK:7/HP:5]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Reborn</b> At the end of your turn,
+    //       summon a 1/1 Scarab with <b>Taunt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - REBORN = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_229] Mischief Maker - COST:3 [ATK:3/HP:3]
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Swap the top card of your deck
+    //       with your opponent's.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_250] Infested Goblin - COST:3 [ATK:2/HP:3]
+    // - Set: Uldum, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b> <b>Deathrattle:</b> Add two 1/1 Scarabs
+    //       with <b>Taunt</b> to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_271] Injured Tol'vir - COST:2 [ATK:2/HP:6]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> Deal 3 damage to this minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_274] Wasteland Assassin - COST:5 [ATK:4/HP:2]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b> <b>Reborn</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - STEALTH = 1
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_275] Bone Wraith - COST:4 [ATK:2/HP:5]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b> <b>Reborn</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_282] Jar Dealer - COST:1 [ATK:1/HP:1]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Add a random 1-Cost minion
+    //       to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_289] Fishflinger - COST:2 [ATK:3/HP:2]
+    // - Race: Murloc, Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Add a random Murloc
+    //       to each player's hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_290] History Buff - COST:3 [ATK:3/HP:4]
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Whenever you play a minion,
+    //       give a random minion in your hand +1/+1.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_304] King Phaoris - COST:10 [ATK:5/HP:5]
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> For each spell in your hand,
+    //       summon a random minion of the same Cost.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_309] Dwarven Archaeologist - COST:2 [ATK:2/HP:3]
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: After you <b>Discover</b> a card,
+    //       reduce its cost by (1).
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_450] Vilefiend - COST:2 [ATK:2/HP:2]
+    // - Race: Demon, Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Lifesteal</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - LIFESTEAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_616] Titanic Lackey (*) - COST:1 [ATK:1/HP:1]
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a friendly minion +2 Health
+    //       and <b>Taunt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_702] Mortuary Machine - COST:5 [ATK:8/HP:8]
+    // - Race: Mechanical, Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: After your opponent plays a minion,
+    //       give it <b>Reborn</b>.
+    // --------------------------------------------------------
+    // RefTag:
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_703] Desert Obelisk - COST:5 [ATK:0/HP:5]
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: If you control 3 of these at the end of your turn,
+    //       deal 5 damage to a random enemy.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_705] Mogu Cultist - COST:1 [ATK:1/HP:1]
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your board is full of Mogu Cultists,
+    //       sacrifice them all and summon Highkeeper Ra.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_706] Blatant Decoy - COST:6 [ATK:5/HP:5]
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Each player summons
+    //       the lowest Cost minion from their hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_712] Bug Collector - COST:2 [ATK:2/HP:1]
+    // - Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon a 1/1 Locust with <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_719] Desert Hare - COST:3 [ATK:1/HP:1]
+    // - Race: Beast, Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon two 1/1 Desert Hares.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_721] Colossus of the Moon - COST:10 [ATK:10/HP:10]
+    // - Set: Uldum, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Divine Shield</b> <b>Reborn</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DIVINE_SHIELD = 1
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_723] Murmy - COST:1 [ATK:1/HP:1]
+    // - Race: Murloc, Set: Uldum, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Reborn</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - REBORN = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_727] Body Wrapper - COST:4 [ATK:4/HP:4]
+    // - Set: Uldum, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Discover</b> a friendly minion
+    //       that died this game. Shuffle it into your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddNeutralNonCollect(PowersType& powers,
                                          PlayReqsType& playReqs,
                                          EntouragesType& entourages)
 {
-    (void)powers;
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_174t] Sea Serpent (*) - COST:3 [ATK:3/HP:4]
+    // - Race: Beast, Set: Uldum
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [ULD_178a] Siamat's Wind (*) - COST:0
+    // - Faction: Neutral, Set: Uldum
+    // --------------------------------------------------------
+    // Text: Give Siamat <b>Windfury</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - HIDE_STATS = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - WINDFURY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [ULD_178a2] Siamat's Shield (*) - COST:0
+    // - Faction: Neutral, Set: Uldum
+    // --------------------------------------------------------
+    // Text: Give Siamat <b>Divine Shield</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - HIDE_STATS = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - DIVINE_SHIELD = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [ULD_178a3] Siamat's Heart (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Give Siamat <b>Taunt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - HIDE_STATS = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [ULD_178a4] Siamat's Speed (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Give Siamat <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - HIDE_STATS = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [ULD_179e] Commanded (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Phalanx Commander is granting this +2 Attack.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [ULD_183e] Anubisath Power (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: +3/+3.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [ULD_185e] Enraged (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: +2 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ENRAGED = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [ULD_189e] Bravery (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Doubled Health.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [ULD_191e] Assisting! (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: +2 Health.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [ULD_197e] Stuck! (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: -2 Attack this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [ULD_209t] Mystery Choice! (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Add a random spell to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - HIDE_STATS = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [ULD_214e] Charity (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Costs (1) less.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_215t] Scarab (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Beast, Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [ULD_217e] Microwrapped (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Attack increased.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [ULD_256e] Frayed (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: +2/+2 from Into the Fray.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [ULD_258e] Tough (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Increased stats from Armagedillo.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [ULD_290e] Erudite (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Increased stats from History Buff.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [ULD_291pe] Heart of Vir'naal (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Your <b>Battlecries</b> trigger twice this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [ULD_309e] Archaelogical Study (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: Costs (1) less.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_430t] Locust (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Beast, Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [ULD_616e] Hardened (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: +2 Health and <b>Taunt</b>.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_705t] Highkeeper Ra (*) - COST:10 [ATK:20/HP:20]
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: At the end of your turn,
+    //       deal 20 damage to all enemies.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [ULD_728e] Subdued (*) - COST:0
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: 1/1.
+    // --------------------------------------------------------
 }
 
 void UldumCardsGen::AddAll(PowersType& powers, PlayReqsType& playReqs,

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -1,0 +1,188 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/CardSets/UldumCardsGen.hpp>
+
+namespace RosettaStone
+{
+void UldumCardsGen::AddHeroes(PowersType& powers, PlayReqsType& playReqs,
+                              EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddHeroPowers(PowersType& powers, PlayReqsType& playReqs,
+                                  EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddDruid(PowersType& powers, PlayReqsType& playReqs,
+                             EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddDruidNonCollect(PowersType& powers,
+                                       PlayReqsType& playReqs,
+                                       EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddHunter(PowersType& powers, PlayReqsType& playReqs,
+                              EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddHunterNonCollect(PowersType& powers,
+                                        PlayReqsType& playReqs,
+                                        EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddMage(PowersType& powers, PlayReqsType& playReqs,
+                            EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddMageNonCollect(PowersType& powers,
+                                      PlayReqsType& playReqs,
+                                      EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddPaladin(PowersType& powers, PlayReqsType& playReqs,
+                               EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddPaladinNonCollect(PowersType& powers,
+                                         PlayReqsType& playReqs,
+                                         EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddPriest(PowersType& powers, PlayReqsType& playReqs,
+                              EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddPriestNonCollect(PowersType& powers,
+                                        PlayReqsType& playReqs,
+                                        EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddRogue(PowersType& powers, PlayReqsType& playReqs,
+                             EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddRogueNonCollect(PowersType& powers,
+                                       PlayReqsType& playReqs,
+                                       EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddShaman(PowersType& powers, PlayReqsType& playReqs,
+                              EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddShamanNonCollect(PowersType& powers,
+                                        PlayReqsType& playReqs,
+                                        EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddWarlock(PowersType& powers, PlayReqsType& playReqs,
+                               EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddWarlockNonCollect(PowersType& powers,
+                                         PlayReqsType& playReqs,
+                                         EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddWarrior(PowersType& powers, PlayReqsType& playReqs,
+                               EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddWarriorNonCollect(PowersType& powers,
+                                         PlayReqsType& playReqs,
+                                         EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddNeutral(PowersType& powers, PlayReqsType& playReqs,
+                               EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddNeutralNonCollect(PowersType& powers,
+                                         PlayReqsType& playReqs,
+                                         EntouragesType& entourages)
+{
+    (void)powers;
+}
+
+void UldumCardsGen::AddAll(PowersType& powers, PlayReqsType& playReqs,
+                           EntouragesType& entourages)
+{
+    AddHeroes(powers, playReqs, entourages);
+    AddHeroPowers(powers, playReqs, entourages);
+
+    AddDruid(powers, playReqs, entourages);
+    AddDruidNonCollect(powers, playReqs, entourages);
+
+    AddHunter(powers, playReqs, entourages);
+    AddHunterNonCollect(powers, playReqs, entourages);
+
+    AddMage(powers, playReqs, entourages);
+    AddMageNonCollect(powers, playReqs, entourages);
+
+    AddPaladin(powers, playReqs, entourages);
+    AddPaladinNonCollect(powers, playReqs, entourages);
+
+    AddPriest(powers, playReqs, entourages);
+    AddPriestNonCollect(powers, playReqs, entourages);
+
+    AddRogue(powers, playReqs, entourages);
+    AddRogueNonCollect(powers, playReqs, entourages);
+
+    AddShaman(powers, playReqs, entourages);
+    AddShamanNonCollect(powers, playReqs, entourages);
+
+    AddWarlock(powers, playReqs, entourages);
+    AddWarlockNonCollect(powers, playReqs, entourages);
+
+    AddWarrior(powers, playReqs, entourages);
+    AddWarriorNonCollect(powers, playReqs, entourages);
+
+    AddNeutral(powers, playReqs, entourages);
+    AddNeutralNonCollect(powers, playReqs, entourages);
+}
+}  // namespace RosettaStone

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -2026,26 +2026,6 @@ void UldumCardsGen::AddNeutral(PowersType& powers, PlayReqsType& playReqs,
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [ULD_616] Titanic Lackey (*) - COST:1 [ATK:1/HP:1]
-    // - Set: Uldum
-    // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Give a friendly minion +2 Health
-    //       and <b>Taunt</b>.
-    // --------------------------------------------------------
-    // GameTag:
-    // - BATTLECRY = 1
-    // - MARK_OF_EVIL = 1
-    // --------------------------------------------------------
-    // PlayReq:
-    // - REQ_MINION_TARGET = 0
-    // - REQ_TARGET_IF_AVAILABLE = 0
-    // - REQ_FRIENDLY_TARGET = 0
-    // --------------------------------------------------------
-    // RefTag:
-    // - TAUNT = 1
-    // --------------------------------------------------------
-
-    // --------------------------------------- MINION - NEUTRAL
     // [ULD_702] Mortuary Machine - COST:5 [ATK:8/HP:8]
     // - Race: Mechanical, Set: Uldum, Rarity: Epic
     // --------------------------------------------------------
@@ -2351,6 +2331,26 @@ void UldumCardsGen::AddNeutralNonCollect(PowersType& powers,
     // --------------------------------------------------------
     // GameTag:
     // - RUSH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ULD_616] Titanic Lackey (*) - COST:1 [ATK:1/HP:1]
+    // - Set: Uldum
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a friendly minion +2 Health
+    //       and <b>Taunt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - MARK_OF_EVIL = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL

--- a/Tests/UnitTests/CardSets/DalaranCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DalaranCardsGenTests.cpp
@@ -1,0 +1,12 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <Utils/CardSetUtils.hpp>
+
+TEST(DalaranCardsGen, Temp)
+{
+    EXPECT_TRUE(true);
+}

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -1,0 +1,12 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <Utils/CardSetUtils.hpp>
+
+TEST(DragonsCardsGen, Temp)
+{
+    EXPECT_TRUE(true);
+}

--- a/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/Expert1CardsGenTests.cpp
@@ -9026,6 +9026,20 @@ TEST(NeutralExpert1Test, EX1_021_ThrallmarFarseer)
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [EX1_023] Silvermoon Guardian - COST:4 [ATK:3/HP:3]
+// - Faction: Horde, Set: Expert1, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Divine Shield</b>
+// --------------------------------------------------------
+// GameTag:
+// - DIVINE_SHIELD = 1
+// --------------------------------------------------------
+TEST(NeutralExpert1Test, EX1_023_SilvermoonGuardian)
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [EX1_028] Stranglethorn Tiger - COST:5 [ATK:5/HP:5]
 // - Race: Beast, Faction: Alliance, Set: Expert1, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -1,0 +1,12 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <Utils/CardSetUtils.hpp>
+
+TEST(UldumCardsGen, Temp)
+{
+    EXPECT_TRUE(true);
+}


### PR DESCRIPTION
This revision includes:
- Create card generation files for standard cardsets
    - `DalaranCardsGen`
    - `UldumCardsGen`
    - `DragonsCardsGen`
- Add information for standard cardsets
    - `DALARAN`
    - `ULDUM`
    - `DRAGONS`
- Add RosettaStone 2020 roadmap