### PR TITLE
Implement 23 ULDUM cards

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -623,11 +623,11 @@ DALARAN | DAL_800 | Zayle, Shadow Cloak | O
 Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
 ULDUM | ULD_003 | Zephrys the Great |  
-ULDUM | ULD_131 | Untapped Potential |  
+ULDUM | ULD_131 | Untapped Potential | O
 ULDUM | ULD_133 | Crystal Merchant | O
-ULDUM | ULD_134 | BEEEES!!! |  
-ULDUM | ULD_135 | Hidden Oasis |  
-ULDUM | ULD_136 | Worthy Expedition |  
+ULDUM | ULD_134 | BEEEES!!! | O
+ULDUM | ULD_135 | Hidden Oasis | O
+ULDUM | ULD_136 | Worthy Expedition | O
 ULDUM | ULD_137 | Garden Gnome |  
 ULDUM | ULD_138 | Anubisath Defender |  
 ULDUM | ULD_139 | Elise the Enlightened |  
@@ -758,7 +758,7 @@ ULDUM | ULD_726 | Ancient Mysteries |
 ULDUM | ULD_727 | Body Wrapper |  
 ULDUM | ULD_728 | Subdue |  
 
-- Progress: 18% (25 of 135 Cards)
+- Progress: 21% (29 of 135 Cards)
 
 ## Descent of Dragons
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -679,17 +679,17 @@ ULDUM | ULD_206 | Restless Mummy | O
 ULDUM | ULD_207 | Ancestral Guardian | O
 ULDUM | ULD_208 | Khartut Defender |  
 ULDUM | ULD_209 | Vulpera Scoundrel |  
-ULDUM | ULD_212 | Wild Bloodstinger |  
+ULDUM | ULD_212 | Wild Bloodstinger | O
 ULDUM | ULD_214 | Generous Mummy |  
 ULDUM | ULD_215 | Wrapped Golem |  
-ULDUM | ULD_216 | Puzzle Box of Yogg-Saron |  
+ULDUM | ULD_216 | Puzzle Box of Yogg-Saron | O
 ULDUM | ULD_217 | Micro Mummy |  
 ULDUM | ULD_229 | Mischief Maker |  
 ULDUM | ULD_231 | Whirlkick Master |  
-ULDUM | ULD_236 | Tortollan Pilgrim |  
-ULDUM | ULD_238 | Reno the Relicologist |  
-ULDUM | ULD_239 | Flame Ward |  
-ULDUM | ULD_240 | Arcane Flakmage |  
+ULDUM | ULD_236 | Tortollan Pilgrim | O
+ULDUM | ULD_238 | Reno the Relicologist | O
+ULDUM | ULD_239 | Flame Ward | O
+ULDUM | ULD_240 | Arcane Flakmage | O
 ULDUM | ULD_250 | Infested Goblin |  
 ULDUM | ULD_253 | Tomb Warden |  
 ULDUM | ULD_256 | Into the Fray |  
@@ -715,21 +715,21 @@ ULDUM | ULD_289 | Fishflinger | O
 ULDUM | ULD_290 | History Buff |  
 ULDUM | ULD_291 | Corrupt the Waters |  
 ULDUM | ULD_292 | Oasis Surger | O
-ULDUM | ULD_293 | Cloud Prince |  
+ULDUM | ULD_293 | Cloud Prince | O
 ULDUM | ULD_304 | King Phaoris |  
 ULDUM | ULD_309 | Dwarven Archaeologist |  
 ULDUM | ULD_324 | Impbalming |  
 ULDUM | ULD_326 | Bazaar Burglary |  
 ULDUM | ULD_327 | Bazaar Mugger |  
 ULDUM | ULD_328 | Clever Disguise |  
-ULDUM | ULD_329 | Dune Sculptor |  
-ULDUM | ULD_410 | Scarlet Webweaver |  
+ULDUM | ULD_329 | Dune Sculptor | O
+ULDUM | ULD_410 | Scarlet Webweaver | O
 ULDUM | ULD_413 | Splitting Axe |  
-ULDUM | ULD_429 | Hunter's Pack |  
+ULDUM | ULD_429 | Hunter's Pack | O
 ULDUM | ULD_430 | Desert Spear | O
 ULDUM | ULD_431 | Making Mummies | O
-ULDUM | ULD_433 | Raid the Sky Temple |  
-ULDUM | ULD_435 | Naga Sand Witch |  
+ULDUM | ULD_433 | Raid the Sky Temple | O
+ULDUM | ULD_435 | Naga Sand Witch | O
 ULDUM | ULD_438 | Salhet's Pride |  
 ULDUM | ULD_439 | Sandwasp Queen |  
 ULDUM | ULD_450 | Vilefiend | O
@@ -754,11 +754,11 @@ ULDUM | ULD_720 | Bloodsworn Mercenary |
 ULDUM | ULD_721 | Colossus of the Moon | O
 ULDUM | ULD_723 | Murmy | O
 ULDUM | ULD_724 | Activate the Obelisk |  
-ULDUM | ULD_726 | Ancient Mysteries |  
+ULDUM | ULD_726 | Ancient Mysteries | O
 ULDUM | ULD_727 | Body Wrapper |  
 ULDUM | ULD_728 | Subdue |  
 
-- Progress: 25% (35 of 135 Cards)
+- Progress: 35% (48 of 135 Cards)
 
 ## Descent of Dragons
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -628,17 +628,17 @@ ULDUM | ULD_133 | Crystal Merchant | O
 ULDUM | ULD_134 | BEEEES!!! | O
 ULDUM | ULD_135 | Hidden Oasis | O
 ULDUM | ULD_136 | Worthy Expedition | O
-ULDUM | ULD_137 | Garden Gnome |  
-ULDUM | ULD_138 | Anubisath Defender |  
-ULDUM | ULD_139 | Elise the Enlightened |  
+ULDUM | ULD_137 | Garden Gnome | O
+ULDUM | ULD_138 | Anubisath Defender | O
+ULDUM | ULD_139 | Elise the Enlightened | O
 ULDUM | ULD_140 | Supreme Archaeology |  
 ULDUM | ULD_143 | Pharaoh's Blessing |  
 ULDUM | ULD_145 | Brazen Zealot |  
-ULDUM | ULD_151 | Ramkahen Wildtamer |  
+ULDUM | ULD_151 | Ramkahen Wildtamer | O
 ULDUM | ULD_152 | Pressure Plate | O
 ULDUM | ULD_154 | Hyena Alpha | O
 ULDUM | ULD_155 | Unseal the Vault | O
-ULDUM | ULD_156 | Dinotamer Brann |  
+ULDUM | ULD_156 | Dinotamer Brann | O
 ULDUM | ULD_157 | Questing Explorer |  
 ULDUM | ULD_158 | Sandstorm Elemental |  
 ULDUM | ULD_160 | Sinister Deal |  
@@ -714,7 +714,7 @@ ULDUM | ULD_288 | Anka, the Buried |
 ULDUM | ULD_289 | Fishflinger | O
 ULDUM | ULD_290 | History Buff |  
 ULDUM | ULD_291 | Corrupt the Waters |  
-ULDUM | ULD_292 | Oasis Surger |  
+ULDUM | ULD_292 | Oasis Surger | O
 ULDUM | ULD_293 | Cloud Prince |  
 ULDUM | ULD_304 | King Phaoris |  
 ULDUM | ULD_309 | Dwarven Archaeologist |  
@@ -758,7 +758,7 @@ ULDUM | ULD_726 | Ancient Mysteries |
 ULDUM | ULD_727 | Body Wrapper |  
 ULDUM | ULD_728 | Subdue |  
 
-- Progress: 21% (29 of 135 Cards)
+- Progress: 25% (35 of 135 Cards)
 
 ## Descent of Dragons
 

--- a/Documents/TaskList.md
+++ b/Documents/TaskList.md
@@ -23,6 +23,7 @@
 * ApplyEffectTask
 * ArmorTask
 * AttackTask
+* CastRandomSpellTask
 * ChanceTask
 * ChangeAttackingTargetTask
 * ChangeEntityTask

--- a/Includes/Rosetta/Cards/Card.hpp
+++ b/Includes/Rosetta/Cards/Card.hpp
@@ -73,6 +73,14 @@ class Card
     //! \return The flag that indicates whether it is Lackey.
     bool IsLackey() const;
 
+    //! Returns the flag that indicates whether it is a card with two Choose One
+    //! options involving transform or specific summon effects is played while
+    //! controlling Ossirian Tear.
+    //! \return The flag that indicates whether it is a card with two Choose One
+    //! options involving transform or specific summon effects is played while
+    //! controlling Ossirian Tear, false otherwise.
+    bool IsTransformMinion() const;
+
     //! Returns the flag that indicates whether it is Galakrond.
     //! \return The flag that indicates whether it is Galakrond.
     bool IsGalakrond() const;

--- a/Includes/Rosetta/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/Conditions/SelfCondition.hpp
@@ -332,10 +332,15 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition HasNotSpellDamageOnHero();
 
-    //! SelfCondition wrapper for checking the hero has spell card
+    //! SelfCondition wrapper for checking the player has spell card
     //! that costs 5 or more in hand.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition Has5MoreCostSpellInHand();
+
+    //! SelfCondition wrapper for checking the player casts a spell
+    //! that costs (5) or more this turn.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition Cast5MoreCostSpellInThisTurn();
 
     //! SelfCondition wrapper for checking the threshold value.
     //! \param relaSign The comparer to check condition.

--- a/Includes/Rosetta/Enchants/PlayerAuraEffects.hpp
+++ b/Includes/Rosetta/Enchants/PlayerAuraEffects.hpp
@@ -56,6 +56,7 @@ class PlayerAuraEffects
     int m_resourcesUsed = 0;
     int m_extraTriggerSecret = 0;
     int m_megaWindfury = 0;
+    int m_chooseBoth = 0;
 };
 }  // namespace RosettaStone
 

--- a/Includes/Rosetta/Enums/ChoiceEnums.hpp
+++ b/Includes/Rosetta/Enums/ChoiceEnums.hpp
@@ -23,6 +23,7 @@ enum class DiscoverType
     HEISTBARON_TOGWAGGLE,
     MADAME_LAZUL,
     SWAMPQUEEN_HAGATHA,
+    TORTOLLAN_PILGRIM,
 };
 
 //! The action type of choice.

--- a/Includes/Rosetta/Enums/ChoiceEnums.hpp
+++ b/Includes/Rosetta/Enums/ChoiceEnums.hpp
@@ -39,6 +39,7 @@ enum class ChoiceAction
     ENVOY_OF_LAZUL,      //!< Envoy Of Lazul.
     SIGHTLESS_WATCHER,   //!< Sightless Watcher.
     SWAMPQUEEN_HAGATHA,  //!< Swampqueen Hagatha.
+    TORTOLLAN_PILGRIM,   //!< Tortollan Pilgrim.
 };
 }  // namespace RosettaStone
 

--- a/Includes/Rosetta/Enums/ChoiceEnums.hpp
+++ b/Includes/Rosetta/Enums/ChoiceEnums.hpp
@@ -14,6 +14,7 @@ enum class DiscoverType
 {
     INVALID,
     SPELL,
+    CHOOSE_ONE,
     DRAGON,
     LEGENDARY_MINION_SUMMON,
     DEATHRATTLE_MINION_DIED,

--- a/Includes/Rosetta/Loaders/TargetingPredicates.hpp
+++ b/Includes/Rosetta/Loaders/TargetingPredicates.hpp
@@ -107,6 +107,11 @@ class TargetingPredicates
     //! Predicate wrapper for checking the target requires that it has taunt.
     //! \return Generated TargetingPredicate for intended purpose.
     static TargetingPredicate ReqMustTargetTaunter();
+
+    //! Predicate wrapper for checking the player has at least \p value secrets.
+    //! \param value The number of minimum secrets.
+    //! \return Generated TargetingPredicate for intended purpose.
+    static AvailabilityPredicate MinimumFriendlySecrets(int value);
 };
 }  // namespace RosettaStone
 

--- a/Includes/Rosetta/Models/Player.hpp
+++ b/Includes/Rosetta/Models/Player.hpp
@@ -136,6 +136,10 @@ class Player : public Entity
     //! \return true if for this player triggers secret twice, false otherwise.
     bool ExtraTriggerSecret() const;
 
+    //! Returns whether this player chooses both cards.
+    //! \return true if for this player chooses both cards, false otherwise.
+    bool ChooseBoth() const;
+
     //! Returns total amount of mana available.
     //! \return Total amount of mana available.
     int GetTotalMana() const;

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -128,6 +128,7 @@
 #include <Rosetta/Tasks/SimpleTasks/ApplyEffectTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AttackTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/CastRandomSpellTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ChanceTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ChangeAttackingTargetTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ChangeEntityTask.hpp>

--- a/Includes/Rosetta/Tasks/SimpleTasks/CastRandomSpellTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/CastRandomSpellTask.hpp
@@ -1,0 +1,32 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_CAST_RANDOM_SPELL_TASK_HPP
+#define ROSETTASTONE_CAST_RANDOM_SPELL_TASK_HPP
+
+#include <Rosetta/Tasks/ITask.hpp>
+
+namespace RosettaStone::SimpleTasks
+{
+//!
+//! \brief CastRandomSpellTask class.
+//!
+//! This class represents the task for casting random spell.
+//!
+class CastRandomSpellTask : public ITask
+{
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player* player) override;
+
+    //! Internal method of Clone().
+    //! \return The cloned task.
+    std::unique_ptr<ITask> CloneImpl() override;
+};
+}  // namespace RosettaStone::SimpleTasks
+
+#endif  // ROSETTASTONE_CAST_RANDOM_SPELL_TASK_HPP

