### PR TITLE
Implement ability 'Lackey', 'Invoke' and 11 DRAGONS cards

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -720,10 +720,10 @@ ULDUM | ULD_728 | Subdue |
 
 Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
-DRAGONS | DRG_006 | Corrosive Breath |  
-DRAGONS | DRG_007 | Stormhammer |  
-DRAGONS | DRG_008 | Righteous Cause |  
-DRAGONS | DRG_010 | Diving Gryphon |  
+DRAGONS | DRG_006 | Corrosive Breath | O
+DRAGONS | DRG_007 | Stormhammer | O
+DRAGONS | DRG_008 | Righteous Cause | O
+DRAGONS | DRG_010 | Diving Gryphon | O
 DRAGONS | DRG_019 | Scion of Ruin |  
 DRAGONS | DRG_020 | EVIL Quartermaster |  
 DRAGONS | DRG_021 | Ritual Chopper |  
@@ -751,7 +751,7 @@ DRAGONS | DRG_057 | Hot Air Balloon |
 DRAGONS | DRG_058 | Wing Commander |  
 DRAGONS | DRG_059 | Goboglide Tech |  
 DRAGONS | DRG_060 | Fire Hawk |  
-DRAGONS | DRG_061 | Gyrocopter |  
+DRAGONS | DRG_061 | Gyrocopter | O
 DRAGONS | DRG_062 | Wyrmrest Purifier |  
 DRAGONS | DRG_063 | Dragonmaw Poacher |  
 DRAGONS | DRG_064 | Zul'Drak Ritualist |  
@@ -831,7 +831,7 @@ DRAGONS | DRG_270 | Malygos, Aspect of Magic |
 DRAGONS | DRG_300 | Fate Weaver |  
 DRAGONS | DRG_301 | Whispers of EVIL |  
 DRAGONS | DRG_302 | Grave Rune |  
-DRAGONS | DRG_303 | Disciple of Galakrond |  
+DRAGONS | DRG_303 | Disciple of Galakrond | O
 DRAGONS | DRG_304 | Chronobreaker |  
 DRAGONS | DRG_306 | Envoy of Lazul |  
 DRAGONS | DRG_307 | Breath of the Infinite |  
@@ -855,13 +855,13 @@ DRAGONS | DRG_401 | Grizzled Wizard |
 DRAGONS | DRG_402 | Sathrovarr |  
 DRAGONS | DRG_403 | Blowtorch Saboteur |  
 DRAGONS | DRG_500 | Molten Breath |  
-DRAGONS | DRG_600 | Galakrond, the Wretched |  
-DRAGONS | DRG_610 | Galakrond, the Nightmare |  
-DRAGONS | DRG_620 | Galakrond, the Tempest |  
-DRAGONS | DRG_650 | Galakrond, the Unbreakable |  
-DRAGONS | DRG_660 | Galakrond, the Unspeakable |  
+DRAGONS | DRG_600 | Galakrond, the Wretched | O
+DRAGONS | DRG_610 | Galakrond, the Nightmare | O
+DRAGONS | DRG_620 | Galakrond, the Tempest | O
+DRAGONS | DRG_650 | Galakrond, the Unbreakable | O
+DRAGONS | DRG_660 | Galakrond, the Unspeakable | O
 
-- Progress: 2% (3 of 140 Cards)
+- Progress: 10% (14 of 140 Cards)
 
 ## Galakrond's Awakening
 

--- a/Documents/TaskList.md
+++ b/Documents/TaskList.md
@@ -16,6 +16,7 @@
 * AddAuraEffectTask
 * AddCardTask
 * AddEnchantmentTask
+* AddLackeyTask
 * AddStackToTask
 * ArmorTask
 * ChanceTask
@@ -49,6 +50,7 @@
 * HealTask
 * IncludeAdjacentTask
 * IncludeTask
+* InvokeTask
 * ManaCrystalTask
 * MathMultiplyTask
 * MathNumberIndexTask

--- a/Includes/Rosetta/Actions/PlayCard.hpp
+++ b/Includes/Rosetta/Actions/PlayCard.hpp
@@ -22,6 +22,14 @@ namespace RosettaStone::Generic
 void PlayCard(Player* player, Playable* source, Character* target = nullptr,
               int fieldPos = -1, int chooseOne = 0);
 
+//! Plays a hero card from player's hand.
+//! \param player The player to play hero card.
+//! \param hero A pointer to hero card to play.
+//! \param target A target of the character to receive power.
+//! \param chooseOne The index of chosen card from two cards.
+void PlayHero(Player* player, Hero* hero, Character* target = nullptr,
+              int chooseOne = 0);
+
 //! Plays a minion card from player's hand.
 //! \param player The player to play minion card.
 //! \param minion A pointer to minion card to play.

--- a/Includes/Rosetta/Cards/Card.hpp
+++ b/Includes/Rosetta/Cards/Card.hpp
@@ -65,6 +65,10 @@ class Card
     //! \return true if this card has game tag, and false otherwise.
     bool HasGameTag(GameTag gameTag) const;
 
+    //! Returns the flag that indicates whether it is Galakrond.
+    //! \return The flag that indicates whether it is Galakrond.
+    bool IsGalakrond() const;
+
     //! Returns the flag that indicates whether it is untouchable.
     //! \return The flag that indicates whether it is untouchable.
     bool IsUntouchable() const;

--- a/Includes/Rosetta/Cards/Card.hpp
+++ b/Includes/Rosetta/Cards/Card.hpp
@@ -65,6 +65,10 @@ class Card
     //! \return true if this card has game tag, and false otherwise.
     bool HasGameTag(GameTag gameTag) const;
 
+    //! Returns the flag that indicates whether it is Lackey.
+    //! \return The flag that indicates whether it is Lackey.
+    bool IsLackey() const;
+
     //! Returns the flag that indicates whether it is Galakrond.
     //! \return The flag that indicates whether it is Galakrond.
     bool IsGalakrond() const;

--- a/Includes/Rosetta/Cards/CardDef.hpp
+++ b/Includes/Rosetta/Cards/CardDef.hpp
@@ -38,10 +38,13 @@ class CardDef
     //! \param _chooseCardIDs The choose card IDs data.
     explicit CardDef(Power _power, std::vector<std::string> _chooseCardIDs);
 
-    //! Constructs card def with given \p _power and \p _questProgressTotal.
+    //! Constructs card def with given \p _power, \p _questProgressTotal
+    //! and \p _heroPowerDbfID.
     //! \param _power The power data.
     //! \param _questProgressTotal The quest progress total data.
-    explicit CardDef(Power _power, int _questProgressTotal);
+    //! \param _heroPowerDbfID The hero power defID data.
+    explicit CardDef(Power _power, int _questProgressTotal,
+                     int _heroPowerDbfID);
 
     //! Constructs card def with given \p _power, \p _playReqs and
     //! \p _chooseCardIDs.
@@ -66,6 +69,7 @@ class CardDef
     std::vector<std::string> chooseCardIDs;
     std::vector<std::string> entourages;
     int questProgressTotal = 0;
+    int heroPowerDbfID = 0;
 };
 }  // namespace RosettaStone
 

--- a/Includes/Rosetta/Cards/Cards.hpp
+++ b/Includes/Rosetta/Cards/Cards.hpp
@@ -79,6 +79,10 @@ class Cards
     //! \return A list of all wild cards.
     static const std::vector<Card*>& GetAllWildCards();
 
+    //! Returns a list of Lackey cards.
+    //! \return A list of Lackey cards.
+    static std::vector<Card*> GetLackeys();
+
     //! Returns a card that matches \p id.
     //! \param id The ID of the card.
     //! \return A card that matches \p id.
@@ -171,6 +175,7 @@ class Cards
     static std::array<std::vector<Card*>, NUM_PLAYER_CLASS> m_wildCards;
     static std::vector<Card*> m_allStandardCards;
     static std::vector<Card*> m_allWildCards;
+    static std::vector<Card*> m_lackeys;
 };
 }  // namespace RosettaStone
 

--- a/Includes/Rosetta/Commons/Utils.hpp
+++ b/Includes/Rosetta/Commons/Utils.hpp
@@ -112,6 +112,20 @@ std::vector<T*> ChooseNElements(const std::vector<T*>& list, std::size_t amount)
     return results;
 }
 
+//! Finds out if \p value ends with \p ending.
+//! \param value The original string.
+//! \param ending The suffix string to check.
+//! \return true if \p value ends with \p ending, false otherwise.
+inline bool EndsWith(const std::string& value, const std::string& ending)
+{
+    if (ending.size() > value.size())
+    {
+        return false;
+    }
+
+    return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+}
+
 //! Decodes Base64 based string.
 //! \param src Base64 based string.
 //! \return A unsigned char type container consists of decoded string.

--- a/Includes/Rosetta/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/Conditions/SelfCondition.hpp
@@ -114,6 +114,10 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsFrozen();
 
+    //! SelfCondition wrapper for checking the entity is rush.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsRush();
+
     //! SelfCondition wrapper for checking the entity has not stealth.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition HasNotStealth();

--- a/Includes/Rosetta/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/Conditions/SelfCondition.hpp
@@ -81,8 +81,8 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsRace(Race race);
 
-    //! SelfCondition wrapper for checking there is the entity with \p race in
-    //! field zone.
+    //! SelfCondition wrapper for checking there is the entity
+    //! with \p race in field zone.
     //! \param race The race for checking.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsControllingRace(Race race);
@@ -91,6 +91,12 @@ class SelfCondition
     //! in the owner's secret zone.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsControllingSecret();
+
+    //! SelfCondition wrapper for checking the player has entity
+    //! with \p race in hand zone.
+    //! \param race The race for checking.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsHoldingRace(Race race);
 
     //! SelfCondition wrapper for checking the entity is minion.
     //! \return Generated SelfCondition for intended purpose.

--- a/Includes/Rosetta/Models/Minion.hpp
+++ b/Includes/Rosetta/Models/Minion.hpp
@@ -50,6 +50,10 @@ class Minion : public Character
     //! \param value The value of last board position.
     void SetLastBoardPos(int value);
 
+    //! Returns the flag that indicates whether it is Lackey.
+    //! \return The flag that indicates whether it is Lackey.
+    bool IsLackey() const;
+
     //! Returns the flag that indicates whether it is untouchable.
     //! \return The flag that indicates whether it is untouchable.
     bool IsUntouchable() const;

--- a/Includes/Rosetta/Models/Player.hpp
+++ b/Includes/Rosetta/Models/Player.hpp
@@ -209,6 +209,9 @@ class Player : public Entity
     //! \param value The value of main Galakrond.
     void SetMainGalakrond(int value);
 
+    //! Increases the value of invoke.
+    void IncreaseInvoke();
+
     //! Adds hero and hero power.
     //! \param heroCard A card that represents hero.
     //! \param powerCard A card that represents hero power.

--- a/Includes/Rosetta/Models/Player.hpp
+++ b/Includes/Rosetta/Models/Player.hpp
@@ -201,14 +201,6 @@ class Player : public Entity
     //! \param value The number of friendly minions that died this turn.
     void SetNumFriendlyMinionsDiedThisTurn(int value);
 
-    //! Returns the value of main Galakrond.
-    //! \return The value of main Galakrond.
-    CardClass GetMainGalakrond() const;
-
-    //! Sets the value of main Galakrond.
-    //! \param value The value of main Galakrond.
-    void SetMainGalakrond(int value);
-
     //! Upgrades the Galakrond hero card.
     void UpgradeGalakrond();
 

--- a/Includes/Rosetta/Models/Player.hpp
+++ b/Includes/Rosetta/Models/Player.hpp
@@ -201,6 +201,14 @@ class Player : public Entity
     //! \param value The number of friendly minions that died this turn.
     void SetNumFriendlyMinionsDiedThisTurn(int value);
 
+    //! Returns the value of main Galakrond.
+    //! \return The value of main Galakrond.
+    CardClass GetMainGalakrond() const;
+
+    //! Sets the value of main Galakrond.
+    //! \param value The value of main Galakrond.
+    void SetMainGalakrond(int value);
+
     //! Adds hero and hero power.
     //! \param heroCard A card that represents hero.
     //! \param powerCard A card that represents hero power.

--- a/Includes/Rosetta/Models/Player.hpp
+++ b/Includes/Rosetta/Models/Player.hpp
@@ -209,6 +209,9 @@ class Player : public Entity
     //! \param value The value of main Galakrond.
     void SetMainGalakrond(int value);
 
