### PR TITLE
Update Hearthstone patches

### DIFF
--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -64,10 +64,10 @@ constexpr std::array<CardSet, 22> WILD_CARD_SETS = {
 };
 
 //! The number of all cards.
-constexpr int NUM_ALL_CARDS = 9057;
+constexpr int NUM_ALL_CARDS = 9156;
 
 //! The number of Battlegrounds cards.
-constexpr int NUM_BATTLEGROUNDS_CARDS = 447;
+constexpr int NUM_BATTLEGROUNDS_CARDS = 461;
 
 //! The number of player class.
 //! \note Druid, Hunter, Mage, Paladin, Priest, Rogue, Shaman, Warlock, Warrior,
@@ -105,7 +105,7 @@ constexpr int MAX_SECERT_SIZE = 5;
 constexpr int NUM_BATTLEGROUNDS_PLAYERS = 8;
 
 //! The number of heroes in Battlegrounds.
-constexpr int NUM_BATTLEGROUNDS_HEROES = 34;
+constexpr int NUM_BATTLEGROUNDS_HEROES = 37;
 
 //! The number of heroes on the selection list in Battlegrounds.
 constexpr int NUM_HEROES_ON_SELECTION_LIST = 4;

--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -148,22 +148,22 @@ constexpr int NUM_TIER6_MINIONS = 11;
 
 //! A list of Tier 1 minion dbfIDs in Battlegrounds.
 // Alleycat (40426)
-// Dire Wolf Alpha (985)
 // Dragonspawn Lieutenant (60628)
 // Fiendish Servant (56112)
 // Mecharoo (48886)
 // Micro Machine (60055)
 // Murloc Tidecaller (475)
 // Murloc Tidehunter (976)
-// Righteous Protector (42467)
+// Rabid Saurolisk (62162)
 // Red Whelp (59968)
+// Righteous Protector (42467)
 // Rockpool Hunter (41245)
 // Selfless Hero (38740)
 // Vulgar Homunculus (43121)
 // Wrath Weaver (59670)
 constexpr std::array<int, NUM_TIER1_MINIONS> TIER1_MINIONS = {
-    40426, 985,   60628, 56112, 48886, 60055, 475,
-    976,   42467, 59968, 41245, 38740, 43121, 59670
+    40426, 60628, 56112, 48886, 60055, 475,   976,
+    62162, 59968, 42467, 41245, 38740, 43121, 59670
 };
 
 //! A list of Tier 2 minion dbfIDs in Battlegrounds.

--- a/Resources/cards.collectible.json
+++ b/Resources/cards.collectible.json
@@ -659,7 +659,7 @@
             "CHOOSE_ONE"
         ],
         "name": "Living Roots",
-        "rarity": "EPIC",
+        "rarity": "COMMON",
         "set": "TGT",
         "text": "<b>Choose One -</b> Deal $2 damage; or Summon two 1/1 Saplings.",
         "type": "SPELL"
@@ -5833,7 +5833,7 @@
         "artist": "Wayne Wu",
         "cardClass": "PALADIN",
         "collectible": true,
-        "cost": 6,
+        "cost": 5,
         "dbfId": 56394,
         "flavor": "Proper justice. Throw the book at him!",
         "id": "BT_011",
