### PR TITLE
Implement ability 'Rush', 'Twinspell' and 2 DALARAN cards

### DIFF
--- a/Includes/Rosetta/Games/Game.hpp
+++ b/Includes/Rosetta/Games/Game.hpp
@@ -210,6 +210,7 @@ class Game
     Step nextStep = Step::INVALID;
 
     std::map<int, Playable*> entityList;
+    std::vector<int> rushMinions;
 
     TaskQueue taskQueue;
     TaskStack taskStack;

--- a/Includes/Rosetta/Models/Character.hpp
+++ b/Includes/Rosetta/Models/Character.hpp
@@ -128,6 +128,10 @@ class Character : public Playable
     //! \return Whether attack is possible.
     bool CanAttack() const;
 
+    //! Returns whether it can't attack.
+    //! \return Whether it can't attack.
+    bool CantAttack() const;
+
     //! Returns whether it can't attack heroes.
     //! \return Whether it can't attack heroes.
     bool CantAttackHeroes() const;

--- a/Includes/Rosetta/Models/Character.hpp
+++ b/Includes/Rosetta/Models/Character.hpp
@@ -128,6 +128,10 @@ class Character : public Playable
     //! \return Whether attack is possible.
     bool CanAttack() const;
 
+    //! Returns whether it can't attack heroes.
+    //! \return Whether it can't attack heroes.
+    bool CantAttackHeroes() const;
+
     //! Returns whether the target is valid in attack.
     //! \param opponent The opponent player.
     //! \param target A pointer to the target.

--- a/Includes/Rosetta/Models/Character.hpp
+++ b/Includes/Rosetta/Models/Character.hpp
@@ -128,16 +128,16 @@ class Character : public Playable
     //! \return Whether attack is possible.
     bool CanAttack() const;
 
-    //! Returns whether the target is valid in combat.
+    //! Returns whether the target is valid in attack.
     //! \param opponent The opponent player.
     //! \param target A pointer to the target.
     //! \return true if the target is valid, and false otherwise.
-    bool IsValidCombatTarget(Player* opponent, Character* target) const;
+    bool IsValidAttackTarget(Player* opponent, Character* target) const;
 
-    //! Returns a list of valid target in combat.
+    //! Returns a list of valid target in attack.
     //! \param opponent The opponent player.
     //! \return A list of pointer to valid target.
-    std::vector<Character*> GetValidCombatTargets(Player* opponent) const;
+    std::vector<Character*> GetValidAttackTargets(Player* opponent) const;
 
     //! Takes damage from a certain other entity.
     //! \param source An entity to give damage.

--- a/Includes/Rosetta/Models/Minion.hpp
+++ b/Includes/Rosetta/Models/Minion.hpp
@@ -58,6 +58,10 @@ class Minion : public Character
     //! \return The flag that indicates whether it has charge.
     bool HasCharge() const;
 
+    //! Returns the flag that indicates whether it is rush.
+    //! \return The flag that indicates whether it is rush.
+    bool IsRush() const;
+
     //! Disables all special effects on this minion.
     void Silence();
 

--- a/Includes/Rosetta/Models/Minion.hpp
+++ b/Includes/Rosetta/Models/Minion.hpp
@@ -62,6 +62,14 @@ class Minion : public Character
     //! \return The flag that indicates whether it is rush.
     bool IsRush() const;
 
+    //! Returns the flag that indicates whether it is attackable by rush.
+    //! \return The flag that indicates whether it is attackable by rush.
+    bool IsAttackableByRush() const;
+
+    //! Sets the flag that indicates whether it is attackable by rush.
+    //! \param attackable The value of attackable.
+    void SetAttackableByRush(bool attackable);
+
     //! Disables all special effects on this minion.
     void Silence();
 

--- a/Includes/Rosetta/Models/Spell.hpp
+++ b/Includes/Rosetta/Models/Spell.hpp
@@ -49,6 +49,10 @@ class Spell : public Playable
     //! \return Whether spell is countered.
     bool IsCountered() const;
 