+    //! Upgrades the Galakrond hero card.
+    void UpgradeGalakrond();
+
     //! Returns the value of invoke.
     //! \return The value of invoke.
     int GetInvoke() const;
@@ -229,6 +232,7 @@ class Player : public Entity
     Mulligan mulliganState = Mulligan::INVALID;
     std::optional<Choice> choice = std::nullopt;
 
+    Playable* galakrond = nullptr;
     Player* opponent = nullptr;
 
     PlayerAuraEffects playerAuraEffects;

--- a/Includes/Rosetta/Models/Player.hpp
+++ b/Includes/Rosetta/Models/Player.hpp
@@ -209,6 +209,10 @@ class Player : public Entity
     //! \param value The value of main Galakrond.
     void SetMainGalakrond(int value);
 
+    //! Returns the value of invoke.
+    //! \return The value of invoke.
+    int GetInvoke() const;
+
     //! Increases the value of invoke.
     void IncreaseInvoke();
 

--- a/Includes/Rosetta/Models/Player.hpp
+++ b/Includes/Rosetta/Models/Player.hpp
@@ -84,9 +84,13 @@ class Player : public Entity
     //! \return Player's setaside zone.
     SetasideZone* GetSetasideZone() const;
 
-    //! Returns player's hero.
-    //! \return Player's hero.
+    //! Returns the hero of the player.
+    //! \return The hero of the player.
     Hero* GetHero() const;
+
+    //! Sets the hero of the player.
+    //! \param hero The hero of the player.
+    void SetHero(Hero* hero);
 
     //! Returns player's hero power.
     //! \return Player's hero power.

--- a/Includes/Rosetta/Models/Weapon.hpp
+++ b/Includes/Rosetta/Models/Weapon.hpp
@@ -63,6 +63,10 @@ class Weapon : public Playable
     //! Remove the value of durability by amount.
     //! \param amount The amount to be removed.
     void RemoveDurability(int amount);
+
+    //! Returns the flag that indicates whether it is immune.
+    //! \return The flag that indicates whether it is immune.
+    bool IsImmune() const;
 };
 }  // namespace RosettaStone
 

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -151,6 +151,7 @@
 #include <Rosetta/Tasks/SimpleTasks/HealTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/IncludeAdjacentTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/IncludeTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/InvokeTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ManaCrystalTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/MathMultiplyTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/MathNumberIndexTask.hpp>

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -117,6 +117,7 @@
 #include <Rosetta/Tasks/SimpleTasks/AddAuraEffectTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddCardTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/AddLackeyTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ChanceTask.hpp>

--- a/Includes/Rosetta/Tasks/SimpleTasks/AddLackeyTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/AddLackeyTask.hpp
@@ -1,0 +1,39 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_ADD_LACKEY_TASK_HPP
+#define ROSETTASTONE_ADD_LACKEY_TASK_HPP
+
+#include <Rosetta/Tasks/ITask.hpp>
+
+namespace RosettaStone::SimpleTasks
+{
+//!
+//! \brief AddLackeyTask class.
+//!
+//! This class represents the task for adding Lackey to hand.
+//!
+class AddLackeyTask : public ITask
+{
+ public:
+    //! Constructs task with given \p amount.
+    //! \param amount The amount to draw Lackey.
+    explicit AddLackeyTask(int amount);
+
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player* player) override;
+
+    //! Internal method of Clone().
+    //! \return The cloned task.
+    std::unique_ptr<ITask> CloneImpl() override;
+
+    int m_amount = 0;
+};
+}  // namespace RosettaStone::SimpleTasks
+
+#endif  // ROSETTASTONE_ADD_LACKEY_TASK_HPP

--- a/Includes/Rosetta/Tasks/SimpleTasks/InvokeTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/InvokeTask.hpp
@@ -1,0 +1,37 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_INVOKE_TASK_HPP
+#define ROSETTASTONE_INVOKE_TASK_HPP
+
+#include <Rosetta/Tasks/ITask.hpp>
+
+namespace RosettaStone::SimpleTasks
+{
+//!
+//! \brief InvokeTask class.
+//!
+//! This class represents the task for processing ability 'Invoke'. When an
+//! Invoke card is played, the Hero Power of Galakrond will be activated, as
+//! long as the player has a Galakrond hero card in their hand, deck, or
+//! battlefield. Invoke cards are also needed to upgrade Galakrond's Battlecry.
+//! Two are needed to upgrade him once, and four are needed to fully upgrade
+//! him.
+//!
+class InvokeTask : public ITask
+{
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player* player) override;
+
+    //! Internal method of Clone().
+    //! \return The cloned task.
+    std::unique_ptr<ITask> CloneImpl() override;
+};
+}  // namespace RosettaStone::SimpleTasks
+
+#endif  // ROSETTASTONE_INVOKE_TASK_HPP

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Expansions
 
-  * 2% Descent of Dragons (3 of 140 cards)
+  * 10% Descent of Dragons (14 of 140 cards)
   * 18% Saviors of Uldum (25 of 135 cards)
   * 12% Rise of Shadows (17 of 136 cards)
   * 0% Rastakhan's Rumble (0 of 135 Cards)

--- a/Sources/Rosetta/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/Actions/PlayCard.cpp
@@ -78,6 +78,12 @@ void PlayCard(Player* player, Playable* source, Character* target, int fieldPos,
     // Pass to sub-logic
     switch (source->card->GetCardType())
     {
+        case CardType::HERO:
+        {
+            const auto hero = dynamic_cast<Hero*>(source);
+            PlayHero(player, hero, target, chooseOne);
+            break;
+        }
         case CardType::MINION:
         {
             const auto minion = dynamic_cast<Minion*>(source);
@@ -93,7 +99,7 @@ void PlayCard(Player* player, Playable* source, Character* target, int fieldPos,
         case CardType::WEAPON:
         {
             const auto weapon = dynamic_cast<Weapon*>(source);
-            PlayWeapon(player, weapon, target); 
+            PlayWeapon(player, weapon, target);
             break;
         }
         default:

--- a/Sources/Rosetta/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/Actions/PlayCard.cpp
@@ -5,10 +5,12 @@
 
 #include <Rosetta/Actions/CastSpell.hpp>
 #include <Rosetta/Actions/PlayCard.hpp>
+#include <Rosetta/Cards/Cards.hpp>
 #include <Rosetta/Games/Game.hpp>
 #include <Rosetta/Zones/FieldZone.hpp>
 #include <Rosetta/Zones/GraveyardZone.hpp>
 #include <Rosetta/Zones/HandZone.hpp>
+#include <Rosetta/Zones/SetasideZone.hpp>
 
 namespace RosettaStone::Generic
 {
@@ -76,19 +78,22 @@ void PlayCard(Player* player, Playable* source, Character* target, int fieldPos,
     // Pass to sub-logic
     switch (source->card->GetCardType())
     {
-        case CardType::MINION: {
+        case CardType::MINION:
+        {
             const auto minion = dynamic_cast<Minion*>(source);
             PlayMinion(player, minion, target, fieldPos, chooseOne);
             break;
         }
-        case CardType::SPELL: {
+        case CardType::SPELL:
+        {
             const auto spell = dynamic_cast<Spell*>(source);
             PlaySpell(player, spell, target, chooseOne);
             break;
         }
-        case CardType::WEAPON: {
+        case CardType::WEAPON:
+        {
             const auto weapon = dynamic_cast<Weapon*>(source);
-            PlayWeapon(player, weapon, target);
+            PlayWeapon(player, weapon, target); 
             break;
         }
         default:
@@ -101,6 +106,45 @@ void PlayCard(Player* player, Playable* source, Character* target, int fieldPos,
     {
         player->SetComboActive(true);
     }
+}
+
+void PlayHero(Player* player, Hero* hero, Character* target, int chooseOne)
+{
+    Hero* oldHero = player->GetHero();
+
+    hero->SetZoneType(ZoneType::PLAY);
+    hero->SetHealth(oldHero->GetMaxHealth());
+    hero->SetDamage(oldHero->GetDamage());
+    hero->SetArmor(oldHero->GetArmor() + hero->card->gameTags[GameTag::ARMOR]);
+    hero->SetExhausted(oldHero->IsExhausted());
+
+    player->GetSetasideZone()->Add(oldHero);
+    hero->weapon = oldHero->weapon;
+    player->GetSetasideZone()->Add(oldHero->heroPower);
+    hero->heroPower = dynamic_cast<HeroPower*>(Entity::GetFromCard(
+        player, Cards::FindCardByDbfID(hero->GetGameTag(GameTag::HERO_POWER))));
+    if (auto trigger = hero->heroPower->card->power.GetTrigger(); trigger)
+    {
+        trigger->Activate(hero->heroPower);
+    }
+
+    player->SetHero(hero);
+    if (auto trigger = hero->card->power.GetTrigger(); trigger)
+    {
+        trigger->Activate(hero);
+    }
+
+    player->game->taskQueue.StartEvent();
+    player->game->triggerManager.OnPlayCardTrigger(hero);
+    player->game->ProcessTasks();
+    player->game->taskQueue.EndEvent();
+    player->game->ProcessDestroyAndUpdateAura();
+
+    player->game->taskQueue.StartEvent();
+    hero->ActivateTask(PowerType::POWER, target, chooseOne);
+    player->game->ProcessTasks();
+    player->game->taskQueue.EndEvent();
+    player->game->ProcessDestroyAndUpdateAura();
 }
 
 void PlayMinion(Player* player, Minion* minion, Character* target, int fieldPos,

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -3,6 +3,7 @@
 // Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
+#include <Rosetta/Auras/AdaptiveEffect.hpp>
 #include <Rosetta/CardSets/DragonsCardsGen.hpp>
 #include <Rosetta/Conditions/RelaCondition.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
@@ -522,6 +523,12 @@ void DragonsCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DURABILITY = 2
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<AdaptiveEffect>(
+        std::make_shared<SelfCondition>(
+            SelfCondition::IsControllingRace(Race::DRAGON)),
+        GameTag::IMMUNE));
+    cards.emplace("DRG_007", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
     // [DRG_010] Diving Gryphon - COST:3 [ATK:4/HP:1]

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -629,7 +629,7 @@ void DragonsCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::USE_HERO_POWER));
     power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
         TaskList{ std::make_shared<SummonTask>("DRG_255t2", 3) }) };
-    cards.emplace("DRG_255", CardDef(power, 3));
+    cards.emplace("DRG_255", CardDef(power, 3, 0));
 
     // ---------------------------------------- MINION - HUNTER
     // [DRG_256] Dragonbane - COST:4 [ATK:3/HP:5]
@@ -926,7 +926,7 @@ void DragonsCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
         TaskList{ std::make_shared<AddEnchantmentTask>(
             "DRG_008e", EntityType::MINIONS) }) };
-    cards.emplace("DRG_008", CardDef(power, 5));
+    cards.emplace("DRG_008", CardDef(power, 5, 0));
 
     // --------------------------------------- MINION - PALADIN
     // [DRG_225] Sky Claw - COST:3 [ATK:1/HP:2]

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -9,7 +9,6 @@
 #include <Rosetta/Enchants/Enchants.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddLackeyTask.hpp>
-#include <Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DrawStackTask.hpp>
@@ -190,6 +189,9 @@ void DragonsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("DRG_620t4", 2));
+    cards.emplace("DRG_620", CardDef(power, 0, 55808));
 
     // ------------------------------------------ HERO - SHAMAN
     // [DRG_620t2] Galakrond, the Apocalypse (*) - COST:7 [ATK:0/HP:30]
@@ -365,6 +367,9 @@ void DragonsCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("DRG_238t14t3", 1));
+    cards.emplace("DRG_238p4", CardDef(power));
 
     // ------------------------------------ HERO_POWER - PRIEST
     // [DRG_238p5] Galakrond's Wit (*) - COST:2
@@ -1538,6 +1543,8 @@ void DragonsCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 
 void DragonsCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [DRG_068e] Toasty (*) - COST:0
     // - Set: Dragons
@@ -1599,6 +1606,9 @@ void DragonsCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DRG_238t14t3", CardDef(power));
 
     // ---------------------------------------- MINION - SHAMAN
     // [DRG_620t4] Brewing Storm (*) - COST:2 [ATK:2/HP:2]
@@ -1609,6 +1619,9 @@ void DragonsCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DRG_620t4", CardDef(power));
 
     // ---------------------------------------- MINION - SHAMAN
     // [DRG_620t5] Living Storm (*) - COST:4 [ATK:4/HP:4]

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -13,6 +13,10 @@
 #include <Rosetta/Tasks/SimpleTasks/FlagTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/QuestProgressTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/SummonTask.hpp>
+#include "Rosetta/Tasks/SimpleTasks/IncludeTask.hpp"
+#include "Rosetta/Tasks/SimpleTasks/FilterStackTask.hpp"
+#include "Rosetta/Tasks/SimpleTasks/RandomTask.hpp"
+#include "Rosetta/Tasks/SimpleTasks/DrawStackTask.hpp"
 
 using namespace RosettaStone::SimpleTasks;
 
@@ -543,6 +547,13 @@ void DragonsCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::DECK));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRush()) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddPowerTask(std::make_shared<DrawStackTask>(1));
+    cards.emplace("DRG_010", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
     // [DRG_095] Veranus - COST:6 [ATK:7/HP:6]

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -5,7 +5,9 @@
 
 #include <Rosetta/CardSets/DragonsCardsGen.hpp>
 #include <Rosetta/Conditions/RelaCondition.hpp>
+#include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/FlagTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/QuestProgressTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/SummonTask.hpp>
 
@@ -13,6 +15,9 @@ using namespace RosettaStone::SimpleTasks;
 
 namespace RosettaStone
 {
+using PlayReqs = std::map<PlayReq, int>;
+using ChooseCardIDs = std::vector<std::string>;
+using Entourages = std::vector<std::string>;
 using TaskList = std::vector<std::shared_ptr<ITask>>;
 using EntityTypeList = std::vector<EntityType>;
 using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
@@ -487,6 +492,26 @@ void DragonsCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // Text: Deal 3 damage to a minion. If you're holding
     //       a Dragon, it also hits the enemy hero.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsHoldingRace(Race::DRAGON)) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true,
+        TaskList{
+            std::make_shared<DamageTask>(EntityType::TARGET, 3, true),
+            std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 3, true) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        false,
+        TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 3, true) }));
+    cards.emplace(
+        "DRG_006",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ---------------------------------------- WEAPON - HUNTER
     // [DRG_007] Stormhammer - COST:3 [ATK:3/HP:0]

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -278,6 +278,15 @@ void DragonsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // - HERO_POWER = 55805
     // - GALAKROND_HERO_CARD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::DECK));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsMinion()) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 2));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DRG_650e2", EntityType::STACK));
+    power.AddPowerTask(std::make_shared<DrawStackTask>(2));
+    cards.emplace("DRG_650t2", CardDef(power, 0, 55805));
 
     // ----------------------------------------- HERO - WARRIOR
     // [DRG_650t3] Galakrond, Azeroth's End (*) - COST:7 [ATK:0/HP:30]
@@ -2767,6 +2776,9 @@ void DragonsCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +4/+4.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DRG_650e2"));
+    cards.emplace("DRG_650e2", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [DRG_650e3] Galakrond's Strength (*) - COST:0

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -15,6 +15,7 @@
 #include <Rosetta/Tasks/SimpleTasks/FlagTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/IncludeTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/QuestProgressTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/RandomCardTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/SummonTask.hpp>
 
@@ -33,6 +34,8 @@ using EffectList = std::vector<std::shared_ptr<IEffect>>;
 
 void DragonsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- HERO - WARLOCK
     // [DRG_600] Galakrond, the Wretched - COST:7 [ATK:0/HP:30]
     // - Set: Dragons, Rarity: Legendary
@@ -48,6 +51,11 @@ void DragonsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // - 676 = 1
     // - GALAKROND_HERO_CARD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<RandomCardTask>(
+        CardType::MINION, CardClass::INVALID, Race::DEMON));
+    power.AddPowerTask(std::make_shared<SummonTask>());
+    cards.emplace("DRG_600", CardDef(power, 0, 55807));
 
     // ----------------------------------------- HERO - WARLOCK
     // [DRG_600t2] Galakrond, the Apocalypse (*) - COST:7 [ATK:0/HP:30]