--- a/Includes/Rosetta/Tasks/SimpleTasks/RandomCardTask.hpp
+++ b/Includes/Rosetta/Tasks/SimpleTasks/RandomCardTask.hpp
@@ -21,12 +21,22 @@ class RandomCardTask : public ITask
     //! Constructs task with various arguments.
     //! \param cardType The type of card to filter.
     //! \param cardClass The class of card to filter.
+    //! \param tags A list of game tags to filter.
+    //! \param opposite The flag that indicates the card is for the opponent.
+    explicit RandomCardTask(CardType cardType, CardClass cardClass,
+                            std::map<GameTag, int> tags, bool opposite = false);
+
+    //! Constructs task with various arguments.
+    //! \param cardType The type of card to filter.
+    //! \param cardClass The class of card to filter.
     //! \param race The race of card to filter.
     //! \param rarity The rarity of card to filter.
+    //! \param tags A list of game tags to filter.
     //! \param opposite The flag that indicates the card is for the opponent.
     explicit RandomCardTask(CardType cardType, CardClass cardClass,
                             Race race = Race::INVALID,
                             Rarity rarity = Rarity::INVALID,
+                            std::map<GameTag, int> tags = {},
                             bool opposite = false);
 
     //! Returns card list that fits the criteria.
@@ -35,11 +45,12 @@ class RandomCardTask : public ITask
     //! \param cardClass The class of card to filter.
     //! \param race The race of card to filter.
     //! \param rarity The rarity of card to filter.
+    //! \param tags A list of game tags to filter.
     //! \return A list of cards that fits the criteria.
     static std::vector<Card*> GetCardList(
         Entity* source, CardType cardType = CardType::INVALID,
         CardClass cardClass = CardClass::INVALID, Race race = Race::INVALID,
-        Rarity rarity = Rarity::INVALID);
+        Rarity rarity = Rarity::INVALID, std::map<GameTag, int> tags = {});
 
  private:
     //! Processes task logic internally and returns meta data.
@@ -55,6 +66,7 @@ class RandomCardTask : public ITask
     CardClass m_cardClass = CardClass::INVALID;
     Race m_race = Race::INVALID;
     Rarity m_rarity = Rarity::INVALID;
+    std::map<GameTag, int> m_tags;
     bool m_opposite = false;
 };
 }  // namespace RosettaStone::SimpleTasks

--- a/Includes/Rosetta/Zones/Zone.hpp
+++ b/Includes/Rosetta/Zones/Zone.hpp
@@ -135,7 +135,7 @@ class UnlimitedZone : public Zone<Playable>
     //! \param zonePos The zone position of entity.
     void Add(Playable* entity, int zonePos = -1) override
     {
-        if (entity->player != m_player)
+        if (const auto player = entity->player; player && player != m_player)
         {
             throw std::logic_error(
                 "Can't add an opponent's entity to own zones");

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 ### Expansions
 
   * **100% Descent of Dragons (140 of 140 cards)**
-  * 25% Saviors of Uldum (35 of 135 cards)
+  * 35% Saviors of Uldum (48 of 135 cards)
   * **100% Rise of Shadows (136 of 136 cards)**
   * 0% Rastakhan's Rumble (0 of 135 Cards)
   * 0% The Boomsday Project (0 of 135 Cards)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 ### Expansions
 
   * **100% Descent of Dragons (140 of 140 cards)**
-  * 21% Saviors of Uldum (29 of 135 cards)
+  * 25% Saviors of Uldum (35 of 135 cards)
   * **100% Rise of Shadows (136 of 136 cards)**
   * 0% Rastakhan's Rumble (0 of 135 Cards)
   * 0% The Boomsday Project (0 of 135 Cards)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 ### Expansions
 
   * **100% Descent of Dragons (140 of 140 cards)**
-  * 18% Saviors of Uldum (25 of 135 cards)
+  * 21% Saviors of Uldum (29 of 135 cards)
   * **100% Rise of Shadows (136 of 136 cards)**
   * 0% Rastakhan's Rumble (0 of 135 Cards)
   * 0% The Boomsday Project (0 of 135 Cards)

--- a/Sources/Rosetta/Actions/Summon.cpp
+++ b/Sources/Rosetta/Actions/Summon.cpp
@@ -40,8 +40,13 @@ void Summon(Minion* minion, int fieldPos, Entity* summoner)
 void SummonReborn(Minion* minion)
 {
     int alternateCount = 0;
-    const int zonePos = SummonTask::GetPosition(minion, SummonSide::RIGHT,
+    int zonePos = SummonTask::GetPosition(minion, SummonSide::RIGHT,
                                                 nullptr, alternateCount);
+    if (zonePos > minion->player->GetFieldZone()->GetCount())
+    {
+        zonePos = minion->player->GetFieldZone()->GetCount();
+    }
+
     const auto copy = dynamic_cast<Minion*>(
         Entity::GetFromCard(minion->player, minion->card, minion->GetGameTags(),
                             minion->player->GetFieldZone()));

--- a/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/CardSets/Expert1CardsGen.cpp
@@ -264,7 +264,8 @@ void Expert1CardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - TAUNT = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(nullptr);
+    power.AddPowerTask(
+        std::make_shared<TransformTask>(EntityType::SOURCE, "OG_044a"));
     cards.emplace("EX1_165",
                   CardDef(power, ChooseCardIDs{ "EX1_165a", "EX1_165b" }));
 

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -614,6 +614,14 @@ void UldumCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::HAND));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsMinion()),
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::BEAST)) }));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("ULD_410e", EntityType::STACK));
+    cards.emplace("ULD_410", CardDef(power));
 
     // ----------------------------------------- SPELL - HUNTER
     // [ULD_429] Hunter's Pack - COST:3
@@ -727,6 +735,9 @@ void UldumCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Costs (5) less.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(std::make_shared<Enchant>(Effects::ReduceCost(5)));
+    cards.emplace("ULD_410e", CardDef(power));
 }
 
 void UldumCardsGen::AddMage(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -573,6 +573,14 @@ void UldumCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsNoDuplicateInDeck()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<SummonTask>("ULD_156t3",
+                                                     SummonSide::RIGHT) }));
+    cards.emplace("ULD_156", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
     // [ULD_212] Wild Bloodstinger - COST:6 [ATK:6/HP:9]
@@ -698,6 +706,9 @@ void UldumCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - CHARGE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("ULD_156t3", CardDef(power));
 
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [ULD_410e] Weaved (*) - COST:0

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -11,6 +11,7 @@
 #include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AttackTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/CastRandomSpellTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/CopyTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/CustomTask.hpp>
@@ -18,6 +19,7 @@
 #include <Rosetta/Tasks/SimpleTasks/DestroyTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DiscoverTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DrawTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FlagTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/HealTask.hpp>
@@ -755,12 +757,18 @@ void UldumCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
 void UldumCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------- SPELL - MAGE
     // [ULD_216] Puzzle Box of Yogg-Saron - COST:10
     // - Faction: Neutral, Set: Uldum, Rarity: Epic
     // --------------------------------------------------------
     // Text: Cast 10 random spells <i>(targets chosen randomly).</i>
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<EnqueueTask>(
+        TaskList{ std::make_shared<CastRandomSpellTask>() }, 10, true));
+    cards.emplace("ULD_216", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [ULD_236] Tortollan Pilgrim - COST:8 [ATK:5/HP:5]

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -288,6 +288,11 @@ void UldumCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<AdaptiveCostEffect>(
+        [](Playable* playable) { return 0; }, EffectOperator::SET,
+        SelfCondition::Cast5MoreCostSpellInThisTurn()));
+    cards.emplace("ULD_138", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [ULD_139] Elise the Enlightened - COST:5 [ATK:5/HP:5]

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -29,6 +29,7 @@ using namespace RosettaStone::SimpleTasks;
 namespace RosettaStone
 {
 using PlayReqs = std::map<PlayReq, int>;
+using ChooseCardIDs = std::vector<std::string>;
 using TaskList = std::vector<std::shared_ptr<ITask>>;
 using EntityTypeList = std::vector<EntityType>;
 using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
@@ -237,6 +238,11 @@ void UldumCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("ULD_135",
+                  CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } },
+                          ChooseCardIDs{ "ULD_135a", "ULD_135b" }));
 
     // ------------------------------------------ SPELL - DRUID
     // [ULD_136] Worthy Expedition - COST:1
@@ -331,6 +337,12 @@ void UldumCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("ULD_135at", SummonSide::SPELL));
+    cards.emplace(
+        "ULD_135a",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ----------------------------------------- MINION - DRUID
     // [ULD_135at] Vir'naal Ancient (*) - COST:6 [ATK:6/HP:6]
@@ -341,6 +353,9 @@ void UldumCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("ULD_135at", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [ULD_135b] Drink the Water (*) - COST:0
@@ -351,6 +366,11 @@ void UldumCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // PlayReq:
     // - REQ_TARGET_TO_PLAY = 0
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<HealTask>(EntityType::TARGET, 12));
+    cards.emplace(
+        "ULD_135b",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ----------------------------------------- MINION - DRUID
     // [ULD_137t] Treant (*) - COST:2 [ATK:2/HP:2]

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -36,6 +36,7 @@ using namespace RosettaStone::SimpleTasks;
 
 namespace RosettaStone
 {
+using GameTags = std::map<GameTag, int>;
 using PlayReqs = std::map<PlayReq, int>;
 using ChooseCardIDs = std::vector<std::string>;
 using TaskList = std::vector<std::shared_ptr<ITask>>;
@@ -633,6 +634,18 @@ void UldumCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<RandomCardTask>(
+        CardType::MINION, CardClass::HUNTER, Race::BEAST));
+    power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
+    power.AddPowerTask(
+        std::make_shared<RandomCardTask>(CardType::SPELL, CardClass::HUNTER,
+                                         GameTags{ { GameTag::SECRET, 1 } }));
+    power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
+    power.AddPowerTask(
+        std::make_shared<RandomCardTask>(CardType::WEAPON, CardClass::HUNTER));
+    power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
+    cards.emplace("ULD_429", CardDef(power));
 
     // ---------------------------------------- WEAPON - HUNTER
     // [ULD_430] Desert Spear - COST:3 [ATK:1/HP:0]
@@ -2279,9 +2292,9 @@ void UldumCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     power.AddPowerTask(std::make_shared<RandomCardTask>(
         CardType::MINION, CardClass::INVALID, Race::MURLOC));
     power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
-    power.AddPowerTask(
-        std::make_shared<RandomCardTask>(CardType::MINION, CardClass::INVALID,
-                                         Race::MURLOC, Rarity::INVALID, true));
+    power.AddPowerTask(std::make_shared<RandomCardTask>(
+        CardType::MINION, CardClass::INVALID, Race::MURLOC, Rarity::INVALID,
+        GameTags{}, true));
     power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
     cards.emplace("ULD_289", CardDef(power));
 

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -328,6 +328,10 @@ void UldumCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - CHOOSE_ONE = 1
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("ULD_292", CardDef(power, PlayReqs{},
+                                     ChooseCardIDs{ "ULD_292a", "ULD_292b" }));
 }
 
 void UldumCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
@@ -410,6 +414,10 @@ void UldumCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Gain +2/+2.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("ULD_292ae", EntityType::SOURCE));
+    cards.emplace("ULD_292a", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [ULD_292ae] Focused (*) - COST:0
@@ -417,6 +425,9 @@ void UldumCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("ULD_292ae"));
+    cards.emplace("ULD_292ae", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [ULD_292b] Divide and Conquer (*) - COST:0
@@ -427,6 +438,11 @@ void UldumCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // PlayReq:
     // - REQ_NUM_MINION_SLOTS = 2
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonCopyTask>(EntityType::SOURCE));
+    cards.emplace(
+        "ULD_292b",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 2 } }));
 }
 
 void UldumCardsGen::AddHunter(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -13,6 +13,7 @@
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DestroyTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/DiscoverTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FlagTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/HealTask.hpp>
@@ -254,6 +255,9 @@ void UldumCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - DISCOVER = 1
     // - USE_DISCOVER_VISUALS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DiscoverTask>(DiscoverType::CHOOSE_ONE));
+    cards.emplace("ULD_136", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [ULD_137] Garden Gnome - COST:4 [ATK:2/HP:3]

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -798,6 +798,21 @@ void UldumCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsNoDuplicateInDeck()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true,
+        TaskList{ std::make_shared<EnqueueTask>(
+            TaskList{
+                std::make_shared<FilterStackTask>(
+                    SelfCondList{ std::make_shared<SelfCondition>(
+                        SelfCondition::IsNotDead()) }),
+                std::make_shared<RandomTask>(EntityType::ENEMY_MINIONS, 1),
+                std::make_shared<DamageTask>(EntityType::STACK, 1) },
+            10) }));
+    cards.emplace("ULD_238", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [ULD_239] Flame Ward - COST:3

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -824,6 +824,16 @@ void UldumCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACKED));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->tasks = {
+        std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 3, true),
+        std::make_shared<SetGameTagTask>(EntityType::SOURCE, GameTag::REVEALED,
+                                         1),
+        std::make_shared<MoveToGraveyardTask>(EntityType::SOURCE)
+    };
+    cards.emplace("ULD_239", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [ULD_240] Arcane Flakmage - COST:2 [ATK:3/HP:2]

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -25,6 +25,10 @@
 #include <Rosetta/Tasks/SimpleTasks/SummonCopyTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/SummonTask.hpp>
 
+#include "Rosetta/Tasks/SimpleTasks/CustomTask.hpp"
+#include "Rosetta/Zones/HandZone.hpp"
+#include <Rosetta/Actions/Copy.hpp>
+
 using namespace RosettaStone::SimpleTasks;
 
 namespace RosettaStone
@@ -305,6 +309,25 @@ void UldumCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsNoDuplicateInDeck()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<CustomTask>(
+                  [](Player* player, [[maybe_unused]] Entity* source,
+                     [[maybe_unused]] Playable* target) {
+                      for (auto& handCard : player->GetHandZone()->GetAll())
+                      {
+                          if (player->GetHandZone()->IsFull())
+                          {
+                              break;
+                          }
+
+                          Generic::Copy(player, handCard, ZoneType::HAND);
+                      }
+                  }) }));
+    cards.emplace("ULD_139", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [ULD_273] Overflow - COST:7

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -845,6 +845,15 @@ void UldumCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_CAST));
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    power.GetTrigger()->condition =
+        std::make_shared<SelfCondition>(SelfCondition::IsSecret());
+    power.GetTrigger()->tasks = {
+        std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 2),
+    };
+    cards.emplace("ULD_240", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [ULD_293] Cloud Prince - COST:5 [ATK:4/HP:4]

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -9,11 +9,11 @@
 #include <Rosetta/Enchants/Enchants.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/AttackTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DestroyTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DrawTask.hpp>
-#include <Rosetta/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FlagTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/HealTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/MoveToGraveyardTask.hpp>
@@ -210,6 +210,16 @@ void UldumCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - REQ_MINION_TARGET = 0
     // - REQ_NUM_MINION_SLOTS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("ULD_134t", 4, SummonSide::SPELL, true));
+    power.AddPowerTask(std::make_shared<AttackTask>(EntityType::STACK,
+                                                    EntityType::TARGET, true));
+    cards.emplace(
+        "ULD_134",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ------------------------------------------ SPELL - DRUID
     // [ULD_135] Hidden Oasis - COST:6
@@ -299,10 +309,15 @@ void UldumCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 
 void UldumCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- MINION - DRUID
     // [ULD_134t] Bee (*) - COST:1 [ATK:1/HP:1]
     // - Race: Beast, Set: Uldum
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("ULD_134t", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [ULD_135a] Befriend the Ancient (*) - COST:0

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -18,6 +18,7 @@
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DestroyTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DiscoverTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/DrawStackTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FilterStackTask.hpp>
@@ -937,10 +938,21 @@ void UldumCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::DECK));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsSecret()) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("ULD_726e", EntityType::STACK));
+    power.AddPowerTask(std::make_shared<DrawStackTask>(1));
+    cards.emplace("ULD_726", CardDef(power));
 }
 
 void UldumCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------- ENCHANTMENT - MAGE
     // [ULD_435e] Sandwitched (*) - COST:0
     // - Set: Uldum