@@ -5905,10 +5905,10 @@
     },
     {
         "artist": "Anton Zemskov",
-        "attack": 2,
+        "attack": 1,
         "cardClass": "PALADIN",
         "collectible": true,
-        "cost": 2,
+        "cost": 1,
         "dbfId": 56445,
         "flavor": "Will check to make sure you have a valid libramary card.",
         "health": 3,
@@ -6203,7 +6203,7 @@
         "artist": "Dave Allsop",
         "cardClass": "SHAMAN",
         "collectible": true,
-        "cost": 5,
+        "cost": 4,
         "dbfId": 56467,
         "flavor": "Weeks of underwater cross-training have really built up her fourarms.",
         "id": "BT_110",
@@ -6229,7 +6229,7 @@
     },
     {
         "artist": "Konstantin Turovec",
-        "attack": 4,
+        "attack": 5,
         "cardClass": "SHAMAN",
         "collectible": true,
         "cost": 5,
@@ -6373,7 +6373,7 @@
         "name": "Teron Gorefiend",
         "rarity": "LEGENDARY",
         "set": "BLACK_TEMPLE",
-        "text": "<b>Battlecry:</b> Destroy all friendly minions. <b>Deathrattle:</b> Resummon them with +1/+1.",
+        "text": "[x]<b>Battlecry:</b> Destroy all\nother friendly minions.\n<b>Deathrattle:</b> Resummon\nthem with +1/+1.",
         "type": "MINION"
     },
     {
@@ -6547,7 +6547,7 @@
     },
     {
         "artist": "Ivan Fomin",
-        "attack": 6,
+        "attack": 5,
         "cardClass": "WARRIOR",
         "collectible": true,
         "cost": 7,
@@ -6764,7 +6764,7 @@
         "dbfId": 57979,
         "elite": true,
         "flavor": "What is a shadowjeweler? A miserable little pile of secrets.",
-        "health": 5,
+        "health": 4,
         "id": "BT_188",
         "mechanics": [
             "TRIGGER_VISUAL"
@@ -7016,7 +7016,7 @@
         "name": "Scavenger's Ingenuity",
         "rarity": "COMMON",
         "set": "BLACK_TEMPLE",
-        "text": "Draw a Beast.\nGive it +3/+3.",
+        "text": "Draw a Beast.\nGive it +2/+2.",
         "type": "SPELL"
     },
     {
@@ -7048,12 +7048,13 @@
         "dbfId": 57619,
         "elite": true,
         "flavor": "\"Throw it back! THROW IT BACK!\"",
-        "health": 3,
+        "health": 5,
         "id": "BT_230",
         "mechanics": [
             "BATTLECRY"
         ],
         "name": "The Lurker Below",
+        "race": "BEAST",
         "rarity": "LEGENDARY",
         "set": "BLACK_TEMPLE",
         "targetingArrowText": "Deal 3 damage.",
@@ -7164,7 +7165,7 @@
         "attack": 4,
         "cardClass": "NEUTRAL",
         "collectible": true,
-        "cost": 6,
+        "cost": 7,
         "dbfId": 56622,
         "elite": true,
         "flavor": "“Descent of Dragons was merely a set back!”",
@@ -7395,7 +7396,7 @@
         "race": "DEMON",
         "rarity": "RARE",
         "set": "BLACK_TEMPLE",
-        "text": "<b>Dormant</b> for 2 turns.\nWhen this awakens,\ngive all minions in your hand +2/+2.",
+        "text": "<b>Dormant</b> for 2 turns.\nWhen this awakens,\ngive all minions in your hand +2/+1.",
         "type": "MINION"
     },
     {
@@ -7537,7 +7538,7 @@
     },
     {
         "artist": "Andrew Hou",
-        "attack": 2,
+        "attack": 1,
         "cardClass": "DEMONHUNTER",
         "collectible": true,
         "cost": 1,
@@ -7720,7 +7721,7 @@
     },
     {
         "artist": "Arthur Bozonnet",
-        "attack": 2,
+        "attack": 1,
         "cardClass": "DEMONHUNTER",
         "collectible": true,
         "cost": 1,
@@ -7860,7 +7861,7 @@
         "cost": 7,
         "dbfId": 58455,
         "flavor": "Furious that she only has six warglaives. The Sightless Watcher has eight! The fel is always greener on the other side.",
-        "health": 7,
+        "health": 5,
         "id": "BT_493",
         "mechanics": [
             "TRIGGER_VISUAL"
@@ -7874,7 +7875,7 @@
     },
     {
         "artist": "Paul Mafayon",
-        "attack": 7,
+        "attack": 6,
         "cardClass": "DEMONHUNTER",
         "collectible": true,
         "cost": 5,
@@ -7987,7 +7988,7 @@
         "artist": "Slawomir Maniak",
         "cardClass": "DEMONHUNTER",
         "collectible": true,
-        "cost": 5,
+        "cost": 6,
         "dbfId": 58201,
         "flavor": "A fellow of evil possessed, of most devious shadow. He hath turned on his kin a thousand times, and now, how abhorred in all imagination he is!",
         "id": "BT_601",
@@ -8144,7 +8145,7 @@
         ],
         "set": "BLACK_TEMPLE",
         "targetingArrowText": "Return a minion to hand.",
-        "text": "[x]<b>Battlecry:</b> If you control a\n<b>Secret</b>, return a minion\nto its owner's hand.\nIt costs (2) more.",
+        "text": "[x]<b>Battlecry:</b> If you control a\n<b>Secret</b>, return a minion\nto its owner's hand.\nIt costs (1) more.",
         "type": "MINION"
     },
     {
@@ -8424,7 +8425,7 @@
         "type": "MINION"
     },
     {
-        "artist": "Eva Widermann",
+        "artist": "Evgeniy Dlinnov",
         "attack": 3,
         "cardClass": "NEUTRAL",
         "collectible": true,
@@ -8680,7 +8681,7 @@
         "name": "Eye Beam",
         "rarity": "EPIC",
         "set": "DEMON_HUNTER_INITIATE",
-        "text": "<b>Lifesteal</b>. Deal $3 damage to a minion.\n<b>Outcast:</b> This costs (0).",
+        "text": "<b>Lifesteal</b>. Deal $3 damage to a minion.\n<b>Outcast:</b> This costs (1).",
         "type": "SPELL"
     },
     {
@@ -8734,7 +8735,7 @@
         "collectible": true,
         "cost": 3,
         "dbfId": 56583,
-        "durability": 3,
+        "durability": 2,
         "flavor": "The ancient Aldrachi were the greatest warriors in the universe. Imagine their power if they'd put the handle at the END of the blade.",
         "id": "BT_921",
         "mechanics": [
@@ -8770,7 +8771,7 @@
         "attack": 10,
         "cardClass": "DEMONHUNTER",
         "collectible": true,
-        "cost": 5,
+        "cost": 6,
         "dbfId": 56649,
         "flavor": "Can I get a pair of size XXXXXL manacles?",
         "health": 6,
@@ -8784,10 +8785,10 @@
     },
     {
         "artist": "Jerry Mascho",
-        "attack": 3,
+        "attack": 4,
         "cardClass": "DEMONHUNTER",
         "collectible": true,
-        "cost": 3,
+        "cost": 4,
         "dbfId": 56652,
         "elite": true,
         "flavor": "Altruis betrayed Illidan to forge his own way in Outland. With Blackjack. And Netherdrakes.",
@@ -16851,7 +16852,7 @@
         "attack": 4,
         "cardClass": "NEUTRAL",
         "collectible": true,
-        "cost": 3,
+        "cost": 4,
         "dbfId": 55421,
         "flavor": "Legend holds that it's bad luck to harm it. So maybe just pat it on the head, okay?",
         "health": 3,
@@ -20835,7 +20836,7 @@
             "BATTLECRY"
         ],
         "name": "Psychic Conjurer",
-        "rarity": "COMMON",
+        "rarity": "FREE",
         "set": "CORE",
         "text": "<b>Battlecry:</b> Copy a card in your opponent’s deck and add it to your hand.",
         "type": "MINION"
@@ -20849,7 +20850,7 @@
         "flavor": "It infuses, it enthuses, it amuses!",
         "id": "EX1_194",
         "name": "Power Infusion",
-        "rarity": "COMMON",
+        "rarity": "FREE",
         "set": "CORE",
         "text": "Give a minion +2/+6.",
         "type": "SPELL"
@@ -36551,20 +36552,6 @@
         "type": "MINION"
     },
     {
-        "cardClass": "NEUTRAL",
-        "collectible": true,
-        "collectionText": " |4(Candle, Candles).",
-        "dbfId": 61009,
-        "id": "LOOT_526e",
-        "mechanics": [
-            "TRIGGER_VISUAL"
-        ],
-        "name": "Darkness Awaits",
-        "set": "LOOTAPALOOZA",
-        "text": "<b>Dormant</b>. Awaken when you opponent draws",
-        "type": "ENCHANTMENT"
-    },
-    {
         "artist": "Tooth",
         "attack": 2,
         "cardClass": "PRIEST",
@@ -36779,7 +36766,7 @@
         "name": "Sacrificial Pact",
         "rarity": "FREE",
         "set": "CORE",
-        "text": "Destroy a Demon. Restore #5 Health to your hero.",
+        "text": "Destroy a friendly Demon. Restore #5 Health to your hero.",
         "type": "SPELL"
     },
     {
@@ -42144,6 +42131,7 @@
         "health": 8,
         "id": "TRL_535",
         "mechanics": [
+            "ADJACENT_BUFF",
             "TRIGGER_VISUAL"
         ],
         "name": "Snapjaw Shellfighter",
@@ -44968,13 +44956,13 @@
     },
     {
         "artist": "James Ryman",
-        "attack": 3,
+        "attack": 2,
         "cardClass": "WARRIOR",
         "collectible": true,
         "cost": 3,
         "dbfId": 54492,
         "flavor": "You look really hurt. You could use a friend!",
-        "health": 3,
+        "health": 2,
         "id": "ULD_720",
         "mechanics": [
             "BATTLECRY"
@@ -45417,7 +45405,7 @@
         "questReward": "UNG_028t",
         "rarity": "LEGENDARY",
         "set": "UNGORO",
-        "text": "[x]<b>Quest:</b> Cast 6 spells that\ndidn't start in your deck.\n<b>Reward:</b> Time Warp.",
+        "text": "[x]<b>Quest:</b> Cast 8 spells that\ndidn't start in your deck.\n<b>Reward:</b> Time Warp.",
         "type": "SPELL"
     },
     {
@@ -46692,7 +46680,7 @@
         "artist": "Tyler Walpole",
         "cardClass": "WARLOCK",
         "collectible": true,
-        "cost": 2,
+        "cost": 4,
         "dbfId": 41872,
         "flavor": "Help save mana.  Donate blood today!",
         "id": "UNG_832",
@@ -48256,7 +48244,7 @@
         "cost": 4,
         "dbfId": 56122,
         "flavor": "Not to be confused with the \"friendsy” felwing.",
-        "health": 3,
+        "health": 2,
         "id": "YOD_032",
         "name": "Frenzied Felwing",
         "race": "DEMON",

--- a/Resources/cards.json
+++ b/Resources/cards.json
@@ -853,7 +853,7 @@
             "CHOOSE_ONE"
         ],
         "name": "Living Roots",
-        "rarity": "EPIC",
+        "rarity": "COMMON",
         "set": "TGT",
         "text": "<b>Choose One -</b> Deal $2 damage; or Summon two 1/1 Saplings.",
         "type": "SPELL"
@@ -3095,16 +3095,6 @@
     {
         "cardClass": "DRUID",
         "cost": 2,
-        "dbfId": 2737,
-        "id": "AT_132_DRUID",
-        "name": "Dire Shapeshift",
-        "set": "TGT",
-        "text": "<b>Hero Power</b>\n+2 Attack this turn.\n+2 Armor.",
-        "type": "HERO_POWER"
-    },
-    {
-        "cardClass": "DRUID",
-        "cost": 2,
         "dbfId": 51465,
         "id": "AT_132_DRUIDa",
         "name": "Dire Shapeshift",
@@ -3148,62 +3138,11 @@
         "cardClass": "HUNTER",
         "collectionText": "<b>Hero Power</b>\nDeal $3 damage.",
         "cost": 2,
-        "dbfId": 2738,
-        "id": "AT_132_HUNTER",
-        "name": "Ballista Shot",
-        "set": "TGT",
-        "text": "<b>Hero Power</b>\nDeal $3 damage to the enemy hero.",
-        "type": "HERO_POWER"
-    },
-    {
-        "cardClass": "HUNTER",
-        "collectionText": "<b>Hero Power</b>\nDeal $3 damage.",
-        "cost": 2,
         "dbfId": 60337,
         "id": "AT_132_HUNTER_H1",
         "name": "Ballista Shot",
         "set": "HERO_SKINS",
         "text": "<b>Hero Power</b>\nDeal $3 damage to the enemy hero.",
-        "type": "HERO_POWER"
-    },
-    {
-        "cardClass": "MAGE",
-        "cost": 2,
-        "dbfId": 2739,
-        "id": "AT_132_MAGE",
-        "name": "Fireblast Rank 2",
-        "set": "TGT",
-        "text": "<b>Hero Power</b>\nDeal $2 damage.",
-        "type": "HERO_POWER"
-    },
-    {
-        "cardClass": "PALADIN",
-        "cost": 2,
-        "dbfId": 2740,
-        "id": "AT_132_PALADIN",
-        "name": "The Silver Hand",
-        "set": "TGT",
-        "text": "<b>Hero Power</b>\nSummon two 1/1 Recruits.",
-        "type": "HERO_POWER"
-    },
-    {
-        "cardClass": "PRIEST",
-        "cost": 2,
-        "dbfId": 2741,
-        "id": "AT_132_PRIEST",
-        "name": "Heal",
-        "set": "TGT",
-        "text": "<b>Hero Power</b>\nRestore #4 Health.",
-        "type": "HERO_POWER"
-    },
-    {
-        "cardClass": "ROGUE",
-        "cost": 2,
-        "dbfId": 2743,
-        "id": "AT_132_ROGUE",
-        "name": "Poisoned Daggers",
-        "set": "TGT",
-        "text": "<b>Hero Power</b>\nEquip a 2/2 Weapon.",
         "type": "HERO_POWER"
     },
     {
@@ -3237,16 +3176,6 @@
         "name": "Poisoned Dagger",
         "set": "HERO_SKINS",
         "type": "WEAPON"
-    },
-    {
-        "cardClass": "SHAMAN",
-        "cost": 2,
-        "dbfId": 2742,
-        "id": "AT_132_SHAMAN",
-        "name": "Totemic Slam",
-        "set": "TGT",
-        "text": "<b>Hero Power</b>\nSummon a Totem of your choice.",
-        "type": "HERO_POWER"
     },
     {
         "attack": 0,
@@ -3298,16 +3227,6 @@
     {
         "cardClass": "WARLOCK",
         "cost": 2,
-        "dbfId": 2744,
-        "id": "AT_132_WARLOCK",
-        "name": "Soul Tap",
-        "set": "TGT",
-        "text": "<b>Hero Power</b>\nDraw a card.",
-        "type": "HERO_POWER"
-    },
-    {
-        "cardClass": "WARLOCK",
-        "cost": 2,
         "dbfId": 51468,
         "id": "AT_132_WARLOCKa",
         "name": "Soul Tap",
@@ -3323,16 +3242,6 @@
         "name": "Soul Tap",
         "set": "HERO_SKINS",
         "text": "<b>Hero Power</b>\nDraw a card.",
-        "type": "HERO_POWER"
-    },
-    {
-        "cardClass": "WARRIOR",
-        "cost": 2,
-        "dbfId": 2745,
-        "id": "AT_132_WARRIOR",
-        "name": "Tank Up!",
-        "set": "TGT",
-        "text": "<b>Hero Power</b>\nGain 4 Armor.",
         "type": "HERO_POWER"
     },
     {
@@ -4446,6 +4355,36 @@
         "name": "Deflect-o-Shield",
         "set": "BATTLEGROUNDS",
         "text": "Increased stats.",
+        "type": "ENCHANTMENT"
+    },
+    {
+        "attack": 3,
+        "battlegroundsPremiumDbfId": 62165,
+        "cardClass": "HUNTER",
+        "cost": 3,
+        "dbfId": 62162,
+        "health": 1,
+        "id": "BGS_075",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Rabid Saurolisk",
+        "race": "BEAST",
+        "referencedTags": [
+            "DEATHRATTLE"
+        ],
+        "set": "BATTLEGROUNDS",
+        "techLevel": 1,
+        "text": "After you play a minion with <b>Deathrattle</b>, gain +1/+1.",
+        "type": "MINION"
+    },
+    {
+        "cardClass": "HUNTER",
+        "dbfId": 62164,
+        "id": "BGS_075e",
+        "name": "Rabid",
+        "set": "BATTLEGROUNDS",
+        "text": "+1/+1.",
         "type": "ENCHANTMENT"
     },
     {
@@ -13463,7 +13402,7 @@
         "artist": "Wayne Wu",
         "cardClass": "PALADIN",
         "collectible": true,
-        "cost": 6,
+        "cost": 5,
         "dbfId": 56394,
         "flavor": "Proper justice. Throw the book at him!",
         "id": "BT_011",
@@ -13575,10 +13514,10 @@
     },
     {
         "artist": "Anton Zemskov",
-        "attack": 2,
+        "attack": 1,
         "cardClass": "PALADIN",
         "collectible": true,
-        "cost": 2,
+        "cost": 1,
         "dbfId": 56445,
         "flavor": "Will check to make sure you have a valid libramary card.",
         "health": 3,
@@ -14005,7 +13944,7 @@
         "artist": "Dave Allsop",
         "cardClass": "SHAMAN",
         "collectible": true,
-        "cost": 5,
+        "cost": 4,
         "dbfId": 56467,
         "flavor": "Weeks of underwater cross-training have really built up her fourarms.",
         "id": "BT_110",
@@ -14040,7 +13979,7 @@
     },
     {
         "artist": "Konstantin Turovec",
-        "attack": 4,
+        "attack": 5,
         "cardClass": "SHAMAN",
         "collectible": true,
         "cost": 5,
@@ -14211,7 +14150,7 @@
         "name": "Teron Gorefiend",
         "rarity": "LEGENDARY",
         "set": "BLACK_TEMPLE",
-        "text": "<b>Battlecry:</b> Destroy all friendly minions. <b>Deathrattle:</b> Resummon them with +1/+1.",
+        "text": "[x]<b>Battlecry:</b> Destroy all\nother friendly minions.\n<b>Deathrattle:</b> Resummon\nthem with +1/+1.",
         "type": "MINION"
     },
     {
@@ -14553,7 +14492,7 @@
     },
     {
         "artist": "Ivan Fomin",
-        "attack": 6,
+        "attack": 5,
         "cardClass": "WARRIOR",
         "collectible": true,
         "cost": 7,
@@ -14712,7 +14651,7 @@
         "type": "MINION"
     },
     {
-        "artist": "Evgeniy Dlinnov",
+        "artist": "Eva Widermann",
         "attack": 1,
         "cardClass": "NEUTRAL",
         "cost": 1,
@@ -14900,7 +14839,7 @@
         "dbfId": 57979,
         "elite": true,
         "flavor": "What is a shadowjeweler? A miserable little pile of secrets.",
-        "health": 5,
+        "health": 4,
         "id": "BT_188",
         "mechanics": [
             "TRIGGER_VISUAL"
@@ -15238,15 +15177,16 @@
         "name": "Scavenger's Ingenuity",
         "rarity": "COMMON",
         "set": "BLACK_TEMPLE",
-        "text": "Draw a Beast.\nGive it +3/+3.",
+        "text": "Draw a Beast.\nGive it +2/+2.",
         "type": "SPELL"
     },
     {
+        "cardClass": "NEUTRAL",
         "dbfId": 57621,
         "id": "BT_213e",
         "name": "Pack Tactics",
         "set": "BLACK_TEMPLE",
-        "text": "+3/+3.",
+        "text": "+2/+2.",
         "type": "ENCHANTMENT"
     },
     {
@@ -15278,12 +15218,13 @@
         "dbfId": 57619,
         "elite": true,
         "flavor": "\"Throw it back! THROW IT BACK!\"",
-        "health": 3,
+        "health": 5,
         "id": "BT_230",
         "mechanics": [
             "BATTLECRY"
         ],
         "name": "The Lurker Below",
+        "race": "BEAST",
         "rarity": "LEGENDARY",
         "set": "BLACK_TEMPLE",
         "targetingArrowText": "Deal 3 damage.",
@@ -15403,7 +15344,7 @@
         "attack": 4,
         "cardClass": "NEUTRAL",
         "collectible": true,
-        "cost": 6,
+        "cost": 7,
         "dbfId": 56622,
         "elite": true,
         "flavor": "“Descent of Dragons was merely a set back!”",
@@ -15707,7 +15648,7 @@
         "race": "DEMON",
         "rarity": "RARE",
         "set": "BLACK_TEMPLE",
-        "text": "<b>Dormant</b> for 2 turns.\nWhen this awakens,\ngive all minions in your hand +2/+2.",
+        "text": "<b>Dormant</b> for 2 turns.\nWhen this awakens,\ngive all minions in your hand +2/+1.",
         "type": "MINION"
     },
     {
@@ -15716,7 +15657,7 @@
         "id": "BT_305e",
         "name": "Scrap Weapons",
         "set": "BLACK_TEMPLE",
-        "text": "+2/+2.",
+        "text": "+2/+1.",
         "type": "ENCHANTMENT"
     },
     {
@@ -15894,7 +15835,7 @@
     },
     {
         "artist": "Andrew Hou",
-        "attack": 2,
+        "attack": 1,
         "cardClass": "DEMONHUNTER",
         "collectible": true,
         "cost": 1,
@@ -16142,7 +16083,7 @@
     },
     {
         "artist": "Arthur Bozonnet",
-        "attack": 2,
+        "attack": 1,
         "cardClass": "DEMONHUNTER",
         "collectible": true,
         "cost": 1,
@@ -16282,7 +16223,7 @@
         "cost": 7,
         "dbfId": 58455,
         "flavor": "Furious that she only has six warglaives. The Sightless Watcher has eight! The fel is always greener on the other side.",
-        "health": 7,
+        "health": 5,
         "id": "BT_493",
         "mechanics": [
             "TRIGGER_VISUAL"
@@ -16296,7 +16237,7 @@
     },
     {
         "artist": "Paul Mafayon",
-        "attack": 7,
+        "attack": 6,
         "cardClass": "DEMONHUNTER",
         "collectible": true,
         "cost": 5,
@@ -16413,6 +16354,15 @@
         "type": "ENCHANTMENT"
     },
     {
+        "cardClass": "DEMONHUNTER",
+        "dbfId": 57568,
+        "id": "BT_512e3",
+        "name": "Branded",
+        "set": "BLACK_TEMPLE",
+        "text": "Takes 1 damage at the end of each turn.",
+        "type": "ENCHANTMENT"
+    },
+    {
         "artist": "L. Lullabi & K. Turovec",
         "cardClass": "DEMONHUNTER",
         "collectible": true,
@@ -16430,7 +16380,7 @@
         "artist": "Slawomir Maniak",
         "cardClass": "DEMONHUNTER",
         "collectible": true,
-        "cost": 5,
+        "cost": 6,
         "dbfId": 58201,
         "flavor": "A fellow of evil possessed, of most devious shadow. He hath turned on his kin a thousand times, and now, how abhorred in all imagination he is!",
         "id": "BT_601",
@@ -16637,7 +16587,7 @@
         ],
         "set": "BLACK_TEMPLE",
         "targetingArrowText": "Return a minion to hand.",
-        "text": "[x]<b>Battlecry:</b> If you control a\n<b>Secret</b>, return a minion\nto its owner's hand.\nIt costs (2) more.",
+        "text": "[x]<b>Battlecry:</b> If you control a\n<b>Secret</b>, return a minion\nto its owner's hand.\nIt costs (1) more.",
         "type": "MINION"
     },
     {
@@ -16646,7 +16596,7 @@
         "id": "BT_711e",
         "name": "Stunned",
         "set": "BLACK_TEMPLE",
-        "text": "Costs (2) more.",
+        "text": "Costs (1) more.",
         "type": "ENCHANTMENT"
     },
     {
@@ -17019,7 +16969,7 @@
         "type": "MINION"
     },
     {
-        "artist": "Eva Widermann",
+        "artist": "Evgeniy Dlinnov",
         "attack": 3,
         "cardClass": "NEUTRAL",
         "collectible": true,
@@ -17342,7 +17292,7 @@
         "name": "Eye Beam",
         "rarity": "EPIC",
         "set": "DEMON_HUNTER_INITIATE",
-        "text": "<b>Lifesteal</b>. Deal $3 damage to a minion.\n<b>Outcast:</b> This costs (0).",
+        "text": "<b>Lifesteal</b>. Deal $3 damage to a minion.\n<b>Outcast:</b> This costs (1).",
         "type": "SPELL"
     },
     {
@@ -17433,7 +17383,7 @@
         "collectible": true,
         "cost": 3,
         "dbfId": 56583,
-        "durability": 3,
+        "durability": 2,
         "flavor": "The ancient Aldrachi were the greatest warriors in the universe. Imagine their power if they'd put the handle at the END of the blade.",
         "id": "BT_921",
         "mechanics": [
@@ -17482,7 +17432,7 @@
         "attack": 10,
         "cardClass": "DEMONHUNTER",
         "collectible": true,
-        "cost": 5,
+        "cost": 6,
         "dbfId": 56649,
         "flavor": "Can I get a pair of size XXXXXL manacles?",
         "health": 6,
@@ -17496,10 +17446,10 @@
     },
     {
         "artist": "Jerry Mascho",
-        "attack": 3,
+        "attack": 4,
         "cardClass": "DEMONHUNTER",
         "collectible": true,
-        "cost": 3,
+        "cost": 4,
         "dbfId": 56652,
         "elite": true,
         "flavor": "Altruis betrayed Illidan to forge his own way in Outland. With Blackjack. And Netherdrakes.",
@@ -17513,6 +17463,882 @@
         "set": "DEMON_HUNTER_INITIATE",
         "text": "[x]After you play the left-\nor right-most card in your\nhand, deal 1 damage\nto all enemies.",
         "type": "MINION"
+    },
+    {
+        "cardClass": "DEMONHUNTER",
+        "dbfId": 60074,
+        "health": 30,
+        "id": "BTA_01",
+        "name": "Aranna Starseeker",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 62009,
+        "id": "BTA_01p",
+        "name": "The Right Tool",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "DEMONHUNTER",
+        "dbfId": 60079,
+        "health": 30,
+        "id": "BTA_02",
+        "name": "Aranna, Unleashed",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 62010,
+        "id": "BTA_02p",
+        "name": "Slice and Dice",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO_POWER"
+    },
+    {
+        "attack": 2,
+        "cardClass": "ROGUE",
+        "cost": 3,
+        "dbfId": 60080,
+        "health": 5,
+        "id": "BTA_03",
+        "name": "Baduu, Outcast",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Battlecry:</b> Draw 2 cards. <b>Outcast:</b> Instead, draw 3 cards.",
+        "type": "MINION"
+    },
+    {
+        "attack": 3,
+        "cardClass": "DRUID",
+        "cost": 3,
+        "dbfId": 60083,
+        "health": 3,
+        "id": "BTA_05",
+        "name": "Sklibb, Outcast",
+        "set": "BLACK_TEMPLE",
+        "text": "Gain 1 Mana Crystal.<b>\nOutcast:</b> Gain another Mana Crystal.",
+        "type": "MINION"
+    },
+    {
+        "attack": 4,
+        "cardClass": "DEMONHUNTER",
+        "cost": 3,
+        "dbfId": 60084,
+        "health": 5,
+        "id": "BTA_06",
+        "name": "Sklibb, Demon Hunter",
+        "set": "BLACK_TEMPLE",
+        "text": "Gain 2 Mana Crystals . <b>Outcast:</b> Also destroy 2 of your opponent's Mana Crystals.",
+        "type": "MINION"
+    },
+    {
+        "attack": 2,
+        "cardClass": "PRIEST",
+        "cost": 3,
+        "dbfId": 60087,
+        "health": 5,
+        "id": "BTA_07",
+        "mechanics": [
+            "BATTLECRY",
+            "OUTCAST"
+        ],
+        "name": "Karnuk, Outcast",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Battlecry:</b> Restore 5 Health.\n<b>Outcast:</b> Addtionally restore 5 Health to all friendly minions.",
+        "type": "MINION"
+    },
+    {
+        "attack": 4,
+        "cardClass": "DEMONHUNTER",
+        "cost": 3,
+        "dbfId": 60088,
+        "health": 8,
+        "id": "BTA_08",
+        "name": "Karnuk, Demon Hunter",
+        "set": "BLACK_TEMPLE",
+        "type": "MINION"
+    },
+    {
+        "attack": 2,
+        "cardClass": "SHAMAN",
+        "cost": 3,
+        "dbfId": 60089,
+        "health": 4,
+        "id": "BTA_09",
+        "name": "Shal'ja, Outcast",
+        "set": "BLACK_TEMPLE",
+        "type": "MINION"
+    },
+    {
+        "attack": 3,
+        "cardClass": "DEMONHUNTER",
+        "cost": 3,
+        "dbfId": 60091,
+        "health": 5,
+        "id": "BTA_10",
+        "name": "Shal'ja, Demon Hunter",
+        "set": "BLACK_TEMPLE",
+        "type": "MINION"
+    },
+    {
+        "attack": 5,
+        "cardClass": "NEUTRAL",
+        "cost": 6,
+        "dbfId": 60119,
+        "health": 7,
+        "id": "BTA_11",
+        "mechanics": [
+            "BATTLECRY",
+            "CHARGE"
+        ],
+        "name": "Rustsworn Champion",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Charge</b>. <b>Battlecry:</b> Your opponent discards a random card.",
+        "type": "MINION"
+    },
+    {
+        "attack": 3,
+        "cardClass": "NEUTRAL",
+        "cost": 4,
+        "dbfId": 60133,
+        "health": 5,
+        "id": "BTA_12",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Rusted Legion Gan'arg",
+        "set": "BLACK_TEMPLE",
+        "text": "At the end of your turn, reduce the Cost of a random card in your hand by (3).",
+        "type": "MINION"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "dbfId": 60134,
+        "id": "BTA_12e",
+        "name": "Rust-Forged",
+        "set": "BLACK_TEMPLE",
+        "text": "Costs (3) less.",
+        "type": "ENCHANTMENT"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 3,
+        "dbfId": 60296,
+        "id": "BTA_13",
+        "name": "Deteriorate",
+        "set": "BLACK_TEMPLE",
+        "text": "Deal $3 Damage. If that kills it, summon a 4/4 Imprisoned Scrap Imp.",
+        "type": "SPELL"
+    },
+    {
+        "attack": 4,
+        "cardClass": "NEUTRAL",
+        "cost": 4,
+        "dbfId": 60298,
+        "health": 6,
+        "id": "BTA_14",
+        "mechanics": [
+            "POISONOUS",
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Rusted Basilisk",
+        "race": "BEAST",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Poisonous</b>\nAt the start of your turn, deal 1 damage to a random enemy.",
+        "type": "MINION"
+    },
+    {
+        "cardClass": "WARLOCK",
+        "cost": 5,
+        "dbfId": 60299,
+        "id": "BTA_15",
+        "name": "Endless Legion",
+        "set": "BLACK_TEMPLE",
+        "text": "Draw 3 cards. Summon any minions drawn and cast any spells drawn at random.",
+        "type": "SPELL"
+    },
+    {
+        "attack": 8,
+        "cardClass": "NEUTRAL",
+        "cost": 8,
+        "dbfId": 60316,
+        "health": 8,
+        "id": "BTA_16",
+        "mechanics": [
+            "DEATHRATTLE"
+        ],
+        "name": "Rusted Fungal Giant",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Deathrattle:</b> Summon a random Mech.",
+        "type": "MINION"
+    },
+    {
+        "attack": 1,
+        "cardClass": "NEUTRAL",
+        "cost": 2,
+        "dbfId": 60321,
+        "health": 4,
+        "id": "BTA_17",
+        "mechanics": [
+            "TAUNT",
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Rusted Voidwalker",
+        "race": "DEMON",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Taunt</b>. At the start of your turn, restore 2 health to this minion.",
+        "type": "MINION"
+    },
+    {
+        "cardClass": "DEMONHUNTER",
+        "dbfId": 60324,
+        "health": 30,
+        "id": "BTA_18",
+        "name": "Aranna in Training",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "WARLOCK",
+        "dbfId": 59774,
+        "health": 30,
+        "id": "BTA_BOSS_01h",
+        "name": "Inquisitor Dakrel",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 2,
+        "dbfId": 59791,
+        "id": "BTA_BOSS_01p",
+        "name": "Spread the Word",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Hero Power:</b> \nDestroy a friendly minion to add a random Demon or Mech to your hand.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "WARLOCK",
+        "dbfId": 60058,
+        "health": 30,
+        "id": "BTA_BOSS_02h",
+        "name": "Xur'goth",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "WARLOCK",
+        "cost": 2,
+        "dbfId": 60059,
+        "id": "BTA_BOSS_02p",
+        "name": "Rusted Gaze",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Passive Hero Power:</b> \nYour <b>Dormant</b> minions cost (2) less but take 1 additional turn to spawn whenever a friendly minion dies.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "HUNTER",
+        "dbfId": 60062,
+        "id": "BTA_BOSS_03e",
+        "mechanics": [
+            "TAG_ONE_TURN_EFFECT"
+        ],
+        "name": "Ravage",
+        "set": "BLACK_TEMPLE",
+        "text": "+3 Attack this turn.",
+        "type": "ENCHANTMENT"
+    },
+    {
+        "cardClass": "HUNTER",
+        "dbfId": 60060,
+        "health": 30,
+        "id": "BTA_BOSS_03h",
+        "name": "Zixor, Apex Predator",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "HUNTER",
+        "cost": 1,
+        "dbfId": 60061,
+        "id": "BTA_BOSS_03p",
+        "name": "Ravenous Omnivore",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Hero Power:</b> \nGain +3 Attack this turn.",
+        "type": "HERO_POWER"
+    },
+    {
+        "attack": 0,
+        "cardClass": "DRUID",
+        "cost": 1,
+        "dbfId": 60065,
+        "health": 6,
+        "id": "BTA_BOSS_03t",
+        "mechanics": [
+            "TAUNT"
+        ],
+        "name": "Glowcap Mushroom",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Taunt</b>",
+        "type": "MINION"
+    },
+    {
+        "cardClass": "WARRIOR",
+        "dbfId": 60138,
+        "health": 30,
+        "id": "BTA_BOSS_04h",
+        "name": "Baltharak",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 60142,
+        "id": "BTA_BOSS_04p",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "All Shall Serve",
+        "set": "BLACK_TEMPLE",
+        "text": "Passive Hero Power: Whenever a Demon dies, draw a card and restore 10 Health to your hero.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "WARLOCK",
+        "dbfId": 60149,
+        "health": 30,
+        "id": "BTA_BOSS_05h",
+        "name": "Kanrethad Prime",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 3,
+        "dbfId": 60150,
+        "id": "BTA_BOSS_05p",
+        "name": "Rebuild from Scrap",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Hero Power:</b> Resurrect a friendly minion that has died this game.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "WARRIOR",
+        "dbfId": 60155,
+        "health": 30,
+        "id": "BTA_BOSS_06h",
+        "name": "Burgrak Cruelchain",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 60156,
+        "id": "BTA_BOSS_06p",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Grease Monkey",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Passive Hero Power:</b> Each time a Mech dies, give both players a <b>Spare Part</b>.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 62011,
+        "id": "BTA_BOSS_06t",
+        "name": "Broken Demolisher",
+        "set": "BLACK_TEMPLE"
+    },
+    {
+        "cardClass": "WARLOCK",
+        "dbfId": 60160,
+        "health": 30,
+        "id": "BTA_BOSS_07h",
+        "name": "Felstorm Run",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "dbfId": 60161,
+        "health": 30,
+        "id": "BTA_BOSS_07h2",
+        "name": "Stolen Demolisher",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 62012,
+        "id": "BTA_BOSS_07p",
+        "name": "Felstorm Tornado",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Hero Power:</b>\nMinions are falling out of the Felstorm! <20 turns remaining to escape!>",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 2,
+        "dbfId": 60167,
+        "id": "BTA_BOSS_07p2",
+        "name": "Reroute Power",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Hero Power:</b>\n The next spell you play this turn casts twice.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "dbfId": 60168,
+        "id": "BTA_BOSS_07p2e",
+        "mechanics": [
+            "TAG_ONE_TURN_EFFECT"
+        ],
+        "name": "Reroute Power Player Enchantment",
+        "set": "BLACK_TEMPLE",
+        "text": "The next spell you play this turn casts twice.",
+        "type": "ENCHANTMENT"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 62013,
+        "id": "BTA_BOSS_07s",
+        "name": "Turbo Boost!",
+        "set": "BLACK_TEMPLE",
+        "type": "SPELL"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 2,
+        "dbfId": 60169,
+        "id": "BTA_BOSS_07s2",
+        "mechanics": [
+            "AFFECTED_BY_SPELL_POWER"
+        ],
+        "name": "Exhaust Backfire",
+        "set": "BLACK_TEMPLE",
+        "text": "Deal $2 damage to all minions.",
+        "type": "SPELL"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 2,
+        "dbfId": 60170,
+        "id": "BTA_BOSS_07s3",
+        "mechanics": [
+            "AFFECTED_BY_SPELL_POWER"
+        ],
+        "name": "Fel Cannons",
+        "set": "BLACK_TEMPLE",
+        "text": "Blast a random minion for $8 damage.",
+        "type": "SPELL"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 2,
+        "dbfId": 60173,
+        "id": "BTA_BOSS_07s4",
+        "name": "Self Repairs",
+        "set": "BLACK_TEMPLE",
+        "text": "Restore 5 Health to your Hero and gain 5 Armor.",
+        "type": "SPELL"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 62014,
+        "id": "BTA_BOSS_07s5",
+        "name": "Refueling",
+        "set": "BLACK_TEMPLE",
+        "type": "SPELL"
+    },
+    {
+        "cardClass": "WARRIOR",
+        "dbfId": 60162,
+        "health": 30,
+        "id": "BTA_BOSS_08h",
+        "name": "Mother Shahraz",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 60163,
+        "id": "BTA_BOSS_08p",
+        "name": "Parry and Riposte",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Passive Hero Power:</b>\nThe first time you are attacked each turn, prevent it and deal that damage back to the attacker.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "SHAMAN",
+        "dbfId": 61900,
+        "health": 30,
+        "id": "BTA_BOSS_09h",
+        "name": "Shal'ja, Outcast",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "DEMONHUNTER",
+        "cost": 2,
+        "dbfId": 60175,
+        "id": "BTA_BOSS_09p",
+        "name": "Fel Lightning",
+        "set": "BLACK_TEMPLE",
+        "text": "[x]<b>Hero Power:</b>\nDeal 1 damage to all \nenemy minions and then \ndeal 3 damage to the \nenemy hero.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "PRIEST",
+        "dbfId": 60239,
+        "health": 30,
+        "id": "BTA_BOSS_10h",
+        "name": "Karnuk, Outcast",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "DRUID",
+        "dbfId": 60240,
+        "health": 30,
+        "id": "BTA_BOSS_10h2",
+        "name": "Sklibb, Outcast",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 2,
+        "dbfId": 60236,
+        "id": "BTA_BOSS_10p",
+        "mechanics": [
+            "LIFESTEAL"
+        ],
+        "name": "Demonic Light",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Hero Power:</b>\n <b>Lifesteal</b>. \nDeal 2 damage.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 2,
+        "dbfId": 60241,
+        "id": "BTA_BOSS_10p2",
+        "name": "Felspores",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Hero Power:</b>\nSummon a 0/3 Felcap Mushroom with <b>Taunt</b>.",
+        "type": "HERO_POWER"
+    },
+    {
+        "attack": 0,
+        "cardClass": "NEUTRAL",
+        "cost": 2,
+        "dbfId": 60242,
+        "health": 3,
+        "id": "BTA_BOSS_10t",
+        "mechanics": [
+            "TAUNT"
+        ],
+        "name": "Felcap Mushroom",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Taunt</b>",
+        "type": "MINION"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "dbfId": 60246,
+        "id": "BTA_BOSS_11e",
+        "name": "Rocket Powered",
+        "set": "BLACK_TEMPLE",
+        "text": "Powered by rockets!",
+        "type": "ENCHANTMENT"
+    },
+    {
+        "cardClass": "ROGUE",
+        "dbfId": 61901,
+        "health": 30,
+        "id": "BTA_BOSS_11h",
+        "name": "Jek'haz",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 60244,
+        "id": "BTA_BOSS_11p",
+        "name": "Rocket Wings",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Passive Hero Power:</b>\nYour minions have <b>Rush</b> and <b>Windfury</b>.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 60245,
+        "id": "BTA_BOSS_11pe",
+        "mechanics": [
+            "AURA"
+        ],
+        "name": "Rocket Wings Player Enchant",
+        "set": "BLACK_TEMPLE"
+    },
+    {
+        "cardClass": "WARLOCK",
+        "dbfId": 60271,
+        "health": 30,
+        "id": "BTA_BOSS_12h",
+        "name": "Magtheridon Prime",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 60272,
+        "id": "BTA_BOSS_12p",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "From My Oil Comes Rust",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Passive Hero Power:</b> \nWhenever your hero takes damage, summon a \n2/2 Rusted Fel Orc.",
+        "type": "HERO_POWER"
+    },
+    {
+        "attack": 2,
+        "cardClass": "NEUTRAL",
+        "cost": 2,
+        "dbfId": 60273,
+        "health": 2,
+        "id": "BTA_BOSS_12t",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Rusted Fel Orc",
+        "set": "BLACK_TEMPLE",
+        "text": "Whenever this minion attacks, give all Rusted Fel Orcs +1 Attack.",
+        "type": "MINION"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "dbfId": 62040,
+        "id": "BTA_BOSS_12te",
+        "name": "Rusted Rage",
+        "set": "BLACK_TEMPLE",
+        "text": "Has +1 Attack.",
+        "type": "ENCHANTMENT"
+    },
+    {
+        "cardClass": "MAGE",
+        "dbfId": 60274,
+        "health": 30,
+        "id": "BTA_BOSS_13h",
+        "name": "Gok'amok",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 2,
+        "dbfId": 60275,
+        "id": "BTA_BOSS_13p",
+        "name": "Second Opinion",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Hero Power:</b>\nCast a random Warlock or Mage spell.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "WARLOCK",
+        "dbfId": 61902,
+        "health": 15,
+        "id": "BTA_BOSS_14h",
+        "name": "Flikk",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "WARRIOR",
+        "dbfId": 62015,
+        "health": 30,
+        "id": "BTA_BOSS_14h2",
+        "name": "Rusted Fel Reaver",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "WARLOCK",
+        "cost": 1,
+        "dbfId": 61904,
+        "id": "BTA_BOSS_14p",
+        "name": "Summon Scrap Imp",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Hero Power:</b> \nSummon a Mecha-Imp.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 2,
+        "dbfId": 60292,
+        "id": "BTA_BOSS_14p2",
+        "name": "Hulking Monstrosity",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Hero Power:</b>\nGive a friendly minion +5 Attack.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "dbfId": 60293,
+        "id": "BTA_BOSS_14p2e",
+        "name": "Fueled by Fel",
+        "set": "BLACK_TEMPLE",
+        "text": "Has +5 Attack.",
+        "type": "ENCHANTMENT"
+    },
+    {
+        "cardClass": "ROGUE",
+        "dbfId": 59824,
+        "health": 30,
+        "id": "BTA_BOSS_15h",
+        "name": "Baduu, Corrupted",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 59825,
+        "id": "BTA_BOSS_15p",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Corrupted by Rust",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Passive Hero Power:</b>\n Whenever a friendly minion with <b>Stealth</b> attacks, add a random Demon to your hand.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "WARLOCK",
+        "dbfId": 60289,
+        "health": 50,
+        "id": "BTA_BOSS_16h",
+        "name": "Mecha-Jaraxxus",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "WARLOCK",
+        "cost": 0,
+        "dbfId": 61920,
+        "id": "BTA_BOSS_16p",
+        "name": "Powered by Fel and Hatred",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Hero Power:</b>\nActivate whichever Generator has more power. If they are equal, disable this for two turns.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 60287,
+        "id": "BTA_BOSS_16s",
+        "name": "Demonic Forging",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Discover</b> a Demon and summon 2 Dormant copies of it.",
+        "type": "SPELL"
+    },
+    {
+        "attack": 0,
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 61921,
+        "health": 0,
+        "id": "BTA_BOSS_16t",
+        "name": "Fel Reactor",
+        "set": "BLACK_TEMPLE",
+        "type": "MINION"
+    },
+    {
+        "attack": 0,
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 61922,
+        "health": 0,
+        "id": "BTA_BOSS_16t2",
+        "name": "Hatred Reactor",
+        "set": "BLACK_TEMPLE",
+        "type": "MINION"
+    },
+    {
+        "cardClass": "DEMONHUNTER",
+        "dbfId": 60290,
+        "health": 30,
+        "id": "BTA_BOSS_17h",
+        "name": "Illidan Stormrage",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 60291,
+        "id": "BTA_BOSS_17p",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Burning Rage",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Passive Hero Power:</b>\nWhenever your hero attacks, deal 1 damage to all enemies.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "WARLOCK",
+        "dbfId": 60325,
+        "health": 30,
+        "id": "BTA_BOSS_18h",
+        "name": "Doom Lord Kazzak",
+        "set": "BLACK_TEMPLE",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 60326,
+        "id": "BTA_BOSS_18p",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Twisted Reflection",
+        "set": "BLACK_TEMPLE",
+        "text": "<b>Passive Hero Power:</b>\n Whenever an enemy minion dies, restore 5 Health to your hero.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 60333,
+        "id": "BTA_BOSS_19h",
+        "name": "Magtheridon",
+        "set": "BLACK_TEMPLE"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 60334,
+        "id": "BTA_BOSS_19p",
+        "name": "Blast Nova",
+        "set": "BLACK_TEMPLE"
     },
     {
         "artist": "James Ryman",
@@ -23382,14 +24208,14 @@
     },
     {
         "cardClass": "PRIEST",
-        "cost": 2,
-        "dbfId": 479,
-        "id": "CS1h_001",
-        "name": "Lesser Heal",
+        "cost": 1,
+        "dbfId": 62850,
+        "id": "CS1_130_Puzzle",
+        "name": "Holy Smite",
         "rarity": "FREE",
         "set": "CORE",
-        "text": "<b>Hero Power</b>\nRestore #2 Health.",
-        "type": "HERO_POWER"
+        "text": "Deal $2 damage.",
+        "type": "SPELL"
     },
     {
         "cardClass": "PRIEST",
@@ -23474,6 +24300,17 @@
         "rarity": "FREE",
         "set": "CORE",
         "text": "Give a minion +2 Health.",
+        "type": "SPELL"
+    },
+    {
+        "cardClass": "PRIEST",
+        "cost": 0,
+        "dbfId": 62917,
+        "id": "CS2_004_Puzzle",
+        "name": "Power Word: Shield",
+        "rarity": "FREE",
+        "set": "CORE",
+        "text": "Give a minion +2 Health.\nDraw a card.",
         "type": "SPELL"
     },
     {
@@ -23642,17 +24479,6 @@
         "set": "CORE",
         "text": "Draw a card. <i>(You can only have 10 Mana in your tray.)</i>",
         "type": "SPELL"
-    },
-    {
-        "cardClass": "DRUID",
-        "cost": 2,
-        "dbfId": 1123,
-        "id": "CS2_017",
-        "name": "Shapeshift",
-        "rarity": "FREE",
-        "set": "CORE",
-        "text": "<b>Hero Power</b>\n+1 Attack this turn.\n+1 Armor.",
-        "type": "HERO_POWER"
     },
     {
         "cardClass": "DRUID",
@@ -23919,18 +24745,6 @@
     {
         "cardClass": "MAGE",
         "cost": 2,
-        "dbfId": 807,
-        "id": "CS2_034",
-        "name": "Fireblast",
-        "rarity": "FREE",
-        "set": "CORE",
-        "targetingArrowText": "Deal 1 damage.",
-        "text": "<b>Hero Power</b>\nDeal $1 damage.",
-        "type": "HERO_POWER"
-    },
-    {
-        "cardClass": "MAGE",
-        "cost": 2,
         "dbfId": 2831,
         "id": "CS2_034_H1",
         "name": "Fireblast",
@@ -24181,17 +24995,6 @@
     {
         "cardClass": "SHAMAN",
         "cost": 2,
-        "dbfId": 687,
-        "id": "CS2_049",
-        "name": "Totemic Call",
-        "rarity": "FREE",
-        "set": "CORE",
-        "text": "<b>Hero Power</b>\nSummon a random Totem.",
-        "type": "HERO_POWER"
-    },
-    {
-        "cardClass": "SHAMAN",
-        "cost": 2,
         "dbfId": 40247,
         "id": "CS2_049_H1",
         "name": "Totemic Call",
@@ -24355,17 +25158,6 @@
         "set": "EXPERT1",
         "text": "One of your cards costs (3) less.",
         "type": "ENCHANTMENT"
-    },
-    {
-        "cardClass": "WARLOCK",
-        "cost": 2,
-        "dbfId": 300,
-        "id": "CS2_056",
-        "name": "Life Tap",
-        "rarity": "FREE",
-        "set": "CORE",
-        "text": "<b>Hero Power</b>\nDraw a card and take $2 damage.",
-        "type": "HERO_POWER"
     },
     {
         "cardClass": "WARLOCK",
@@ -24714,17 +25506,6 @@
     {
         "cardClass": "ROGUE",
         "cost": 2,
-        "dbfId": 730,
-        "id": "CS2_083b",
-        "name": "Dagger Mastery",
-        "rarity": "FREE",
-        "set": "CORE",
-        "text": "<b>Hero Power</b>\nEquip a 1/2 Dagger.",
-        "type": "HERO_POWER"
-    },
-    {
-        "cardClass": "ROGUE",
-        "cost": 2,
         "dbfId": 45821,
         "id": "CS2_083b_H1",
         "name": "Dagger Mastery",
@@ -24941,17 +25722,6 @@
     {
         "cardClass": "PALADIN",
         "cost": 2,
-        "dbfId": 472,
-        "id": "CS2_101",
-        "name": "Reinforce",
-        "rarity": "FREE",
-        "set": "CORE",
-        "text": "<b>Hero Power</b>\nSummon a 1/1 Silver Hand Recruit.",
-        "type": "HERO_POWER"
-    },
-    {
-        "cardClass": "PALADIN",
-        "cost": 2,
         "dbfId": 2832,
         "id": "CS2_101_H1",
         "name": "Reinforce",
@@ -25037,17 +25807,6 @@
         "rarity": "FREE",
         "set": "CORE",
         "type": "MINION"
-    },
-    {
-        "cardClass": "WARRIOR",
-        "cost": 2,
-        "dbfId": 725,
-        "id": "CS2_102",
-        "name": "Armor Up!",
-        "rarity": "FREE",
-        "set": "CORE",
-        "text": "<b>Hero Power</b>\nGain 2 Armor.",
-        "type": "HERO_POWER"
     },
     {
         "cardClass": "WARRIOR",
@@ -37144,7 +37903,7 @@
         "attack": 4,
         "cardClass": "NEUTRAL",
         "collectible": true,
-        "cost": 3,
+        "cost": 4,
         "dbfId": 55421,
         "flavor": "Legend holds that it's bad luck to harm it. So maybe just pat it on the head, okay?",
         "health": 3,
@@ -42944,18 +43703,6 @@
         "cardClass": "HUNTER",
         "collectionText": "<b>Hero Power</b>\nDeal $2 damage.",
         "cost": 2,
-        "dbfId": 229,
-        "id": "DS1h_292",
-        "name": "Steady Shot",
-        "rarity": "FREE",
-        "set": "CORE",
-        "text": "<b>Hero Power</b>\nDeal $2 damage to the enemy hero.",
-        "type": "HERO_POWER"
-    },
-    {
-        "cardClass": "HUNTER",
-        "collectionText": "<b>Hero Power</b>\nDeal $2 damage.",
-        "cost": 2,
         "dbfId": 2833,
         "id": "DS1h_292_H1",
         "name": "Steady Shot",
@@ -45550,7 +46297,7 @@
             "BATTLECRY"
         ],
         "name": "Psychic Conjurer",
-        "rarity": "COMMON",
+        "rarity": "FREE",
         "set": "CORE",
         "text": "<b>Battlecry:</b> Copy a card in your opponent’s deck and add it to your hand.",
         "type": "MINION"
@@ -45564,7 +46311,7 @@
         "flavor": "It infuses, it enthuses, it amuses!",
         "id": "EX1_194",
         "name": "Power Infusion",
-        "rarity": "COMMON",
+        "rarity": "FREE",
         "set": "CORE",
         "text": "Give a minion +2/+6.",
         "type": "SPELL"
@@ -62738,6 +63485,27 @@
     },
     {
         "cardClass": "WARRIOR",
+        "cost": 2,
+        "dbfId": 725,
+        "id": "HERO_01bp",
+        "name": "Armor Up!",
+        "rarity": "FREE",
+        "set": "CORE",
+        "text": "<b>Hero Power</b>\nGain 2 Armor.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "WARRIOR",
+        "cost": 2,
+        "dbfId": 2745,
+        "id": "HERO_01bp2",
+        "name": "Tank Up!",
+        "set": "CORE",
+        "text": "<b>Hero Power</b>\nGain 4 Armor.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "WARRIOR",
         "collectible": true,
         "dbfId": 58787,
         "health": 30,
@@ -62779,6 +63547,27 @@
         "rarity": "FREE",
         "set": "HERO_SKINS",
         "type": "HERO"
+    },
+    {
+        "cardClass": "SHAMAN",
+        "cost": 2,
+        "dbfId": 687,
+        "id": "HERO_02bp",
+        "name": "Totemic Call",
+        "rarity": "FREE",
+        "set": "CORE",
+        "text": "<b>Hero Power</b>\nSummon a random Totem.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "SHAMAN",
+        "cost": 2,
+        "dbfId": 2742,
+        "id": "HERO_02bp2",
+        "name": "Totemic Slam",
+        "set": "CORE",
+        "text": "<b>Hero Power</b>\nSummon a Totem of your choice.",
+        "type": "HERO_POWER"
     },
     {
         "cardClass": "SHAMAN",
@@ -62847,6 +63636,27 @@
         "type": "HERO"
     },
     {
+        "cardClass": "ROGUE",
+        "cost": 2,
+        "dbfId": 730,
+        "id": "HERO_03bp",
+        "name": "Dagger Mastery",
+        "rarity": "FREE",
+        "set": "CORE",
+        "text": "<b>Hero Power</b>\nEquip a 1/2 Dagger.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "ROGUE",
+        "cost": 2,
+        "dbfId": 2743,
+        "id": "HERO_03bp2",
+        "name": "Poisoned Daggers",
+        "set": "CORE",
+        "text": "<b>Hero Power</b>\nEquip a 2/2 Weapon.",
+        "type": "HERO_POWER"
+    },
+    {
         "cardClass": "PALADIN",
         "collectible": true,
         "dbfId": 671,
@@ -62878,6 +63688,27 @@
         "rarity": "EPIC",
         "set": "HERO_SKINS",
         "type": "HERO"
+    },
+    {
+        "cardClass": "PALADIN",
+        "cost": 2,
+        "dbfId": 472,
+        "id": "HERO_04bp",
+        "name": "Reinforce",
+        "rarity": "FREE",
+        "set": "CORE",
+        "text": "<b>Hero Power</b>\nSummon a 1/1 Silver Hand Recruit.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "PALADIN",
+        "cost": 2,
+        "dbfId": 2740,
+        "id": "HERO_04bp2",
+        "name": "The Silver Hand",
+        "set": "CORE",
+        "text": "<b>Hero Power</b>\nSummon two 1/1 Recruits.",
+        "type": "HERO_POWER"
     },
     {
         "cardClass": "PALADIN",
@@ -62936,6 +63767,29 @@
     },
     {
         "cardClass": "HUNTER",
+        "collectionText": "<b>Hero Power</b>\nDeal $2 damage.",
+        "cost": 2,
+        "dbfId": 229,
+        "id": "HERO_05bp",
+        "name": "Steady Shot",
+        "rarity": "FREE",
+        "set": "CORE",
+        "text": "<b>Hero Power</b>\nDeal $2 damage to the enemy hero.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "HUNTER",
+        "collectionText": "<b>Hero Power</b>\nDeal $3 damage.",
+        "cost": 2,
+        "dbfId": 2738,
+        "id": "HERO_05bp2",
+        "name": "Ballista Shot",
+        "set": "CORE",
+        "text": "<b>Hero Power</b>\nDeal $3 damage to the enemy hero.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "HUNTER",
         "collectible": true,
         "dbfId": 60335,
         "health": 30,
@@ -62978,6 +63832,27 @@
         "rarity": "EPIC",
         "set": "HERO_SKINS",
         "type": "HERO"
+    },
+    {
+        "cardClass": "DRUID",
+        "cost": 2,
+        "dbfId": 1123,
+        "id": "HERO_06bp",
+        "name": "Shapeshift",
+        "rarity": "FREE",
+        "set": "CORE",
+        "text": "<b>Hero Power</b>\n+1 Attack this turn.\n+1 Armor.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "DRUID",
+        "cost": 2,
+        "dbfId": 2737,
+        "id": "HERO_06bp2",
+        "name": "Dire Shapeshift",
+        "set": "CORE",
+        "text": "<b>Hero Power</b>\n+2 Attack this turn.\n+2 Armor.",
+        "type": "HERO_POWER"
     },
     {
         "cardClass": "DRUID",
@@ -63036,6 +63911,27 @@
     },
     {
         "cardClass": "WARLOCK",
+        "cost": 2,
+        "dbfId": 300,
+        "id": "HERO_07bp",
+        "name": "Life Tap",
+        "rarity": "FREE",
+        "set": "CORE",
+        "text": "<b>Hero Power</b>\nDraw a card and take $2 damage.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "WARLOCK",
+        "cost": 2,
+        "dbfId": 2744,
+        "id": "HERO_07bp2",
+        "name": "Soul Tap",
+        "set": "CORE",
+        "text": "<b>Hero Power</b>\nDraw a card.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "WARLOCK",
         "collectible": true,
         "dbfId": 57763,
         "health": 30,
@@ -63077,6 +63973,28 @@
         "rarity": "EPIC",
         "set": "HERO_SKINS",
         "type": "HERO"
+    },
+    {
+        "cardClass": "MAGE",
+        "cost": 2,
+        "dbfId": 807,
+        "id": "HERO_08bp",
+        "name": "Fireblast",
+        "rarity": "FREE",
+        "set": "CORE",
+        "targetingArrowText": "Deal 1 damage.",
+        "text": "<b>Hero Power</b>\nDeal $1 damage.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "MAGE",
+        "cost": 2,
+        "dbfId": 2739,
+        "id": "HERO_08bp2",
+        "name": "Fireblast Rank 2",
+        "set": "CORE",
+        "text": "<b>Hero Power</b>\nDeal $2 damage.",
+        "type": "HERO_POWER"
     },
     {
         "cardClass": "MAGE",
@@ -63134,6 +64052,27 @@
     },
     {
         "cardClass": "PRIEST",
+        "cost": 2,
+        "dbfId": 479,
+        "id": "HERO_09bp",
+        "name": "Lesser Heal",
+        "rarity": "FREE",
+        "set": "CORE",
+        "text": "<b>Hero Power</b>\nRestore #2 Health.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "PRIEST",
+        "cost": 2,
+        "dbfId": 2741,
+        "id": "HERO_09bp2",
+        "name": "Heal",
+        "set": "CORE",
+        "text": "<b>Hero Power</b>\nRestore #4 Health.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "PRIEST",
         "collectible": true,
         "dbfId": 57767,
         "health": 30,
@@ -63171,7 +64110,7 @@
         "cardClass": "DEMONHUNTER",
         "cost": 1,
         "dbfId": 60224,
-        "id": "HERO_10p",
+        "id": "HERO_10bp",
         "name": "Demon Claws",
         "set": "CORE",
         "text": "[x]<b>Hero Power</b>\n+1 Attack this turn.",
@@ -63182,7 +64121,7 @@
         "cardClass": "DEMONHUNTER",
         "cost": 1,
         "dbfId": 60483,
-        "id": "HERO_10p_UP",
+        "id": "HERO_10bp2",
         "name": "Demon's Bite",
         "set": "CORE",
         "text": "[x]<b>Hero Power</b>\n+2 Attack this turn.",
@@ -63191,7 +64130,7 @@
     {
         "cardClass": "DEMONHUNTER",
         "dbfId": 56723,
-        "id": "HERO_10pe",
+        "id": "HERO_10bpe",
         "mechanics": [
             "TAG_ONE_TURN_EFFECT"
         ],
@@ -63203,7 +64142,7 @@
     {
         "cardClass": "DEMONHUNTER",
         "dbfId": 59837,
-        "id": "HERO_10pe_UP",
+        "id": "HERO_10pe2",
         "mechanics": [
             "TAG_ONE_TURN_EFFECT"
         ],
@@ -78137,7 +79076,6 @@
     },
     {
         "cardClass": "NEUTRAL",
-        "collectible": true,
         "collectionText": " |4(Candle, Candles).",
         "dbfId": 61009,
         "id": "LOOT_526e",
@@ -83295,7 +84233,7 @@
         "name": "Sacrificial Pact",
         "rarity": "FREE",
         "set": "CORE",
-        "text": "Destroy a Demon. Restore #5 Health to your hero.",
+        "text": "Destroy a friendly Demon. Restore #5 Health to your hero.",
         "type": "SPELL"
     },
     {
@@ -89230,6 +90168,39 @@
         "type": "HERO"
     },
     {
+        "battlegroundsHero": true,
+        "cardClass": "NEUTRAL",
+        "dbfId": 61912,
+        "health": 40,
+        "hideCost": true,
+        "id": "TB_BaconShop_HERO_60",
+        "name": "Kael'thas Sunstrider",
+        "set": "BATTLEGROUNDS",
+        "type": "HERO"
+    },
+    {
+        "battlegroundsHero": true,
+        "cardClass": "NEUTRAL",
+        "dbfId": 61913,
+        "health": 40,
+        "hideCost": true,
+        "id": "TB_BaconShop_HERO_61",
+        "name": "Lady Vashj",
+        "set": "BATTLEGROUNDS",
+        "type": "HERO"
+    },
+    {
+        "battlegroundsHero": true,
+        "cardClass": "NEUTRAL",
+        "dbfId": 61914,
+        "health": 40,
+        "hideCost": true,
+        "id": "TB_BaconShop_HERO_62",
+        "name": "Maiev Shadowsong",
+        "set": "BATTLEGROUNDS",
+        "type": "HERO"
+    },
+    {
         "cardClass": "NEUTRAL",
         "dbfId": 59194,
         "health": 0,
@@ -89902,7 +90873,7 @@
         "id": "TB_BaconShop_HP_054",
         "name": "Manastorm",
         "set": "BATTLEGROUNDS",
-        "text": "[x]<b>Passive Hero Power</b>\nMinions cost 2 Gold.\n<b>Refresh</b> costs 2 Gold.",
+        "text": "<b>Passive Hero Power</b>\nMinions cost 2 Gold\n<b>Refresh</b> costs 2 Gold.\n Tavern Tiers cost (1) more.",
         "type": "HERO_POWER"
     },
     {
@@ -90019,6 +90990,83 @@
         "set": "BATTLEGROUNDS",
         "text": "[x]<b>Passive Hero Power</b>\nAfter you upgrade Bob's\nTavern to Tavern Tier 5,\n<b>Discover</b> two Dragons.",
         "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 0,
+        "dbfId": 61917,
+        "hideCost": true,
+        "id": "TB_BaconShop_HP_066",
+        "name": "Verdant Spheres",
+        "set": "BATTLEGROUNDS",
+        "text": "[x]<b>Passive Hero Power</b>\nEvery third minion you\nbuy gains +2/+2.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "dbfId": 62149,
+        "id": "TB_BaconShop_HP_066e",
+        "name": "Verdant!",
+        "set": "BATTLEGROUNDS",
+        "text": "+2/+2.",
+        "type": "ENCHANTMENT"
+    },
+    {
+        "cardClass": "SHAMAN",
+        "cost": 0,
+        "dbfId": 61918,
+        "hideCost": true,
+        "id": "TB_BaconShop_HP_067",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Evolving Electricity",
+        "set": "BATTLEGROUNDS",
+        "text": "[x]<b>Passive Hero Power</b>\nAfter you upgrade Bob's\nTavern, replace his minions\n   with ones of a higher Tier.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "cost": 1,
+        "dbfId": 61919,
+        "id": "TB_BaconShop_HP_068",
+        "name": "Imprison",
+        "set": "BATTLEGROUNDS",
+        "text": "[x]<b>Hero Power</b>\nMake a minion in Bob's\nTavern <b>Dormant</b>. After 2\n  turns, get it with +1/+1.",
+        "type": "HERO_POWER"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "collectionText": " |4(turn, turns).",
+        "dbfId": 61936,
+        "id": "TB_BaconShop_HP_068e",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Imprisoned",
+        "set": "BATTLEGROUNDS",
+        "text": "<b>Dormant</b>. Awaken in",
+        "type": "ENCHANTMENT"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "dbfId": 62265,
+        "id": "TB_BaconShop_HP_068e2",
+        "name": "Awakened",
+        "set": "BATTLEGROUNDS",
+        "text": "+1/+1.",
+        "type": "ENCHANTMENT"
+    },
+    {
+        "cardClass": "NEUTRAL",
+        "dbfId": 62006,
+        "id": "TB_BaconShop_HP_068pe",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "ImprisonedWatcher",
+        "set": "BATTLEGROUNDS",
+        "type": "ENCHANTMENT"
     },
     {
         "cardClass": "DEMONHUNTER",
@@ -92583,6 +93631,36 @@
         "dbfId": 61935,
         "id": "TB_BaconUps_124e",
         "name": "Felfin Fueled",
+        "set": "BATTLEGROUNDS",
+        "text": "+2/+2.",
+        "type": "ENCHANTMENT"
+    },
+    {
+        "attack": 6,
+        "battlegroundsNormalDbfId": 62162,
+        "cardClass": "HUNTER",
+        "cost": 3,
+        "dbfId": 62165,
+        "health": 2,
+        "id": "TB_BaconUps_125",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Rabid Saurolisk",
+        "race": "BEAST",
+        "referencedTags": [
+            "DEATHRATTLE"
+        ],
+        "set": "BATTLEGROUNDS",
+        "techLevel": 1,
+        "text": "After you play a minion with <b>Deathrattle</b>, gain +2/+2.",
+        "type": "MINION"
+    },
+    {
+        "cardClass": "HUNTER",
+        "dbfId": 62166,
+        "id": "TB_BaconUps_125e",
+        "name": "Rabid",
         "set": "BATTLEGROUNDS",
         "text": "+2/+2.",
         "type": "ENCHANTMENT"
@@ -104283,6 +105361,7 @@
         "health": 8,
         "id": "TRL_535",
         "mechanics": [
+            "ADJACENT_BUFF",
             "TRIGGER_VISUAL"
         ],
         "name": "Snapjaw Shellfighter",
@@ -106305,6 +107384,7 @@
         "health": 4,
         "id": "TRLA_172",
         "mechanics": [
+            "ADJACENT_BUFF",
             "START_OF_GAME"
         ],
         "name": "Rallying Quilboar",
@@ -111890,13 +112970,13 @@
     },
     {
         "artist": "James Ryman",
-        "attack": 3,
+        "attack": 2,
         "cardClass": "WARRIOR",
         "collectible": true,
         "cost": 3,
         "dbfId": 54492,
         "flavor": "You look really hurt. You could use a friend!",
-        "health": 3,
+        "health": 2,
         "id": "ULD_720",
         "mechanics": [
             "BATTLECRY"
@@ -117142,7 +118222,7 @@
     },
     {
         "cardClass": "WARLOCK",
-        "dbfId": 57568,
+        "dbfId": 63097,
         "id": "ULDA_BOSS_72e",
         "name": "Cursed!",
         "set": "ULDUM",
@@ -118932,7 +120012,7 @@
         "questReward": "UNG_028t",
         "rarity": "LEGENDARY",
         "set": "UNGORO",
-        "text": "[x]<b>Quest:</b> Cast 6 spells that\ndidn't start in your deck.\n<b>Reward:</b> Time Warp.",
+        "text": "[x]<b>Quest:</b> Cast 8 spells that\ndidn't start in your deck.\n<b>Reward:</b> Time Warp.",
         "type": "SPELL"
     },
     {
@@ -120728,7 +121808,7 @@
         "artist": "Tyler Walpole",
         "cardClass": "WARLOCK",
         "collectible": true,
-        "cost": 2,
+        "cost": 4,
         "dbfId": 41872,
         "flavor": "Help save mana.  Donate blood today!",
         "id": "UNG_832",
@@ -123383,7 +124463,7 @@
         "cost": 4,
         "dbfId": 56122,
         "flavor": "Not to be confused with the \"friendsy” felwing.",
-        "health": 3,
+        "health": 2,
         "id": "YOD_032",
         "name": "Frenzied Felwing",
         "race": "DEMON",

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2098,10 +2098,11 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // [NEW1_003] Sacrificial Pact - COST:0
     // - Set: Core, Rarity: Free
     // --------------------------------------------------------
-    // Text: Destroy a Demon. Restore 5 Health to your hero.
+    // Text: Destroy a friendly Demon. Restore 5 Health to your hero.
     // --------------------------------------------------------
     // PlayReq:
     // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_FRIENDLY_TARGET = 0
     // - REQ_TARGET_WITH_RACE = 15
     // --------------------------------------------------------
     power.ClearData();
@@ -2110,6 +2111,7 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     cards.emplace(
         "NEW1_003",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_FRIENDLY_TARGET, 0 },
                                  { PlayReq::REQ_TARGET_WITH_RACE, 15 } }));
 }
 
@@ -2433,7 +2435,7 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_352", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [BT_495] Glaivebound Adept (*) - COST:5 [ATK:7/HP:4]
+    // [BT_495] Glaivebound Adept (*) - COST:5 [ATK:6/HP:4]
     // - Set: Core, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> If your hero attacked this turn,

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2497,7 +2497,7 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // GameTag:
     // - LIFESTEAL = 1
-    // - DURABILITY = 3
+    // - DURABILITY = 2
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -174,51 +174,18 @@ void CoreCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 {
     Power power;
 
-    // ------------------------------------ HERO_POWER - PRIEST
-    // [CS1h_001] Lesser Heal (*) - COST:2
+    // ----------------------------------- HERO_POWER - WARRIOR
+    // [HERO_01bp] Armor Up! (*) - COST:2
     // - Faction: Neutral, Set: Core, Rarity: Free
     // --------------------------------------------------------
-    // Text: <b>Hero Power</b> Restore 2 Health.
-    // --------------------------------------------------------
-    // PlayReq:
-    // - REQ_TARGET_TO_PLAY = 0
+    // Text: <b>Hero Power</b> Gain 2 Armor.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<HealTask>(EntityType::TARGET, 2));
-    cards.emplace(
-        "CS1h_001",
-        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
-
-    // ------------------------------------- HERO_POWER - DRUID
-    // [CS2_017] Shapeshift (*) - COST:2
-    // - Faction: Neutral, Set: Core, Rarity: Free
-    // --------------------------------------------------------
-    // Text: <b>Hero Power</b> +1 Attack this turn. +1 Armor.
-    // --------------------------------------------------------
-    power.ClearData();
-    power.AddPowerTask(
-        std::make_shared<AddEnchantmentTask>("CS2_017o", EntityType::HERO));
-    power.AddPowerTask(std::make_shared<ArmorTask>(1));
-    cards.emplace("CS2_017", CardDef(power));
-
-    // -------------------------------------- HERO_POWER - MAGE
-    // [CS2_034] Fireblast (*) - COST:2
-    // - Faction: Neutral, Set: Core, Rarity: Free
-    // --------------------------------------------------------
-    // Text: <b>Hero Power</b> Deal 1 damage.
-    // --------------------------------------------------------
-    // PlayReq:
-    // - REQ_TARGET_TO_PLAY = 0
-    // --------------------------------------------------------
-    power.ClearData();
-    power.AddPowerTask(
-        std::make_shared<DamageTask>(EntityType::TARGET, 1, false));
-    cards.emplace(
-        "CS2_034",
-        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
+    power.AddPowerTask(std::make_shared<ArmorTask>(2));
+    cards.emplace("HERO_01bp", CardDef(power));
 
     // ------------------------------------ HERO_POWER - SHAMAN
-    // [CS2_049] Totemic Call (*) - COST:2
+    // [HERO_02bp] Totemic Call (*) - COST:2
     // - Faction: Neutral, Set: Core, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Summon a random Totem.
@@ -266,37 +233,25 @@ void CoreCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
         return 0;
     }));
     cards.emplace(
-        "CS2_049",
+        "HERO_02bp",
         CardDef(power,
                 PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 },
                           { PlayReq::REQ_ENTIRE_ENTOURAGE_NOT_IN_PLAY, 0 } },
                 ChooseCardIDs{},
                 Entourages{ "CS2_050", "CS2_051", "CS2_052", "NEW1_009" }));
 
-    // ----------------------------------- HERO_POWER - WARLOCK
-    // [CS2_056] Life Tap (*) - COST:2
-    // - Faction: Neutral, Set: Core, Rarity: Free
-    // --------------------------------------------------------
-    // Text: <b>Hero Power</b> Draw a card and take 2 damage.
-    // --------------------------------------------------------
-    power.ClearData();
-    power.AddPowerTask(
-        std::make_shared<DamageTask>(EntityType::HERO, 2, false));
-    power.AddPowerTask(std::make_shared<DrawTask>(1));
-    cards.emplace("CS2_056", CardDef(power));
-
     // ------------------------------------- HERO_POWER - ROGUE
-    // [CS2_083b] Dagger Mastery (*) - COST:2
+    // [HERO_03bp] Dagger Mastery (*) - COST:2
     // - Faction: Neutral, Set: Core, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Equip a 1/2 Dagger.
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(std::make_shared<WeaponTask>("CS2_082"));
-    cards.emplace("CS2_083b", CardDef(power));
+    cards.emplace("HERO_03bp", CardDef(power));
 
     // ----------------------------------- HERO_POWER - PALADIN
-    // [CS2_101] Reinforce (*) - COST:2
+    // [HERO_04bp] Reinforce (*) - COST:2
     // - Faction: Neutral, Set: Core, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Summon a 1/1 Silver Hand Recruit.
@@ -308,21 +263,11 @@ void CoreCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     power.AddPowerTask(
         std::make_shared<SummonTask>("CS2_101t", SummonSide::DEFAULT));
     cards.emplace(
-        "CS2_101",
+        "HERO_04bp",
         CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
-    // ----------------------------------- HERO_POWER - WARRIOR
-    // [CS2_102] Armor Up! (*) - COST:2
-    // - Faction: Neutral, Set: Core, Rarity: Free
-    // --------------------------------------------------------
-    // Text: <b>Hero Power</b> Gain 2 Armor.
-    // --------------------------------------------------------
-    power.ClearData();
-    power.AddPowerTask(std::make_shared<ArmorTask>(2));
-    cards.emplace("CS2_102", CardDef(power));
-
     // ------------------------------------ HERO_POWER - HUNTER
-    // [DS1h_292] Steady Shot (*) - COST:2
+    // [HERO_05bp] Steady Shot (*) - COST:2
     // - Faction: Neutral, Set: Core, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Deal 2 damage to the enemy hero.
@@ -335,31 +280,86 @@ void CoreCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     power.AddPowerTask(
         std::make_shared<DamageTask>(EntityType::TARGET, 2, false));
     cards.emplace(
-        "DS1h_292",
+        "HERO_05bp",
         CardDef(power, PlayReqs{ { PlayReq::REQ_STEADY_SHOT, 0 },
                                  { PlayReq::REQ_MINION_OR_ENEMY_HERO, 0 } }));
 
+    // ------------------------------------- HERO_POWER - DRUID
+    // [HERO_06bp] Shapeshift (*) - COST:2
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b> +1 Attack this turn. +1 Armor.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("CS2_017o", EntityType::HERO));
+    power.AddPowerTask(std::make_shared<ArmorTask>(1));
+    cards.emplace("HERO_06bp", CardDef(power));
+
+    // ----------------------------------- HERO_POWER - WARLOCK
+    // [HERO_07bp] Life Tap (*) - COST:2
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b> Draw a card and take 2 damage.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::HERO, 2, false));
+    power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cards.emplace("HERO_07bp", CardDef(power));
+
+    // -------------------------------------- HERO_POWER - MAGE
+    // [HERO_08bp] Fireblast (*) - COST:2
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b> Deal 1 damage.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 1, false));
+    cards.emplace(
+        "HERO_08bp",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
+
+    // ------------------------------------ HERO_POWER - PRIEST
+    // [HERO_09bp] Lesser Heal (*) - COST:2
+    // - Faction: Neutral, Set: Core, Rarity: Free
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b> Restore 2 Health.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<HealTask>(EntityType::TARGET, 2));
+    cards.emplace(
+        "HERO_09bp",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
+
     // ------------------------------- HERO_POWER - DEMONHUNTER
-    // [HERO_10p] Demon Claws (*) - COST:1
+    // [HERO_10bp] Demon Claws (*) - COST:1
     // - Faction: Neutral, Set: Core, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> +1 Attack this turn.
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(
-        std::make_shared<AddEnchantmentTask>("HERO_10pe", EntityType::HERO));
-    cards.emplace("HERO_10p", CardDef(power));
+        std::make_shared<AddEnchantmentTask>("HERO_10bpe", EntityType::HERO));
+    cards.emplace("HERO_10bp", CardDef(power));
 
     // ------------------------------- HERO_POWER - DEMONHUNTER
-    // [HERO_10p_UP] Demon's Bite (*) - COST:1
+    // [HERO_10bp2] Demon's Bite (*) - COST:1
     // - Faction: Neutral, Set: Core, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b>\ +2 Attack this turn.
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(
-        std::make_shared<AddEnchantmentTask>("HERO_10pe_UP", EntityType::HERO));
-    cards.emplace("HERO_10p_UP", CardDef(power));
+        std::make_shared<AddEnchantmentTask>("HERO_10pe2", EntityType::HERO));
+    cards.emplace("HERO_10bp2", CardDef(power));
 }
 
 void CoreCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
@@ -2563,7 +2563,7 @@ void CoreCardsGen::AddDemonHunterNonCollect(
     cards.emplace("BT_512e", CardDef(power));
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
-    // [HERO_10pe] Demon Claws (*) - COST:0
+    // [HERO_10bpe] Demon Claws (*) - COST:0
     // - Set: Core
     // --------------------------------------------------------
     // Text: Your hero has +1 Attack this turn.
@@ -2572,11 +2572,11 @@ void CoreCardsGen::AddDemonHunterNonCollect(
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddEnchant(Enchants::GetEnchantFromText("HERO_10pe"));
-    cards.emplace("HERO_10pe", CardDef(power));
+    power.AddEnchant(Enchants::GetEnchantFromText("HERO_10bpe"));
+    cards.emplace("HERO_10bpe", CardDef(power));
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
-    // [HERO_10pe_UP] Demon's Bite (*) - COST:0
+    // [HERO_10pe2] Demon's Bite (*) - COST:0
     // - Set: Core
     // --------------------------------------------------------
     // Text: Your hero has +2 Attack this turn.
@@ -2585,8 +2585,8 @@ void CoreCardsGen::AddDemonHunterNonCollect(
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddEnchant(Enchants::GetEnchantFromText("HERO_10pe_UP"));
-    cards.emplace("HERO_10pe_UP", CardDef(power));
+    power.AddEnchant(Enchants::GetEnchantFromText("HERO_10pe2"));
+    cards.emplace("HERO_10pe2", CardDef(power));
 }
 
 void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/DemonHunterInitCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DemonHunterInitCardsGen.cpp
@@ -96,7 +96,7 @@ void DemonHunterInitCardsGen::AddDemonHunter(
     cards.emplace("BT_271", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [BT_351] Battlefiend - COST:1 [ATK:2/HP:2]
+    // [BT_351] Battlefiend - COST:1 [ATK:1/HP:2]
     // - Race: Demon, Set: Demon Hunter Initiate, Rarity: Common
     // --------------------------------------------------------
     // Text: After your hero attacks, gain +1 Attack.
@@ -404,7 +404,7 @@ void DemonHunterInitCardsGen::AddDemonHunter(
     cards.emplace("BT_922", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [BT_937] Altruis the Outcast - COST:3 [ATK:3/HP:2]
+    // [BT_937] Altruis the Outcast - COST:4 [ATK:4/HP:2]
     // - Set: Demon Hunter Initiate, Rarity: Legendary
     // --------------------------------------------------------
     // Text: After you play the left- or right-most card in your hand,

--- a/Sources/Rosetta/PlayMode/CardSets/DemonHunterInitCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DemonHunterInitCardsGen.cpp
@@ -343,7 +343,7 @@ void DemonHunterInitCardsGen::AddDemonHunter(
     // - Set: Demon Hunter Initiate, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Lifesteal</b>. Deal 3 damage to a minion.
-    //       <b>Outcast:</b> This costs (0).
+    //       <b>Outcast:</b> This costs (1).
     // --------------------------------------------------------
     // GameTag:
     // - LIFESTEAL = 1
@@ -361,7 +361,7 @@ void DemonHunterInitCardsGen::AddDemonHunter(
             playable->GetZonePosition() ==
                 playable->player->GetHandZone()->GetCount() - 1)
         {
-            return playable->GetGameTag(GameTag::COST);
+            return playable->GetGameTag(GameTag::COST) - 1;
         }
 
         return 0;

--- a/Sources/Rosetta/PlayMode/Cards/Cards.cpp
+++ b/Sources/Rosetta/PlayMode/Cards/Cards.cpp
@@ -365,25 +365,25 @@ Card* Cards::GetDefaultHeroPower(CardClass cardClass)
     switch (cardClass)
     {
         case CardClass::DRUID:
-            return FindCardByID("CS2_017");
+            return FindCardByID("HERO_06bp");
         case CardClass::HUNTER:
-            return FindCardByID("DS1h_292");
+            return FindCardByID("HERO_05bp");
         case CardClass::MAGE:
-            return FindCardByID("CS2_034");
+            return FindCardByID("HERO_08bp");
         case CardClass::PALADIN:
-            return FindCardByID("CS2_101");
+            return FindCardByID("HERO_04bp");
         case CardClass::PRIEST:
-            return FindCardByID("CS1h_001");
+            return FindCardByID("HERO_09bp");
         case CardClass::ROGUE:
-            return FindCardByID("CS2_083b");
+            return FindCardByID("HERO_03bp");
         case CardClass::SHAMAN:
-            return FindCardByID("CS2_049");
+            return FindCardByID("HERO_02bp");
         case CardClass::WARLOCK:
-            return FindCardByID("CS2_056");
+            return FindCardByID("HERO_07bp");
         case CardClass::WARRIOR:
-            return FindCardByID("CS2_102");
+            return FindCardByID("HERO_01bp");
         case CardClass::DEMONHUNTER:
-            return FindCardByID("HERO_10p");
+            return FindCardByID("HERO_10bp");
         default:
             return &emptyCard;
     }

--- a/Sources/Rosetta/PlayMode/Tasks/PlayerTasks/HeroPowerTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/PlayerTasks/HeroPowerTask.cpp
@@ -18,9 +18,9 @@ TaskStatus HeroPowerTask::Impl(Player* player)
 {
     HeroPower& power = player->GetHeroPower();
 
-    // NOTE: 'Steady Shot' (DS1h_292) can target by some cards
+    // NOTE: 'Steady Shot' (HERO_05bp) can target by some cards
     // e.g. Steamwheedle Sniper, Dwarven Sharpshooter
-    if (power.card->id == "DS1h_292")
+    if (power.card->id == "HERO_05bp")
     {
         if (const auto& auraEffects = player->playerAuraEffects;
             auraEffects.GetValue(GameTag::CAN_TARGET_MINION_BY_HERO_POWER) == 1)

--- a/Tests/PythonTests/test_cards.py
+++ b/Tests/PythonTests/test_cards.py
@@ -137,7 +137,7 @@ def test_find_card_by_type():
 	assert not cards6
 	assert not cards8
 	assert not cards10
-	assert not cards11
+	assert len(cards11) == 4
 
 def test_find_card_by_race():
 	cards = pyRosetta.Cards.find_card_by_race(pyRosetta.Race.INVALID)
@@ -204,13 +204,13 @@ def test_hero_card():
 	assert pyRosetta.Cards.hero_card(pyRosetta.CardClass.DEATHKNIGHT).id == ''
 
 def test_default_hero_power():
-	assert pyRosetta.Cards.find_card_by_id('CS2_017').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.DRUID).id
-	assert pyRosetta.Cards.find_card_by_id('DS1h_292').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.HUNTER).id
-	assert pyRosetta.Cards.find_card_by_id('CS2_034').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.MAGE).id
-	assert pyRosetta.Cards.find_card_by_id('CS2_101').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.PALADIN).id
-	assert pyRosetta.Cards.find_card_by_id('CS1h_001').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.PRIEST).id
-	assert pyRosetta.Cards.find_card_by_id('CS2_083b').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.ROGUE).id
-	assert pyRosetta.Cards.find_card_by_id('CS2_049').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.SHAMAN).id
-	assert pyRosetta.Cards.find_card_by_id('CS2_056').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.WARLOCK).id
-	assert pyRosetta.Cards.find_card_by_id('CS2_102').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.WARRIOR).id
+	assert pyRosetta.Cards.find_card_by_id('HERO_06bp').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.DRUID).id
+	assert pyRosetta.Cards.find_card_by_id('HERO_05bp').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.HUNTER).id
+	assert pyRosetta.Cards.find_card_by_id('HERO_08bp').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.MAGE).id
+	assert pyRosetta.Cards.find_card_by_id('HERO_04bp').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.PALADIN).id
+	assert pyRosetta.Cards.find_card_by_id('HERO_09bp').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.PRIEST).id
+	assert pyRosetta.Cards.find_card_by_id('HERO_03bp').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.ROGUE).id
+	assert pyRosetta.Cards.find_card_by_id('HERO_02bp').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.SHAMAN).id
+	assert pyRosetta.Cards.find_card_by_id('HERO_07bp').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.WARLOCK).id
+	assert pyRosetta.Cards.find_card_by_id('HERO_01bp').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.WARRIOR).id
 	assert pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.DEATHKNIGHT).id == ''