@@ -283,6 +291,8 @@ void DragonsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 
 void DragonsCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------- HERO_POWER - WARRIOR
     // [DRG_238p] Galakrond's Might (*) - COST:2
     // - Set: Dragons
@@ -303,6 +313,9 @@ void DragonsCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Summon two 1/1 Imps.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("DRG_238t12t2", 2));
+    cards.emplace("DRG_238p3", CardDef(power));
 
     // ------------------------------------ HERO_POWER - SHAMAN
     // [DRG_238p4] Galakrond's Fury (*) - COST:2
@@ -1694,6 +1707,8 @@ void DragonsCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 void DragonsCardsGen::AddWarlockNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------- ENCHANTMENT - WARLOCK
     // [DRG_202e] Power of the Cult (*) - COST:0
     // - Set: Dragons
@@ -1720,6 +1735,9 @@ void DragonsCardsGen::AddWarlockNonCollect(
     // [DRG_238t12t2] Draconic Imp (*) - COST:1 [ATK:1/HP:1]
     // - Race: Demon, Set: Dragons
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DRG_238t12t2", CardDef(power));
 }
 
 void DragonsCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -9,8 +9,10 @@
 #include <Rosetta/Enchants/Enchants.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddLackeyTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/DestroyTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DrawStackTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/EnqueueTask.hpp>
@@ -329,6 +331,12 @@ void DragonsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // - 676 = 1
     // - GALAKROND_HERO_CARD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<IncludeTask>(EntityType::ENEMY_MINIONS));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddPowerTask(std::make_shared<DestroyTask>(EntityType::STACK));
+    cards.emplace("DRG_660", CardDef(power, 0, 55810));
 
     // ------------------------------------------ HERO - PRIEST
     // [DRG_660t2] Galakrond, the Apocalypse (*) - COST:7 [ATK:0/HP:30]
@@ -416,6 +424,11 @@ void DragonsCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Add a random Priest minion to your hand.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<RandomCardTask>(CardType::MINION, CardClass::PRIEST));
+    power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
+    cards.emplace("DRG_238p5", CardDef(power));
 }
 
 void DragonsCardsGen::AddDruid(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -232,6 +232,10 @@ void DragonsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("DRG_620t6", 2));
+    power.AddPowerTask(std::make_shared<WeaponTask>("DRG_238ht"));
+    cards.emplace("DRG_620t3", CardDef(power, 0, 55808));
 
     // ----------------------------------------- HERO - WARRIOR
     // [DRG_650] Galakrond, the Unbreakable - COST:7 [ATK:0/HP:30]
@@ -1648,6 +1652,9 @@ void DragonsCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DRG_620t6", CardDef(power));
 }
 
 void DragonsCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -10,13 +10,13 @@
 #include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/DrawStackTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FlagTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/IncludeTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/QuestProgressTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/SummonTask.hpp>
-#include "Rosetta/Tasks/SimpleTasks/IncludeTask.hpp"
-#include "Rosetta/Tasks/SimpleTasks/FilterStackTask.hpp"
-#include "Rosetta/Tasks/SimpleTasks/RandomTask.hpp"
-#include "Rosetta/Tasks/SimpleTasks/DrawStackTask.hpp"
 
 using namespace RosettaStone::SimpleTasks;
 

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -302,6 +302,16 @@ void DragonsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // - HERO_POWER = 55805
     // - GALAKROND_HERO_CARD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::DECK));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsMinion()) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 4));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DRG_650e3", EntityType::STACK));
+    power.AddPowerTask(std::make_shared<DrawStackTask>(4));
+    power.AddPowerTask(std::make_shared<WeaponTask>("DRG_238ht"));
+    cards.emplace("DRG_650t3", CardDef(power, 0, 55805));
 
     // ------------------------------------------ HERO - PRIEST
     // [DRG_660] Galakrond, the Unspeakable - COST:7 [ATK:0/HP:30]
@@ -2786,6 +2796,9 @@ void DragonsCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +4/+4.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DRG_650e3"));
+    cards.emplace("DRG_650e3", CardDef(power));
 }
 
 void DragonsCardsGen::AddAll(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -353,6 +353,12 @@ void DragonsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // - HERO_POWER = 55810
     // - GALAKROND_HERO_CARD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<IncludeTask>(EntityType::ENEMY_MINIONS));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 2));
+    power.AddPowerTask(std::make_shared<DestroyTask>(EntityType::STACK));
+    cards.emplace("DRG_660t2", CardDef(power, 0, 55810));
 
     // ------------------------------------------ HERO - PRIEST
     // [DRG_660t3] Galakrond, Azeroth's End (*) - COST:7 [ATK:0/HP:30]

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -374,6 +374,13 @@ void DragonsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // - HERO_POWER = 55810
     // - GALAKROND_HERO_CARD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<IncludeTask>(EntityType::ENEMY_MINIONS));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 4));
+    power.AddPowerTask(std::make_shared<DestroyTask>(EntityType::STACK));
+    power.AddPowerTask(std::make_shared<WeaponTask>("DRG_238ht"));
+    cards.emplace("DRG_660t3", CardDef(power, 0, 55810));
 }
 
 void DragonsCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -8,9 +8,12 @@
 #include <Rosetta/Conditions/RelaCondition.hpp>
 #include <Rosetta/Enchants/Enchants.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/AddLackeyTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DrawStackTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FlagTask.hpp>
@@ -120,6 +123,11 @@ void DragonsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // - 676 = 1
     // - GALAKROND_HERO_CARD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawTask>(1, true));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DRG_610e", EntityType::STACK));
+    cards.emplace("DRG_610", CardDef(power, 0, 55806));
 
     // ------------------------------------------- HERO - ROGUE
     // [DRG_610t2] Galakrond, the Apocalypse (*) - COST:7 [ATK:0/HP:30]
@@ -323,6 +331,9 @@ void DragonsCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Add a <b>Lackey</b> to your hand.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<AddLackeyTask>(1));
+    cards.emplace("DRG_238p2", CardDef(power));
 
     // ----------------------------------- HERO_POWER - WARLOCK
     // [DRG_238p3] Galakrond's Malice (*) - COST:2
@@ -1345,6 +1356,8 @@ void DragonsCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 
 void DragonsCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------ ENCHANTMENT - ROGUE
     // [DRG_030e] Praise Galakrond! (*) - COST:0
     // - Set: Dragons
@@ -1383,6 +1396,9 @@ void DragonsCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Costs (0).
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(std::make_shared<Enchant>(Effects::SetCost(0)));
+    cards.emplace("DRG_610e", CardDef(power));
 }
 
 void DragonsCardsGen::AddShaman(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -1953,6 +1953,9 @@ void DragonsCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - WINDFURY = 1
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DRG_061", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [DRG_062] Wyrmrest Purifier - COST:2 [ATK:3/HP:2]

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -253,6 +253,15 @@ void DragonsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // - 676 = 1
     // - GALAKROND_HERO_CARD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::DECK));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsMinion()) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DRG_650e", EntityType::STACK));
+    power.AddPowerTask(std::make_shared<DrawStackTask>(1));
+    cards.emplace("DRG_650", CardDef(power, 0, 55805));
 
     // ----------------------------------------- HERO - WARRIOR
     // [DRG_650t2] Galakrond, the Apocalypse (*) - COST:7 [ATK:0/HP:30]
@@ -344,6 +353,10 @@ void DragonsCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Give your hero +3 Attack this turn.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DRG_238t10e", EntityType::HERO));
+    cards.emplace("DRG_238p", CardDef(power));
 
     // ------------------------------------- HERO_POWER - ROGUE
     // [DRG_238p2] Galakrond's Guile (*) - COST:2
@@ -1925,6 +1938,8 @@ void DragonsCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 void DragonsCardsGen::AddWarriorNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [DRG_238t10e] Galakrond's Might (*) - COST:0
     // - Set: Dragons
@@ -1934,6 +1949,9 @@ void DragonsCardsGen::AddWarriorNonCollect(
     // GameTag:
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DRG_238t10e"));
+    cards.emplace("DRG_238t10e", CardDef(power));
 }
 
 void DragonsCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
@@ -2739,6 +2757,9 @@ void DragonsCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +4/+4.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DRG_650e"));
+    cards.emplace("DRG_650e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [DRG_650e2] Galakrond's Strength (*) - COST:0

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -164,6 +164,12 @@ void DragonsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // - HERO_POWER = 55806
     // - GALAKROND_HERO_CARD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawTask>(4, true));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DRG_610e", EntityType::STACK));
+    power.AddPowerTask(std::make_shared<WeaponTask>("DRG_238ht"));
+    cards.emplace("DRG_610t3", CardDef(power, 0, 55806));
 
     // ------------------------------------------ HERO - SHAMAN
     // [DRG_620] Galakrond, the Tempest - COST:7 [ATK:0/HP:30]

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -211,6 +211,9 @@ void DragonsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("DRG_620t5", 2));
+    cards.emplace("DRG_620t2", CardDef(power, 0, 55808));
 
     // ------------------------------------------ HERO - SHAMAN
     // [DRG_620t3] Galakrond, Azeroth's End (*) - COST:7 [ATK:0/HP:30]
@@ -1632,6 +1635,9 @@ void DragonsCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DRG_620t5", CardDef(power));
 
     // ---------------------------------------- MINION - SHAMAN
     // [DRG_620t6] Raging Storm (*) - COST:8 [ATK:8/HP:8]

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -6,6 +6,8 @@
 #include <Rosetta/Auras/AdaptiveEffect.hpp>
 #include <Rosetta/CardSets/DragonsCardsGen.hpp>
 #include <Rosetta/Conditions/RelaCondition.hpp>
+#include <Rosetta/Enchants/Enchants.hpp>
+#include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FlagTask.hpp>
@@ -895,6 +897,8 @@ void DragonsCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
 
 void DragonsCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- SPELL - PALADIN
     // [DRG_008] Righteous Cause - COST:1
     // - Set: Dragons, Rarity: Rare
@@ -906,6 +910,12 @@ void DragonsCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // - QUEST_PROGRESS_TOTAL = 5
     // - SIDEQUEST = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::SUMMON));
+    power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
+        TaskList{ std::make_shared<AddEnchantmentTask>(
+            "DRG_008e", EntityType::MINIONS) }) };
+    cards.emplace("DRG_008", CardDef(power, 5));
 
     // --------------------------------------- MINION - PALADIN
     // [DRG_225] Sky Claw - COST:3 [ATK:1/HP:2]
