### PR TITLE
Implement 7 ULDUM cards and ability 'Lifesteal'

### DIFF
--- a/Documents/AbilityList.md
+++ b/Documents/AbilityList.md
@@ -22,7 +22,7 @@
 * [x] Freeze
 * [x] Immune
 * [ ] Inspire
-* [ ] Lifesteal
+* [x] Lifesteal
 * [ ] Magnetic
 * [ ] Mega-Windfury
 * [ ] Overkill

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -691,7 +691,7 @@ ULDUM | ULD_433 | Raid the Sky Temple |
 ULDUM | ULD_435 | Naga Sand Witch |  
 ULDUM | ULD_438 | Salhet's Pride |  
 ULDUM | ULD_439 | Sandwasp Queen |  
-ULDUM | ULD_450 | Vilefiend |  
+ULDUM | ULD_450 | Vilefiend | O
 ULDUM | ULD_500 | Sir Finley of the Sands |  
 ULDUM | ULD_702 | Mortuary Machine |  
 ULDUM | ULD_703 | Desert Obelisk |  

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -618,7 +618,7 @@ ULDUM | ULD_178 | Siamat |
 ULDUM | ULD_179 | Phalanx Commander |  
 ULDUM | ULD_180 | Sunstruck Henchman |  
 ULDUM | ULD_181 | Earthquake |  
-ULDUM | ULD_182 | Spitting Camel |  
+ULDUM | ULD_182 | Spitting Camel | O
 ULDUM | ULD_183 | Anubisath Warbringer |  
 ULDUM | ULD_184 | Kobold Sandtrooper |  
 ULDUM | ULD_185 | Temple Berserker |  

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -717,7 +717,7 @@ ULDUM | ULD_726 | Ancient Mysteries |
 ULDUM | ULD_727 | Body Wrapper |  
 ULDUM | ULD_728 | Subdue |  
 
-- Progress: 4% (6 of 135 Cards)
+- Progress: 4% (7 of 135 Cards)
 
 ## Rise of Shadows
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -659,7 +659,7 @@ ULDUM | ULD_266 | Grandmummy |
 ULDUM | ULD_268 | Psychopomp |  
 ULDUM | ULD_269 | Wretched Reclaimer |  
 ULDUM | ULD_270 | Sandhoof Waterbearer |  
-ULDUM | ULD_271 | Injured Tol'vir |  
+ULDUM | ULD_271 | Injured Tol'vir | O
 ULDUM | ULD_272 | Holy Ripple |  
 ULDUM | ULD_273 | Overflow |  
 ULDUM | ULD_274 | Wasteland Assassin |  

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -717,7 +717,7 @@ ULDUM | ULD_726 | Ancient Mysteries |
 ULDUM | ULD_727 | Body Wrapper |  
 ULDUM | ULD_728 | Subdue |  
 
-- Progress: 0% (0 of 135 Cards)
+- Progress: 4% (6 of 135 Cards)
 
 ## Rise of Shadows
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -626,7 +626,7 @@ ULDUM | ULD_186 | Pharaoh Cat |
 ULDUM | ULD_188 | Golden Scarab |  
 ULDUM | ULD_189 | Faceless Lurker |  
 ULDUM | ULD_190 | Pit Crocolisk |  
-ULDUM | ULD_191 | Beaming Sidekick |  
+ULDUM | ULD_191 | Beaming Sidekick | O
 ULDUM | ULD_193 | Living Monument |  
 ULDUM | ULD_194 | Wasteland Scorpid |  
 ULDUM | ULD_195 | Frightened Flunky |  

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -612,7 +612,7 @@ ULDUM | ULD_170 | Weaponized Wasp |
 ULDUM | ULD_171 | Totemic Surge |  
 ULDUM | ULD_172 | Plague of Murlocs |  
 ULDUM | ULD_173 | Vessina |  