@@ -954,6 +966,9 @@ void UldumCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Costs (0).
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(std::make_shared<Enchant>(Effects::SetCost(0)));
+    cards.emplace("ULD_726e", CardDef(power));
 }
 
 void UldumCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -54,6 +54,11 @@ void UldumCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - HIDE_STATS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<Aura>(
+        AuraType::PLAYER, EffectList{ std::make_shared<Effect>(
+                              GameTag::CHOOSE_BOTH, EffectOperator::SET, 1) }));
+    cards.emplace("ULD_131p", CardDef(power));
 
     // ----------------------------------- HERO_POWER - WARLOCK
     // [ULD_140p] Tome of Origination (*) - COST:2
@@ -172,6 +177,13 @@ void UldumCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - 839 = 1
     // - QUEST_REWARD_DATABASE_ID = 53499
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->condition =
+        std::make_shared<SelfCondition>(SelfCondition::IsUnspentMana());
+    power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
+        "ULD_131p") };
+    cards.emplace("ULD_131", CardDef(power, 4, 0));
 
     // ----------------------------------------- MINION - DRUID
     // [ULD_133] Crystal Merchant - COST:2 [ATK:1/HP:4]

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -3,6 +3,7 @@
 // Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
+#include <Rosetta/Actions/Copy.hpp>
 #include <Rosetta/CardSets/UldumCardsGen.hpp>
 #include <Rosetta/Conditions/RelaCondition.hpp>
 #include <Rosetta/Enchants/Effects.hpp>
@@ -11,12 +12,16 @@
 #include <Rosetta/Tasks/SimpleTasks/AddStackToTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/AttackTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/ConditionTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/CopyTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/CustomTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DestroyTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DiscoverTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DrawTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/FlagTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/HealTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/IncludeTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/MoveToGraveyardTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/QuestProgressTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/RandomCardTask.hpp>
@@ -24,10 +29,7 @@
 #include <Rosetta/Tasks/SimpleTasks/SetGameTagTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/SummonCopyTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/SummonTask.hpp>
-
-#include "Rosetta/Tasks/SimpleTasks/CustomTask.hpp"
-#include "Rosetta/Zones/HandZone.hpp"
-#include <Rosetta/Actions/Copy.hpp>
+#include <Rosetta/Zones/HandZone.hpp>
 
 using namespace RosettaStone::SimpleTasks;
 
@@ -481,6 +483,14 @@ void UldumCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::HAND));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::BEAST)) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddPowerTask(
+        std::make_shared<CopyTask>(EntityType::STACK, ZoneType::HAND));
+    cards.emplace("ULD_151", CardDef(power));
 
     // ----------------------------------------- SPELL - HUNTER
     // [ULD_152] Pressure Plate - COST:2

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -269,6 +269,14 @@ void UldumCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::Has5MoreCostSpellInHand()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<SummonTask>("ULD_137t", 2,
+                                                     SummonSide::ALTERNATE) }));
+    cards.emplace("ULD_137", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [ULD_138] Anubisath Defender - COST:5 [ATK:3/HP:5]
@@ -380,6 +388,9 @@ void UldumCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // [ULD_137t] Treant (*) - COST:2 [ATK:2/HP:2]
     // - Set: Uldum
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("ULD_137t", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [ULD_288e] Buried (*) - COST:0

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -871,6 +871,20 @@ void UldumCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsControllingSecret()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 6) }));
+    cards.emplace(
+        "ULD_293",
+        CardDef(
+            power,
+            PlayReqs{
+                { PlayReq::REQ_TARGET_IF_AVAILABLE_AND_MINIMUM_FRIENDLY_SECRETS,
+                  1 } }));
 
     // ------------------------------------------ MINION - MAGE
     // [ULD_329] Dune Sculptor - COST:3 [ATK:3/HP:3]

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -782,6 +782,10 @@ void UldumCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - DISCOVER = 1
     // - USE_DISCOVER_VISUALS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DiscoverTask>(DiscoverType::TORTOLLAN_PILGRIM));
+    cards.emplace("ULD_236", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [ULD_238] Reno the Relicologist - COST:6 [ATK:4/HP:6]

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -28,6 +28,7 @@
 #include <Rosetta/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/SetGameTagTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/SummonCopyTask.hpp>
+#include <Rosetta/Tasks/SimpleTasks/SummonStackTask.hpp>
 #include <Rosetta/Tasks/SimpleTasks/SummonTask.hpp>
 #include <Rosetta/Zones/HandZone.hpp>
 
@@ -262,7 +263,8 @@ void UldumCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - USE_DISCOVER_VISUALS = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<DiscoverTask>(DiscoverType::CHOOSE_ONE));
+    power.AddPowerTask(
+        std::make_shared<DiscoverTask>(DiscoverType::CHOOSE_ONE));
     cards.emplace("ULD_136", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
@@ -592,6 +594,15 @@ void UldumCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::ENEMY_HAND));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsMinion()) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddPowerTask(std::make_shared<SummonStackTask>(true));
+    power.AddPowerTask(std::make_shared<AttackTask>(EntityType::SOURCE,
+                                                    EntityType::STACK, true));
+    cards.emplace("ULD_212", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
     // [ULD_410] Scarlet Webweaver - COST:6 [ATK:5/HP:5]

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -893,6 +893,13 @@ void UldumCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // Text: After you cast a spell, add a random Mage
     //       minion to your hand.
     // --------------------------------------------------------
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_CAST));
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    power.GetTrigger()->tasks = {
+        std::make_shared<RandomCardTask>(CardType::MINION, CardClass::MAGE),
+        std::make_shared<AddStackToTask>(EntityType::HAND)
+    };
+    cards.emplace("ULD_329", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [ULD_433] Raid the Sky Temple - COST:1

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -928,6 +928,13 @@ void UldumCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::HAND));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsSpell()) }));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("ULD_435e", EntityType::STACK));
+    cards.emplace("ULD_435", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [ULD_726] Ancient Mysteries - COST:2
@@ -959,6 +966,9 @@ void UldumCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Costs (5).
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(std::make_shared<Enchant>(Effects::SetCost(5)));
+    cards.emplace("ULD_435e", CardDef(power));
 
     // ------------------------------------- ENCHANTMENT - MAGE
     // [ULD_726e] Translated (*) - COST:0

--- a/Sources/Rosetta/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/CardSets/UldumCardsGen.cpp
@@ -147,6 +147,15 @@ void UldumCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // PlayReq:
     // - REQ_HAND_NOT_FULL = 0
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<RandomCardTask>(CardType::SPELL, CardClass::MAGE));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("ULD_433e", EntityType::STACK));
+    power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
+    cards.emplace(
+        "ULD_433p",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_HAND_NOT_FULL, 0 } }));
 
     // ----------------------------------- HERO_POWER - WARRIOR
     // [ULD_711p3] Anraphet's Core (*) - COST:2
@@ -917,6 +926,12 @@ void UldumCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - 839 = 1
     // - QUEST_REWARD_DATABASE_ID = 53946
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::CAST_SPELL));
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
+        "ULD_433p") };
+    cards.emplace("ULD_433", CardDef(power, 10, 0));
 
     // ------------------------------------------ MINION - MAGE
     // [ULD_435] Naga Sand Witch - COST:5 [ATK:5/HP:5]
@@ -1613,6 +1628,8 @@ void UldumCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 
 void UldumCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [ULD_171e] Big Surge (*) - COST:0
     // - Set: Uldum
@@ -1636,6 +1653,9 @@ void UldumCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Costs (2) less.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(std::make_shared<Enchant>(Effects::ReduceCost(2)));
+    cards.emplace("ULD_433e", CardDef(power));
 }
 
 void UldumCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/Cards/Card.cpp
+++ b/Sources/Rosetta/Cards/Card.cpp
@@ -9,6 +9,7 @@
 #include <Rosetta/Models/Player.hpp>
 #include <Rosetta/Zones/FieldZone.hpp>
 #include <Rosetta/Zones/GraveyardZone.hpp>
+#include <Rosetta/Zones/HandZone.hpp>
 #include <Rosetta/Zones/SecretZone.hpp>
 
 #include <iostream>
@@ -382,6 +383,14 @@ bool Card::IsPlayableByCardReq(Player* player) const
             case PlayReq::REQ_SECRET_ZONE_CAP_FOR_NON_SECRET:
             {
                 if (player->GetSecretZone()->IsFull())
+                {
+                    return false;
+                }
+                break;
+            }
+            case PlayReq::REQ_HAND_NOT_FULL:
+            {
+                if (player->GetHandZone()->IsFull())
                 {
                     return false;
                 }

--- a/Sources/Rosetta/Cards/Card.cpp
+++ b/Sources/Rosetta/Cards/Card.cpp
@@ -204,6 +204,27 @@ bool Card::IsLackey() const
     return false;
 }
 
+bool Card::IsTransformMinion() const
+{
+    // NOTE: Transformed minions list
+    // EX1_165: Druid of the Claw -> OG_044a
+    // BRM_010: Druid of the Flame -> OG_044b
+    // AT_042: Druid of the Saber -> OG_044c
+    // UNG_101: Shellshifter -> UNG_101t3
+    // ICC_051: Druid of the Swarm -> ICC_051t3
+    // GIL_188: Druid of the Scythe -> GIL_188t3
+    // TRL_343: Wardruid Loti -> TRL_343et1
+    // BT_136: Msshi'fn Prime -> BT_136tt3
+    if (id == "EX1_165" || id == "BRM_010" || id == "AT_042" ||
+        id == "UNG_101" || id == "ICC_051" || id == "GIL_188" ||
+        id == "TRL_343" || id == "BT_136")
+    {
+        return true;
+    }
+
+    return false;
+}
+
 bool Card::IsGalakrond() const
 {
     // NOTE: Galakrond hero card list

--- a/Sources/Rosetta/Cards/Card.cpp
+++ b/Sources/Rosetta/Cards/Card.cpp
@@ -97,6 +97,12 @@ void Card::Initialize()
                 targetingPredicate.emplace_back(
                     TargetingPredicates::ReqTargetWithDeathrattle());
                 break;
+            case PlayReq::REQ_TARGET_IF_AVAILABLE_AND_MINIMUM_FRIENDLY_SECRETS:
+                needsTarget = true;
+                targetingAvailabilityPredicate.emplace_back(
+                    TargetingPredicates::MinimumFriendlySecrets(
+                        requirement.second));
+                break;
             default:
                 continue;
         }
@@ -405,6 +411,8 @@ bool Card::IsPlayableByCardReq(Player* player) const
             case PlayReq::REQ_MINION_TARGET:
             case PlayReq::REQ_ENEMY_TARGET:
             case PlayReq::REQ_NONSELF_TARGET:
+            case PlayReq::
+                REQ_TARGET_IF_AVAILABLE_AND_MINIMUM_FRIENDLY_SECRETS:
                 break;
             default:
                 break;

--- a/Sources/Rosetta/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/Conditions/SelfCondition.cpp
@@ -680,6 +680,21 @@ SelfCondition SelfCondition::Has5MoreCostSpellInHand()
     });
 }
 