@@ -2353,6 +2363,9 @@ void DragonsCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DRG_008e"));
+    cards.emplace("DRG_008e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [DRG_049e] Well Fed (*) - COST:0

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -144,6 +144,11 @@ void DragonsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // - HERO_POWER = 55806
     // - GALAKROND_HERO_CARD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawTask>(2, true));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DRG_610e", EntityType::STACK));
+    cards.emplace("DRG_610t2", CardDef(power, 0, 55806));
 
     // ------------------------------------------- HERO - ROGUE
     // [DRG_610t3] Galakrond, Azeroth's End (*) - COST:7 [ATK:0/HP:30]

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -19,6 +19,7 @@
 #include <Rosetta/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FlagTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/IncludeTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/InvokeTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/QuestProgressTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/RandomCardTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/RandomTask.hpp>
@@ -1190,6 +1191,8 @@ void DragonsCardsGen::AddPaladinNonCollect(
 
 void DragonsCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- MINION - PRIEST
     // [DRG_090] Murozond the Infinite - COST:8 [ATK:8/HP:8]
     // - Race: Dragon, Set: Dragons, Rarity: Legendary
@@ -1259,6 +1262,9 @@ void DragonsCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // - 676 = 1
     // - EMPOWER = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<InvokeTask>());
+    cards.emplace("DRG_303", CardDef(power));
 
     // ---------------------------------------- MINION - PRIEST
     // [DRG_304] Chronobreaker - COST:5 [ATK:4/HP:5]

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -11,6 +11,7 @@
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DrawStackTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FlagTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/IncludeTask.hpp>
@@ -18,7 +19,7 @@
 #include <Rosetta/Tasks/SimpleTasks/RandomCardTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/SummonTask.hpp>
-#include <Rosetta/Tasks/SimpleTasks/EnqueueTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/WeaponTask.hpp>
 
 using namespace RosettaStone::SimpleTasks;
 
@@ -94,6 +95,14 @@ void DragonsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // - HERO_POWER = 55807
     // - GALAKROND_HERO_CARD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<EnqueueTask>(
+        TaskList{ std::make_shared<RandomCardTask>(
+                      CardType::MINION, CardClass::INVALID, Race::DEMON),
+                  std::make_shared<SummonTask>() },
+        4));
+    power.AddPowerTask(std::make_shared<WeaponTask>("DRG_238ht"));
+    cards.emplace("DRG_600t3", CardDef(power, 0, 55807));
 
     // ------------------------------------------- HERO - ROGUE
     // [DRG_610] Galakrond, the Nightmare - COST:7 [ATK:0/HP:30]

--- a/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/DragonsCardsGen.cpp
@@ -18,6 +18,7 @@
 #include <Rosetta/Tasks/SimpleTasks/RandomCardTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/SummonTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/EnqueueTask.hpp>
 
 using namespace RosettaStone::SimpleTasks;
 
@@ -71,6 +72,13 @@ void DragonsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // - HERO_POWER = 55807
     // - GALAKROND_HERO_CARD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<EnqueueTask>(
+        TaskList{ std::make_shared<RandomCardTask>(
+                      CardType::MINION, CardClass::INVALID, Race::DEMON),
+                  std::make_shared<SummonTask>() },
+        2));
+    cards.emplace("DRG_600t2", CardDef(power, 0, 55807));
 
     // ----------------------------------------- HERO - WARLOCK
     // [DRG_600t3] Galakrond, Azeroth's End (*) - COST:7 [ATK:0/HP:30]

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -444,7 +444,7 @@ void UldumCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
     power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
         "ULD_155p") };
-    cards.emplace("ULD_155", CardDef(power, 20));
+    cards.emplace("ULD_155", CardDef(power, 20, 0));
 
     // ---------------------------------------- MINION - HUNTER
     // [ULD_156] Dinotamer Brann - COST:7 [ATK:2/HP:4]
@@ -804,7 +804,7 @@ void UldumCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
         std::make_shared<SelfCondition>(SelfCondition::HasReborn());
     power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
         "ULD_431p") };
-    cards.emplace("ULD_431", CardDef(power, 5));
+    cards.emplace("ULD_431", CardDef(power, 5, 0));
 
     // --------------------------------------- MINION - PALADIN
     // [ULD_438] Salhet's Pride - COST:3 [ATK:3/HP:1]

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -2129,6 +2129,7 @@ void UldumCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddPowerTask(std::make_shared<RandomCardTask>(
         CardType::MINION, CardClass::INVALID, Race::MURLOC));
+    power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
     power.AddPowerTask(
         std::make_shared<RandomCardTask>(CardType::MINION, CardClass::INVALID,
                                          Race::MURLOC, Rarity::INVALID, true));

--- a/Sources/Rosetta/Cards/Card.cpp
+++ b/Sources/Rosetta/Cards/Card.cpp
@@ -169,6 +169,26 @@ bool Card::HasGameTag(GameTag gameTag) const
     return gameTags.find(gameTag) != gameTags.end();
 }
 
+bool Card::IsGalakrond() const
+{
+    // NOTE: Galakrond hero card list
+    // DRG_600: Galakrond, the Wretched
+    // DRG_610: Galakrond, the Nightmare
+    // DRG_620: Galakrond, the Tempest
+    // DRG_650: Galakrond, the Unbreakable
+    // DRG_660: Galakrond, the Unspeakable
+    if (id == "DRG_600" || id == "DRG_600t2" || id == "DRG_600t3" ||
+        id == "DRG_610" || id == "DRG_610t2" || id == "DRG_610t3" ||
+        id == "DRG_620" || id == "DRG_620t2" || id == "DRG_620t3" ||
+        id == "DRG_650" || id == "DRG_650t2" || id == "DRG_650t3" ||
+        id == "DRG_660" || id == "DRG_660t2" || id == "DRG_660t3")
+    {
+        return true;
+    }
+
+    return false;
+}
+
 bool Card::IsUntouchable() const
 {
     return HasGameTag(GameTag::UNTOUCHABLE) &&

--- a/Sources/Rosetta/Cards/Card.cpp
+++ b/Sources/Rosetta/Cards/Card.cpp
@@ -169,6 +169,22 @@ bool Card::HasGameTag(GameTag gameTag) const
     return gameTags.find(gameTag) != gameTags.end();
 }
 
+bool Card::IsLackey() const
+{
+    if (id == "DAL_613" ||  // DAL_613: Faceless Lackey
+        id == "DAL_614" ||  // DAL_614: Kobold Lackey
+        id == "DAL_615" ||  // DAL_615: Witchy Lackey
+        id == "DAL_739" ||  // DAL_739: Goblin Lackey
+        id == "DAL_741" ||  // DAL_741: Ethereal Lackey
+        id == "ULD_616" ||  // ULD_616: Titanic Lackey
+        id == "DRG_052")    // DRG_052: Draconic Lackey
+    {
+        return true;
+    }
+
+    return false;
+}
+
 bool Card::IsGalakrond() const
 {
     // NOTE: Galakrond hero card list

--- a/Sources/Rosetta/Cards/CardDef.cpp
+++ b/Sources/Rosetta/Cards/CardDef.cpp
@@ -26,8 +26,10 @@ CardDef::CardDef(Power _power, std::vector<std::string> _chooseCardIDs)
     // Do nothing
 }
 
-CardDef::CardDef(Power _power, int _questProgressTotal)
-    : power(std::move(_power)), questProgressTotal(_questProgressTotal)
+CardDef::CardDef(Power _power, int _questProgressTotal, int _heroPowerDbfID)
+    : power(std::move(_power)),
+      questProgressTotal(_questProgressTotal),
+      heroPowerDbfID(_heroPowerDbfID)
 {
     // Do nothing
 }

--- a/Sources/Rosetta/Cards/Cards.cpp
+++ b/Sources/Rosetta/Cards/Cards.cpp
@@ -58,13 +58,7 @@ Cards::Cards()
             m_allWildCards.emplace_back(card);
         }
 
-        if (card->id == "DAL_613" ||  // DAL_613: Faceless Lackey
-            card->id == "DAL_614" ||  // DAL_614: Kobold Lackey
-            card->id == "DAL_615" ||  // DAL_615: Witchy Lackey
-            card->id == "DAL_739" ||  // DAL_739: Goblin Lackey
-            card->id == "DAL_741" ||  // DAL_741: Ethereal Lackey
-            card->id == "ULD_616" ||  // ULD_616: Titanic Lackey
-            card->id == "DRG_052")    // DRG_052: Draconic Lackey
+        if (card->IsLackey())
         {
             m_lackeys.emplace_back(card);
         }

--- a/Sources/Rosetta/Cards/Cards.cpp
+++ b/Sources/Rosetta/Cards/Cards.cpp
@@ -19,6 +19,7 @@ std::array<std::vector<Card*>, NUM_PLAYER_CLASS> Cards::m_standardCards;
 std::array<std::vector<Card*>, NUM_PLAYER_CLASS> Cards::m_wildCards;
 std::vector<Card*> Cards::m_allStandardCards;
 std::vector<Card*> Cards::m_allWildCards;
+std::vector<Card*> Cards::m_lackeys;
 
 Cards::Cards()
 {
@@ -43,7 +44,7 @@ Cards::Cards()
             if (card->GetCardClass() != CardClass::NEUTRAL)
             {
                 m_standardCards[cardClass].emplace_back(card);
-            }     
+            }
             m_allStandardCards.emplace_back(card);
         }
 
@@ -55,6 +56,17 @@ Cards::Cards()
                 m_wildCards[cardClass].emplace_back(card);
             }
             m_allWildCards.emplace_back(card);
+        }
+
+        if (card->id == "DAL_613" ||  // DAL_613: Faceless Lackey
+            card->id == "DAL_614" ||  // DAL_614: Kobold Lackey
+            card->id == "DAL_615" ||  // DAL_615: Witchy Lackey
+            card->id == "DAL_739" ||  // DAL_739: Goblin Lackey
+            card->id == "DAL_741" ||  // DAL_741: Ethereal Lackey
+            card->id == "ULD_616" ||  // ULD_616: Titanic Lackey
+            card->id == "DRG_052")    // DRG_052: Draconic Lackey
+        {
+            m_lackeys.emplace_back(card);
         }
     }
 }
@@ -100,6 +112,11 @@ const std::vector<Card*>& Cards::GetAllStandardCards()
 const std::vector<Card*>& Cards::GetAllWildCards()
 {
     return m_allWildCards;
+}
+
+std::vector<Card*> Cards::GetLackeys()
+{
+    return m_lackeys;
 }
 
 Card* Cards::FindCardByID(const std::string_view& id)

--- a/Sources/Rosetta/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/Conditions/SelfCondition.cpp
@@ -149,6 +149,21 @@ SelfCondition SelfCondition::IsControllingSecret()
     });
 }
 