--- a/Tests/PythonTests/test_cards.py
+++ b/Tests/PythonTests/test_cards.py
@@ -201,6 +201,7 @@ def test_hero_card():
 	assert pyRosetta.Cards.find_card_by_id('HERO_02').id == pyRosetta.Cards.hero_card(pyRosetta.CardClass.SHAMAN).id
 	assert pyRosetta.Cards.find_card_by_id('HERO_07').id == pyRosetta.Cards.hero_card(pyRosetta.CardClass.WARLOCK).id
 	assert pyRosetta.Cards.find_card_by_id('HERO_01').id == pyRosetta.Cards.hero_card(pyRosetta.CardClass.WARRIOR).id
+	assert pyRosetta.Cards.find_card_by_id('HERO_10').id == pyRosetta.Cards.hero_card(pyRosetta.CardClass.DEMONHUNTER).id
 	assert pyRosetta.Cards.hero_card(pyRosetta.CardClass.DEATHKNIGHT).id == ''
 
 def test_default_hero_power():
@@ -213,4 +214,5 @@ def test_default_hero_power():
 	assert pyRosetta.Cards.find_card_by_id('HERO_02bp').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.SHAMAN).id
 	assert pyRosetta.Cards.find_card_by_id('HERO_07bp').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.WARLOCK).id
 	assert pyRosetta.Cards.find_card_by_id('HERO_01bp').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.WARRIOR).id