+SelfCondition SelfCondition::Cast5MoreCostSpellInThisTurn()
+{
+    return SelfCondition([=](Playable* playable) -> bool {
+        for (auto& card : playable->player->cardsPlayedThisTurn)
+        {
+            if (card->GetCardType() == CardType::SPELL && card->GetCost() >= 5)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    });
+}
+
 SelfCondition SelfCondition::CheckThreshold(RelaSign relaSign)
 {
     return SelfCondition([=](Playable* playable) -> bool {

--- a/Sources/Rosetta/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/Conditions/SelfCondition.cpp
@@ -607,7 +607,7 @@ SelfCondition SelfCondition::IsManaCrystalFull()
 SelfCondition SelfCondition::IsUnspentMana()
 {
     return SelfCondition([=](Playable* playable) -> bool {
-        return playable->player->GetRemainingMana();
+        return playable->player->GetRemainingMana() > 0;
     });
 }
 

--- a/Sources/Rosetta/Enchants/PlayerAuraEffects.cpp
+++ b/Sources/Rosetta/Enchants/PlayerAuraEffects.cpp
@@ -30,6 +30,8 @@ int PlayerAuraEffects::GetValue(GameTag tag) const
             return m_extraTriggerSecret;
         case GameTag::MEGA_WINDFURY:
             return m_megaWindfury;
+        case GameTag::CHOOSE_BOTH:
+            return m_chooseBoth;
         default:
             throw std::invalid_argument(
                 "PlayerAuraEffects::GetValue() - Invalid game tag!");
@@ -64,6 +66,9 @@ void PlayerAuraEffects::SetValue(GameTag tag, int value)
             break;
         case GameTag::MEGA_WINDFURY:
             m_megaWindfury = value;
+            break;
+        case GameTag::CHOOSE_BOTH:
+            m_chooseBoth = value;
             break;
         default:
             throw std::invalid_argument(

--- a/Sources/Rosetta/Loaders/TargetingPredicates.cpp
+++ b/Sources/Rosetta/Loaders/TargetingPredicates.cpp
@@ -6,6 +6,7 @@
 
 #include <Rosetta/Loaders/TargetingPredicates.hpp>
 #include <Rosetta/Models/Player.hpp>
+#include <Rosetta/Zones/SecretZone.hpp>
 
 #include <stdexcept>
 
@@ -122,4 +123,12 @@ TargetingPredicate TargetingPredicates::ReqMustTargetTaunter()
 {
     return [=](Character* character) { return character->HasTaunt(); };
 }
+
+AvailabilityPredicate TargetingPredicates::MinimumFriendlySecrets(int value)
+{
+    return [=](Player* player, [[maybe_unused]] Card* card) {
+        return player->GetSecretZone()->GetCount() >= value;
+    };
+}
+
 }  // namespace RosettaStone

--- a/Sources/Rosetta/Models/Playable.cpp
+++ b/Sources/Rosetta/Models/Playable.cpp
@@ -503,7 +503,8 @@ bool Playable::CheckTargetingType(Card* card, Character* target)
 void Playable::ActivateTask(PowerType type, Character* target, int chooseOne,
                             Playable* chooseBase)
 {
-    if (HasChooseOne())
+    // TODO: Remove code '56057' after the card 'Rising Winds' is implemented
+    if (HasChooseOne() && card->dbfID != 56057)
     {
         if (player->ChooseBoth() && !card->IsTransformMinion())
         {

--- a/Sources/Rosetta/Models/Playable.cpp
+++ b/Sources/Rosetta/Models/Playable.cpp
@@ -505,7 +505,7 @@ void Playable::ActivateTask(PowerType type, Character* target, int chooseOne,
 {
     if (HasChooseOne())
     {
-        if (player->ChooseBoth())
+        if (player->ChooseBoth() && !card->IsTransformMinion())
         {
             Playable* playable0 =
                 GetFromCard(player, Cards::FindCardByID(card->chooseCardIDs[0]),

--- a/Sources/Rosetta/Models/Playable.cpp
+++ b/Sources/Rosetta/Models/Playable.cpp
@@ -503,12 +503,29 @@ bool Playable::CheckTargetingType(Card* card, Character* target)
 void Playable::ActivateTask(PowerType type, Character* target, int chooseOne,
                             Playable* chooseBase)
 {
-    if (HasChooseOne() && chooseOne > 0)
+    if (HasChooseOne())
     {
-        Playable* playable = GetFromCard(
-            player, Cards::FindCardByID(card->chooseCardIDs[chooseOne - 1]),
-            std::nullopt, player->GetSetasideZone());
-        playable->ActivateTask(type, target, chooseOne, this);
+        if (player->ChooseBoth())
+        {
+            Playable* playable0 =
+                GetFromCard(player, Cards::FindCardByID(card->chooseCardIDs[0]),
+                            std::nullopt, player->GetSetasideZone());
+            playable0->ActivateTask(type, target, chooseOne, this);
+            Playable* playable1 =
+                GetFromCard(player, Cards::FindCardByID(card->chooseCardIDs[1]),
+                            std::nullopt, player->GetSetasideZone());
+            playable1->ActivateTask(type, target, chooseOne, this);
+            return;
+        }
+
+        if (!player->ChooseBoth() && chooseOne > 0)
+        {
+            Playable* playable = GetFromCard(
+                player, Cards::FindCardByID(card->chooseCardIDs[chooseOne - 1]),
+                std::nullopt, player->GetSetasideZone());
+            playable->ActivateTask(type, target, chooseOne, this);
+            return;
+        }
     }
 
     std::vector<std::shared_ptr<ITask>> tasks;

--- a/Sources/Rosetta/Models/Player.cpp
+++ b/Sources/Rosetta/Models/Player.cpp
@@ -173,6 +173,11 @@ bool Player::ExtraTriggerSecret() const
     return playerAuraEffects.GetValue(GameTag::EXTRA_TRIGGER_SECRET) > 0;
 }
 
+bool Player::ChooseBoth() const
+{
+    return playerAuraEffects.GetValue(GameTag::CHOOSE_BOTH) > 0;
+}
+
 int Player::GetTotalMana() const
 {
     return GetGameTag(GameTag::RESOURCES);

--- a/Sources/Rosetta/Tasks/SimpleTasks/AttackTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/AttackTask.cpp
@@ -18,25 +18,34 @@ AttackTask::AttackTask(EntityType attacker, EntityType defender, bool force)
 
 TaskStatus AttackTask::Impl(Player* player)
 {
-    const auto attacker = dynamic_cast<Character*>(IncludeTask::GetEntities(
-        m_attackerType, player, m_source, m_target)[0]);
+    auto playables =
+        IncludeTask::GetEntities(m_attackerType, player, m_source, m_target);
     const auto defender = dynamic_cast<Character*>(IncludeTask::GetEntities(
         m_defenderType, player, m_source, m_target)[0]);
 
-    if (!m_force && attacker->CantAttack())
+    for (auto& playable : playables)
     {
-        return TaskStatus::STOP;
-    }
+        const auto attacker = dynamic_cast<Character*>(playable);
+        if (attacker == nullptr)
+        {
+            continue;
+        }
 
-    if (defender->card->IsUntouchable())
-    {
-        return TaskStatus::STOP;
-    }
+        if (!m_force && attacker->CantAttack())
+        {
+            continue;
+        }
 
-    std::unique_ptr<EventMetaData> temp =
-        std::move(player->game->currentEventData);
-    Generic::Attack(attacker->player, attacker, defender, true);
-    player->game->currentEventData = std::move(temp);
+        if (defender->card->IsUntouchable())
+        {
+            continue;
+        }
+
+        std::unique_ptr<EventMetaData> temp =
+            std::move(player->game->currentEventData);
+        Generic::Attack(attacker->player, attacker, defender, true);
+        player->game->currentEventData = std::move(temp);
+    }
 
     return TaskStatus::COMPLETE;
 }

--- a/Sources/Rosetta/Tasks/SimpleTasks/AttackTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/AttackTask.cpp
@@ -29,6 +29,10 @@ TaskStatus AttackTask::Impl(Player* player)
     }
 
     const auto defender = dynamic_cast<Character*>(defenders[0]);
+    if (defender == nullptr)
+    {
+        return TaskStatus::STOP;
+    }
 
     for (auto& playable : playables)
     {

--- a/Sources/Rosetta/Tasks/SimpleTasks/AttackTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/AttackTask.cpp
@@ -20,8 +20,15 @@ TaskStatus AttackTask::Impl(Player* player)
 {
     auto playables =
         IncludeTask::GetEntities(m_attackerType, player, m_source, m_target);
-    const auto defender = dynamic_cast<Character*>(IncludeTask::GetEntities(
-        m_defenderType, player, m_source, m_target)[0]);
+    auto defenders =
+        IncludeTask::GetEntities(m_defenderType, player, m_source, m_target);
+
+    if (defenders.empty())
+    {
+        return TaskStatus::STOP;
+    }
+
+    const auto defender = dynamic_cast<Character*>(defenders[0]);
 
     for (auto& playable : playables)
     {

--- a/Sources/Rosetta/Tasks/SimpleTasks/CastRandomSpellTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/CastRandomSpellTask.cpp
@@ -52,6 +52,7 @@ TaskStatus CastRandomSpellTask::Impl(Player* player)
     if (spellToCast->IsSecret() && player->GetSecretZone()->IsFull())
     {
         player->GetGraveyardZone()->Add(spellToCast);
+        player->SetGameTag(GameTag::CAST_RANDOM_SPELLS, 0);
         return TaskStatus::COMPLETE;
     }
 
@@ -81,7 +82,6 @@ TaskStatus CastRandomSpellTask::Impl(Player* player)
     player->choice = choiceTemp;
 
     player->SetGameTag(GameTag::CAST_RANDOM_SPELLS, 0);
-
     return TaskStatus::COMPLETE;
 }
 

--- a/Sources/Rosetta/Tasks/SimpleTasks/CastRandomSpellTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/CastRandomSpellTask.cpp
@@ -1,0 +1,92 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/Actions/CastSpell.hpp>
+#include <Rosetta/Actions/Choose.hpp>
+#include <Rosetta/Cards/Cards.hpp>
+#include <Rosetta/Games/Game.hpp>
+#include <Rosetta/Models/Spell.hpp>
+#include <Rosetta/Tasks/SimpleTasks/CastRandomSpellTask.hpp>
+#include <Rosetta/Zones/GraveyardZone.hpp>
+#include <Rosetta/Zones/SecretZone.hpp>
+
+#include <effolkronium/random.hpp>
+
+using Random = effolkronium::random_static;
+
+namespace RosettaStone::SimpleTasks
+{
+TaskStatus CastRandomSpellTask::Impl(Player* player)
+{
+    player->SetGameTag(GameTag::CAST_RANDOM_SPELLS, 1);
+
+    std::vector<Card*> result;
+
+    const auto cards = m_source->game->GetFormatType() == FormatType::STANDARD
+                           ? Cards::GetAllStandardCards()
+                           : Cards::GetAllWildCards();
+
+    for (const auto& card : cards)
+    {
+        if (card->GetCardType() == CardType::SPELL && !card->IsQuest())
+        {
+            // NOTE: Puzzle Box of Yogg-Saron can cast any collectible spell
+            // except another Puzzle Box of Yogg-Saron.
+            // References:
+            // https://twitter.com/Celestalon/status/1158895101537607681
+            if (m_source->card->dbfID == 53442 && card->dbfID == 53442)
+            {
+                continue;
+            }
+
+            result.emplace_back(card);
+        }
+    }
+
+    const auto randIdx = Random::get<std::size_t>(0, result.size() - 1);
+    auto spellToCast =
+        dynamic_cast<Spell*>(Entity::GetFromCard(player, result[randIdx]));
+
+    if (spellToCast->IsSecret() && player->GetSecretZone()->IsFull())
+    {
+        player->GetGraveyardZone()->Add(spellToCast);
+        return TaskStatus::COMPLETE;
+    }
+
+    const auto randTarget = spellToCast->GetRandomValidTarget();
+    const int randChooseOne = Random::get<int>(1, 2);
+
+    const auto choiceTemp = player->choice;
+    player->choice = nullptr;
+
+    player->game->taskQueue.StartEvent();
+    Generic::CastSpell(player, spellToCast, randTarget, randChooseOne);
+    player->game->ProcessDestroyAndUpdateAura();
+    player->game->taskQueue.EndEvent();
+
+    while (player->choice != nullptr)
+    {
+        const auto idx =
+            Random::get<std::size_t>(0, player->choice->choices.size() - 1);
+
+        player->game->taskQueue.StartEvent();
+        Generic::ChoicePick(player, player->choice->choices[idx]);
+        player->game->ProcessTasks();
+        player->game->taskQueue.EndEvent();
+        player->game->ProcessDestroyAndUpdateAura();
+    }
+
+    player->choice = choiceTemp;
+
+    player->SetGameTag(GameTag::CAST_RANDOM_SPELLS, 0);
+
+    return TaskStatus::COMPLETE;
+}
+
+std::unique_ptr<ITask> CastRandomSpellTask::CloneImpl()
+{
+    return std::make_unique<CastRandomSpellTask>();
+}
+}  // namespace RosettaStone::SimpleTasks

--- a/Sources/Rosetta/Tasks/SimpleTasks/DamageNumberTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/DamageNumberTask.cpp
@@ -32,6 +32,11 @@ TaskStatus DamageNumberTask::Impl(Player* player)
     for (auto& playable : playables)
     {
         const auto character = dynamic_cast<Character*>(playable);
+        if (character == nullptr)
+        {
+            continue;
+        }
+
         Generic::TakeDamageToCharacter(dynamic_cast<Playable*>(m_source),
                                        character, damage, m_isSpellDamage);
     }

--- a/Sources/Rosetta/Tasks/SimpleTasks/DamageTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/DamageTask.cpp
@@ -40,6 +40,10 @@ TaskStatus DamageTask::Impl(Player* player)
     {
         const auto source = dynamic_cast<Playable*>(m_source);
         const auto character = dynamic_cast<Character*>(playable);
+        if (character == nullptr)
+        {
+            continue;
+        }
 
         int randomDamage = 0;
         if (m_randomDamage > 0)

--- a/Sources/Rosetta/Tasks/SimpleTasks/DiscoverTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/DiscoverTask.cpp
@@ -8,6 +8,7 @@
 #include <Rosetta/Cards/Cards.hpp>
 #include <Rosetta/Games/Game.hpp>
 #include <Rosetta/Tasks/SimpleTasks/DiscoverTask.hpp>
+#include <Rosetta/Zones/DeckZone.hpp>
 #include <Rosetta/Zones/GraveyardZone.hpp>
 #include <Rosetta/Zones/HandZone.hpp>
 
@@ -319,6 +320,31 @@ std::vector<Card*> DiscoverTask::Discover(Game* game, Player* player,
                 }
             }
             break;
+        case DiscoverType::TORTOLLAN_PILGRIM:
+        {
+            choiceAction = ChoiceAction::TORTOLLAN_PILGRIM;
+
+            std::vector<int> list;
+            for (auto& playable : player->GetDeckZone()->GetAll())
+            {
+                if (playable->card->GetCardType() == CardType::SPELL)
+                {
+                    list.emplace_back(playable->card->dbfID);
+                }
+            }
+
+            std::sort(list.begin(), list.end());
+            const auto last = std::unique(list.begin(), list.end());
+            list.erase(last, list.end());
+            Random::shuffle(list.begin(), list.end());
+
+            for (auto& dbfID : list)
+            {
+                cards.emplace_back(Cards::FindCardByDbfID(dbfID));
+            }
+
+            break;
+        }
         default:
             throw std::out_of_range(
                 "DiscoverTask::Discover() - Invalid discover type");

--- a/Sources/Rosetta/Tasks/SimpleTasks/DiscoverTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/DiscoverTask.cpp
@@ -230,6 +230,16 @@ std::vector<Card*> DiscoverTask::Discover(Game* game, Player* player,
                 }
             }
             break;
+        case DiscoverType::CHOOSE_ONE:
+            choiceAction = ChoiceAction::HAND;
+            for (auto& card : allCards)
+            {
+                if (card->HasGameTag(GameTag::CHOOSE_ONE))
+                {
+                    cards.emplace_back(card);
+                }
+            }
+            break;
         case DiscoverType::DRAGON:
             choiceAction = ChoiceAction::HAND;
             for (auto& card : allCards)

--- a/Sources/Rosetta/Tasks/SimpleTasks/DrawMinionTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/DrawMinionTask.cpp
@@ -28,6 +28,11 @@ TaskStatus DrawMinionTask::Impl(Player* player)
         return TaskStatus::STOP;
     }
 
+    if (m_addToStack)
+    {
+        player->game->taskStack.playables.clear();
+    }
+
     std::vector<Playable*> cards;
     cards.reserve(m_amount);
 
@@ -65,6 +70,11 @@ TaskStatus DrawMinionTask::Impl(Player* player)
                 cards.emplace_back(deckCard);
             }
         }
+    }
+
+    if (cards.empty())
+    {
+        return TaskStatus::STOP;
     }
 
     if (static_cast<int>(cards.size()) <= m_amount)

--- a/Sources/Rosetta/Tasks/SimpleTasks/DrawMinionTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/DrawMinionTask.cpp
@@ -22,15 +22,15 @@ DrawMinionTask::DrawMinionTask(bool lowestCost, int amount, bool addToStack)
 
 TaskStatus DrawMinionTask::Impl(Player* player)
 {
+    if (m_addToStack)
+    {
+        player->game->taskStack.playables.clear();
+    }
+
     auto deck = player->GetDeckZone()->GetAll();
     if (deck.empty())
     {
         return TaskStatus::STOP;
-    }
-
-    if (m_addToStack)
-    {
-        player->game->taskStack.playables.clear();
     }
 
     std::vector<Playable*> cards;

--- a/Sources/Rosetta/Tasks/SimpleTasks/IncludeAdjacentTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/IncludeAdjacentTask.cpp
@@ -47,9 +47,7 @@ TaskStatus IncludeAdjacentTask::Impl(Player* player)
 
     if (center == nullptr)
     {
-        throw std::logic_error(
-            "IncludeAdjacentTask::Impl() - Can't obtain adjacent minions of "
-            "non-minion.");
+        return TaskStatus::STOP;
     }
 
     if (center->GetZoneType() == ZoneType::PLAY)

--- a/Sources/Rosetta/Tasks/SimpleTasks/QuestProgressTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/QuestProgressTask.cpp
@@ -80,6 +80,12 @@ TaskStatus QuestProgressTask::Impl(Player* player)
             {
                 delete player->GetHero()->heroPower;
                 player->GetHero()->heroPower = heroPower;
+
+                // Process aura
+                if (heroPower->card->power.GetAura())
+                {
+                    heroPower->card->power.GetAura()->Activate(heroPower);
+                }
             }
             else
             {

--- a/Sources/Rosetta/Tasks/SimpleTasks/QuestProgressTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/QuestProgressTask.cpp
@@ -38,6 +38,11 @@ QuestProgressTask::QuestProgressTask(
 
 TaskStatus QuestProgressTask::Impl(Player* player)
 {
+    if (player->GetGameTag(GameTag::CAST_RANDOM_SPELLS) == 1)
+    {
+        return TaskStatus::STOP;
+    }
+
     auto spell = dynamic_cast<Spell*>(m_source);
     if (spell == nullptr)
     {

--- a/Sources/Rosetta/Tasks/SimpleTasks/RandomCardTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/RandomCardTask.cpp
@@ -9,6 +9,8 @@
 
 #include <effolkronium/random.hpp>
 
+#include <utility>
+
 using Random = effolkronium::random_static;
 
 namespace RosettaStone::SimpleTasks
@@ -20,11 +22,23 @@ RandomCardTask::RandomCardTask(EntityType entityType, bool opposite)
 }
 
 RandomCardTask::RandomCardTask(CardType cardType, CardClass cardClass,
-                               Race race, Rarity rarity, bool opposite)
+                               std::map<GameTag, int> tags, bool opposite)
+    : m_cardType(cardType),
+      m_cardClass(cardClass),
+      m_tags(std::move(tags)),
+      m_opposite(opposite)
+{
+    // Do nothing
+}
+
+RandomCardTask::RandomCardTask(CardType cardType, CardClass cardClass,
+                               Race race, Rarity rarity,
+                               std::map<GameTag, int> tags, bool opposite)
     : m_cardType(cardType),
       m_cardClass(cardClass),
       m_race(race),
       m_rarity(rarity),
+      m_tags(std::move(tags)),
       m_opposite(opposite)
 {
     // Do nothing
@@ -33,7 +47,8 @@ RandomCardTask::RandomCardTask(CardType cardType, CardClass cardClass,
 std::vector<Card*> RandomCardTask::GetCardList(Entity* source,
                                                CardType cardType,
                                                CardClass cardClass, Race race,
-                                               Rarity rarity)
+                                               Rarity rarity,
+                                               std::map<GameTag, int> tags)
 {
     std::vector<Card*> result;
 
@@ -50,7 +65,22 @@ std::vector<Card*> RandomCardTask::GetCardList(Entity* source,
                 (race == Race::INVALID || race == card->GetRace()) &&
                 (rarity == Rarity::INVALID || rarity == card->GetRarity()))
             {
-                result.emplace_back(card);
+                bool check = true;
+
+                for (auto& tag : tags)
+                {
+                    if (!card->HasGameTag(tag.first) ||
+                        card->gameTags[tag.first] != tag.second)
+                    {
+                        check = false;
+                        break;
+                    }
+                }
+
+                if (check)
+                {
+                    result.emplace_back(card);
+                }
             }
         }
     }
@@ -69,7 +99,22 @@ std::vector<Card*> RandomCardTask::GetCardList(Entity* source,
                 (race == Race::INVALID || race == card->GetRace()) &&
                 (rarity == Rarity::INVALID || rarity == card->GetRarity()))
             {
-                result.emplace_back(card);
+                bool check = true;
+
+                for (auto& tag : tags)
+                {
+                    if (!card->HasGameTag(tag.first) ||
+                        card->gameTags[tag.first] != tag.second)
+                    {
+                        check = false;
+                        break;
+                    }
+                }
+
+                if (check)
+                {
+                    result.emplace_back(card);
+                }
             }
         }
     }
@@ -86,7 +131,22 @@ std::vector<Card*> RandomCardTask::GetCardList(Entity* source,
                 (race == Race::INVALID || race == card->GetRace()) &&
                 (rarity == Rarity::INVALID || rarity == card->GetRarity()))
             {
-                result.emplace_back(card);
+                bool check = true;
+
+                for (auto& tag : tags)
+                {
+                    if (!card->HasGameTag(tag.first) ||
+                        card->gameTags[tag.first] != tag.second)
+                    {
+                        check = false;
+                        break;
+                    }
+                }
+
+                if (check)
+                {
+                    result.emplace_back(card);
+                }
             }
         }
     }
@@ -115,7 +175,7 @@ TaskStatus RandomCardTask::Impl(Player* player)
     }
 
     auto cardsList =
-        GetCardList(m_source, m_cardType, cardClass, m_race, m_rarity);
+        GetCardList(m_source, m_cardType, cardClass, m_race, m_rarity, m_tags);
     if (cardsList.empty())
     {
         return TaskStatus::STOP;
@@ -133,7 +193,7 @@ TaskStatus RandomCardTask::Impl(Player* player)
 std::unique_ptr<ITask> RandomCardTask::CloneImpl()
 {
     auto clonedTask = std::make_unique<RandomCardTask>(
-        m_cardType, m_cardClass, m_race, m_rarity, m_opposite);
+        m_cardType, m_cardClass, m_race, m_rarity, m_tags, m_opposite);
     clonedTask->m_entityType = m_entityType;
 
     return clonedTask;

--- a/Sources/Rosetta/Tasks/SimpleTasks/RandomEntourageTask.cpp
+++ b/Sources/Rosetta/Tasks/SimpleTasks/RandomEntourageTask.cpp
@@ -21,6 +21,8 @@ RandomEntourageTask::RandomEntourageTask(int count, bool isOpponent)
 
 TaskStatus RandomEntourageTask::Impl(Player* player)
 {
+    std::vector<Playable*> list;
+
     if (m_source == nullptr || m_source->card->entourages.empty())
     {
         return TaskStatus::STOP;
@@ -40,8 +42,10 @@ TaskStatus RandomEntourageTask::Impl(Player* player)
 
         Playable* entouragePlayable =
             Entity::GetFromCard(player, entourageCard);
-        player->game->taskStack.playables.emplace_back(entouragePlayable);
+        list.emplace_back(entouragePlayable);
     }
+
+    player->game->taskStack.playables = list;
 
     return TaskStatus::COMPLETE;
 }

--- a/Sources/Rosetta/Triggers/Trigger.cpp
+++ b/Sources/Rosetta/Triggers/Trigger.cpp
@@ -161,6 +161,12 @@ std::shared_ptr<Trigger> Trigger::Activate(Playable* source,
         case TriggerType::AFTER_ATTACKED:
             switch (triggerSource)
             {
+                case TriggerSource::HERO:
+                {
+                    source->player->GetHero()->afterAttackedTrigger +=
+                        instance->handler;
+                    break;
+                }
                 case TriggerSource::SELF:
                 {
                     auto minion = dynamic_cast<Minion*>(source);
@@ -306,6 +312,11 @@ void Trigger::Remove() const
         case TriggerType::AFTER_ATTACKED:
             switch (triggerSource)
             {
+                case TriggerSource::HERO:
+                {
+                    m_owner->player->GetHero()->afterAttackedTrigger -= handler;
+                    break;
+                }
                 case TriggerSource::SELF:
                 {
                     auto minion = dynamic_cast<Minion*>(m_owner);

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -1707,6 +1707,57 @@ TEST_CASE("[Mage : Minion] - ULD_329 : Dune Sculptor")
     CHECK_EQ(curHand[0]->card->GetCardClass(), CardClass::MAGE);
 }
 
+// ------------------------------------------- SPELL - MAGE
+// [ULD_726] Ancient Mysteries - COST:2
+// - Set: Uldum, Rarity: Common
+// --------------------------------------------------------
+// Text: Draw a <b>Secret</b> from your deck. It costs (0).
+// --------------------------------------------------------
+// RefTag:
+// - SECRET = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - ULD_726 : Ancient Mysteries")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 2)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Flame Ward");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Wisp");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& curDeck = *(curPlayer->GetDeckZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Ancient Mysteries"));
+
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curDeck.GetCount(), 26);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->card->IsSecret(), true);
+    CHECK_EQ(curHand[4]->GetCost(), 0);
+    CHECK_EQ(curDeck.GetCount(), 25);
+}
+
 // --------------------------------------- MINION - PALADIN
 // [ULD_207] Ancestral Guardian - COST:4 [ATK:4/HP:2]
 // - Set: Uldum, Rarity: Common

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -17,6 +17,116 @@ using namespace RosettaStone;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ------------------------------------------ SPELL - DRUID
+// [ULD_131] Untapped Potential - COST:1
+// - Set: Uldum, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Quest:</b> End 4 turns with any unspent Mana.
+//       <b>Reward:</b> Ossirian Tear.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - QUEST = 1
+// - QUEST_PROGRESS_TOTAL = 4
+// - 676 = 1
+// - 839 = 1
+// - QUEST_REWARD_DATABASE_ID = 53499
+// --------------------------------------------------------
+//TEST_CASE("[Druid : Spell] - ULD_131 : Untapped Potential")
+//{
+//    GameConfig config;
+//    config.player1Class = CardClass::DRUID;
+//    config.player2Class = CardClass::WARRIOR;
+//    config.startPlayer = PlayerType::PLAYER1;
+//    config.doFillDecks = true;
+//    config.autoRun = false;
+//
+//    Game game(config);
+//    game.Start();
+//    game.ProcessUntil(Step::MAIN_ACTION);
+//
+//    Player* curPlayer = game.GetCurrentPlayer();
+//    Player* opPlayer = game.GetOpponentPlayer();
+//    curPlayer->SetTotalMana(1);
+//    curPlayer->SetUsedMana(0);
+//    opPlayer->SetTotalMana(10);
+//    opPlayer->SetUsedMana(0);
+//
+//    auto& curField = *(curPlayer->GetFieldZone());
+//    auto& opField = *(opPlayer->GetFieldZone());
+//    const auto curSecret = curPlayer->GetSecretZone();
+//
+//    const auto card1 = Generic::DrawCard(
+//        curPlayer, Cards::FindCardByName("Untapped Potential"));
+//    const auto card2 = Generic::DrawCard(
+//        curPlayer, Cards::FindCardByName("Druid of the Claw"));
+//    const auto card3 =
+//        Generic::DrawCard(curPlayer, Cards::FindCardByName("Starfall"));
+//    const auto card4 =
+//        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+//
+//    auto quest = dynamic_cast<Spell*>(card1);
+//
+//    game.Process(curPlayer, PlayCardTask::Spell(card1));
+//    CHECK(curSecret->quest != nullptr);
+//    CHECK_EQ(quest->GetQuestProgress(), 0);
+//    CHECK_EQ(quest->GetQuestProgressTotal(), 4);
+//
+//    game.Process(curPlayer, EndTurnTask());
+//    game.ProcessUntil(Step::MAIN_ACTION);
+//
+//    CHECK_EQ(quest->GetQuestProgress(), 0);
+//
+//    game.Process(opPlayer, EndTurnTask());
+//    game.ProcessUntil(Step::MAIN_ACTION);
+//
+//    game.Process(curPlayer, EndTurnTask());
+//    game.ProcessUntil(Step::MAIN_ACTION);
+//
+//    CHECK_EQ(quest->GetQuestProgress(), 1);
+//
+//    game.Process(opPlayer, EndTurnTask());
+//    game.ProcessUntil(Step::MAIN_ACTION);
+//
+//    game.Process(curPlayer, EndTurnTask());
+//    game.ProcessUntil(Step::MAIN_ACTION);
+//
+//    CHECK_EQ(quest->GetQuestProgress(), 2);
+//
+//    game.Process(opPlayer, EndTurnTask());
+//    game.ProcessUntil(Step::MAIN_ACTION);
+//
+//    game.Process(curPlayer, EndTurnTask());
+//    game.ProcessUntil(Step::MAIN_ACTION);
+//
+//    CHECK_EQ(quest->GetQuestProgress(), 3);
+//
+//    game.Process(opPlayer, EndTurnTask());
+//    game.ProcessUntil(Step::MAIN_ACTION);
+//
+//    game.Process(curPlayer, EndTurnTask());
+//    game.ProcessUntil(Step::MAIN_ACTION);
+//
+//    CHECK(curSecret->quest == nullptr);
+//    CHECK_EQ(quest->GetQuestProgress(), 4);
+//    CHECK_EQ(curPlayer->GetHero()->heroPower->card->id, "ULD_131p");
+//
+//    game.Process(opPlayer, PlayCardTask::Minion(card4));
+//
+//    game.Process(opPlayer, EndTurnTask());
+//    game.ProcessUntil(Step::MAIN_ACTION);
+//
+//    game.Process(curPlayer, PlayCardTask::Minion(card2));
+//    CHECK_EQ(curField.GetCount(), 1);
+//    CHECK_EQ(curField[0]->GetAttack(), 4);
+//    CHECK_EQ(curField[0]->GetHealth(), 6);
+//    CHECK_EQ(curField[0]->HasCharge(), true);
+//    CHECK_EQ(curField[0]->HasTaunt(), true);
+//
+//    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card4));
+//    CHECK_EQ(opField[0]->GetHealth(), 5);
+//}
+
 // ----------------------------------------- MINION - DRUID
 // [ULD_133] Crystal Merchant - COST:2 [ATK:1/HP:4]
 // - Set: Uldum, Rarity: Epic

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -1246,6 +1246,43 @@ TEST_CASE("[Hunter : Spell] - ULD_713 : Swarm of Locusts")
     }
 }
 
+// ------------------------------------------- SPELL - MAGE
+// [ULD_216] Puzzle Box of Yogg-Saron - COST:10
+// - Faction: Neutral, Set: Uldum, Rarity: Epic
+// --------------------------------------------------------
+// Text: Cast 10 random spells <i>(targets chosen randomly).</i>
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - ULD_216 : Puzzle Box of Yogg-Saron")
+{
+    for (int i = 0; i < 100; ++i)
+    {
+        GameConfig config;
+        config.player1Class = CardClass::MAGE;
+        config.player2Class = CardClass::PALADIN;
+        config.startPlayer = PlayerType::PLAYER1;
+        config.doFillDecks = true;
+        config.autoRun = false;
+
+        Game game(config);
+        game.Start();
+        game.ProcessUntil(Step::MAIN_ACTION);
+
+        Player* curPlayer = game.GetCurrentPlayer();
+        Player* opPlayer = game.GetOpponentPlayer();
+        curPlayer->SetTotalMana(10);
+        curPlayer->SetUsedMana(0);
+        opPlayer->SetTotalMana(10);
+        opPlayer->SetUsedMana(0);
+
+        const auto card1 = Generic::DrawCard(
+            curPlayer, Cards::FindCardByName("Puzzle Box of Yogg-Saron"));
+
+        game.Process(curPlayer, PlayCardTask::Spell(card1));
+        CHECK_EQ(curPlayer->GetGameTag(GameTag::CAST_RANDOM_SPELLS), 0);
+        CHECK_EQ(curPlayer->GetNumSpellsPlayedThisTurn(), 1);
+    }
+}
+
 // --------------------------------------- MINION - PALADIN
 // [ULD_207] Ancestral Guardian - COST:4 [ATK:4/HP:2]
 // - Set: Uldum, Rarity: Common

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -1707,6 +1707,122 @@ TEST_CASE("[Mage : Minion] - ULD_329 : Dune Sculptor")
     CHECK_EQ(curHand[0]->card->GetCardClass(), CardClass::MAGE);
 }
 
+// ------------------------------------------- SPELL - MAGE
+// [ULD_433] Raid the Sky Temple - COST:1
+// - Set: Uldum, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Quest:</b> Cast 10 spells.
+//       <b>Reward: </b>Ascendant Scroll.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - QUEST = 1
+// - QUEST_PROGRESS_TOTAL = 10
+// - 676 = 1
+// - 839 = 1
+// - QUEST_REWARD_DATABASE_ID = 53946
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - ULD_433 : Raid the Sky Temple")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto curHero = curPlayer->GetHero();
+    auto& curHand = *(curPlayer->GetHandZone());
+    const auto curSecret = curPlayer->GetSecretZone();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Raid the Sky Temple"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Preparation"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Preparation"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Preparation"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Preparation"));
+    const auto card6 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Preparation"));
+
+    auto quest = dynamic_cast<Spell*>(card1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK(curSecret->quest != nullptr);
+    CHECK_EQ(quest->GetQuestProgress(), 0);
+    CHECK_EQ(quest->GetQuestProgressTotal(), 10);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(quest->GetQuestProgress(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(quest->GetQuestProgress(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card4));
+    CHECK_EQ(quest->GetQuestProgress(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card5));
+    CHECK_EQ(quest->GetQuestProgress(), 4);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card6));
+    CHECK_EQ(quest->GetQuestProgress(), 5);
+
+    const auto card7 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Preparation"));
+    const auto card8 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Preparation"));
+    const auto card9 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Preparation"));
+    const auto card10 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Preparation"));
+    const auto card11 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Preparation"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card7));
+    CHECK_EQ(quest->GetQuestProgress(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card8));
+    CHECK_EQ(quest->GetQuestProgress(), 7);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card9));
+    CHECK_EQ(quest->GetQuestProgress(), 8);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card10));
+    CHECK_EQ(quest->GetQuestProgress(), 9);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card11));
+    CHECK(curSecret->quest == nullptr);
+    CHECK_EQ(quest->GetQuestProgress(), 10);
+    CHECK_EQ(curHero->heroPower->card->id, "ULD_433p");
+    CHECK_EQ(curHand.GetCount(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curHand.GetCount(), 1);
+    const int originalCost = curHand[0]->card->GetCost();
+    const int reducedCost = curHand[0]->GetCost();
+    CHECK_LE(originalCost - reducedCost, 2);
+}
+
 // ------------------------------------------ MINION - MAGE
 // [ULD_435] Naga Sand Witch - COST:5 [ATK:5/HP:5]
 // - Set: Uldum, Rarity: Rare

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -650,7 +650,7 @@ TEST_CASE("[Druid : Minion] - ULD_292 : Oasis Surger")
 // GameTag:
 // - BATTLECRY = 1
 // --------------------------------------------------------