+SelfCondition SelfCondition::IsHoldingRace(Race race)
+{
+    return SelfCondition([=](Playable* playable) -> bool {
+        for (auto& minion : playable->player->GetHandZone()->GetAll())
+        {
+            if (minion->card->GetRace() == race)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    });
+}
+
 SelfCondition SelfCondition::IsMinion()
 {
     return SelfCondition([=](Playable* playable) -> bool {

--- a/Sources/Rosetta/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/Conditions/SelfCondition.cpp
@@ -199,6 +199,19 @@ SelfCondition SelfCondition::IsFrozen()
     });
 }
 
+SelfCondition SelfCondition::IsRush()
+{
+    return SelfCondition([=](Playable* playable) -> bool {
+        const auto minion = dynamic_cast<Minion*>(playable);
+        if (!minion)
+        {
+            return false;
+        }
+
+        return minion->IsRush();
+    });
+}
+
 SelfCondition SelfCondition::HasNotStealth()
 {
     return SelfCondition([=](Playable* playable) -> bool {

--- a/Sources/Rosetta/Games/Game.cpp
+++ b/Sources/Rosetta/Games/Game.cpp
@@ -72,7 +72,14 @@ Game::Game(const GameConfig& gameConfig) : m_gameConfig(gameConfig)
         Playable* playable = Entity::GetFromCard(
             GetPlayer1(), &card, std::nullopt, GetPlayer1()->GetDeckZone());
         GetPlayer1()->GetDeckZone()->Add(playable);
+
+        //! Set Galakrond hero card
+        if (card.IsGalakrond())
+        {
+            GetPlayer1()->galakrond = playable;
+        }
     }
+
     for (auto& card : m_gameConfig.player2Deck)
     {
         if (card.id.empty())
@@ -83,6 +90,12 @@ Game::Game(const GameConfig& gameConfig) : m_gameConfig(gameConfig)
         Playable* playable = Entity::GetFromCard(
             GetPlayer2(), &card, std::nullopt, GetPlayer2()->GetDeckZone());
         GetPlayer2()->GetDeckZone()->Add(playable);
+
+        //! Set Galakrond hero card
+        if (card.IsGalakrond())
+        {
+            GetPlayer2()->galakrond = playable;
+        }
     }
 
     // Fill cards to deck

--- a/Sources/Rosetta/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/Loaders/CardLoader.cpp
@@ -75,6 +75,8 @@ void CardLoader::Load(std::vector<Card*>& cards)
                                 ? 0
                                 : static_cast<int>(StrToEnum<Faction>(
                                       cardData["faction"].get<std::string>()));
+        const int armor =
+            cardData["armor"].is_null() ? 0 : cardData["armor"].get<int>();
         const int health =
             cardData["health"].is_null() ? 0 : cardData["health"].get<int>();
         const int rarity = cardData["rarity"].is_null()
@@ -118,6 +120,7 @@ void CardLoader::Load(std::vector<Card*>& cards)
         card->gameTags[GameTag::DAMAGE] = 0;
         card->gameTags[GameTag::DURABILITY] = durability;
         card->gameTags[GameTag::FACTION] = faction;
+        card->gameTags[GameTag::ARMOR] = armor;
         card->gameTags[GameTag::HEALTH] = health;
         card->gameTags[GameTag::RARITY] = rarity;
         card->gameTags[GameTag::SPELLPOWER] = spellPower;

--- a/Sources/Rosetta/Loaders/InternalCardLoader.cpp
+++ b/Sources/Rosetta/Loaders/InternalCardLoader.cpp
@@ -22,6 +22,7 @@ void InternalCardLoader::Load(std::vector<Card*>& cards)
         card->entourages = cardDef.entourages;
         card->gameTags[GameTag::QUEST_PROGRESS_TOTAL] =
             cardDef.questProgressTotal;
+        card->gameTags[GameTag::HERO_POWER] = cardDef.heroPowerDbfID;
     }
 }
 }  // namespace RosettaStone

--- a/Sources/Rosetta/Models/Character.cpp
+++ b/Sources/Rosetta/Models/Character.cpp
@@ -141,6 +141,12 @@ bool Character::HasDivineShield() const
 
 bool Character::CanAttack() const
 {
+    //! If the current player is opponent, returns false
+    if (player != game->GetCurrentPlayer())
+    {
+        return false;
+    }
+
     // If the value of attack is 0, returns false
     if (GetAttack() == 0)
     {

--- a/Sources/Rosetta/Models/Minion.cpp
+++ b/Sources/Rosetta/Models/Minion.cpp
@@ -4,6 +4,7 @@
 // personal capacity and are not conveying any rights to any intellectual
 // property of any third parties.
 
+#include <Rosetta/Cards/Cards.hpp>
 #include <Rosetta/Commons/Utils.hpp>
 #include <Rosetta/Games/Game.hpp>
 #include <Rosetta/Models/Enchantment.hpp>
@@ -28,6 +29,13 @@ int Minion::GetLastBoardPos() const
 void Minion::SetLastBoardPos(int value)
 {
     SetGameTag(GameTag::TAG_LAST_KNOWN_COST_IN_HAND, value);
+}
+
+bool Minion::IsLackey() const
+{
+    auto lackeys = Cards::GetLackeys();
+
+    return std::find(lackeys.begin(), lackeys.end(), card) != lackeys.end();
 }
 
 bool Minion::IsUntouchable() const

--- a/Sources/Rosetta/Models/Player.cpp
+++ b/Sources/Rosetta/Models/Player.cpp
@@ -4,6 +4,7 @@
 // personal capacity and are not conveying any rights to any intellectual
 // property of any third parties.
 
+#include <Rosetta/Cards/Cards.hpp>
 #include <Rosetta/Commons/Utils.hpp>
 #include <Rosetta/Models/HeroPower.hpp>
 #include <Rosetta/Models/Player.hpp>
@@ -252,6 +253,34 @@ CardClass Player::GetMainGalakrond() const
 void Player::SetMainGalakrond(int value)
 {
     SetGameTag(GameTag::MAIN_GALAKROND, value);
+}
+
+void Player::UpgradeGalakrond()
+{
+    // If the player has already turned into Galakrond, return false.
+    if (galakrond->GetZoneType() == ZoneType::PLAY)
+    {
+        return;
+    }
+
+    const auto cardID = galakrond->card->id;
+
+    // If Galakrond have already upgraded to the final stage, return false.
+    if (EndsWith(cardID, "t3"))
+    {
+        return;
+    }
+
+    // NOTE: The length of level 1 card IDs is 7.
+    // For example, "DRG_600".
+    if (cardID.size() == 7)
+    {
+        galakrond->card = Cards::FindCardByID(cardID + "t2");
+    }
+    else if (EndsWith(cardID, "t2"))
+    {
+        galakrond->card = Cards::FindCardByID(cardID.substr(0, 7) + "t3");
+    }
 }
 
 int Player::GetInvoke() const

--- a/Sources/Rosetta/Models/Player.cpp
+++ b/Sources/Rosetta/Models/Player.cpp
@@ -254,6 +254,11 @@ void Player::SetMainGalakrond(int value)
     SetGameTag(GameTag::MAIN_GALAKROND, value);
 }
 
+int Player::GetInvoke() const
+{
+    return GetGameTag(GameTag::INVOKE_COUNTER);
+}
+
 void Player::IncreaseInvoke()
 {
     const int val = GetGameTag(GameTag::INVOKE_COUNTER);

--- a/Sources/Rosetta/Models/Player.cpp
+++ b/Sources/Rosetta/Models/Player.cpp
@@ -254,6 +254,12 @@ void Player::SetMainGalakrond(int value)
     SetGameTag(GameTag::MAIN_GALAKROND, value);
 }
 
+void Player::IncreaseInvoke()
+{
+    const int val = GetGameTag(GameTag::INVOKE_COUNTER);
+    SetGameTag(GameTag::INVOKE_COUNTER, val + 1);
+}
+
 void Player::AddHeroAndPower(Card* heroCard, Card* powerCard)
 {
     Weapon* weapon = nullptr;

--- a/Sources/Rosetta/Models/Player.cpp
+++ b/Sources/Rosetta/Models/Player.cpp
@@ -244,6 +244,16 @@ void Player::SetNumFriendlyMinionsDiedThisTurn(int value)
     SetGameTag(GameTag::NUM_FRIENDLY_MINIONS_THAT_DIED_THIS_TURN, value);
 }
 
+CardClass Player::GetMainGalakrond() const
+{
+    return static_cast<CardClass>(GetGameTag(GameTag::MAIN_GALAKROND));
+}
+
+void Player::SetMainGalakrond(int value)
+{
+    SetGameTag(GameTag::MAIN_GALAKROND, value);
+}
+
 void Player::AddHeroAndPower(Card* heroCard, Card* powerCard)
 {
     Weapon* weapon = nullptr;

--- a/Sources/Rosetta/Models/Player.cpp
+++ b/Sources/Rosetta/Models/Player.cpp
@@ -102,6 +102,11 @@ Hero* Player::GetHero() const
     return m_hero;
 }
 
+void Player::SetHero(Hero* hero)
+{
+    m_hero = hero;
+}
+
 HeroPower& Player::GetHeroPower() const
 {
     return *m_hero->heroPower;

--- a/Sources/Rosetta/Models/Player.cpp
+++ b/Sources/Rosetta/Models/Player.cpp
@@ -245,16 +245,6 @@ void Player::SetNumFriendlyMinionsDiedThisTurn(int value)
     SetGameTag(GameTag::NUM_FRIENDLY_MINIONS_THAT_DIED_THIS_TURN, value);
 }
 
-CardClass Player::GetMainGalakrond() const
-{
-    return static_cast<CardClass>(GetGameTag(GameTag::MAIN_GALAKROND));
-}
-
-void Player::SetMainGalakrond(int value)
-{
-    SetGameTag(GameTag::MAIN_GALAKROND, value);
-}
-
 void Player::UpgradeGalakrond()
 {
     // If the player has already turned into Galakrond, return false.

--- a/Sources/Rosetta/Models/Weapon.cpp
+++ b/Sources/Rosetta/Models/Weapon.cpp
@@ -52,4 +52,9 @@ void Weapon::RemoveDurability(int amount)
 {
     SetDurability(GetDurability() - amount);
 }
+
+bool Weapon::IsImmune() const
+{
+    return static_cast<bool>(GetGameTag(GameTag::IMMUNE));
+}
 }  // namespace RosettaStone

--- a/Sources/Rosetta/Tasks/SimpleTasks/AddLackeyTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/AddLackeyTask.cpp
@@ -1,0 +1,44 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/Actions/Generic.hpp>
+#include <Rosetta/Cards/Cards.hpp>
+#include <Rosetta/Games/Game.hpp>
+#include <Rosetta/Tasks/SimpleTasks/AddLackeyTask.hpp>
+#include <Rosetta/Zones/HandZone.hpp>
+
+#include <effolkronium/random.hpp>
+
+using Random = effolkronium::random_static;
+
+namespace RosettaStone::SimpleTasks
+{
+AddLackeyTask::AddLackeyTask(int amount) : m_amount(amount)
+{
+    // Do nothing
+}
+
+TaskStatus AddLackeyTask::Impl(Player* player)
+{
+    auto lackeys = Cards::GetLackeys();
+
+    std::vector<Playable*> cards;
+
+    for (int i = 0; i < m_amount && !player->GetHandZone()->IsFull(); ++i)
+    {
+        const auto idx = Random::get<std::size_t>(0, lackeys.size() - 1);
+        const auto lackey = Entity::GetFromCard(
+            player, lackeys.at(idx), std::nullopt, player->GetHandZone());
+        Generic::AddCardToHand(player, lackey);
+    }
+
+    return TaskStatus::COMPLETE;
+}
+
+std::unique_ptr<ITask> AddLackeyTask::CloneImpl()
+{
+    return std::make_unique<AddLackeyTask>(m_amount);
+}
+}  // namespace RosettaStone::SimpleTasks

--- a/Sources/Rosetta/Tasks/SimpleTasks/AddLackeyTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/AddLackeyTask.cpp
@@ -28,9 +28,8 @@ TaskStatus AddLackeyTask::Impl(Player* player)
 
     for (int i = 0; i < m_amount && !player->GetHandZone()->IsFull(); ++i)
     {
-        const auto idx = Random::get<std::size_t>(0, lackeys.size() - 1);
         const auto lackey = Entity::GetFromCard(
-            player, lackeys.at(idx), std::nullopt, player->GetHandZone());
+            player, *Random::get(lackeys), std::nullopt, player->GetHandZone());
         Generic::AddCardToHand(player, lackey);
     }
 