+	assert pyRosetta.Cards.find_card_by_id('HERO_10bp').id == pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.DEMONHUNTER).id
 	assert pyRosetta.Cards.default_hero_power(pyRosetta.CardClass.DEATHKNIGHT).id == ''

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4799,10 +4799,11 @@ TEST_CASE("[Warlock : Spell] - EX1_308 : Soulfire")
 // [NEW1_003] Sacrificial Pact - COST:0
 // - Set: Core, Rarity: Free
 // --------------------------------------------------------
-// Text: Destroy a Demon. Restore 5 Health to your hero.
+// Text: Destroy a friendly Demon. Restore 5 Health to your hero.
 // --------------------------------------------------------
 // PlayReq:
 // - REQ_TARGET_TO_PLAY = 0
+// - REQ_FRIENDLY_TARGET = 0
 // - REQ_TARGET_WITH_RACE = 15
 // --------------------------------------------------------
 TEST_CASE("[Warlock : Spell] - NEW1_003 : Sacrificial Pact")
@@ -5632,7 +5633,7 @@ TEST_CASE("[Demon Hunter : Minion] - BT_352 : Satyr Overseer")
 }
 
 // ----------------------------------- MINION - DEMONHUNTER
-// [BT_495] Glaivebound Adept (*) - COST:5 [ATK:7/HP:4]
+// [BT_495] Glaivebound Adept (*) - COST:5 [ATK:6/HP:4]
 // - Set: Core, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> If your hero attacked this turn,

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5839,7 +5839,7 @@ TEST_CASE("[Demon Hunter : Weapon] - BT_921 : Aldrachi Warblades")
     game.Process(curPlayer, PlayCardTask::Weapon(card1));
     CHECK_EQ(curPlayer->GetHero()->HasWeapon(), true);
     CHECK_EQ(curPlayer->GetHero()->GetAttack(), 2);