-TEST_CASE("[Hunter : Spell] - ULD_151 : Ramkahen Wildtamer")
+TEST_CASE("[Hunter : Minion] - ULD_151 : Ramkahen Wildtamer")
 {
     GameConfig config;
     config.player1Class = CardClass::HUNTER;
@@ -928,6 +928,69 @@ TEST_CASE("[Hunter : Spell] - ULD_155 : Unseal the Vault")
     CHECK_EQ(curField[0]->GetAttack(), 5);
     CHECK_EQ(opField[0]->GetAttack(), 1);
     CHECK_EQ(opField[0]->GetAttack(), 1);
+}
+
+// ---------------------------------------- MINION - HUNTER
+// [ULD_156] Dinotamer Brann - COST:7 [ATK:2/HP:4]
+// - Set: Uldum, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If your deck has no duplicates,
+//       summon King Krush.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - ULD_156 : Dinotamer Brann")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 6; ++i)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Malygos");
+        config.player2Deck[i] = Cards::FindCardByName("Malygos");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Dinotamer Brann"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Dinotamer Brann"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask(card2, nullptr, 0));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[0]->card->name, "Dinotamer Brann");
+    CHECK_EQ(curField[1]->card->name, "King Krush");
+    CHECK_EQ(curField[1]->GetAttack(), 8);
+    CHECK_EQ(curField[1]->GetHealth(), 8);
+    CHECK_EQ(curField[1]->HasCharge(), true);
+    CHECK_EQ(curField[2]->card->name, "Dinotamer Brann");
 }
 
 // ---------------------------------------- WEAPON - HUNTER

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -455,6 +455,64 @@ TEST_CASE("[Druid : Minion] - ULD_138 : Anubisath Defender")
     CHECK_EQ(card1->GetCost(), 5);
 }
 