--- a/Sources/Rosetta/Tasks/SimpleTasks/InvokeTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/InvokeTask.cpp
@@ -1,0 +1,50 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/Games/Game.hpp>
+#include <Rosetta/Models/Player.hpp>
+#include <Rosetta/Tasks/SimpleTasks/InvokeTask.hpp>
+#include "Rosetta/Cards/Cards.hpp"
+
+namespace RosettaStone::SimpleTasks
+{
+TaskStatus InvokeTask::Impl(Player* player)
+{
+    if (player->galakrond == nullptr)
+    {
+        return TaskStatus::COMPLETE;
+    }
+
+    // Upgrade Galakrond's Battlecry
+    player->IncreaseInvoke();
+
+    if (player->GetInvoke() == 2 || player->GetInvoke() == 4)
+    {
+        player->UpgradeGalakrond();
+    }
+
+    // Activate hero power of Galakrond
+    auto heroPower = Cards::FindCardByDbfID(
+        player->galakrond->GetGameTag(GameTag::HERO_POWER));
+    auto heroPowerTasks = heroPower->power.GetPowerTask();
+    for (auto& task : heroPowerTasks)
+    {
+        std::unique_ptr<ITask> clonedTask = task->Clone();
+
+        clonedTask->SetPlayer(player);
+        clonedTask->SetSource(player);
+        clonedTask->SetTarget(nullptr);
+
+        clonedTask->Run();
+    }
+
+    return TaskStatus::COMPLETE;
+}
+
+std::unique_ptr<ITask> InvokeTask::CloneImpl()
+{
+    return std::make_unique<InvokeTask>();
+}
+}  // namespace RosettaStone::SimpleTasks

--- a/Sources/Rosetta/Tasks/SimpleTasks/RandomCardTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/RandomCardTask.cpp
@@ -81,6 +81,7 @@ TaskStatus RandomCardTask::Impl(Player* player)
         return TaskStatus::STOP;
     }
 
+    player->game->taskStack.playables.clear();
     const auto idx = Random::get<std::size_t>(0, cardsList.size() - 1);
     auto card = Entity::GetFromCard(m_opposite ? player->opponent : player,
                                     cardsList.at(idx));

--- a/Tests/UnitTests/CardSets/DalaranCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DalaranCardsGenTests.cpp
@@ -274,7 +274,7 @@ TEST_CASE("[Druid : Minion] - DAL_355 : Lifeweaver")
 // GameTag:
 // - DEATHRATTLE = 1
 // --------------------------------------------------------
-TEST_CASE("[Druid : Spell] - DAL_604 : Ursatron")
+TEST_CASE("[Hunter : Minion] - DAL_604 : Ursatron")
 {
     GameConfig config;
     config.player1Class = CardClass::MAGE;
@@ -465,7 +465,7 @@ TEST_CASE("[Mage : Minion] - DAL_163 : Messenger Raven")
 // RefTag:
 // - FREEZE = 1
 // --------------------------------------------------------
-TEST_CASE("[Mage : Minion] - DAL_577 : Ray of Frost")
+TEST_CASE("[Mage : Spell] - DAL_577 : Ray of Frost")
 {
     GameConfig config;
     config.player1Class = CardClass::MAGE;

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -163,7 +163,7 @@ TEST_CASE("[Hunter : Weapon] - DRG_007 : Stormhammer")
 // - BATTLECRY = 1
 // - RUSH = 1
 // --------------------------------------------------------
-TEST_CASE("[Druid : Spell] - DAL_604 : Ursatron")
+TEST_CASE("[Hunter : Minion] - DRG_010 : Diving Gryphon")
 {
     GameConfig config;
     config.player1Class = CardClass::HUNTER;

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -1382,6 +1382,72 @@ TEST_CASE("[Paladin : Spell] - DRG_008 : Righteous Cause")
     CHECK_EQ(curField[5]->GetHealth(), 1);
 }
 
+// ---------------------------------------- MINION - PRIEST
+// [DRG_303] Disciple of Galakrond - COST:1 [ATK:1/HP:2]
+// - Set: Dragons, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> <b>Invoke</b> Galakrond.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - 676 = 1
+// - EMPOWER = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - DRG_303 : Disciple of Galakrond")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    config.player1Deck[0] = *Cards::FindCardByName("Galakrond, the Unspeakable");
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Disciple of Galakrond"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Disciple of Galakrond"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Disciple of Galakrond"));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Disciple of Galakrond"));
+
+    CHECK_EQ(curPlayer->GetInvoke(), 0);
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetInvoke(), 1);
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetInvoke(), 2);
+    CHECK_EQ(curHand[0]->card->id, "DRG_660t2");
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curPlayer->GetInvoke(), 3);
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(curPlayer->GetInvoke(), 4);
+    CHECK_EQ(curHand[0]->card->id, "DRG_660t3");
+    CHECK_EQ(curHand.GetCount(), 5);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [DRG_061] Gyrocopter - COST:6 [ATK:4/HP:5]
 // - Race: Mechanical, Set: Dragons, Rarity: Common

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -124,6 +124,65 @@ TEST_CASE("[Warlock : Hero] - DRG_600t2 : Galakrond, the Apocalypse")
     CHECK_EQ(curField[3]->card->name, "Draconic Imp");
 }
 
+// ----------------------------------------- HERO - WARLOCK
+// [DRG_600t3] Galakrond, Azeroth's End (*) - COST:7 [ATK:0/HP:30]
+// - Set: Dragons, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Summon 4 random Demons.
+//       Equip a 5/2 Claw.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// - ARMOR = 5
+// - HERO_POWER = 55807
+// - GALAKROND_HERO_CARD = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Hero] - DRG_600t3 : Galakrond, Azeroth's End")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByID("DRG_600t3"));
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+    CHECK_EQ(curField.GetCount(), 4);
+    CHECK_EQ(curField[0]->card->GetRace(), Race::DEMON);
+    CHECK_EQ(curField[1]->card->GetRace(), Race::DEMON);
+    CHECK_EQ(curField[2]->card->GetRace(), Race::DEMON);
+    CHECK_EQ(curField[3]->card->GetRace(), Race::DEMON);
+    CHECK_EQ(curPlayer->GetWeapon().card->name, "Dragon Claw");
+    CHECK_EQ(curPlayer->GetWeapon().GetAttack(), 5);
+    CHECK_EQ(curPlayer->GetWeapon().GetDurability(), 2);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curField.GetCount(), 6);
+    CHECK_EQ(curField[4]->card->name, "Draconic Imp");
+    CHECK_EQ(curField[5]->card->name, "Draconic Imp");
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [DRG_006] Corrosive Breath - COST:2
 // - Set: Dragons, Rarity: Common

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -741,7 +741,7 @@ TEST_CASE("[Warrior : Hero] - DRG_650t2 : Galakrond, the Apocalypse")
 // - HERO_POWER = 55805
 // - GALAKROND_HERO_CARD = 1
 // --------------------------------------------------------
-TEST_CASE("[Warrior : Hero] - DRG_650t2 : Galakrond, the Apocalypse")
+TEST_CASE("[Warrior : Hero] - DRG_650t3 : Galakrond, Azeroth's End")
 {
     GameConfig config;
     config.player1Class = CardClass::WARRIOR;
@@ -870,6 +870,77 @@ TEST_CASE("[Priest : Hero] - DRG_660 : Galakrond, the Unspeakable")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 20);
     CHECK_EQ(opPlayer->GetHero()->GetArmor(), 5);
     CHECK_EQ(curField.GetCount(), 3);
+
+    game.Process(opPlayer, HeroPowerTask());
+    CHECK_EQ(opHand.GetCount(), 7);
+    CHECK_EQ(opHand[6]->card->GetCardClass(), CardClass::PRIEST);
+}
+
+// ------------------------------------------ HERO - PRIEST
+// [DRG_660t2] Galakrond, the Apocalypse (*) - COST:7 [ATK:0/HP:30]
+// - Set: Dragons, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Destroy 2 random enemy minions.
+//       <i>(@)</i>
+// --------------------------------------------------------
+// GameTag:
+// - TAG_SCRIPT_DATA_NUM_2 = 2
+// - ELITE = 1
+// - BATTLECRY = 1
+// - ARMOR = 5
+// - HERO_POWER = 55810
+// - GALAKROND_HERO_CARD = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Hero] - DRG_660t2 : Galakrond, the Apocalypse")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 30; ++i)
+    {
+        config.player1Deck[i] = *Cards::FindCardByName("Wisp");
+        config.player2Deck[i] = *Cards::FindCardByName("Wisp");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    opPlayer->GetHero()->SetDamage(10);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& opHand = *(opPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByID("DRG_660t2"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[0]));
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[0]));
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[0]));
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[0]));
+    CHECK_EQ(curField.GetCount(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(opPlayer->GetHero()->GetArmor(), 5);
+    CHECK_EQ(curField.GetCount(), 2);
 
     game.Process(opPlayer, HeroPowerTask());
     CHECK_EQ(opHand.GetCount(), 7);

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -379,6 +379,21 @@ TEST_CASE("[Paladin : Spell] - DRG_008 : Righteous Cause")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [DRG_061] Gyrocopter - COST:6 [ATK:4/HP:5]
+// - Race: Mechanical, Set: Dragons, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Rush</b> <b>Windfury</b>
+// --------------------------------------------------------
+// GameTag:
+// - WINDFURY = 1
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - DRG_061 : Gyrocopter")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [DRG_065] Hippogryph - COST:4 [ATK:2/HP:6]
 // - Race: Beast, Set: Dragons, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -8,6 +8,7 @@
 
 #include <Rosetta/Actions/Draw.hpp>
 #include <Rosetta/Cards/Cards.hpp>
+#include <Rosetta/Zones/HandZone.hpp>
 #include <Rosetta/Zones/FieldZone.hpp>
 #include <Rosetta/Zones/SecretZone.hpp>
 
@@ -149,6 +150,58 @@ TEST_CASE("[Hunter : Weapon] - DRG_007 : Stormhammer")
     game.Process(curPlayer, AttackTask(curHero, opHero));
     CHECK_EQ(curHero->weapon, nullptr);
     CHECK_EQ(opHero->GetHealth(), 21);
+}
+
+// ---------------------------------------- MINION - HUNTER
+// [DRG_010] Diving Gryphon - COST:3 [ATK:4/HP:1]
+// - Race: Beast, Set: Dragons, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Rush</b> <b>Battlecry:</b> Draw a
+//       <b>Rush</b> minion from your deck.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - DAL_604 : Ursatron")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 5; ++i)
+    {
+        config.player1Deck[i] = *Cards::FindCardByName("Restless Mummy");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Diving Gryphon"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Diving Gryphon"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(curHand[5]->card->name, "Restless Mummy");
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curHand.GetCount(), 5);
 }
 
 // ----------------------------------------- SPELL - HUNTER

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -515,6 +515,77 @@ TEST_CASE("[Shaman : Hero] - DRG_620t2 : Galakrond, the Apocalypse")
     CHECK_EQ(curField[2]->IsRush(), true);
 }
 
+// ------------------------------------------ HERO - SHAMAN
+// [DRG_620t3] Galakrond, Azeroth's End (*) - COST:7 [ATK:0/HP:30]
+// - Set: Dragons, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Summon two 8/8 Storms with <b>Rush</b>.
+//       Equip a 5/2 Claw.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// - ARMOR = 5
+// - HERO_POWER = 55808
+// - GALAKROND_HERO_CARD = 1
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Hero] - DRG_620t3 : Galakrond, Azeroth's End")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(10);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByID("DRG_620t3"));
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Raging Storm");
+    CHECK_EQ(curField[0]->card->GetRace(), Race::ELEMENTAL);
+    CHECK_EQ(curField[0]->GetAttack(), 8);
+    CHECK_EQ(curField[0]->GetHealth(), 8);
+    CHECK_EQ(curField[0]->IsRush(), true);
+    CHECK_EQ(curField[1]->card->name, "Raging Storm");
+    CHECK_EQ(curField[1]->card->GetRace(), Race::ELEMENTAL);
+    CHECK_EQ(curField[1]->GetAttack(), 8);
+    CHECK_EQ(curField[1]->GetHealth(), 8);
+    CHECK_EQ(curField[1]->IsRush(), true);
+    CHECK_EQ(curPlayer->GetWeapon().card->name, "Dragon Claw");
+    CHECK_EQ(curPlayer->GetWeapon().GetAttack(), 5);
+    CHECK_EQ(curPlayer->GetWeapon().GetDurability(), 2);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curField[2]->card->name, "Windswept Elemental");
+    CHECK_EQ(curField[2]->card->GetRace(), Race::ELEMENTAL);
+    CHECK_EQ(curField[2]->GetAttack(), 2);
+    CHECK_EQ(curField[2]->GetHealth(), 1);
+    CHECK_EQ(curField[2]->IsRush(), true);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [DRG_006] Corrosive Breath - COST:2
 // - Set: Dragons, Rarity: Common

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -70,6 +70,60 @@ TEST_CASE("[Warlock : Hero] - DRG_600 : Galakrond, the Wretched")
     CHECK_EQ(curField[2]->card->name, "Draconic Imp");
 }
 