-    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 3);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 2);
 
     game.Process(curPlayer, HeroPowerTask());
     CHECK_EQ(curPlayer->GetHero()->GetAttack(), 3);
@@ -5847,7 +5847,7 @@ TEST_CASE("[Demon Hunter : Weapon] - BT_921 : Aldrachi Warblades")
     game.Process(curPlayer,
                  AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 18);
-    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 2);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 1);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -17,19 +17,16 @@ using namespace PlayMode;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
-// ------------------------------------ HERO_POWER - PRIEST
-// [CS1h_001] Lesser Heal (*) - COST:2
+// ----------------------------------- HERO_POWER - WARRIOR
+// [HERO_01bp] Armor Up! (*) - COST:2
 // - Faction: Neutral, Set: Core, Rarity: Free
 // --------------------------------------------------------
-// Text: <b>Hero Power</b> Restore 2 Health.
+// Text: <b>Hero Power</b> Gain 2 Armor.
 // --------------------------------------------------------
-// PlayReq:
-// - REQ_TARGET_TO_PLAY = 0
-// --------------------------------------------------------
-TEST_CASE("[Priest : Hero Power] - CS1h_001 : Lesser Heal")
+TEST_CASE("[Warrior : Hero Power] - HERO_01bp : Armor Up!")
 {
     GameConfig config;
-    config.player1Class = CardClass::PRIEST;
+    config.player1Class = CardClass::WARRIOR;
     config.player2Class = CardClass::MAGE;
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = true;
@@ -46,130 +43,15 @@ TEST_CASE("[Priest : Hero Power] - CS1h_001 : Lesser Heal")
     opPlayer->SetTotalMana(10);
     opPlayer->SetUsedMana(0);
 
-    game.Process(curPlayer, EndTurnTask());
-    game.ProcessUntil(Step::MAIN_ACTION);
-
-    game.Process(opPlayer, HeroPowerTask(curPlayer->GetHero()));
-    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 29);
-
-    game.Process(opPlayer, EndTurnTask());
-    game.ProcessUntil(Step::MAIN_ACTION);
-
-    game.Process(curPlayer, HeroPowerTask(curPlayer->GetHero()));
-
-    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
-}
-
-// ------------------------------------- HERO_POWER - DRUID
-// [CS2_017] Shapeshift (*) - COST:2
-// - Faction: Neutral, Set: Core, Rarity: Free
-// --------------------------------------------------------
-// Text: <b>Hero Power</b> +1 Attack this turn. +1 Armor.
-// --------------------------------------------------------
-TEST_CASE("[Druid : Hero Power] - CS2_017 : Shapeshift")
-{
-    GameConfig config;
-    config.player1Class = CardClass::DRUID;
-    config.player2Class = CardClass::PRIEST;
-    config.startPlayer = PlayerType::PLAYER1;
-    config.doFillDecks = true;
-    config.autoRun = false;
-
-    Game game(config);
-    game.Start();
-    game.ProcessUntil(Step::MAIN_ACTION);
-
-    Player* curPlayer = game.GetCurrentPlayer();
-    Player* opPlayer = game.GetOpponentPlayer();
-    curPlayer->SetTotalMana(10);
-    curPlayer->SetUsedMana(0);
-    opPlayer->SetTotalMana(10);
-    opPlayer->SetUsedMana(0);
-
-    auto& opField = *(opPlayer->GetFieldZone());
-
-    const auto card1 =
-        Generic::DrawCard(opPlayer, Cards::FindCardByName("Northshire Cleric"));
-
-    game.Process(curPlayer, EndTurnTask());
-    game.ProcessUntil(Step::MAIN_ACTION);
-
-    game.Process(opPlayer, PlayCardTask::Minion(card1));
-
-    game.Process(opPlayer, EndTurnTask());
-    game.ProcessUntil(Step::MAIN_ACTION);
-
-    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
-    CHECK_EQ(opField[0]->GetHealth(), 3);
 
     game.Process(curPlayer, HeroPowerTask());
 
-    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 1);
-    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 1);
-
-    game.Process(curPlayer, AttackTask(curPlayer->GetHero(), card1));
-    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 1);
-    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
-    CHECK_EQ(opField[0]->GetHealth(), 2);
-
-    game.Process(curPlayer, EndTurnTask());
-    game.ProcessUntil(Step::MAIN_ACTION);
-
-    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
-    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
-}
-
-// -------------------------------------- HERO_POWER - MAGE
-// [CS2_034] Fireblast (*) - COST:2
-// - Faction: Neutral, Set: Core, Rarity: Free
-// --------------------------------------------------------
-// Text: <b>Hero Power</b> Deal 1 damage.
-// --------------------------------------------------------
-// PlayReq:
-// - REQ_TARGET_TO_PLAY = 0
-// --------------------------------------------------------
-TEST_CASE("[Mage : Hero Power] - CS2_034 : Fireblast")
-{
-    GameConfig config;
-    config.player1Class = CardClass::MAGE;
-    config.player2Class = CardClass::PRIEST;
-    config.startPlayer = PlayerType::PLAYER1;
-    config.doFillDecks = true;
-    config.autoRun = false;
-
-    Game game(config);
-    game.Start();
-    game.ProcessUntil(Step::MAIN_ACTION);
-
-    Player* curPlayer = game.GetCurrentPlayer();
-    Player* opPlayer = game.GetOpponentPlayer();
-    curPlayer->SetTotalMana(10);
-    curPlayer->SetUsedMana(0);
-    opPlayer->SetTotalMana(10);
-    opPlayer->SetUsedMana(0);
-
-    auto& opField = *(opPlayer->GetFieldZone());
-
-    const auto card1 =
-        Generic::DrawCard(opPlayer, Cards::FindCardByName("Northshire Cleric"));
-
-    game.Process(curPlayer, EndTurnTask());
-    game.ProcessUntil(Step::MAIN_ACTION);
-
-    game.Process(opPlayer, PlayCardTask::Minion(card1));
-    CHECK_EQ(opField[0]->GetHealth(), 3);
-
-    game.Process(opPlayer, EndTurnTask());
-    game.ProcessUntil(Step::MAIN_ACTION);
-
-    game.Process(curPlayer, HeroPowerTask(card1));
-
-    CHECK_EQ(opField[0]->GetHealth(), 2);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 2);
 }
 
 // ------------------------------------ HERO_POWER - SHAMAN