+// ----------------------------------------- MINION - DRUID
+// [ULD_139] Elise the Enlightened - COST:5 [ATK:5/HP:5]
+// - Set: Uldum, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If your deck has no duplicates,
+//       duplicate your hand.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - ULD_139 : Elise the Enlightened")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Elise the Enlightened"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Moonfire"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wrath"));
+    const auto card6 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Acornbearer"));
+    const auto card7 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Ironbark Protector"));
+
+    CHECK_EQ(curHand.GetCount(), 7);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 10);
+    CHECK_EQ(curHand[6]->card->name, "Wisp");
+    CHECK_EQ(curHand[7]->card->name, "Wolfrider");
+    CHECK_EQ(curHand[8]->card->name, "Moonfire");
+    CHECK_EQ(curHand[9]->card->name, "Wrath");
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [ULD_273] Overflow - COST:7
 // - Set: Uldum, Rarity: Rare

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -1707,6 +1707,55 @@ TEST_CASE("[Mage : Minion] - ULD_329 : Dune Sculptor")
     CHECK_EQ(curHand[0]->card->GetCardClass(), CardClass::MAGE);
 }
 
+// ------------------------------------------ MINION - MAGE
+// [ULD_435] Naga Sand Witch - COST:5 [ATK:5/HP:5]
+// - Set: Uldum, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Change the Cost of spells
+//       in your hand to (5).
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - ULD_435 : Naga Sand Witch")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Naga Sand Witch"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Frostbolt"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Pyroblast"));
+
+    CHECK_EQ(card2->GetCost(), 4);
+    CHECK_EQ(card3->GetCost(), 2);
+    CHECK_EQ(card4->GetCost(), 10);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(card2->GetCost(), 5);
+    CHECK_EQ(card3->GetCost(), 5);
+    CHECK_EQ(card4->GetCost(), 5);
+}
+
 // ------------------------------------------- SPELL - MAGE
 // [ULD_726] Ancient Mysteries - COST:2
 // - Set: Uldum, Rarity: Common

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -532,6 +532,57 @@ TEST_CASE("[Druid : Spell] - ULD_273 : Overflow")
     CHECK_EQ(opHand.GetCount(), 6);
 }
 