+// ----------------------------------------- HERO - WARLOCK
+// [DRG_600t2] Galakrond, the Apocalypse (*) - COST:7 [ATK:0/HP:30]
+// - Set: Dragons, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Summon 2 random Demons. <i>(@)</i>
+// --------------------------------------------------------
+// GameTag:
+// - TAG_SCRIPT_DATA_NUM_2 = 2
+// - ELITE = 1
+// - BATTLECRY = 1
+// - ARMOR = 5
+// - HERO_POWER = 55807
+// - GALAKROND_HERO_CARD = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Hero] - DRG_600t2 : Galakrond, the Apocalypse")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByID("DRG_600t2"));
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->GetRace(), Race::DEMON);
+    CHECK_EQ(curField[1]->card->GetRace(), Race::DEMON);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curField.GetCount(), 4);
+    CHECK_EQ(curField[2]->card->name, "Draconic Imp");
+    CHECK_EQ(curField[3]->card->name, "Draconic Imp");
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [DRG_006] Corrosive Breath - COST:2
 // - Set: Dragons, Rarity: Common

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -947,6 +947,79 @@ TEST_CASE("[Priest : Hero] - DRG_660t2 : Galakrond, the Apocalypse")
     CHECK_EQ(opHand[6]->card->GetCardClass(), CardClass::PRIEST);
 }
 
+// ------------------------------------------ HERO - PRIEST
+// [DRG_660t3] Galakrond, Azeroth's End (*) - COST:7 [ATK:0/HP:30]
+// - Set: Dragons, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Destroy 4 random enemy minions.
+//       Equip a 5/2 Claw.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// - ARMOR = 5
+// - HERO_POWER = 55810
+// - GALAKROND_HERO_CARD = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Hero] - DRG_660t3 : Galakrond, Azeroth's End")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 30; ++i)
+    {
+        config.player1Deck[i] = *Cards::FindCardByName("Wisp");
+        config.player2Deck[i] = *Cards::FindCardByName("Wisp");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    opPlayer->GetHero()->SetDamage(10);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& opHand = *(opPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByID("DRG_660t3"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[0]));
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[0]));
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[0]));
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[0]));
+    CHECK_EQ(curField.GetCount(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(opPlayer->GetHero()->GetArmor(), 5);
+    CHECK_EQ(curField.GetCount(), 0);
+    CHECK_EQ(opPlayer->GetWeapon().card->name, "Dragon Claw");
+    CHECK_EQ(opPlayer->GetWeapon().GetAttack(), 5);
+    CHECK_EQ(opPlayer->GetWeapon().GetDurability(), 2);
+
+    game.Process(opPlayer, HeroPowerTask());
+    CHECK_EQ(opHand.GetCount(), 7);
+    CHECK_EQ(opHand[6]->card->GetCardClass(), CardClass::PRIEST);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [DRG_006] Corrosive Breath - COST:2
 // - Set: Dragons, Rarity: Common

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -727,6 +727,83 @@ TEST_CASE("[Warrior : Hero] - DRG_650t2 : Galakrond, the Apocalypse")
     CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
 }
 
+// ----------------------------------------- HERO - WARRIOR
+// [DRG_650t3] Galakrond, Azeroth's End (*) - COST:7 [ATK:0/HP:30]
+// - Set: Dragons, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Draw 4 minions. Give them +4/+4.
+//       Equip a 5/2 Claw.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// - ARMOR = 5
+// - HERO_POWER = 55805
+// - GALAKROND_HERO_CARD = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Hero] - DRG_650t2 : Galakrond, the Apocalypse")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 30; ++i)
+    {
+        config.player1Deck[i] = *Cards::FindCardByName("Wisp");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(10);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByID("DRG_650t3"));
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+    CHECK_EQ(curHand.GetCount(), 8);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[3])->GetAttack(), 1);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[3])->GetHealth(), 1);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[4])->GetAttack(), 5);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[4])->GetHealth(), 5);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[5])->GetAttack(), 5);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[5])->GetHealth(), 5);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[6])->GetAttack(), 5);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[6])->GetHealth(), 5);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[7])->GetAttack(), 5);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[7])->GetHealth(), 5);
+    CHECK_EQ(curPlayer->GetWeapon().card->name, "Dragon Claw");
+    CHECK_EQ(curPlayer->GetWeapon().GetAttack(), 5);
+    CHECK_EQ(curPlayer->GetWeapon().GetDurability(), 2);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curPlayer->GetHero()->CanAttack(), true);
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 8);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    CHECK_EQ(curPlayer->GetHero()->CanAttack(), false);
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 5);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [DRG_006] Corrosive Breath - COST:2
 // - Set: Dragons, Rarity: Common

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -446,6 +446,75 @@ TEST_CASE("[Shaman : Hero] - DRG_620 : Galakrond, the Tempest")
     CHECK_EQ(curField[2]->IsRush(), true);
 }
 
+// ------------------------------------------ HERO - SHAMAN
+// [DRG_620t2] Galakrond, the Apocalypse (*) - COST:7 [ATK:0/HP:30]
+// - Set: Dragons, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Summon two 4/4 Storms with <b>Rush</b>.
+//       <i>(@)</i>
+// --------------------------------------------------------
+// GameTag:
+// - TAG_SCRIPT_DATA_NUM_2 = 2
+// - ELITE = 1
+// - BATTLECRY = 1
+// - ARMOR = 5
+// - HERO_POWER = 55808
+// - GALAKROND_HERO_CARD = 1
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Hero] - DRG_620t2 : Galakrond, the Apocalypse")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(10);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByID("DRG_620t2"));
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Living Storm");
+    CHECK_EQ(curField[0]->card->GetRace(), Race::ELEMENTAL);
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(curField[0]->IsRush(), true);
+    CHECK_EQ(curField[1]->card->name, "Living Storm");
+    CHECK_EQ(curField[1]->card->GetRace(), Race::ELEMENTAL);
+    CHECK_EQ(curField[1]->GetAttack(), 4);
+    CHECK_EQ(curField[1]->GetHealth(), 4);
+    CHECK_EQ(curField[1]->IsRush(), true);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curField[2]->card->name, "Windswept Elemental");
+    CHECK_EQ(curField[2]->card->GetRace(), Race::ELEMENTAL);
+    CHECK_EQ(curField[2]->GetAttack(), 2);
+    CHECK_EQ(curField[2]->GetHealth(), 1);
+    CHECK_EQ(curField[2]->IsRush(), true);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [DRG_006] Corrosive Breath - COST:2
 // - Set: Dragons, Rarity: Common

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -248,6 +248,68 @@ TEST_CASE("[Rogue : Hero] - DRG_610 : Galakrond, the Nightmare")
     CHECK_EQ(dynamic_cast<Minion*>(curHand[5])->IsLackey(), true);
 }
 
+// ------------------------------------------- HERO - ROGUE
+// [DRG_610t2] Galakrond, the Apocalypse (*) - COST:7 [ATK:0/HP:30]
+// - Set: Dragons, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Draw 2 cards. They cost (0).
+//       <i>(@)</i>
+// --------------------------------------------------------
+// GameTag:
+// - TAG_SCRIPT_DATA_NUM_2 = 2
+// - ELITE = 1
+// - BATTLECRY = 1
+// - ARMOR = 5
+// - HERO_POWER = 55806
+// - GALAKROND_HERO_CARD = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Hero] - DRG_610t2 : Galakrond, the Apocalypse")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 30; ++i)
+    {
+        config.player1Deck[i] = *Cards::FindCardByName("Fireball");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(10);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByID("DRG_610t2"));
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(curHand[3]->GetCost(), 4);
+    CHECK_EQ(curHand[4]->GetCost(), 0);
+    CHECK_EQ(curHand[5]->GetCost(), 0);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curHand.GetCount(), 7);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[6])->IsLackey(), true);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [DRG_006] Corrosive Breath - COST:2
 // - Set: Dragons, Rarity: Common

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -310,6 +310,72 @@ TEST_CASE("[Rogue : Hero] - DRG_610t2 : Galakrond, the Apocalypse")
     CHECK_EQ(dynamic_cast<Minion*>(curHand[6])->IsLackey(), true);
 }
 
+// ------------------------------------------- HERO - ROGUE
+// [DRG_610t3] Galakrond, Azeroth's End (*) - COST:7 [ATK:0/HP:30]
+// - Set: Dragons, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Draw 4 cards. They cost (0).
+//       Equip a 5/2 Claw.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// - ARMOR = 5
+// - HERO_POWER = 55806
+// - GALAKROND_HERO_CARD = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Hero] - DRG_610t3 : Galakrond, Azeroth's End")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 30; ++i)
+    {
+        config.player1Deck[i] = *Cards::FindCardByName("Fireball");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(10);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByID("DRG_610t3"));
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+    CHECK_EQ(curHand.GetCount(), 8);
+    CHECK_EQ(curHand[3]->GetCost(), 4);
+    CHECK_EQ(curHand[4]->GetCost(), 0);
+    CHECK_EQ(curHand[5]->GetCost(), 0);
+    CHECK_EQ(curHand[6]->GetCost(), 0);
+    CHECK_EQ(curHand[7]->GetCost(), 0);
+    CHECK_EQ(curPlayer->GetWeapon().card->name, "Dragon Claw");
+    CHECK_EQ(curPlayer->GetWeapon().GetAttack(), 5);
+    CHECK_EQ(curPlayer->GetWeapon().GetDurability(), 2);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curHand.GetCount(), 9);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[8])->IsLackey(), true);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [DRG_006] Corrosive Breath - COST:2
 // - Set: Dragons, Rarity: Common

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -86,7 +86,7 @@ TEST_CASE("[Hunter : Spell] - DRG_006 : Corrosive Breath")
 // GameTag:
 // - DURABILITY = 2
 // --------------------------------------------------------
-TEST_CASE("[Hunter : Spell] - DRG_007 : Stormhammer")
+TEST_CASE("[Hunter : Weapon] - DRG_007 : Stormhammer")
 {
     GameConfig config;
     config.player1Class = CardClass::HUNTER;
@@ -231,6 +231,98 @@ TEST_CASE("[Hunter : Spell] - DRG_255 : Toxic Reinforcements")
 
     game.Process(opPlayer, AttackTask(card2, curField[0]));
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+}
+
+// ---------------------------------------- SPELL - PALADIN
+// [DRG_008] Righteous Cause - COST:1
+// - Set: Dragons, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Sidequest:</b> Summon 5 minions.
+//       <b>Reward:</b> Give your minions +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - QUEST_PROGRESS_TOTAL = 5
+// - SIDEQUEST = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Spell] - DRG_008 : Righteous Cause")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Righteous Cause"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card6 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card7 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    auto quest = dynamic_cast<Spell*>(card1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(quest->GetQuestProgress(), 0);
+    CHECK_EQ(quest->GetQuestProgressTotal(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(quest->GetQuestProgress(), 1);
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(quest->GetQuestProgress(), 2);
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(quest->GetQuestProgress(), 3);
+    CHECK_EQ(curField[2]->GetAttack(), 1);
+    CHECK_EQ(curField[2]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(quest->GetQuestProgress(), 4);
+    CHECK_EQ(curField[3]->GetAttack(), 1);
+    CHECK_EQ(curField[3]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card6));
+    CHECK_EQ(quest->GetQuestProgress(), 5);
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+    CHECK_EQ(curField[2]->GetAttack(), 2);
+    CHECK_EQ(curField[2]->GetHealth(), 2);
+    CHECK_EQ(curField[3]->GetAttack(), 2);
+    CHECK_EQ(curField[3]->GetHealth(), 2);
+    CHECK_EQ(curField[4]->GetAttack(), 2);
+    CHECK_EQ(curField[4]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card7));
+    CHECK_EQ(curField[5]->GetAttack(), 1);
+    CHECK_EQ(curField[5]->GetHealth(), 1);
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -586,6 +586,76 @@ TEST_CASE("[Shaman : Hero] - DRG_620t3 : Galakrond, Azeroth's End")
     CHECK_EQ(curField[2]->IsRush(), true);
 }
 