+    //! Returns whether spell is twinspell.
+    //! \return Whether spell is twinspell.
+    bool IsTwinspell() const;
+
     //! Calculates if a target is valid by testing the game state for each
     //! hardcoded requirement.
     //! \param target The proposed target.

--- a/Sources/Rosetta/Actions/Attack.cpp
+++ b/Sources/Rosetta/Actions/Attack.cpp
@@ -13,7 +13,7 @@ void Attack(Player* player, Character* source, Character* target)
 {
     // Check source can attack and target is valid
     if (!source->CanAttack() ||
-        !source->IsValidCombatTarget(player->opponent, target))
+        !source->IsValidAttackTarget(player->opponent, target))
     {
         return;
     }

--- a/Sources/Rosetta/Actions/CastSpell.cpp
+++ b/Sources/Rosetta/Actions/CastSpell.cpp
@@ -4,9 +4,11 @@
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 #include <Rosetta/Actions/CastSpell.hpp>
+#include <Rosetta/Cards/Cards.hpp>
 #include <Rosetta/Games/Game.hpp>
 #include <Rosetta/Models/Player.hpp>
 #include <Rosetta/Zones/GraveyardZone.hpp>
+#include <Rosetta/Zones/HandZone.hpp>
 #include <Rosetta/Zones/SecretZone.hpp>
 
 namespace RosettaStone::Generic
@@ -48,6 +50,13 @@ void CastSpell(Player* player, Spell* spell, Character* target, int chooseOne)
         else
         {
             spell->ActivateTask(PowerType::POWER, target, chooseOne);
+        }
+
+        if (spell->IsTwinspell())
+        {
+            const auto twinspell = Entity::GetFromCard(
+                player, Cards::FindCardByID(spell->card->id + "ts"));
+            player->GetHandZone()->Add(twinspell);
         }
 
         player->GetGraveyardZone()->Add(spell);

--- a/Sources/Rosetta/CardSets/DalaranCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DalaranCardsGen.cpp
@@ -4,6 +4,8 @@
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 #include <Rosetta/CardSets/DalaranCardsGen.hpp>
+#include <Rosetta/Enchants/Enchants.hpp>
+#include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/HealTask.hpp>
 
 using namespace RosettaStone::SimpleTasks;