+// ----------------------------------------- MINION - DRUID
+// [ULD_292] Oasis Surger - COST:5 [ATK:3/HP:3]
+// - Race: Elemental, Set: Uldum, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Rush</b> <b>Choose One -</b> Gain +2/+2;
+//       or Summon a copy of this minion.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - ULD_292 : Oasis Surger")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Oasis Surger"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Oasis Surger"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1, 1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2, 2));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+    CHECK_EQ(curField[2]->GetAttack(), 3);
+    CHECK_EQ(curField[2]->GetHealth(), 3);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [ULD_152] Pressure Plate - COST:2
 // - Set: Uldum, Rarity: Common

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -993,6 +993,55 @@ TEST_CASE("[Hunter : Minion] - ULD_156 : Dinotamer Brann")
     CHECK_EQ(curField[2]->card->name, "Dinotamer Brann");
 }
 
+// ---------------------------------------- MINION - HUNTER
+// [ULD_212] Wild Bloodstinger - COST:6 [ATK:6/HP:9]
+// - Race: Beast, Set: Uldum, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Summon a minion from
+//       your opponent's hand. Attack it.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - ULD_212 : Wild Bloodstinger")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 6; ++i)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Malygos");
+        config.player2Deck[i] = Cards::FindCardByName("Malygos");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wild Bloodstinger"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 6);
+}
+
 // ---------------------------------------- WEAPON - HUNTER
 // [ULD_430] Desert Spear - COST:3 [ATK:1/HP:0]
 // - Set: Uldum, Rarity: Common

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -1600,6 +1600,65 @@ TEST_CASE("[Mage : Minion] - ULD_240 : Arcane Flakmage")
     CHECK_EQ(curField[0]->GetHealth(), 5);
 }
 
+// ------------------------------------------ MINION - MAGE
+// [ULD_293] Cloud Prince - COST:5 [ATK:4/HP:4]
+// - Race: Elemental, Set: Uldum, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you control a <b>Secret</b>,
+//       deal 6 damage.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE_AND_MINIMUM_FRIENDLY_SECRETS = 1
+// --------------------------------------------------------
+// RefTag:
+// - SECRET = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - ULD_293 : Cloud Prince")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Cloud Prince"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Cloud Prince"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flame Ward"));
+
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card1, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 24);
+}
+
 // --------------------------------------- MINION - PALADIN
 // [ULD_207] Ancestral Guardian - COST:4 [ATK:4/HP:2]
 // - Set: Uldum, Rarity: Common

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -641,6 +641,55 @@ TEST_CASE("[Druid : Minion] - ULD_292 : Oasis Surger")
     CHECK_EQ(curField[2]->GetHealth(), 3);
 }
 
+// ---------------------------------------- MINION - HUNTER
+// [ULD_151] Ramkahen Wildtamer - COST:3 [ATK:4/HP:3]
+// - Set: Uldum, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Copy a random Beast in your hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Spell] - ULD_151 : Ramkahen Wildtamer")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Ramkahen Wildtamer"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("River Crocolisk"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Young Dragonhawk"));
+
+    CHECK_EQ(curHand.GetCount(), 4);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 4);
+    const bool check = curHand[3]->card->name == "River Crocolisk" ||
+                       curHand[3]->card->name == "Young Dragonhawk";
+    CHECK_EQ(check, true);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [ULD_152] Pressure Plate - COST:2
 // - Set: Uldum, Rarity: Common
@@ -654,7 +703,7 @@ TEST_CASE("[Druid : Minion] - ULD_292 : Oasis Surger")
 TEST_CASE("[Hunter : Spell] - ULD_152 : Pressure Plate")
 {
     GameConfig config;
-    config.player1Class = CardClass::MAGE;
+    config.player1Class = CardClass::HUNTER;
     config.player2Class = CardClass::MAGE;
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = true;
@@ -671,9 +720,8 @@ TEST_CASE("[Hunter : Spell] - ULD_152 : Pressure Plate")
     opPlayer->SetTotalMana(10);
     opPlayer->SetUsedMana(0);
 
-    auto& opField = *(opPlayer->GetFieldZone());
-
     auto& curSecret = *(curPlayer->GetSecretZone());
+    auto& opField = *(opPlayer->GetFieldZone());
 
     const auto card1 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Pressure Plate"));

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -200,7 +200,7 @@ TEST_CASE("[Druid : Minion] - ULD_133 : Crystal Merchant")
 // - REQ_MINION_TARGET = 0
 // - REQ_NUM_MINION_SLOTS = 1
 // --------------------------------------------------------
-TEST_CASE("[Druid : Minion] - ULD_134 : BEEEES!!!")
+TEST_CASE("[Druid : Spell] - ULD_134 : BEEEES!!!")
 {
     GameConfig config;
     config.player1Class = CardClass::MAGE;
@@ -241,6 +241,66 @@ TEST_CASE("[Druid : Minion] - ULD_134 : BEEEES!!!")
     CHECK_EQ(curField.GetCount(), 1);
     CHECK_EQ(opField.GetCount(), 1);
     CHECK_EQ(opField[0]->card->name, "Bee");
+}
+
+// ------------------------------------------ SPELL - DRUID
+// [ULD_135] Hidden Oasis - COST:6
+// - Set: Uldum, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Choose One</b> - Summon a 6/6 Ancient with <b>Taunt</b>;
+//       or Restore 12 Health.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - ULD_135 : Hidden Oasis")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(15);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Hidden Oasis"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Hidden Oasis"));
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card1, curPlayer->GetHero(), 1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Vir'naal Ancient");
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, curPlayer->GetHero(), 2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 27);
 }
 
 // ------------------------------------------ SPELL - DRUID

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -140,7 +140,7 @@ TEST_CASE("[Druid : Spell] - ULD_131 : Untapped Potential")
 TEST_CASE("[Druid : Minion] - ULD_133 : Crystal Merchant")
 {
     GameConfig config;
-    config.player1Class = CardClass::MAGE;
+    config.player1Class = CardClass::DRUID;
     config.player2Class = CardClass::MAGE;
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = true;
@@ -187,6 +187,60 @@ TEST_CASE("[Druid : Minion] - ULD_133 : Crystal Merchant")
     game.ProcessUntil(Step::MAIN_ACTION);
     CHECK_EQ(curHand.GetCount(), 6);
     CHECK_EQ(opHand.GetCount(), 7);
+}
+
+// ------------------------------------------ SPELL - DRUID
+// [ULD_134] BEEEES!!! - COST:3 [ATK:1/HP:4]
+// - Set: Uldum, Rarity: Common
+// --------------------------------------------------------
+// Text: Choose a minion. Summon four 1/1 Bees that attack it.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - ULD_134 : BEEEES!!!")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Frostwolf Grunt"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("River Crocolisk"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("BEEEES!!!"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card2));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->card->name, "Bee");
 }
 
 // ------------------------------------------ SPELL - DRUID

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -1042,6 +1042,48 @@ TEST_CASE("[Hunter : Minion] - ULD_212 : Wild Bloodstinger")
     CHECK_EQ(opField[0]->GetHealth(), 6);
 }
 
+// ---------------------------------------- MINION - HUNTER
+// [ULD_410] Scarlet Webweaver - COST:6 [ATK:5/HP:5]
+// - Race: Beast, Set: Uldum, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Reduce the Cost of a random Beast
+//       in your hand by (5).
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - ULD_410 : Scarlet Webweaver")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Scarlet Webweaver"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("King Krush"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(card2->GetCost(), 4);
+    CHECK_EQ(card3->GetCost(), 9);
+}
+
 // ---------------------------------------- WEAPON - HUNTER
 // [ULD_430] Desert Spear - COST:3 [ATK:1/HP:0]
 // - Set: Uldum, Rarity: Common

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -405,6 +405,56 @@ TEST_CASE("[Druid : Minion] - ULD_137 : Garden Gnome")
     CHECK_EQ(curField[3]->card->name, "Garden Gnome");
 }
 
+// ----------------------------------------- MINION - DRUID
+// [ULD_138] Anubisath Defender - COST:5 [ATK:3/HP:5]
+// - Set: Uldum, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Taunt</b>. Costs (0) if you've cast a spell that
+//       costs (5) or more this turn.
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - ULD_138 : Anubisath Defender")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Anubisath Defender"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Starfire"));
+
+    CHECK_EQ(card1->GetCost(), 5);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(card1->GetCost(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card1->GetCost(), 5);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [ULD_273] Overflow - COST:7
 // - Set: Uldum, Rarity: Rare

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -32,100 +32,103 @@ using namespace SimpleTasks;
 // - 839 = 1
 // - QUEST_REWARD_DATABASE_ID = 53499
 // --------------------------------------------------------
-//TEST_CASE("[Druid : Spell] - ULD_131 : Untapped Potential")
-//{
-//    GameConfig config;
-//    config.player1Class = CardClass::DRUID;
-//    config.player2Class = CardClass::WARRIOR;
-//    config.startPlayer = PlayerType::PLAYER1;
-//    config.doFillDecks = true;
-//    config.autoRun = false;
-//
-//    Game game(config);
-//    game.Start();
-//    game.ProcessUntil(Step::MAIN_ACTION);
-//
-//    Player* curPlayer = game.GetCurrentPlayer();
-//    Player* opPlayer = game.GetOpponentPlayer();
-//    curPlayer->SetTotalMana(1);
-//    curPlayer->SetUsedMana(0);
-//    opPlayer->SetTotalMana(10);
-//    opPlayer->SetUsedMana(0);
-//
-//    auto& curField = *(curPlayer->GetFieldZone());
-//    auto& opField = *(opPlayer->GetFieldZone());
-//    const auto curSecret = curPlayer->GetSecretZone();
-//
-//    const auto card1 = Generic::DrawCard(
-//        curPlayer, Cards::FindCardByName("Untapped Potential"));
-//    const auto card2 = Generic::DrawCard(
-//        curPlayer, Cards::FindCardByName("Druid of the Claw"));
-//    const auto card3 =
-//        Generic::DrawCard(curPlayer, Cards::FindCardByName("Starfall"));
-//    const auto card4 =
-//        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
-//
-//    auto quest = dynamic_cast<Spell*>(card1);
-//
-//    game.Process(curPlayer, PlayCardTask::Spell(card1));
-//    CHECK(curSecret->quest != nullptr);
-//    CHECK_EQ(quest->GetQuestProgress(), 0);
-//    CHECK_EQ(quest->GetQuestProgressTotal(), 4);
-//
-//    game.Process(curPlayer, EndTurnTask());
-//    game.ProcessUntil(Step::MAIN_ACTION);
-//
-//    CHECK_EQ(quest->GetQuestProgress(), 0);
-//
-//    game.Process(opPlayer, EndTurnTask());
-//    game.ProcessUntil(Step::MAIN_ACTION);
-//
-//    game.Process(curPlayer, EndTurnTask());
-//    game.ProcessUntil(Step::MAIN_ACTION);
-//
-//    CHECK_EQ(quest->GetQuestProgress(), 1);
-//
-//    game.Process(opPlayer, EndTurnTask());
-//    game.ProcessUntil(Step::MAIN_ACTION);
-//
-//    game.Process(curPlayer, EndTurnTask());
-//    game.ProcessUntil(Step::MAIN_ACTION);
-//
-//    CHECK_EQ(quest->GetQuestProgress(), 2);
-//
-//    game.Process(opPlayer, EndTurnTask());
-//    game.ProcessUntil(Step::MAIN_ACTION);
-//
-//    game.Process(curPlayer, EndTurnTask());
-//    game.ProcessUntil(Step::MAIN_ACTION);
-//
-//    CHECK_EQ(quest->GetQuestProgress(), 3);
-//
-//    game.Process(opPlayer, EndTurnTask());
-//    game.ProcessUntil(Step::MAIN_ACTION);
-//
-//    game.Process(curPlayer, EndTurnTask());
-//    game.ProcessUntil(Step::MAIN_ACTION);
-//
-//    CHECK(curSecret->quest == nullptr);
-//    CHECK_EQ(quest->GetQuestProgress(), 4);
-//    CHECK_EQ(curPlayer->GetHero()->heroPower->card->id, "ULD_131p");
-//
-//    game.Process(opPlayer, PlayCardTask::Minion(card4));
-//
-//    game.Process(opPlayer, EndTurnTask());
-//    game.ProcessUntil(Step::MAIN_ACTION);
-//
-//    game.Process(curPlayer, PlayCardTask::Minion(card2));
-//    CHECK_EQ(curField.GetCount(), 1);
-//    CHECK_EQ(curField[0]->GetAttack(), 4);
-//    CHECK_EQ(curField[0]->GetHealth(), 6);
-//    CHECK_EQ(curField[0]->HasCharge(), true);
-//    CHECK_EQ(curField[0]->HasTaunt(), true);
-//
-//    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card4));
-//    CHECK_EQ(opField[0]->GetHealth(), 5);
-//}
+TEST_CASE("[Druid : Spell] - ULD_131 : Untapped Potential")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(1);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+    const auto curSecret = curPlayer->GetSecretZone();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Untapped Potential"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Druid of the Claw"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Starfall"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    auto quest = dynamic_cast<Spell*>(card1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK(curSecret->quest != nullptr);
+    CHECK_EQ(quest->GetQuestProgress(), 0);
+    CHECK_EQ(quest->GetQuestProgressTotal(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(quest->GetQuestProgress(), 0);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(quest->GetQuestProgress(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(quest->GetQuestProgress(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(quest->GetQuestProgress(), 3);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK(curSecret->quest == nullptr);
+    CHECK_EQ(quest->GetQuestProgress(), 4);
+    CHECK_EQ(curPlayer->GetHero()->heroPower->card->id, "ULD_131p");
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+    CHECK_EQ(curField[0]->HasCharge(), true);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card4));
+    CHECK_EQ(opField[0]->GetHealth(), 5);
+}
 
 // ----------------------------------------- MINION - DRUID
 // [ULD_133] Crystal Merchant - COST:2 [ATK:1/HP:4]

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -1659,6 +1659,54 @@ TEST_CASE("[Mage : Minion] - ULD_293 : Cloud Prince")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 24);
 }
 
+// ------------------------------------------ MINION - MAGE
+// [ULD_329] Dune Sculptor - COST:3 [ATK:3/HP:3]
+// - Set: Uldum, Rarity: Rare
+// --------------------------------------------------------
+// Text: After you cast a spell, add a random Mage
+//       minion to your hand.
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - ULD_329 : Dune Sculptor")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Dune Sculptor"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curHand.GetCount(), 1);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card3));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->GetCardType(), CardType::MINION);
+    CHECK_EQ(curHand[0]->card->GetCardClass(), CardClass::MAGE);
+}
+
 // --------------------------------------- MINION - PALADIN
 // [ULD_207] Ancestral Guardian - COST:4 [ATK:4/HP:2]
 // - Set: Uldum, Rarity: Common

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -490,17 +490,17 @@ TEST_CASE("[Druid : Minion] - ULD_139 : Elise the Enlightened")
 
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::FindCardByName("Elise the Enlightened"));
-    const auto card2 =
+    [[maybe_unused]] const auto card2 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
-    const auto card3 =
+    [[maybe_unused]] const auto card3 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
-    const auto card4 =
+    [[maybe_unused]] const auto card4 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Moonfire"));
-    const auto card5 =
+    [[maybe_unused]] const auto card5 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Wrath"));
-    const auto card6 =
+    [[maybe_unused]] const auto card6 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Acornbearer"));
-    const auto card7 = Generic::DrawCard(
+    [[maybe_unused]] const auto card7 = Generic::DrawCard(
         curPlayer, Cards::FindCardByName("Ironbark Protector"));
 
     CHECK_EQ(curHand.GetCount(), 7);
@@ -674,11 +674,11 @@ TEST_CASE("[Hunter : Minion] - ULD_151 : Ramkahen Wildtamer")
 
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::FindCardByName("Ramkahen Wildtamer"));
-    const auto card2 =
+    [[maybe_unused]] const auto card2 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
-    const auto card3 =
+    [[maybe_unused]] const auto card3 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("River Crocolisk"));
-    const auto card4 =
+    [[maybe_unused]] const auto card4 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Young Dragonhawk"));
 
     CHECK_EQ(curHand.GetCount(), 4);

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -1084,6 +1084,53 @@ TEST_CASE("[Hunter : Minion] - ULD_410 : Scarlet Webweaver")
     CHECK_EQ(card3->GetCost(), 9);
 }
 