+// ----------------------------------------- HERO - WARRIOR
+// [DRG_650] Galakrond, the Unbreakable - COST:7 [ATK:0/HP:30]
+// - Set: Dragons, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Draw 1 minion. Give it +4/+4.
+//       <i>(@)</i>
+// --------------------------------------------------------
+// GameTag:
+// - TAG_SCRIPT_DATA_NUM_2 = 2
+// - ELITE = 1
+// - BATTLECRY = 1
+// - ARMOR = 5
+// - HERO_POWER = 55805
+// - 676 = 1
+// - GALAKROND_HERO_CARD = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Hero] - DRG_650 : Galakrond, the Unbreakable")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 30; ++i)
+    {
+        config.player1Deck[i] = *Cards::FindCardByName("Wisp");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(10);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Galakrond, the Unbreakable"));
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[3])->GetAttack(), 1);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[3])->GetHealth(), 1);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[4])->GetAttack(), 5);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[4])->GetHealth(), 5);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curPlayer->GetHero()->CanAttack(), true);
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    CHECK_EQ(curPlayer->GetHero()->CanAttack(), false);
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [DRG_006] Corrosive Breath - COST:2
 // - Set: Dragons, Rarity: Common

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -37,7 +37,7 @@ TEST_CASE("[Warlock : Hero] - DRG_600 : Galakrond, the Wretched")
     config.player1Class = CardClass::WARLOCK;
     config.player2Class = CardClass::PALADIN;
     config.startPlayer = PlayerType::PLAYER1;
-    config.doFillDecks = false;
+    config.doFillDecks = true;
     config.autoRun = false;
 
     Game game(config);
@@ -50,6 +50,7 @@ TEST_CASE("[Warlock : Hero] - DRG_600 : Galakrond, the Wretched")
     curPlayer->SetUsedMana(0);
     opPlayer->SetTotalMana(10);
     opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(10);
 
     auto& curField = *(curPlayer->GetFieldZone());
 
@@ -90,7 +91,7 @@ TEST_CASE("[Warlock : Hero] - DRG_600t2 : Galakrond, the Apocalypse")
     config.player1Class = CardClass::WARLOCK;
     config.player2Class = CardClass::PALADIN;
     config.startPlayer = PlayerType::PLAYER1;
-    config.doFillDecks = false;
+    config.doFillDecks = true;
     config.autoRun = false;
 
     Game game(config);
@@ -103,6 +104,7 @@ TEST_CASE("[Warlock : Hero] - DRG_600t2 : Galakrond, the Apocalypse")
     curPlayer->SetUsedMana(0);
     opPlayer->SetTotalMana(10);
     opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(10);
 
     auto& curField = *(curPlayer->GetFieldZone());
 
@@ -144,7 +146,7 @@ TEST_CASE("[Warlock : Hero] - DRG_600t3 : Galakrond, Azeroth's End")
     config.player1Class = CardClass::WARLOCK;
     config.player2Class = CardClass::PALADIN;
     config.startPlayer = PlayerType::PLAYER1;
-    config.doFillDecks = false;
+    config.doFillDecks = true;
     config.autoRun = false;
 
     Game game(config);
@@ -157,6 +159,7 @@ TEST_CASE("[Warlock : Hero] - DRG_600t3 : Galakrond, Azeroth's End")
     curPlayer->SetUsedMana(0);
     opPlayer->SetTotalMana(10);
     opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(10);
 
     auto& curField = *(curPlayer->GetFieldZone());
 
@@ -181,6 +184,68 @@ TEST_CASE("[Warlock : Hero] - DRG_600t3 : Galakrond, Azeroth's End")
     CHECK_EQ(curField.GetCount(), 6);
     CHECK_EQ(curField[4]->card->name, "Draconic Imp");
     CHECK_EQ(curField[5]->card->name, "Draconic Imp");
+}
+
+// ------------------------------------------- HERO - ROGUE
+// [DRG_610] Galakrond, the Nightmare - COST:7 [ATK:0/HP:30]
+// - Set: Dragons, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Draw 1 card. It costs (0).
+//       <i>(@)</i>
+// --------------------------------------------------------
+// GameTag:
+// - TAG_SCRIPT_DATA_NUM_2 = 2
+// - ELITE = 1
+// - BATTLECRY = 1
+// - ARMOR = 5
+// - HERO_POWER = 55806
+// - 676 = 1
+// - GALAKROND_HERO_CARD = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Hero] - DRG_610 : Galakrond, the Nightmare")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 30; ++i)
+    {
+        config.player1Deck[i] = *Cards::FindCardByName("Fireball");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(10);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Galakrond, the Nightmare"));
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[3]->GetCost(), 4);
+    CHECK_EQ(curHand[4]->GetCost(), 0);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[5])->IsLackey(), true);
 }
 
 // ----------------------------------------- SPELL - HUNTER

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -376,6 +376,76 @@ TEST_CASE("[Rogue : Hero] - DRG_610t3 : Galakrond, Azeroth's End")
     CHECK_EQ(dynamic_cast<Minion*>(curHand[8])->IsLackey(), true);
 }
 
+// ------------------------------------------ HERO - SHAMAN
+// [DRG_620] Galakrond, the Tempest - COST:7 [ATK:0/HP:30]
+// - Set: Dragons, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Summon two 2/2 Storms with <b>Rush</b>.
+//       <i>(@)</i>
+// --------------------------------------------------------
+// GameTag:
+// - TAG_SCRIPT_DATA_NUM_2 = 2
+// - ELITE = 1
+// - BATTLECRY = 1
+// - ARMOR = 5
+// - HERO_POWER = 55808
+// - 676 = 1
+// - GALAKROND_HERO_CARD = 1
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Hero] - DRG_620 : Galakrond, the Tempest")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(10);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Galakrond, the Tempest"));
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Brewing Storm");
+    CHECK_EQ(curField[0]->card->GetRace(), Race::ELEMENTAL);
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->IsRush(), true);
+    CHECK_EQ(curField[1]->card->name, "Brewing Storm");
+    CHECK_EQ(curField[1]->card->GetRace(), Race::ELEMENTAL);
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+    CHECK_EQ(curField[1]->IsRush(), true);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curField[2]->card->name, "Windswept Elemental");
+    CHECK_EQ(curField[2]->card->GetRace(), Race::ELEMENTAL);
+    CHECK_EQ(curField[2]->GetAttack(), 2);
+    CHECK_EQ(curField[2]->GetHealth(), 1);
+    CHECK_EQ(curField[2]->IsRush(), true);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [DRG_006] Corrosive Breath - COST:2
 // - Set: Dragons, Rarity: Common

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -8,8 +8,8 @@
 
 #include <Rosetta/Actions/Draw.hpp>
 #include <Rosetta/Cards/Cards.hpp>
-#include <Rosetta/Zones/HandZone.hpp>
 #include <Rosetta/Zones/FieldZone.hpp>
+#include <Rosetta/Zones/HandZone.hpp>
 #include <Rosetta/Zones/SecretZone.hpp>
 
 using namespace RosettaStone;
@@ -31,7 +31,7 @@ TEST_CASE("[Hunter : Spell] - DRG_006 : Corrosive Breath")
 {
     GameConfig config;
     config.player1Class = CardClass::HUNTER;
-    config.player2Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::PALADIN;
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = true;
     config.autoRun = false;
@@ -55,7 +55,7 @@ TEST_CASE("[Hunter : Spell] - DRG_006 : Corrosive Breath")
     const auto card2 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Corrosive Breath"));
     const auto card3 =
-        Generic::DrawCard(curPlayer, Cards::FindCardByName("Brightwing"));
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bronze Herald"));
     const auto card4 =
         Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
 

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -16,6 +16,60 @@ using namespace RosettaStone;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ----------------------------------------- HERO - WARLOCK
+// [DRG_600] Galakrond, the Wretched - COST:7 [ATK:0/HP:30]
+// - Set: Dragons, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Summon 1 random Demon. <i>(@)</i>
+// --------------------------------------------------------
+// GameTag:
+// - TAG_SCRIPT_DATA_NUM_2 = 2
+// - ELITE = 1
+// - BATTLECRY = 1
+// - ARMOR = 5
+// - HERO_POWER = 55807
+// - 676 = 1
+// - GALAKROND_HERO_CARD = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Hero] - DRG_600 : Galakrond, the Wretched")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Galakrond, the Wretched"));
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->GetRace(), Race::DEMON);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[1]->card->name, "Draconic Imp");
+    CHECK_EQ(curField[2]->card->name, "Draconic Imp");
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [DRG_006] Corrosive Breath - COST:2
 // - Set: Dragons, Rarity: Common

--- a/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/DragonsCardsGenTests.cpp
@@ -656,6 +656,77 @@ TEST_CASE("[Warrior : Hero] - DRG_650 : Galakrond, the Unbreakable")
     CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
 }
 
+// ----------------------------------------- HERO - WARRIOR
+// [DRG_650t2] Galakrond, the Apocalypse (*) - COST:7 [ATK:0/HP:30]
+// - Set: Dragons, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Draw 2 minions. Give them +4/+4.
+//       <i>(@)</i>
+// --------------------------------------------------------
+// GameTag:
+// - TAG_SCRIPT_DATA_NUM_2 = 2
+// - ELITE = 1
+// - BATTLECRY = 1
+// - ARMOR = 5
+// - HERO_POWER = 55805
+// - GALAKROND_HERO_CARD = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Hero] - DRG_650t2 : Galakrond, the Apocalypse")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 30; ++i)
+    {
+        config.player1Deck[i] = *Cards::FindCardByName("Wisp");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_START);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(10);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByID("DRG_650t2"));
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[3])->GetAttack(), 1);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[3])->GetHealth(), 1);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[4])->GetAttack(), 5);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[4])->GetHealth(), 5);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[5])->GetAttack(), 5);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[5])->GetHealth(), 5);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curPlayer->GetHero()->CanAttack(), true);
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_START);
+
+    CHECK_EQ(curPlayer->GetHero()->CanAttack(), false);
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [DRG_006] Corrosive Breath - COST:2
 // - Set: Dragons, Rarity: Common


### PR DESCRIPTION
This revision includes:
- Implement abilities
  - Lackey: Lackeys are uncollectible minion cards generated by certain cards in the Year of the Dragon. They are mostly restricted to Priest, Rogue, Shaman, Warlock, and Warrior.
  - Invoke: Invoke is an ability introduced in the Descent of Dragons expansion. When an Invoke card is played, the Hero Power of Galakrond will be activated, as long as the player has a Galakrond hero card in their hand, deck, or battlefield.
- Implement 11 DRAGONS cards
  - Corrosive Breath (DRG_006)
  - Stormhammer (DRG_007)
  - Righteous Cause (DRG_008)
  - Diving Gryphon (DRG_010)
  - Gyrocopter (DRG_061)
  - Disciple of Galakrond (DRG_303)
  - Galakrond, the Wretched (DRG_600)
  - Galakrond, the Nightmare (DRG_610)
  - Galakrond, the Tempest (DRG_620)
  - Galakrond, the Unbreakable (DRG_650)
  - Galakrond, the Unspeakable (DRG_660)
- Implement tasks
  - AddLackeyTask: This class represents the task for adding Lackey to hand.
  - InvokeTask: This class represents the task for processing ability 'Invoke'.
- Add functions and methods
  - PlayHero(): Plays a hero card from player's hand.
  - IsGalakrond(): Returns the flag that indicates whether it is Galakrond.
  - GetLackeys(): Returns a list of Lackey cards.
  - EndsWith(): Finds out if value ends with ending.
  - IsHoldingRace(): SelfCondition wrapper for checking the player has entity with race in hand zone.
  - IsRush(): SelfCondition wrapper for checking the entity is rush.
  - IsLackey(): Returns the flag that indicates whether it is Lackey.
  - SetHero(): Sets the hero of the player.
  - UpgradeGalakrond(): Upgrades the Galakrond hero card.
  - GetInvoke(): Returns the value of invoke.
  - IncreaseInvoke(): Increases the value of invoke.
  - IsImmune(): Returns the flag that indicates whether it is immune.
- Fix `Hero::GetAttack()` mechanism (#304)