-// [CS2_049] Totemic Call (*) - COST:2
+// [HERO_02bp] Totemic Call (*) - COST:2
 // - Faction: Neutral, Set: Core, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Hero Power</b> Summon a random Totem.
@@ -180,7 +62,7 @@ TEST_CASE("[Mage : Hero Power] - CS2_034 : Fireblast")
 // - REQ_NUM_MINION_SLOTS = 1
 // - REQ_ENTIRE_ENTOURAGE_NOT_IN_PLAY = 0
 // --------------------------------------------------------
-TEST_CASE("[Shaman : Hero Power] - CS2_049 : Totemic Call")
+TEST_CASE("[Shaman : Hero Power] - HERO_02bp : Totemic Call")
 {
     GameConfig config;
     config.player1Class = CardClass::SHAMAN;
@@ -239,47 +121,13 @@ TEST_CASE("[Shaman : Hero Power] - CS2_049 : Totemic Call")
     CHECK_EQ(opField.GetCount(), 4);
 }
 
-// ----------------------------------- HERO_POWER - WARLOCK
-// [CS2_056] Life Tap (*) - COST:2
-// - Faction: Neutral, Set: Core, Rarity: Free
-// --------------------------------------------------------
-// Text: <b>Hero Power</b> Draw a card and take 2 damage.
-// --------------------------------------------------------
-TEST_CASE("[Warlock : Hero Power] - CS2_056 : Life Tap")
-{
-    GameConfig config;
-    config.player1Class = CardClass::WARLOCK;
-    config.player2Class = CardClass::MAGE;
-    config.startPlayer = PlayerType::PLAYER1;
-    config.doFillDecks = true;
-    config.autoRun = false;
-
-    Game game(config);
-    game.Start();
-    game.ProcessUntil(Step::MAIN_ACTION);
-
-    Player* curPlayer = game.GetCurrentPlayer();
-    Player* opPlayer = game.GetOpponentPlayer();
-    curPlayer->SetTotalMana(10);
-    curPlayer->SetUsedMana(0);
-    opPlayer->SetTotalMana(10);
-    opPlayer->SetUsedMana(0);
-
-    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 4);
-
-    game.Process(curPlayer, HeroPowerTask());
-
-    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
-    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 28);
-}
-
 // ------------------------------------- HERO_POWER - ROGUE