-ULDUM | ULD_174 | Serpent Egg |  
+ULDUM | ULD_174 | Serpent Egg | O
 ULDUM | ULD_177 | Octosari |  
 ULDUM | ULD_178 | Siamat |  
 ULDUM | ULD_179 | Phalanx Commander |  

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -620,7 +620,7 @@ ULDUM | ULD_180 | Sunstruck Henchman |
 ULDUM | ULD_181 | Earthquake |  
 ULDUM | ULD_182 | Spitting Camel | O
 ULDUM | ULD_183 | Anubisath Warbringer |  
-ULDUM | ULD_184 | Kobold Sandtrooper |  
+ULDUM | ULD_184 | Kobold Sandtrooper | O
 ULDUM | ULD_185 | Temple Berserker |  
 ULDUM | ULD_186 | Pharaoh Cat |  
 ULDUM | ULD_188 | Golden Scarab |  

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -701,7 +701,7 @@ ULDUM | ULD_707 | Plague of Wrath |
 ULDUM | ULD_708 | Livewire Lance |  
 ULDUM | ULD_709 | Armored Goon |  
 ULDUM | ULD_711 | Hack the System |  
-ULDUM | ULD_712 | Bug Collector |  
+ULDUM | ULD_712 | Bug Collector | O
 ULDUM | ULD_713 | Swarm of Locusts |  
 ULDUM | ULD_714 | Penance |  
 ULDUM | ULD_715 | Plague of Madness |  

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -2179,7 +2179,7 @@ void UldumCardsGen::AddNeutralNonCollect(PowersType& powers,
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
-    powers.emplace("ULD174t", power);
+    powers.emplace("ULD_174t", power);
 
     // ---------------------------------------- SPELL - NEUTRAL
     // [ULD_178a] Siamat's Wind (*) - COST:0

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -7,6 +7,7 @@
 #include <Rosetta/Enchants/Effects.hpp>
 #include <Rosetta/Enchants/Enchants.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/SummonTask.hpp>
 
 using namespace RosettaStone::SimpleTasks;
 
@@ -2093,6 +2094,9 @@ void UldumCardsGen::AddNeutral(PowersType& powers, PlayReqsType& playReqs,
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("ULD_430t"));
+    powers.emplace("ULD_712", power);
 
     // --------------------------------------- MINION - NEUTRAL
     // [ULD_719] Desert Hare - COST:3 [ATK:1/HP:1]
@@ -2352,6 +2356,9 @@ void UldumCardsGen::AddNeutralNonCollect(PowersType& powers,
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    powers.emplace("ULD_430t", power);
 
     // --------------------------------------- MINION - NEUTRAL
     // [ULD_616] Titanic Lackey (*) - COST:1 [ATK:1/HP:1]

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -8,6 +8,7 @@
 #include <Rosetta/Enchants/Enchants.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/SummonTask.hpp>
 
 using namespace RosettaStone::SimpleTasks;
@@ -1720,6 +1721,13 @@ void UldumCardsGen::AddNeutral(PowersType& powers, PlayReqsType& playReqs,
     // Text: At the end of your turn, deal 1 damage
     //       to another random friendly minion.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->tasks = {
+        std::make_shared<RandomTask>(EntityType::MINIONS_NOSOURCE, 1),
+        std::make_shared<DamageTask>(EntityType::STACK, 1)
+    };
+    powers.emplace("ULD_182", power);
 
     // --------------------------------------- MINION - NEUTRAL
     // [ULD_183] Anubisath Warbringer - COST:9 [ATK:9/HP:6]

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -1651,6 +1651,9 @@ void UldumCardsGen::AddNeutral(PowersType& powers, PlayReqsType& playReqs,
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(std::make_shared<SummonTask>("ULD_174t", SummonSide::DEATHRATTLE));
+    powers.emplace("ULD_174", power);
 
     // --------------------------------------- MINION - NEUTRAL
     // [ULD_177] Octosari - COST:8 [ATK:8/HP:8]
@@ -2154,6 +2157,9 @@ void UldumCardsGen::AddNeutralNonCollect(PowersType& powers,
     // [ULD_174t] Sea Serpent (*) - COST:3 [ATK:3/HP:4]
     // - Race: Beast, Set: Uldum
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    powers.emplace("ULD174t", power);
 
     // ---------------------------------------- SPELL - NEUTRAL
     // [ULD_178a] Siamat's Wind (*) - COST:0

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -7,6 +7,7 @@
 #include <Rosetta/Enchants/Effects.hpp>
 #include <Rosetta/Enchants/Enchants.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/SummonTask.hpp>
 
 using namespace RosettaStone::SimpleTasks;
@@ -1652,7 +1653,8 @@ void UldumCardsGen::AddNeutral(PowersType& powers, PlayReqsType& playReqs,
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddDeathrattleTask(std::make_shared<SummonTask>("ULD_174t", SummonSide::DEATHRATTLE));
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("ULD_174t", SummonSide::DEATHRATTLE));
     powers.emplace("ULD_174", power);
 
     // --------------------------------------- MINION - NEUTRAL
@@ -1958,6 +1960,9 @@ void UldumCardsGen::AddNeutral(PowersType& powers, PlayReqsType& playReqs,
     // - TAUNT = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::SOURCE, 3));
+    powers.emplace("ULD_271", power);
 
     // --------------------------------------- MINION - NEUTRAL
     // [ULD_274] Wasteland Assassin - COST:5 [ATK:4/HP:2]

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -4,6 +4,11 @@
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 #include <Rosetta/CardSets/UldumCardsGen.hpp>
+#include <Rosetta/Enchants/Effects.hpp>
+#include <Rosetta/Enchants/Enchants.hpp>
+#include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
+
+using namespace RosettaStone::SimpleTasks;
 
 namespace RosettaStone
 {
@@ -1608,6 +1613,8 @@ void UldumCardsGen::AddWarriorNonCollect(PowersType& powers,
 void UldumCardsGen::AddNeutral(PowersType& powers, PlayReqsType& playReqs,
                                EntouragesType& entourages)
 {
+    Power power;
+
     // --------------------------------------- MINION - NEUTRAL
     // [ULD_003] Zephrys the Great - COST:2 [ATK:3/HP:2]
     // - Race: Elemental, Set: Uldum, Rarity: Legendary
@@ -1790,6 +1797,14 @@ void UldumCardsGen::AddNeutral(PowersType& powers, PlayReqsType& playReqs,
     // - REQ_FRIENDLY_TARGET = 0
     // - REQ_MINION_TARGET = 0
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("ULD_191e", EntityType::TARGET));
+    powers.emplace("ULD_191", power);
+    playReqs.emplace("ULD_191",
+                     PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },
+                               { PlayReq::REQ_FRIENDLY_TARGET, 0 },
+                               { PlayReq::REQ_MINION_TARGET, 0 } });
 
     // --------------------------------------- MINION - NEUTRAL
     // [ULD_193] Living Monument - COST:10 [ATK:10/HP:10]
@@ -2129,6 +2144,8 @@ void UldumCardsGen::AddNeutralNonCollect(PowersType& powers,
                                          PlayReqsType& playReqs,
                                          EntouragesType& entourages)
 {
+    Power power;
+
     // --------------------------------------- MINION - NEUTRAL
     // [ULD_174t] Sea Serpent (*) - COST:3 [ATK:3/HP:4]
     // - Race: Beast, Set: Uldum
@@ -2240,6 +2257,9 @@ void UldumCardsGen::AddNeutralNonCollect(PowersType& powers,
     // --------------------------------------------------------
     // Text: +2 Health.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("ULD_191e"));
+    powers.emplace("ULD_191e", power);
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [ULD_197e] Stuck! (*) - COST:0

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -1748,6 +1748,10 @@ void UldumCardsGen::AddNeutral(PowersType& powers, PlayReqsType& playReqs,
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 3));
+    powers.emplace("ULD_184", power);
 
     // --------------------------------------- MINION - NEUTRAL
     // [ULD_185] Temple Berserker - COST:2 [ATK:1/HP:2]

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -2048,6 +2048,9 @@ void UldumCardsGen::AddNeutral(PowersType& powers, PlayReqsType& playReqs,
     // GameTag:
     // - LIFESTEAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    powers.emplace("ULD_450", power);
 
     // --------------------------------------- MINION - NEUTRAL
     // [ULD_702] Mortuary Machine - COST:5 [ATK:8/HP:8]

--- a/Sources/Rosetta/Models/Character.cpp
+++ b/Sources/Rosetta/Models/Character.cpp
@@ -310,6 +310,13 @@ int Character::TakeDamage(Playable* source, int damage)
     game->triggerManager.OnDealDamageTrigger(source);
 
     game->ProcessTasks();
+
+    if (source != nullptr && source->GetGameTag(GameTag::LIFESTEAL) == 1 &&
+        amount > 0)
+    {
+        source->player->GetHero()->TakeHeal(source, amount);
+    }
+
     game->taskQueue.EndEvent();
 
     game->currentEventData.reset();

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -380,12 +380,20 @@ TEST(NeutralUldumTest, ULD_712_BugCollector)
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     EXPECT_EQ(curField.GetCount(), 2);
+    EXPECT_EQ(curField[1]->card->name, "Locust");
+    EXPECT_EQ(curField[1]->GetAttack(), 1);
+    EXPECT_EQ(curField[1]->GetHealth(), 1);
+    EXPECT_EQ(curField[1]->GetGameTag(GameTag::RUSH), 1);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_START);
 
     game.Process(opPlayer, PlayCardTask::Minion(card2));
     EXPECT_EQ(opField.GetCount(), 2);
+    EXPECT_EQ(opField[1]->card->name, "Locust");
+    EXPECT_EQ(opField[1]->GetAttack(), 1);
+    EXPECT_EQ(opField[1]->GetHealth(), 1);
+    EXPECT_EQ(opField[1]->GetGameTag(GameTag::RUSH), 1);
 
     game.Process(opPlayer, AttackTask(opField[1], curField[1]));
     EXPECT_EQ(curField.GetCount(), 1);

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -6,7 +6,69 @@
 
 #include <Utils/CardSetUtils.hpp>
 
-TEST(UldumCardsGen, Temp)
+#include <Rosetta/Actions/Draw.hpp>
+#include <Rosetta/Cards/Cards.hpp>
+#include <Rosetta/Zones/DeckZone.hpp>
+#include <Rosetta/Zones/FieldZone.hpp>
+#include <Rosetta/Zones/HandZone.hpp>
+#include <Rosetta/Zones/SecretZone.hpp>
+
+using namespace RosettaStone;
+using namespace PlayerTasks;
+using namespace SimpleTasks;
+
+// --------------------------------------- MINION - NEUTRAL
+// [ULD_191] Beaming Sidekick - COST:1 [ATK:1/HP:2]
+// - Set: Uldum, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give a friendly minion +2 Health.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// - REQ_FRIENDLY_TARGET = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST(NeutralUldumTest, ULD_191_Beaming_Sidekick)
 {
-    EXPECT_TRUE(true);
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Beaming Sidekick"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Beaming Sidekick"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Beaming Sidekick"));
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card1, nullptr));
+    EXPECT_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card1));
+    EXPECT_EQ(curField[0]->GetHealth(), 4);
+    EXPECT_EQ(curField[1]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card3, card2));
+    EXPECT_EQ(curField[0]->GetHealth(), 4);
+    EXPECT_EQ(curField[1]->GetHealth(), 4);
+    EXPECT_EQ(curField[2]->GetHealth(), 2);
 }

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -121,6 +121,46 @@ TEST(NeutralUldumTest, ULD_191_BeamingSidekick)
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [ULD_271] Injured Tol'vir - COST:2 [ATK:2/HP:6]
+// - Set: Uldum, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Battlecry:</b> Deal 3 damage to this minion.
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST(NeutralUldumTest, ULD_271_InjuredTolvir)
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Injured Tol'vir"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    EXPECT_EQ(curField[0]->GetDamage(), 3);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [ULD_712] Bug Collector - COST:2 [ATK:2/HP:1]
 // - Set: Uldum, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -161,6 +161,83 @@ TEST(NeutralUldumTest, ULD_271_InjuredTolvir)
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [ULD_450] Vilefiend - COST:2 [ATK:2/HP:2]
+// - Race: Demon, Set: Uldum, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Lifesteal</b>
+// --------------------------------------------------------
+// GameTag:
+// - LIFESTEAL = 1
+// --------------------------------------------------------
+TEST(NeutralUldumTest, ULD_450_Vilefiend)
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Vilefiend"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Lightwarden"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer,
+                 PlayCardTask::SpellTarget(card3, curPlayer->GetHero()));
+    EXPECT_EQ(curPlayer->GetHero()->GetHealth(), 24);
+    EXPECT_EQ(curField[1]->GetAttack(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(curPlayer, AttackTask(card1, opPlayer->GetHero()));
+    EXPECT_EQ(curPlayer->GetHero()->GetHealth(), 26);
+    EXPECT_EQ(opPlayer->GetHero()->GetHealth(), 28);
+    EXPECT_EQ(curField[1]->GetAttack(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, HeroPowerTask(curPlayer->GetHero()));
+    EXPECT_EQ(curPlayer->GetHero()->GetHealth(), 28);
+    EXPECT_EQ(curField[1]->GetAttack(), 5);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(curPlayer, HeroPowerTask(curPlayer->GetHero()));
+    EXPECT_EQ(curPlayer->GetHero()->GetHealth(), 30);
+    EXPECT_EQ(curField[1]->GetAttack(), 7);
+
+    game.Process(curPlayer, AttackTask(card1, opPlayer->GetHero()));
+    EXPECT_EQ(curPlayer->GetHero()->GetHealth(), 30);
+    EXPECT_EQ(opPlayer->GetHero()->GetHealth(), 26);
+    EXPECT_EQ(curField[1]->GetAttack(), 7);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [ULD_712] Bug Collector - COST:2 [ATK:2/HP:1]
 // - Set: Uldum, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -61,7 +61,7 @@ TEST(NeutralUldumTest, ULD_174_SerpentEgg)
 
     game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
     EXPECT_EQ(curField.GetCount(), 1);
-    EXPECT_EQ(curField[0]->GetAttack(), 3);
+    EXPECT_EQ(curField[0]->card->name, "Sea Serpent");
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -26,7 +26,7 @@ using namespace SimpleTasks;
 // GameTag:
 // - DEATHRATTLE = 1
 // --------------------------------------------------------
-TEST(NeutralUldumTest, ULD_174_Serpent_Egg)
+TEST(NeutralUldumTest, ULD_174_SerpentEgg)
 {
     GameConfig config;
     config.player1Class = CardClass::MAGE;
@@ -78,7 +78,7 @@ TEST(NeutralUldumTest, ULD_174_Serpent_Egg)
 // - REQ_FRIENDLY_TARGET = 0
 // - REQ_MINION_TARGET = 0
 // --------------------------------------------------------
-TEST(NeutralUldumTest, ULD_191_Beaming_Sidekick)
+TEST(NeutralUldumTest, ULD_191_BeamingSidekick)
 {
     GameConfig config;
     config.player1Class = CardClass::MAGE;
@@ -132,7 +132,7 @@ TEST(NeutralUldumTest, ULD_191_Beaming_Sidekick)
 // RefTag:
 // - RUSH = 1
 // --------------------------------------------------------
-TEST(NeutralUldumTest, ULD_712_Bug_Collector)
+TEST(NeutralUldumTest, ULD_712_BugCollector)
 {
     GameConfig config;
     config.player1Class = CardClass::MAGE;

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -72,3 +72,57 @@ TEST(NeutralUldumTest, ULD_191_Beaming_Sidekick)
     EXPECT_EQ(curField[1]->GetHealth(), 4);
     EXPECT_EQ(curField[2]->GetHealth(), 2);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [ULD_712] Bug Collector - COST:2 [ATK:2/HP:1]
+// - Set: Uldum, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Summon a 1/1 Locust with <b>Rush</b>.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST(NeutralUldumTest, ULD_712_Bug_Collector)
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bug Collector"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Bug Collector"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    EXPECT_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    EXPECT_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, AttackTask(opField[1], curField[1]));
+    EXPECT_EQ(curField.GetCount(), 1);
+    EXPECT_EQ(opField.GetCount(), 1);
+}

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -123,6 +123,49 @@ TEST(NeutralUldumTest, ULD_182_SpittingCamel)
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [ULD_184] Kobold Sandtrooper - COST:2 [ATK:2/HP:1]
+// - Faction: Alliance, Set: Uldum, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Deal 3 damage to the enemy hero.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST(NeutralUldumTest, ULD_184_KoboldSandtrooper)
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Kobold Sandtrooper"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    EXPECT_EQ(opPlayer->GetHero()->GetHealth(), 27);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [ULD_191] Beaming Sidekick - COST:1 [ATK:1/HP:2]
 // - Set: Uldum, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -65,6 +65,64 @@ TEST(NeutralUldumTest, ULD_174_SerpentEgg)
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [ULD_182] Spitting Camel - COST:2 [ATK:2/HP:4]
+// - Race: Beast, Set: Uldum, Rarity: Common
+// --------------------------------------------------------
+// Text: At the end of your turn, deal 1 damage
+//       to another random friendly minion.
+// --------------------------------------------------------
+TEST(NeutralUldumTest, ULD_182_SpittingCamel)
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Spitting Camel"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Chillwind Yeti"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Chillwind Yeti"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    EXPECT_EQ(curField[1]->GetHealth(), 5);
+    EXPECT_EQ(curField[2]->GetHealth(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+    EXPECT_EQ(curField[0]->GetHealth(), 4);
+    EXPECT_EQ(curField[1]->GetHealth() + curField[2]->GetHealth(), 9);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+    EXPECT_EQ(curField[0]->GetHealth(), 4);
+    EXPECT_EQ(curField[1]->GetHealth() + curField[2]->GetHealth(), 9);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+    EXPECT_EQ(curField[0]->GetHealth(), 4);
+    EXPECT_EQ(curField[1]->GetHealth() + curField[2]->GetHealth(), 8);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [ULD_191] Beaming Sidekick - COST:1 [ATK:1/HP:2]
 // - Set: Uldum, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -18,6 +18,53 @@ using namespace PlayerTasks;
 using namespace SimpleTasks;
 
 // --------------------------------------- MINION - NEUTRAL
+// [ULD_174] Serpent Egg - COST:2 [ATK:0/HP:3]
+// - Set: Uldum, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Summon a 3/4 Sea Serpent.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST(NeutralUldumTest, ULD_174_Serpent_Egg)
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Serpent Egg"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    EXPECT_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    EXPECT_EQ(curField.GetCount(), 1);
+    EXPECT_EQ(curField[0]->GetAttack(), 3);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [ULD_191] Beaming Sidekick - COST:1 [ATK:1/HP:2]
 // - Set: Uldum, Rarity: Common
 // --------------------------------------------------------


### PR DESCRIPTION
This revision includes:  
- Implement 7 ULDUM cards
    - Beaming Sidekick (ULD_191)
    - Bug Collector (ULD_712)
    - Serpent Egg (ULD_174)
    - Injured Tol'vir (ULD_271)
    - Vilefiend (ULD_450)
    - Spitting Camel (ULD_182)
    - Kobold Sandtrooper (ULD_184)
- Implement ability `Lifesteal`