+// ----------------------------------------- SPELL - HUNTER
+// [ULD_429] Hunter's Pack - COST:3
+// - Set: Uldum, Rarity: Common
+// --------------------------------------------------------
+// Text: Add a random Hunter Beast, <b>Secret</b>,
+//       and weapon to your hand.
+// --------------------------------------------------------
+// RefTag:
+// - SECRET = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Spell] - ULD_429 : Hunter's Pack")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Hunter's Pack"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curHand.GetCount(), 3);
+    CHECK_EQ(curHand[0]->card->GetCardClass(), CardClass::HUNTER);
+    CHECK_EQ(curHand[0]->card->GetCardType(), CardType::MINION);
+    CHECK_EQ(curHand[0]->card->GetRace(), Race::BEAST);
+    CHECK_EQ(curHand[1]->card->GetCardClass(), CardClass::HUNTER);
+    CHECK_EQ(curHand[1]->card->GetCardType(), CardType::SPELL);
+    CHECK_EQ(curHand[1]->card->IsSecret(), true);
+    CHECK_EQ(curHand[2]->card->GetCardClass(), CardClass::HUNTER);
+    CHECK_EQ(curHand[2]->card->GetCardType(), CardType::WEAPON);
+}
+
 // ---------------------------------------- WEAPON - HUNTER
 // [ULD_430] Desert Spear - COST:3 [ATK:1/HP:0]
 // - Set: Uldum, Rarity: Common

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -1542,6 +1542,64 @@ TEST_CASE("[Mage : Spell] - ULD_239 : Flame Ward")
     CHECK_EQ(opField[0]->GetHealth(), 2);
 }
 
+// ------------------------------------------ MINION - MAGE
+// [ULD_240] Arcane Flakmage - COST:2 [ATK:3/HP:2]
+// - Set: Uldum, Rarity: Rare
+// --------------------------------------------------------
+// Text: After you play a <b>Secret</b>,
+//       deal 2 damage to all enemy minions.
+// --------------------------------------------------------
+// RefTag:
+// - SECRET = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - ULD_240 : Arcane Flakmage")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opSecret = *(opPlayer->GetSecretZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Oasis Snapjaw"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Arcane Flakmage"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Flame Ward"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opSecret.GetCount(), 0);
+
+    game.Process(opPlayer, PlayCardTask::Spell(card4));
+    CHECK_EQ(opSecret.GetCount(), 1);
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+}
+
 // --------------------------------------- MINION - PALADIN
 // [ULD_207] Ancestral Guardian - COST:4 [ATK:4/HP:2]
 // - Set: Uldum, Rarity: Common

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -5,6 +5,7 @@
 // property of any third parties.
 
 #include <Utils/CardSetUtils.hpp>
+#include <Utils/TestUtils.hpp>
 
 #include <Rosetta/Actions/Draw.hpp>
 #include <Rosetta/Cards/Cards.hpp>
@@ -301,6 +302,49 @@ TEST_CASE("[Druid : Spell] - ULD_135 : Hidden Oasis")
     game.Process(curPlayer,
                  PlayCardTask::SpellTarget(card2, curPlayer->GetHero(), 2));
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 27);
+}
+
+// ------------------------------------------ SPELL - DRUID
+// [ULD_136] Worthy Expedition - COST:1
+// - Set: Uldum, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Discover</b> a <b>Choose One</b> card.
+// --------------------------------------------------------
+// GameTag:
+// - DISCOVER = 1
+// - USE_DISCOVER_VISUALS = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - ULD_136 : Worthy Expedition")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Worthy Expedition"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK(curPlayer->choice != nullptr);
+
+    auto cards = TestUtils::GetChoiceCards(game);
+    for (auto& card : cards)
+    {
+        CHECK_EQ(card->HasGameTag(GameTag::CHOOSE_ONE), true);
+    }
 }
 
 // ------------------------------------------ SPELL - DRUID

--- a/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/CardSets/UldumCardsGenTests.cpp
@@ -1283,6 +1283,121 @@ TEST_CASE("[Mage : Spell] - ULD_216 : Puzzle Box of Yogg-Saron")
     }
 }
 
+// ------------------------------------------ MINION - MAGE
+// [ULD_236] Tortollan Pilgrim - COST:8 [ATK:5/HP:5]
+// - Set: Uldum, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Battlecry</b>: <b>Discover</b> a copy of
+//       a spell in your deck and cast it with random targets.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - DISCOVER = 1
+// - USE_DISCOVER_VISUALS = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - ULD_236 : Tortollan Pilgrim")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Fireball");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Frostbolt");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Pyroblast");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto curHero = curPlayer->GetHero();
+    auto opHero = opPlayer->GetHero();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Tortollan Pilgrim"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK(curPlayer->choice != nullptr);
+
+    auto cards = TestUtils::GetChoiceCards(game);
+    std::string_view cardName = cards[0]->name;
+
+    const bool check1 = cards[0]->name == "Fireball" ||
+                        cards[0]->name == "Frostbolt" ||
+                        cards[0]->name == "Pyroblast";
+    const bool check2 = cards[1]->name == "Fireball" ||
+                        cards[1]->name == "Frostbolt" ||
+                        cards[1]->name == "Pyroblast";
+    const bool check3 = cards[2]->name == "Fireball" ||
+                        cards[2]->name == "Frostbolt" ||
+                        cards[2]->name == "Pyroblast";
+    const bool check4 = (cards[0]->dbfID != cards[1]->dbfID) &&
+                        (cards[0]->dbfID != cards[2]->dbfID) &&
+                        (cards[1]->dbfID != cards[2]->dbfID);
+    const bool check = check1 && check2 && check3 && check4;
+    CHECK_EQ(check, true);
+
+    curHero->SetDamage(0);
+    opHero->SetDamage(0);
+
+    TestUtils::ChooseNthChoice(game, 1);
+    if (cardName == "Fireball")
+    {
+        const bool check11 = curHero->GetHealth() == 24 &&
+                             curField.GetCount() == 1 &&
+                             opHero->GetHealth() == 30;
+        const bool check12 = curHero->GetHealth() == 30 &&
+                             curField.GetCount() == 0 &&
+                             opHero->GetHealth() == 30;
+        const bool check13 = curHero->GetHealth() == 30 &&
+                             curField.GetCount() == 1 &&
+                             opHero->GetHealth() == 24;
+        const bool check14 = check11 || check12 || check13;
+        CHECK_EQ(check14, true);
+    }
+    else if (cardName == "Frostbolt")
+    {
+        const bool check21 =
+            curHero->GetHealth() == 27 && curHero->IsFrozen() == true &&
+            curField[0]->GetHealth() == 5 && opHero->GetHealth() == 30;
+        const bool check22 =
+            curHero->GetHealth() == 30 && curField[0]->GetHealth() == 2 &&
+            curField[0]->IsFrozen() == true && opHero->GetHealth() == 30;
+        const bool check23 =
+            curHero->GetHealth() == 30 && curField[0]->GetHealth() == 5 &&
+            opHero->GetHealth() == 27 && opHero->IsFrozen() == true;
+        const bool check24 = check21 || check22 || check23;
+        CHECK_EQ(check24, true);
+    }
+    else
+    {
+        const bool check31 = curHero->GetHealth() == 20 &&
+                             curField.GetCount() == 1 &&
+                             opHero->GetHealth() == 30;
+        const bool check32 = curHero->GetHealth() == 30 &&
+                             curField.GetCount() == 0 &&
+                             opHero->GetHealth() == 30;
+        const bool check33 = curHero->GetHealth() == 30 &&
+                             curField.GetCount() == 1 &&
+                             opHero->GetHealth() == 20;
+        const bool check34 = check31 || check32 || check33;
+        CHECK_EQ(check34, true);
+    }
+}
+
 // --------------------------------------- MINION - PALADIN
 // [ULD_207] Ancestral Guardian - COST:4 [ATK:4/HP:2]
 // - Set: Uldum, Rarity: Common


### PR DESCRIPTION
This revision includes:
- Implement 23 ULDUM cards
  - Untapped Potential (ULD_131)
  - BEEEES!!! (ULD_134)
  - Hidden Oasis (ULD_135)
  - Worthy Expedition (ULD_136)
  - Garden Gnome (ULD_137)
  - Anubisath Defender (ULD_138)
  - Elise the Enlightened (ULD_139)
  - Ramkahen Wildtamer (ULD_151)
  - Dinotamer Brann (ULD_156)
  - Wild Bloodstinger (ULD_212)
  - Puzzle Box of Yogg-Saron (ULD_216)
  - Tortollan Pilgrim (ULD_236)
  - Reno the Relicologist (ULD_238)
  - Flame Ward (ULD_239)
  - Arcane Flakmage (ULD_240)
  - Oasis Surger (ULD_292)
  - Cloud Prince (ULD_293)
  - Dune Sculptor (ULD_329)
  - Scarlet Webweaver (ULD_410)
  - Hunter's Pack (ULD_429)
  - Raid the Sky Temple (ULD_433)
  - Naga Sand Witch (ULD_435)
  - Ancient Mysteries (ULD_726)
- Implement tasks
  - CastRandomSpellTask: This class represents the task for casting random spell.
- Add SelfCondition wrappers
  - Cast5MoreCostSpellInThisTurn(): SelfCondition wrapper for checking the player casts a spell that costs (5) or more this turn.
- Add enum values
  - DiscoverType::CHOOSE_ONE
  - DiscoverType::TORTOLLAN_PILGRIM
  - ChoiceAction::TORTOLLAN_PILGRIM
  - DiscoverType::LEGENDARY_MINION_SUMMON
  - DiscoverType::HEISTBARON_TOGWAGGLE
  - SummonSide::ALTERNATE
- Add methods
  - Card::IsTransformMinion(): Returns the flag that indicates whether it is a card with two Choose One options involving transform or specific summon effects is played while controlling Ossirian Tear.
  - Player::ChooseBoth(): Returns whether this player chooses both cards.
  - TargetingPredicates::MinimumFriendlySecrets(): Predicate wrapper for checking the player has at least value secrets.
- Add code to process play requirements
  - PlayReq::REQ_TARGET_IF_AVAILABLE_AND_MINIMUM_FRIENDLY_SECRETS
  - PlayReq::REQ_HAND_NOT_FULL
- Refactor and fix codes
  - Add code to check the value is greater than 0
  - Add code to check the player has 'GameTag::CHOOSE_BOTH'
  - Add code to check a card is transform minion
  - Add code to process hero power's aura
  - Add power tasks of card 'Druid of the Claw' (EX1_165)
  - Add code to allow multiple attackers can attack
  - Add variable 'm_tags' to class 'RandomCardTask' and code to process it
  - Add code to exclude the card 'Rising Winds'
  - Correct the logic of card 'Embiggen' and 'Rolling Fireball'
  - Add code to check the target is 'nullptr'
  - Add code to clear a list of playables in the task stack
  - Add code to check the count of the field zone
  - Add code to check the defender is 'nullptr'
  - Add code to check 'GameTag::CAST_RANDOM_SPELLS'
  - Move the position of the code to clear a list of playable
  - Add code to process hero's trigger 'AFTER_ATTACKED'
  - Correct SonarCloud issue