-// [CS2_083b] Dagger Mastery (*) - COST:2
+// [HERO_03bp] Dagger Mastery (*) - COST:2
 // - Faction: Neutral, Set: Core, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Hero Power</b> Equip a 1/2 Dagger.
 // --------------------------------------------------------
-TEST_CASE("[Rogue : Hero Power] - CS2_083b : Dagger Mastery")
+TEST_CASE("[Rogue : Hero Power] - HERO_03bp : Dagger Mastery")
 {
     GameConfig config;
     config.player1Class = CardClass::ROGUE;
@@ -313,7 +161,7 @@ TEST_CASE("[Rogue : Hero Power] - CS2_083b : Dagger Mastery")
 }
 
 // ----------------------------------- HERO_POWER - PALADIN
-// [CS2_101] Reinforce (*) - COST:2
+// [HERO_04bp] Reinforce (*) - COST:2
 // - Faction: Neutral, Set: Core, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Hero Power</b> Summon a 1/1 Silver Hand Recruit.
@@ -321,7 +169,7 @@ TEST_CASE("[Rogue : Hero Power] - CS2_083b : Dagger Mastery")
 // PlayReq:
 // - REQ_NUM_MINION_SLOTS = 1
 // --------------------------------------------------------
-TEST_CASE("[Paladin : Hero Power] - CS2_101 : Reinforce")
+TEST_CASE("[Paladin : Hero Power] - HERO_04bp : Reinforce")
 {
     GameConfig config;
     config.player1Class = CardClass::PALADIN;
@@ -350,41 +198,8 @@ TEST_CASE("[Paladin : Hero Power] - CS2_101 : Reinforce")
     CHECK_EQ(curField[0]->GetHealth(), 1);
 }
 
-// ----------------------------------- HERO_POWER - WARRIOR
-// [CS2_102] Armor Up! (*) - COST:2
-// - Faction: Neutral, Set: Core, Rarity: Free
-// --------------------------------------------------------
-// Text: <b>Hero Power</b> Gain 2 Armor.
-// --------------------------------------------------------
-TEST_CASE("[Warrior : Hero Power] - CS2_102 : Armor Up!")
-{
-    GameConfig config;
-    config.player1Class = CardClass::WARRIOR;
-    config.player2Class = CardClass::MAGE;
-    config.startPlayer = PlayerType::PLAYER1;
-    config.doFillDecks = true;
-    config.autoRun = false;
-
-    Game game(config);
-    game.Start();
-    game.ProcessUntil(Step::MAIN_ACTION);
-
-    Player* curPlayer = game.GetCurrentPlayer();
-    Player* opPlayer = game.GetOpponentPlayer();
-    curPlayer->SetTotalMana(10);
-    curPlayer->SetUsedMana(0);
-    opPlayer->SetTotalMana(10);
-    opPlayer->SetUsedMana(0);
-
-    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
-
-    game.Process(curPlayer, HeroPowerTask());
-
-    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 2);
-}
-
 // ------------------------------------ HERO_POWER - HUNTER
-// [DS1h_292] Steady Shot (*) - COST:2
+// [HERO_05bp] Steady Shot (*) - COST:2
 // - Faction: Neutral, Set: Core, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Hero Power</b> Deal 2 damage to the enemy hero.
@@ -393,7 +208,7 @@ TEST_CASE("[Warrior : Hero Power] - CS2_102 : Armor Up!")
 // - REQ_STEADY_SHOT = 0
 // - REQ_MINION_OR_ENEMY_HERO = 0
 // --------------------------------------------------------
-TEST_CASE("[Hunter : Hero Power] - DS1h_292 : Steady Shot")
+TEST_CASE("[Hunter : Hero Power] - HERO_05bp : Steady Shot")
 {
     GameConfig config;
     config.player1Class = CardClass::HUNTER;
@@ -418,13 +233,198 @@ TEST_CASE("[Hunter : Hero Power] - DS1h_292 : Steady Shot")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
 }
 