@@ -25,6 +27,8 @@ void DalaranCardsGen::AddHeroPowers(PowersType& powers, PlayReqsType& playReqs,
 void DalaranCardsGen::AddDruid(PowersType& powers, PlayReqsType& playReqs,
                                EntouragesType& entourages)
 {
+    Power power;
+
     // ------------------------------------------ SPELL - DRUID
     // [DAL_256] The Forest's Aid - COST:8
     // - Set: Dalaran, Rarity: Rare
@@ -63,6 +67,11 @@ void DalaranCardsGen::AddDruid(PowersType& powers, PlayReqsType& playReqs,
     // PlayReq:
     // - REQ_MINION_TARGET = 0
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DAL_351e", EntityType::MINIONS));
+    powers.emplace("DAL_351", power);
+    playReqs.emplace("DAL_351", PlayReqs{ { PlayReq::REQ_MINION_TARGET, 0 } });
 
     // ------------------------------------------ SPELL - DRUID
     // [DAL_352] Crystalsong Portal - COST:2
@@ -151,6 +160,8 @@ void DalaranCardsGen::AddDruidNonCollect(PowersType& powers,
                                          PlayReqsType& playReqs,
                                          EntouragesType& entourages)
 {
+    Power power;
+
     // ----------------------------------------- MINION - DRUID
     // [DAL_256t2] Treant (*) - COST:2 [ATK:2/HP:2]
     // - Set: Dalaran
@@ -193,6 +204,12 @@ void DalaranCardsGen::AddDruidNonCollect(PowersType& powers,
     // PlayReq:
     // - REQ_MINION_TARGET = 0
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DAL_351e", EntityType::MINIONS));
+    powers.emplace("DAL_351ts", power);
+    playReqs.emplace("DAL_351ts",
+                     PlayReqs{ { PlayReq::REQ_MINION_TARGET, 0 } });
 
     // ----------------------------------------- MINION - DRUID
     // [DAL_354t] Squirrel (*) - COST:1 [ATK:1/HP:1]
@@ -2033,6 +2050,8 @@ void DalaranCardsGen::AddNeutralNonCollect(PowersType& powers,
                                            PlayReqsType& playReqs,
                                            EntouragesType& entourages)
 {
+    Power power;
+
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [DAL_011e] Lazul's Curse (*) - COST:0
     // - Set: Dalaran
@@ -2110,6 +2129,9 @@ void DalaranCardsGen::AddNeutralNonCollect(PowersType& powers,
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DAL_351e"));
+    powers.emplace("DAL_351e", power);
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [DAL_548e] Arcane Expansion (*) - COST:0

--- a/Sources/Rosetta/CardSets/DalaranCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DalaranCardsGen.cpp
@@ -1987,6 +1987,9 @@ void DalaranCardsGen::AddNeutral(PowersType& powers, PlayReqsType& playReqs,
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    powers.emplace("DAL_760", power);
 
     // --------------------------------------- MINION - NEUTRAL
     // [DAL_771] Soldier of Fortune - COST:4 [ATK:5/HP:6]

--- a/Sources/Rosetta/Games/Game.cpp
+++ b/Sources/Rosetta/Games/Game.cpp
@@ -119,6 +119,8 @@ Game::Game(const GameConfig& gameConfig) : m_gameConfig(gameConfig)
 
 void Game::Initialize()
 {
+    rushMinions.reserve(MAX_FIELD_SIZE);
+
     // Set game to player
     for (auto& p : m_players)
     {
@@ -481,6 +483,16 @@ void Game::MainEnd()
     ProcessTasks();
     taskQueue.EndEvent();
     ProcessDestroyAndUpdateAura();
+
+    if (!rushMinions.empty())
+    {
+        for (auto& minion : rushMinions)
+        {
+            entityList[minion]->SetGameTag(GameTag::ATTACKABLE_BY_RUSH, 0);
+        }
+
+        rushMinions.clear();
+    }
 
     // Set next step
     nextStep = Step::MAIN_CLEANUP;

--- a/Sources/Rosetta/Games/Game.cpp
+++ b/Sources/Rosetta/Games/Game.cpp
@@ -763,7 +763,7 @@ std::tuple<PlayState, PlayState> Game::PerformAction(ActionParams& params)
         {
             Character* source = params.GetAttacker();
             Character* target = params.GetSpecifiedTarget(
-                source->GetValidCombatTargets(GetCurrentPlayer()->opponent));
+                source->GetValidAttackTargets(GetCurrentPlayer()->opponent));
             task = std::make_unique<AttackTask>(source, target);
             break;
         }

--- a/Sources/Rosetta/Models/Character.cpp
+++ b/Sources/Rosetta/Models/Character.cpp
@@ -181,9 +181,21 @@ bool Character::IsValidAttackTarget(Player* opponent, Character* target) const
         return false;
     }
 
-    const Hero* hero = dynamic_cast<Hero*>(target);
-    return !(hero != nullptr &&
-             hero->GetGameTag(GameTag::CANNOT_ATTACK_HEROES) == 1);
+    if (const auto hero = dynamic_cast<Hero*>(target); hero)
+    {
+        if (CantAttackHeroes())
+        {
+            return false;
+        }
+
+        if (const auto minion = dynamic_cast<const Minion*>(this);
+            minion && minion->IsAttackableByRush())
+        {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 std::vector<Character*> Character::GetValidAttackTargets(Player* opponent) const

--- a/Sources/Rosetta/Models/Character.cpp
+++ b/Sources/Rosetta/Models/Character.cpp
@@ -211,9 +211,9 @@ std::vector<Character*> Character::GetValidAttackTargets(Player* opponent) const
 
     for (auto& minion : opponent->GetFieldZone()->GetAll())
     {
-        if (minion->GetGameTag(GameTag::STEALTH) == 0)
+        if (!minion->HasStealth())
         {
-            if (minion->GetGameTag(GameTag::TAUNT) == 1)
+            if (minion->HasTaunt())
             {
                 isExistTauntInField = true;
                 targetsHaveTaunt.emplace_back(minion);
@@ -232,9 +232,8 @@ std::vector<Character*> Character::GetValidAttackTargets(Player* opponent) const
         return targetsHaveTaunt;
     }
 
-    if (GetGameTag(GameTag::CANNOT_ATTACK_HEROES) == 0 &&
-        opponent->GetHero()->GetGameTag(GameTag::IMMUNE) == 0 &&
-        opponent->GetHero()->GetGameTag(GameTag::STEALTH) == 0)
+    if (!CantAttackHeroes() && !opponent->GetHero()->IsImmune() &&
+        !opponent->GetHero()->HasStealth())
     {
         targets.emplace_back(opponent->GetHero());
     }
@@ -285,7 +284,7 @@ int Character::TakeDamage(Playable* source, int damage)
         }
     }
 
-    if (GetGameTag(GameTag::IMMUNE) == 1)
+    if (IsImmune())
     {
         game->taskQueue.EndEvent();
 

--- a/Sources/Rosetta/Models/Character.cpp
+++ b/Sources/Rosetta/Models/Character.cpp
@@ -168,6 +168,11 @@ bool Character::CanAttack() const
     return true;
 }
 
+bool Character::CantAttackHeroes() const
+{
+    return static_cast<bool>(GetGameTag(GameTag::CANNOT_ATTACK_HEROES));
+}
+
 bool Character::IsValidAttackTarget(Player* opponent, Character* target) const
 {
     auto targets = GetValidAttackTargets(opponent);

--- a/Sources/Rosetta/Models/Character.cpp
+++ b/Sources/Rosetta/Models/Character.cpp
@@ -168,9 +168,9 @@ bool Character::CanAttack() const
     return true;
 }
 
-bool Character::IsValidCombatTarget(Player* opponent, Character* target) const
+bool Character::IsValidAttackTarget(Player* opponent, Character* target) const
 {
-    auto targets = GetValidCombatTargets(opponent);
+    auto targets = GetValidAttackTargets(opponent);
     if (std::find(targets.begin(), targets.end(), target) == targets.end())
     {
         return false;
@@ -181,7 +181,7 @@ bool Character::IsValidCombatTarget(Player* opponent, Character* target) const
              hero->GetGameTag(GameTag::CANNOT_ATTACK_HEROES) == 1);
 }
 
-std::vector<Character*> Character::GetValidCombatTargets(Player* opponent) const
+std::vector<Character*> Character::GetValidAttackTargets(Player* opponent) const
 {
     bool isExistTauntInField = false;
     std::vector<Character*> targets;

--- a/Sources/Rosetta/Models/Character.cpp
+++ b/Sources/Rosetta/Models/Character.cpp
@@ -160,12 +160,17 @@ bool Character::CanAttack() const
     }
 
     //! If the character can't attack, returns false
-    if (GetGameTag(GameTag::CANT_ATTACK) == 1)
+    if (CantAttack())
     {
         return false;
     }
 
     return true;
+}
+
+bool Character::CantAttack() const
+{
+    return static_cast<bool>(GetGameTag(GameTag::CANT_ATTACK));
 }
 
 bool Character::CantAttackHeroes() const

--- a/Sources/Rosetta/Models/Minion.cpp
+++ b/Sources/Rosetta/Models/Minion.cpp
@@ -45,6 +45,16 @@ bool Minion::IsRush() const
     return static_cast<bool>(GetGameTag(GameTag::RUSH));
 }
 
+bool Minion::IsAttackableByRush() const
+{
+    return static_cast<bool>(GetGameTag(GameTag::ATTACKABLE_BY_RUSH));
+}
+
+void Minion::SetAttackableByRush(bool attackable)
+{
+    SetGameTag(GameTag::ATTACKABLE_BY_RUSH, static_cast<int>(attackable));
+}
+
 void Minion::Silence()
 {
     SetGameTag(GameTag::TAUNT, 0);

--- a/Sources/Rosetta/Models/Minion.cpp
+++ b/Sources/Rosetta/Models/Minion.cpp
@@ -40,6 +40,11 @@ bool Minion::HasCharge() const
     return static_cast<bool>(GetGameTag(GameTag::CHARGE));
 }
 
+bool Minion::IsRush() const
+{
+    return static_cast<bool>(GetGameTag(GameTag::RUSH));
+}
+
 void Minion::Silence()
 {
     SetGameTag(GameTag::TAUNT, 0);

--- a/Sources/Rosetta/Models/Spell.cpp
+++ b/Sources/Rosetta/Models/Spell.cpp
@@ -28,6 +28,11 @@ bool Spell::IsCountered() const
     return GetGameTag(GameTag::CANT_PLAY) == 1;
 }
 
+bool Spell::IsTwinspell() const
+{
+    return GetGameTag(GameTag::TWINSPELL) == 1;
+}
+
 bool Spell::TargetingRequirements(Character* target) const
 {
     return !target->GetGameTag(GameTag::CANT_BE_TARGETED_BY_SPELLS) &&

--- a/Sources/Rosetta/Views/BoardRefView.cpp
+++ b/Sources/Rosetta/Views/BoardRefView.cpp
@@ -176,7 +176,8 @@ std::vector<Playable*> BoardRefView::GetHandCards() const
     }
 }
 
-std::vector<std::pair<Playable*, bool>> BoardRefView::GetOpponentHandCards() const
+std::vector<std::pair<Playable*, bool>> BoardRefView::GetOpponentHandCards()
+    const
 {
     std::vector<Playable*> playables;
 
@@ -245,6 +246,11 @@ int BoardRefView::GetDeckCardCount(PlayerType playerType) const
 
 bool BoardRefView::IsHeroAttackable(PlayerType playerType) const
 {
+    if (GetCurrentPlayer() != playerType)
+    {
+        return false;
+    }
+
     if (playerType == PlayerType::PLAYER1)
     {
         return m_game.GetPlayer1()->GetHero()->CanAttack();
@@ -257,6 +263,11 @@ bool BoardRefView::IsHeroAttackable(PlayerType playerType) const
 
 bool BoardRefView::IsMinionAttackable(PlayerType playerType, int idx) const
 {
+    if (GetCurrentPlayer() != playerType)
+    {
+        return false;
+    }
+
     if (playerType == PlayerType::PLAYER1)
     {
         const auto fieldZone = m_game.GetPlayer1()->GetFieldZone();

--- a/Sources/Rosetta/Zones/FieldZone.cpp
+++ b/Sources/Rosetta/Zones/FieldZone.cpp
@@ -116,10 +116,17 @@ void FieldZone::Replace(Minion* oldEntity, Minion* newEntity)
         aura->SetIsFieldChanged(true);
     }
 
-    // Set exhausted by checking GameTag::CHARGE
-    if (newEntity->GetGameTag(GameTag::CHARGE) == 0)
+    if (!newEntity->HasCharge())
     {
-        newEntity->SetExhausted(true);
+        if (newEntity->IsRush())
+        {
+            newEntity->SetAttackableByRush(true);
+            newEntity->game->rushMinions.emplace_back(newEntity->id);
+        }
+        else
+        {
+            newEntity->SetExhausted(true);
+        }
     }
 }
 

--- a/Sources/Rosetta/Zones/FieldZone.cpp
+++ b/Sources/Rosetta/Zones/FieldZone.cpp
@@ -43,16 +43,18 @@ std::vector<Minion*> FieldZone::GetAll() const
 
 void FieldZone::Add(Playable* entity, int zonePos)
 {
-    PositioningZone::Add(dynamic_cast<Minion*>(entity), zonePos);
+    const auto minion = dynamic_cast<Minion*>(entity);
 
-    if (entity->GetGameTag(GameTag::CHARGE) != 1)
+    PositioningZone::Add(minion, zonePos);
+
+    if (minion->HasCharge())
     {
-        entity->SetExhausted(true);
+        minion->SetExhausted(true);
     }
 
-    entity->orderOfPlay = entity->game->GetNextOOP();
+    minion->orderOfPlay = minion->game->GetNextOOP();
 
-    ActivateAura(dynamic_cast<Minion*>(entity));
+    ActivateAura(minion);
 
     for (int i = static_cast<int>(adjacentAuras.size()) - 1; i >= 0; --i)
     {
@@ -62,14 +64,16 @@ void FieldZone::Add(Playable* entity, int zonePos)
 
 Playable* FieldZone::Remove(Playable* entity)
 {
-    RemoveAura(dynamic_cast<Minion*>(entity));
+    const auto minion = dynamic_cast<Minion*>(entity);
+
+    RemoveAura(minion);
 
     for (int i = static_cast<int>(adjacentAuras.size()) - 1; i >= 0; --i)
     {
         adjacentAuras[i]->SetIsFieldChanged(true);
     }
 
-    return PositioningZone::Remove(dynamic_cast<Minion*>(entity));
+    return PositioningZone::Remove(minion);
 }
 
 void FieldZone::Replace(Minion* oldEntity, Minion* newEntity)

--- a/Sources/Rosetta/Zones/FieldZone.cpp
+++ b/Sources/Rosetta/Zones/FieldZone.cpp
@@ -54,6 +54,7 @@ void FieldZone::Add(Playable* entity, int zonePos)
             if (minion->IsRush())
             {
                 minion->SetAttackableByRush(true);
+                minion->game->rushMinions.emplace_back(minion->id);
             }
             else
             {

--- a/Sources/Rosetta/Zones/FieldZone.cpp
+++ b/Sources/Rosetta/Zones/FieldZone.cpp
@@ -47,9 +47,19 @@ void FieldZone::Add(Playable* entity, int zonePos)
 
     PositioningZone::Add(minion, zonePos);
 
-    if (minion->HasCharge())
+    if (minion->player == minion->game->GetCurrentPlayer())
     {
-        minion->SetExhausted(true);
+        if (!minion->HasCharge())
+        {
+            if (minion->IsRush())
+            {
+                minion->SetAttackableByRush(true);
+            }
+            else
+            {
+                minion->SetExhausted(true);
+            }
+        }
     }
 
     minion->orderOfPlay = minion->game->GetNextOOP();

--- a/Tests/UnitTests/CardSets/DalaranCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DalaranCardsGenTests.cpp
@@ -17,6 +17,81 @@ using namespace RosettaStone;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ------------------------------------------ SPELL - DRUID
+// [DAL_351] Blessing of the Ancients - COST:3
+// - Set: Dalaran, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Twinspell</b> Give your minions +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - TWINSPELL_COPY = 54128
+// - TWINSPELL = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST(DruidDalaranTest, DAL_351_BlessingOfTheAncients)
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByID("DAL_351"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    EXPECT_EQ(curField[0]->GetAttack(), 1);
+    EXPECT_EQ(curField[0]->GetHealth(), 1);
+    EXPECT_EQ(curField[1]->GetAttack(), 1);
+    EXPECT_EQ(curField[1]->GetHealth(), 1);
+    EXPECT_EQ(curField[2]->GetAttack(), 1);
+    EXPECT_EQ(curField[2]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    EXPECT_EQ(curHand.GetCount(), 1);
+    EXPECT_EQ(curHand[0]->card->id, "DAL_351ts");
+    EXPECT_EQ(curField[0]->GetAttack(), 2);
+    EXPECT_EQ(curField[0]->GetHealth(), 2);
+    EXPECT_EQ(curField[1]->GetAttack(), 2);
+    EXPECT_EQ(curField[1]->GetHealth(), 2);
+    EXPECT_EQ(curField[2]->GetAttack(), 2);
+    EXPECT_EQ(curField[2]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Spell(curHand[0]));
+    EXPECT_EQ(curHand.GetCount(), 0);
+    EXPECT_EQ(curField[0]->GetAttack(), 3);
+    EXPECT_EQ(curField[0]->GetHealth(), 3);
+    EXPECT_EQ(curField[1]->GetAttack(), 3);
+    EXPECT_EQ(curField[1]->GetHealth(), 3);
+    EXPECT_EQ(curField[2]->GetAttack(), 3);
+    EXPECT_EQ(curField[2]->GetHealth(), 3);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [DAL_078] Traveling Healer - COST:4 [ATK:3/HP:2]
 // - Set: Dalaran, Rarity: Common

--- a/Tests/UnitTests/CardSets/DalaranCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DalaranCardsGenTests.cpp
@@ -5,6 +5,7 @@
 // property of any third parties.
 
 #include <Utils/CardSetUtils.hpp>
+
 #include <Rosetta/Actions/Draw.hpp>
 #include <Rosetta/Cards/Cards.hpp>
 #include <Rosetta/Zones/DeckZone.hpp>
@@ -52,7 +53,7 @@ TEST(NeutralDalaranTest, DAL_078_TravellingHealer)
 
     auto& curField = *(curPlayer->GetFieldZone());
     auto opHero = opPlayer->GetHero();
-    
+
     const auto card1 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Traveling Healer"));
     const auto card2 =
@@ -71,4 +72,18 @@ TEST(NeutralDalaranTest, DAL_078_TravellingHealer)
     game.Process(opPlayer, AttackTask(opHero, curField[0]));
 
     EXPECT_EQ(curField[0]->HasDivineShield(), false);
+}
+
+// --------------------------------------- MINION - NEUTRAL
+// [DAL_760] Burly Shovelfist - COST:9 [ATK:9/HP:9]
+// - Set: Dalaran, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Rush</b>
+// --------------------------------------------------------
+// GameTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST(NeutralDalaranTest, DAL_760_BurlyShovelfist)
+{
+    // Do nothing
 }

--- a/Tests/UnitTests/Utils/TestUtils.cpp
+++ b/Tests/UnitTests/Utils/TestUtils.cpp
@@ -7,6 +7,7 @@
 #include <Utils/TestUtils.hpp>
 #include "gtest/gtest.h"
 
+#include <Rosetta/Games/Game.hpp>
 #include <Rosetta/Models/Enchantment.hpp>
 #include <Rosetta/Models/Minion.hpp>
 #include <Rosetta/Models/Player.hpp>
@@ -57,6 +58,8 @@ void PlayMinionCard(Player* player, Card* card)
     const std::map<GameTag, int> tags;
 
     const auto minion = new Minion(player, card, tags);
+    player->game->entityList.emplace(minion->id, minion);
+
     fieldZone.Add(minion);
     fieldZone[minion->GetZonePosition()]->player = player;
 }
@@ -66,6 +69,8 @@ void PlayWeaponCard(Player* player, Card* card)
     const std::map<GameTag, int> tags;
 
     const auto weapon = new Weapon(player, card, tags);
+    player->game->entityList.emplace(weapon->id, weapon);
+
     player->GetHero()->AddWeapon(*weapon);
 }
 
@@ -75,6 +80,8 @@ void PlayEnchantmentCard(Player* player, Card* card, Entity* target)
     const std::map<GameTag, int> tags;
 
     const auto enchantment = new Enchantment(player, card, tags, target, -1);
+    player->game->entityList.emplace(enchantment->id, enchantment);
+
     graveyardZone.Add(enchantment);
 }
 


### PR DESCRIPTION
This revision includes:
- Implement abilities
    - Rush: Rush is an ability allowing a minion to attack other minions the same turn it is summoned or brought under a new player's control. Unlike Charge, Rush cannot be used to attack the enemy hero. Rush is represented by a shifting thick green border around the minion.
    - Twinspell: Twinspell is an ability that is introduced in the Rise of Shadows expansion. When a spell with Twinspell is cast, a copy of that spell without Twinspell will be added to the player's hand.
- Implement 2 DALARAN cards
    - Burly Shovelfist (DAL_760)
    - Blessing of the Ancients (DAL_351)
- Add several methods
    - `IsRush()`, `IsAttackableByRush()`, `SetAttackableByRush()`, `CantAttackHeroes()`, `CantAttack()`, `IsTwinspell()`