+// ------------------------------------- HERO_POWER - DRUID
+// [HERO_06bp] Shapeshift (*) - COST:2
+// - Faction: Neutral, Set: Core, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Hero Power</b> +1 Attack this turn. +1 Armor.
+// --------------------------------------------------------
+TEST_CASE("[Druid : Hero Power] - HERO_06bp : Shapeshift")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Northshire Cleric"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
+    CHECK_EQ(opField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer, HeroPowerTask());
+
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 1);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 1);
+
+    game.Process(curPlayer, AttackTask(curPlayer->GetHero(), card1));
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 1);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
+    CHECK_EQ(opField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
+}
+
+// ----------------------------------- HERO_POWER - WARLOCK
+// [HERO_07bp] Life Tap (*) - COST:2
+// - Faction: Neutral, Set: Core, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Hero Power</b> Draw a card and take 2 damage.
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Hero Power] - HERO_07bp : Life Tap")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 4);
+
+    game.Process(curPlayer, HeroPowerTask());
+
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 28);
+}
+
+// -------------------------------------- HERO_POWER - MAGE
+// [HERO_08bp] Fireblast (*) - COST:2
+// - Faction: Neutral, Set: Core, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Hero Power</b> Deal 1 damage.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Mage : Hero Power] - HERO_08bp : Fireblast")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Northshire Cleric"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(opField[0]->GetHealth(), 3);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, HeroPowerTask(card1));
+
+    CHECK_EQ(opField[0]->GetHealth(), 2);
+}
+
+// ------------------------------------ HERO_POWER - PRIEST
+// [HERO_09bp] Lesser Heal (*) - COST:2
+// - Faction: Neutral, Set: Core, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Hero Power</b> Restore 2 Health.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Hero Power] - HERO_09bp : Lesser Heal")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 29);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, HeroPowerTask(curPlayer->GetHero()));
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
+}
+
 // ------------------------------- HERO_POWER - DEMONHUNTER
-// [HERO_10p] Demon Claws (*) - COST:1
+// [HERO_10bp] Demon Claws (*) - COST:1
 // - Faction: Neutral, Set: Core, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Hero Power</b> +1 Attack this turn.
 // --------------------------------------------------------
-TEST_CASE("[Demon Hunter : Hero Power] - HERO_10p : Demon Claws")
+TEST_CASE("[Demon Hunter : Hero Power] - HERO_10bp : Demon Claws")
 {
     GameConfig config;
     config.player1Class = CardClass::DRUID;

--- a/Tests/UnitTests/PlayMode/CardSets/DemonHunterInitCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DemonHunterInitCardsGenTests.cpp
@@ -213,7 +213,7 @@ TEST_CASE("[Demon Hunter : Weapon] - BT_271 : Flamereaper")
 }
 
 // ----------------------------------- MINION - DEMONHUNTER
-// [BT_351] Battlefiend (*) - COST:1 [ATK:2/HP:2]
+// [BT_351] Battlefiend (*) - COST:1 [ATK:1/HP:2]
 // - Race: Demon, Set: Demon Hunter Initiate, Rarity: Common
 // --------------------------------------------------------
 // Text: After your hero attacks, gain +1 Attack.
@@ -247,12 +247,12 @@ TEST_CASE("[Demon Hunter : Minion] - BT_351 : Battlefiend")
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Battlefiend"));
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
-    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetAttack(), 1);
 
     game.Process(curPlayer, HeroPowerTask());
     game.Process(curPlayer,
                  AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
-    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetAttack(), 2);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);
@@ -263,7 +263,7 @@ TEST_CASE("[Demon Hunter : Minion] - BT_351 : Battlefiend")
     game.Process(curPlayer, HeroPowerTask());
     game.Process(curPlayer,
                  AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
-    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetAttack(), 3);
 }
 
 // ------------------------------------ SPELL - DEMONHUNTER
@@ -1141,7 +1141,7 @@ TEST_CASE("[Demon Hunter : Weapon] - BT_922 : Umberwing")
 }
 
 // ----------------------------------- MINION - DEMONHUNTER
-// [BT_937] Altruis the Outcast - COST:3 [ATK:3/HP:2]
+// [BT_937] Altruis the Outcast - COST:4 [ATK:4/HP:2]
 // - Set: Demon Hunter Initiate, Rarity: Legendary
 // --------------------------------------------------------
 // Text: After you play the left- or right-most card in your hand,

--- a/Tests/UnitTests/PlayMode/CardSets/DemonHunterInitCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DemonHunterInitCardsGenTests.cpp
@@ -972,7 +972,7 @@ TEST_CASE("[Demon Hunter : Spell] - BT_753 : Mana Burn")
 // - Set: Demon Hunter Initiate, Rarity: Epic
 // --------------------------------------------------------
 // Text: <b>Lifesteal</b>. Deal 3 damage to a minion.
-//       <b>Outcast:</b> This costs (0).
+//       <b>Outcast:</b> This costs (1).
 // --------------------------------------------------------
 // GameTag:
 // - LIFESTEAL = 1
@@ -1023,7 +1023,7 @@ TEST_CASE("[Demon Hunter : Spell] - BT_801 : Eye Beam")
     CHECK_EQ(opHero->GetHealth(), 18);
 
     game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
-    CHECK_EQ(opPlayer->GetRemainingMana(), 7);
+    CHECK_EQ(opPlayer->GetRemainingMana(), 6);
     CHECK_EQ(opHero->GetHealth(), 21);
 }
 

--- a/Tests/UnitTests/PlayMode/Cards/CardsTests.cpp
+++ b/Tests/UnitTests/PlayMode/Cards/CardsTests.cpp
@@ -277,23 +277,23 @@ TEST_CASE("[Cards] - GetDefaultHeroPower")
 {
     Cards& instance = Cards::GetInstance();
 
-    CHECK_EQ(instance.FindCardByID("CS2_017")->id,
+    CHECK_EQ(instance.FindCardByID("HERO_06bp")->id,
              instance.GetDefaultHeroPower(CardClass::DRUID)->id);
-    CHECK_EQ(instance.FindCardByID("DS1h_292")->id,
+    CHECK_EQ(instance.FindCardByID("HERO_05bp")->id,
              instance.GetDefaultHeroPower(CardClass::HUNTER)->id);
-    CHECK_EQ(instance.FindCardByID("CS2_034")->id,
+    CHECK_EQ(instance.FindCardByID("HERO_08bp")->id,
              instance.GetDefaultHeroPower(CardClass::MAGE)->id);
-    CHECK_EQ(instance.FindCardByID("CS2_101")->id,
+    CHECK_EQ(instance.FindCardByID("HERO_04bp")->id,
              instance.GetDefaultHeroPower(CardClass::PALADIN)->id);
-    CHECK_EQ(instance.FindCardByID("CS1h_001")->id,
+    CHECK_EQ(instance.FindCardByID("HERO_09bp")->id,
              instance.GetDefaultHeroPower(CardClass::PRIEST)->id);
-    CHECK_EQ(instance.FindCardByID("CS2_083b")->id,
+    CHECK_EQ(instance.FindCardByID("HERO_03bp")->id,
              instance.GetDefaultHeroPower(CardClass::ROGUE)->id);
-    CHECK_EQ(instance.FindCardByID("CS2_049")->id,
+    CHECK_EQ(instance.FindCardByID("HERO_02bp")->id,
              instance.GetDefaultHeroPower(CardClass::SHAMAN)->id);
-    CHECK_EQ(instance.FindCardByID("CS2_056")->id,
+    CHECK_EQ(instance.FindCardByID("HERO_07bp")->id,
              instance.GetDefaultHeroPower(CardClass::WARLOCK)->id);
-    CHECK_EQ(instance.FindCardByID("CS2_102")->id,
+    CHECK_EQ(instance.FindCardByID("HERO_01bp")->id,
              instance.GetDefaultHeroPower(CardClass::WARRIOR)->id);
     CHECK_EQ(instance.GetDefaultHeroPower(CardClass::DEATHKNIGHT)->id, "");
 }

--- a/Tests/UnitTests/PlayMode/Cards/CardsTests.cpp
+++ b/Tests/UnitTests/PlayMode/Cards/CardsTests.cpp
@@ -271,6 +271,8 @@ TEST_CASE("[Cards] - GetHeroCard")
              instance.GetHeroCard(CardClass::WARLOCK)->id);
     CHECK_EQ(instance.FindCardByID("HERO_01")->id,
              instance.GetHeroCard(CardClass::WARRIOR)->id);
+    CHECK_EQ(instance.FindCardByID("HERO_10")->id,
+             instance.GetHeroCard(CardClass::DEMONHUNTER)->id);
     CHECK_EQ(instance.GetHeroCard(CardClass::DEATHKNIGHT)->id, "");
 }
 
@@ -296,6 +298,8 @@ TEST_CASE("[Cards] - GetDefaultHeroPower")
              instance.GetDefaultHeroPower(CardClass::WARLOCK)->id);
     CHECK_EQ(instance.FindCardByID("HERO_01bp")->id,
              instance.GetDefaultHeroPower(CardClass::WARRIOR)->id);
+    CHECK_EQ(instance.FindCardByID("HERO_10bp")->id,
+             instance.GetDefaultHeroPower(CardClass::DEMONHUNTER)->id);
     CHECK_EQ(instance.GetDefaultHeroPower(CardClass::DEATHKNIGHT)->id, "");
 }
 

--- a/Tests/UnitTests/PlayMode/Cards/CardsTests.cpp
+++ b/Tests/UnitTests/PlayMode/Cards/CardsTests.cpp
@@ -175,7 +175,8 @@ TEST_CASE("[Cards] - FindCardByType")
     CHECK(cards6.empty());
     CHECK(cards8.empty());
     CHECK(cards10.empty());
-    CHECK(cards11.empty());
+    // NOTE: It is temporary code and will be modified.
+    CHECK(cards11.size() == 4);
 }
 
 TEST_CASE("[Cards] - FindCardByRace")

--- a/Tests/UnitTests/PlayMode/Games/GameTests.cpp
+++ b/Tests/UnitTests/PlayMode/Games/GameTests.cpp
@@ -339,11 +339,11 @@ TEST_CASE("[Game] - CreateView")
     game.ProcessUntil(Step::MAIN_ACTION);
 
     const auto player1View = game.CreateView();
-    CHECK_EQ(player1View.GetMyHeroPower().cardID, "CS2_102");
+    CHECK_EQ(player1View.GetMyHeroPower().cardID, "HERO_01bp");
 
     game.Process(game.GetCurrentPlayer(), EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);
 
     const auto player2View = game.CreateView();
-    CHECK_EQ(player2View.GetMyHeroPower().cardID, "CS2_083b");
+    CHECK_EQ(player2View.GetMyHeroPower().cardID, "HERO_03bp");
 }

--- a/Tests/UnitTests/PlayMode/Views/BoardRefViewTests.cpp
+++ b/Tests/UnitTests/PlayMode/Views/BoardRefViewTests.cpp
@@ -305,8 +305,8 @@ TEST_CASE("[BoardRefView] - GetHeroPower")
     game.ProcessUntil(Step::MAIN_ACTION);
 
     BoardRefView board(game, game.GetCurrentPlayer()->playerType);
-    CHECK_EQ(board.GetHeroPower(PlayerType::PLAYER1).card->id, "CS2_102");
-    CHECK_EQ(board.GetHeroPower(PlayerType::PLAYER2).card->id, "CS2_083b");
+    CHECK_EQ(board.GetHeroPower(PlayerType::PLAYER1).card->id, "HERO_01bp");
+    CHECK_EQ(board.GetHeroPower(PlayerType::PLAYER2).card->id, "HERO_03bp");
 }
 
 TEST_CASE("[BoardRefView] - GetWeapon")

--- a/Tests/UnitTests/PlayMode/Views/ReducedBoardViewTests.cpp
+++ b/Tests/UnitTests/PlayMode/Views/ReducedBoardViewTests.cpp
@@ -70,7 +70,7 @@ TEST_CASE("[ReducedBoardView] - All")
     CHECK_EQ(reducedBoard1.GetSide(), PlayerType::PLAYER1);
 
     CHECK_EQ(reducedBoard1.GetMyHero().attack, 3);
-    CHECK_EQ(reducedBoard1.GetMyHeroPower().cardID, "CS2_102");
+    CHECK_EQ(reducedBoard1.GetMyHeroPower().cardID, "HERO_01bp");
     CHECK_EQ(reducedBoard1.GetMyWeapon().durability, 2);
     CHECK_EQ(reducedBoard1.GetMyManaCrystal().total, 4);
     CHECK_EQ(reducedBoard1.GetMyManaCrystal().remaining, 0);
@@ -82,7 +82,7 @@ TEST_CASE("[ReducedBoardView] - All")
     CHECK_EQ(reducedBoard1.GetMyDeck().count, 5);
 
     CHECK_EQ(reducedBoard1.GetOpHero().attack, 4);
-    CHECK_EQ(reducedBoard1.GetOpHeroPower().cardID, "CS2_083b");
+    CHECK_EQ(reducedBoard1.GetOpHeroPower().cardID, "HERO_03bp");
     CHECK_EQ(reducedBoard1.GetOpWeapon().durability, 1);
     CHECK_EQ(reducedBoard1.GetOpManaCrystal().total, 7);
     CHECK_EQ(reducedBoard1.GetOpManaCrystal().remaining, 4);


### PR DESCRIPTION
This revision includes
  - Update Hearthstone 17.0.2 Balance Patch (#425)
  - Update Hearthstone Patch 17.2 (#426)
  - Update Hearthstone Patch 17.2.1 (#427)
  - Constant changes
    - NUM_ALL_CARDS: 9057 -> 9156
    - NUM_BATTLEGROUNDS_CARD: 447 -> 461
    - NUM_BATTLEGROUNDS_HEROES: 34 -> 37
  - Card ID changes
    - CS2_017 -> HERO_06bp
    - DS1h_292 -> HERO_05bp
    - CS2_034 -> HERO_08bp
    - CS2_101 -> HERO_04bp
    - CS1h_001 -> HERO_09bp
    - CS2_083b -> HERO_03bp
    - CS2_049 -> HERO_02bp
    - CS2_056 -> HERO_07bp
    - CS2_102 -> HERO_01bp
    - HERO_10p -> HERO_10bp
  - Balance changes (Play mode)
    - Sacrificial Pact Old: Destroy a Demon. Restore 5 Health to your hero. → New: Destroy a friendly Demon. Restore 5 Health to your hero.
    - Glaivebound Adept Old: 7 Attack / 4 Health → New: 6 Attack / 4 Health.
    - Battlefiend Old: 2 Attack / 2 Health → New: 1 Attack / 2 Health.
    - Altruis the Outcast Old: Cost 3 mana, 3 Attack / 2 Health → New: Cost 4 mana. 4 Attack / 2 Health.
    - Eye Beam – Outcast Mana cost increased from 0 to 1.
    - Aldrachi Warblades – Durability decreased from 3 to 2.
  - Balance Changes (Battlegrounds)
    - Dire Wolf Alpha has been removed from the minion pool.
    - New Minion: Rabid Saurolisk - [Tier 1, Beast] 3 Attack, 1 Health.