### PR TITLE
Implement Tier 1 cards of Hearthstone: Battlegrounds

### DIFF
--- a/Includes/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.hpp
+++ b/Includes/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.hpp
@@ -53,13 +53,13 @@ class BattlegroundsCardsGen
     //! \param cards A list of cards to store the data such as powers.
     static void AddTier6Minions(std::map<std::string, CardDef>& cards);
 
-    //! Adds minion cards that are not collectible to \p cards.
+    //! Adds token minion cards.
     //! \param cards A list of cards to store the data such as powers.
-    static void AddMinionsNonCollect(std::map<std::string, CardDef>& cards);
+    static void AddTokenMinions(std::map<std::string, CardDef>& cards);
 
-    //! Adds spell cards that are not collectible to \p cards.
+    //! Adds enchantment cards.
     //! \param cards A list of cards to store the data such as powers.
-    static void AddSpellsNonCollect(std::map<std::string, CardDef>& cards);
+    static void AddEnchantments(std::map<std::string, CardDef>& cards);
 
     //! Adds all cards to \p cards.
     //! \param cards A list of cards to store the data such as powers,

--- a/Includes/Rosetta/Battlegrounds/Cards/Card.hpp
+++ b/Includes/Rosetta/Battlegrounds/Cards/Card.hpp
@@ -72,6 +72,12 @@ class Card
     //! \return the flag that indicates whether it is a Tier 6 minion in pool.
     bool IsTier6MinionInPool() const;
 
+    //! Gets a value indicating whether source entity is playable by card
+    //! requirements. Static requirements are checked.
+    //! \param player The player of the source.
+    //! \return true if it is playable by card requirements, false otherwise.
+    bool IsPlayableByCardReq(Player& player) const;
+
     std::string id;
     int dbfID;
     int normalDbfID;

--- a/Includes/Rosetta/Battlegrounds/Cards/Card.hpp
+++ b/Includes/Rosetta/Battlegrounds/Cards/Card.hpp
@@ -78,6 +78,12 @@ class Card
     //! \return true if it is playable by card requirements, false otherwise.
     bool IsPlayableByCardReq(Player& player) const;
 
+    //! Calculates if a target is valid by testing the game state
+    //! for each hardcoded requirement.
+    //! \param target The proposed target.
+    //! \return true if the proposed target is valid, false otherwise.
+    bool TargetingRequirements(Minion& target) const;
+
     std::string id;
     int dbfID;
     int normalDbfID;

--- a/Includes/Rosetta/Battlegrounds/Cards/Card.hpp
+++ b/Includes/Rosetta/Battlegrounds/Cards/Card.hpp
@@ -7,8 +7,10 @@
 #ifndef ROSETTASTONE_BATTLEGROUNDS_CARD_HPP
 #define ROSETTASTONE_BATTLEGROUNDS_CARD_HPP
 
+#include <Rosetta/Battlegrounds/Cards/TargetingPredicates.hpp>
 #include <Rosetta/Battlegrounds/Enchants/Power.hpp>
 #include <Rosetta/Common/Enums/CardEnums.hpp>
+#include <Rosetta/Common/Enums/TargetingEnums.hpp>
 
 #include <map>
 #include <string>
@@ -23,6 +25,9 @@ namespace RosettaStone::Battlegrounds
 class Card
 {
  public:
+    //! Initializes card data.
+    void Initialize();
+
     //! Returns the value of card type.
     //! \return The value of card type.
     CardType GetCardType() const;
@@ -76,10 +81,15 @@ class Card
     std::string text;
 
     std::map<GameTag, int> gameTags;
+    std::map<PlayReq, int> playRequirements;
 
+    std::vector<TargetingPredicate> targetingPredicate;
+
+    TargetingType targetingType;
     Power power;
 
-    bool isCurHero;
+    bool isCurHero = false;
+    bool mustHaveToTargetToPlay = false;
 };
 }  // namespace RosettaStone::Battlegrounds
 

--- a/Includes/Rosetta/Battlegrounds/Cards/CardDef.hpp
+++ b/Includes/Rosetta/Battlegrounds/Cards/CardDef.hpp
@@ -28,6 +28,11 @@ class CardDef
     //! \param _power The power data.
     explicit CardDef(Power _power);
 
+    //! Constructs card def with given \p _power and \p _playReqs.
+    //! \param _power The power data.
+    //! \param _playReqs The play requirements data.
+    explicit CardDef(Power _power, std::map<PlayReq, int> _playReqs);
+
     Power power;
     std::map<PlayReq, int> playReqs;
 };

--- a/Includes/Rosetta/Battlegrounds/Cards/TargetingPredicates.hpp
+++ b/Includes/Rosetta/Battlegrounds/Cards/TargetingPredicates.hpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef ROSETTASTONE_BATTLEGROUNDS_TARGETING_PREDICATES_HPP
+#define ROSETTASTONE_BATTLEGROUNDS_TARGETING_PREDICATES_HPP
+
+#include <Rosetta/Common/Enums/CardEnums.hpp>
+
+#include <functional>
+
+namespace RosettaStone::Battlegrounds
+{
+class Minion;
+
+using TargetingPredicate = std::function<bool(Minion&)>;
+
+//!
+//! \brief TargetingPredicates class.
+//!
+//! This class includes utility methods for targeting predicate.
+//!
+class TargetingPredicates
+{
+ public:
+    //! Predicate wrapper for checking the target requires that
+    //! it has Race::MURLOC.
+    //! \return Generated TargetingPredicate for intended purpose.
+    static TargetingPredicate ReqMurlocTarget();
+
+    //! Predicate wrapper for checking the target requires that it has \p race.
+    //! \param race The value of race.
+    //! \return Generated TargetingPredicate for intended purpose.
+    static TargetingPredicate ReqTargetWithRace(Race race);
+};
+}  // namespace RosettaStone::Battlegrounds
+
+#endif  // ROSETTASTONE_BATTLEGROUNDS_TARGETING_PREDICATES_HPP

--- a/Includes/Rosetta/Battlegrounds/Enchants/Enchants.hpp
+++ b/Includes/Rosetta/Battlegrounds/Enchants/Enchants.hpp
@@ -22,6 +22,11 @@ class Enchants
     //! Enchant that adds attack and uses script tag.
     inline static Enchant AddAttackScriptTag =
         Enchant{ Effects::AttackN(0), true };
+
+    //! Creates enchant from card's text.
+    //! \param cardID A card's ID.
+    //! \return A newly created enchant from card's text.
+    static Enchant GetEnchantFromText(const std::string& cardID);
 };
 }  // namespace RosettaStone::Battlegrounds
 

--- a/Includes/Rosetta/Battlegrounds/Games/Game.hpp
+++ b/Includes/Rosetta/Battlegrounds/Games/Game.hpp
@@ -77,6 +77,7 @@ class Game
     Race m_excludeRace = Race::INVALID;
     std::vector<std::tuple<std::size_t, std::size_t>> m_playerFightPair;
     std::atomic<int> m_playerCount = 0;
+    std::atomic<int> m_cardIndex = 0;
 };
 }  // namespace RosettaStone::Battlegrounds
 

--- a/Includes/Rosetta/Battlegrounds/Models/Minion.hpp
+++ b/Includes/Rosetta/Battlegrounds/Models/Minion.hpp
@@ -139,6 +139,12 @@ class Minion
     //! false otherwise.
     bool HasAnyValidPlayTargets(Player& player) const;
 
+    //! Determines whether the specified character is a valid target.
+    //! \param player The owner of the minion.
+    //! \param targetIdx The index of proposed target.
+    //! \return true if the specified target is valid, false otherwise.
+    bool IsValidPlayTarget(Player& player, int targetIdx);
+
     //! Checks the targeting type of a card.
     //! \param target The proposed target.
     //! \return true if the targeting type is valid, false otherwise.

--- a/Includes/Rosetta/Battlegrounds/Models/Minion.hpp
+++ b/Includes/Rosetta/Battlegrounds/Models/Minion.hpp
@@ -139,6 +139,8 @@ class Minion
 
     Trigger activatedTrigger;
 
+    std::function<Player&()> getPlayerCallback;
+
  private:
     //! Gets a list of tasks according to the power type.
     //! \param type The type of power.

--- a/Includes/Rosetta/Battlegrounds/Models/Minion.hpp
+++ b/Includes/Rosetta/Battlegrounds/Models/Minion.hpp
@@ -139,6 +139,11 @@ class Minion
     //! false otherwise.
     bool HasAnyValidPlayTargets(Player& player) const;
 
+    //! Checks the targeting type of a card.
+    //! \param target The proposed target.
+    //! \return true if the targeting type is valid, false otherwise.
+    bool CheckTargetingType(Minion& target);
+
     //! Activates the trigger.
     //! \param type The type of trigger.
     //! \param source The source of trigger.

--- a/Includes/Rosetta/Battlegrounds/Models/Minion.hpp
+++ b/Includes/Rosetta/Battlegrounds/Models/Minion.hpp
@@ -126,6 +126,13 @@ class Minion
     //! \return The flag that indicates whether it is destroyed.
     bool IsDestroyed() const;
 
+    //! Gets whether the current field has any valid play targets
+    //! for this playable.
+    //! \param player The owner of the minion.
+    //! \return true if the current field has any valid play targets,
+    //! false otherwise.
+    bool HasAnyValidPlayTargets(Player& player) const;
+
     //! Activates the trigger.
     //! \param type The type of trigger.
     //! \param source The source of trigger.

--- a/Includes/Rosetta/Battlegrounds/Models/Minion.hpp
+++ b/Includes/Rosetta/Battlegrounds/Models/Minion.hpp
@@ -33,6 +33,14 @@ class Minion
     //! \param poolIdx The index of minion pool.
     explicit Minion(Card card, int poolIdx = -1);
 
+    //! Returns the value of index.
+    //! \return The value of index.
+    int GetIndex() const;
+
+    //! Sets the value of index.
+    //! \param index The value of index.
+    void SetIndex(int index);
+
     //! Returns the value of pool index.
     //! \return The value of pool index.
     int GetPoolIndex() const;
@@ -148,6 +156,7 @@ class Minion
     std::vector<TaskType> GetTasks(PowerType type);
 
     Card m_card;
+    int m_index = -1;
     int m_poolIdx = -1;
 
     ZoneType m_zoneType = ZoneType::INVALID;

--- a/Includes/Rosetta/Battlegrounds/Models/Minion.hpp
+++ b/Includes/Rosetta/Battlegrounds/Models/Minion.hpp
@@ -126,6 +126,12 @@ class Minion
     //! \return The flag that indicates whether it is destroyed.
     bool IsDestroyed() const;
 
+    //! Gets a value indicating whether source entity is playable by card
+    //! requirements. Static requirements are checked.
+    //! \param player The owner of the minion.
+    //! \return true if it is playable by card requirements, false otherwise.
+    bool IsPlayableByCardReq(Player& player) const;
+
     //! Gets whether the current field has any valid play targets
     //! for this playable.
     //! \param player The owner of the minion.

--- a/Includes/Rosetta/Battlegrounds/Models/Minion.hpp
+++ b/Includes/Rosetta/Battlegrounds/Models/Minion.hpp
@@ -54,6 +54,11 @@ class Minion
     //! \return The value of game tag.
     int GetGameTag(GameTag tag) const;
 
+    //! Sets the value of game tag.
+    //! \param tag The game tag to set.
+    //! \param value The value of game tag to set.
+    void SetGameTag(GameTag tag, int value);
+
     //! Returns the value of race.
     //! \return The value of race.
     Race GetRace() const;

--- a/Includes/Rosetta/Battlegrounds/Models/Minion.hpp
+++ b/Includes/Rosetta/Battlegrounds/Models/Minion.hpp
@@ -128,11 +128,8 @@ class Minion
 
     //! Activates the trigger.
     //! \param type The type of trigger.
-    //! \param sources A list of trigger sources.
-    //! \param player The owner of the minion.
-    void ActivateTrigger(TriggerType type,
-                         std::initializer_list<TriggerSource> sources,
-                         Player& player);
+    //! \param source The source of trigger.
+    void ActivateTrigger(TriggerType type, Minion& source);
 
     //! Activates the task.
     //! \param type The type of power.

--- a/Includes/Rosetta/Battlegrounds/Models/Player.hpp
+++ b/Includes/Rosetta/Battlegrounds/Models/Player.hpp
@@ -94,6 +94,7 @@ class Player
     std::function<void(Player&)> selectHeroCallback;
     std::function<void(Player&)> prepareTavernMinionsCallback;
     std::function<void(Player&, std::size_t)> purchaseMinionCallback;
+    std::function<int()> getNextCardIndexCallback;
     std::function<void(int)> returnMinionCallback;
     std::function<void(Player&)> clearTavernMinionsCallback;
     std::function<void(Player&)> upgradeTavernCallback;

--- a/Includes/Rosetta/Battlegrounds/Models/Player.hpp
+++ b/Includes/Rosetta/Battlegrounds/Models/Player.hpp
@@ -19,6 +19,8 @@
 
 namespace RosettaStone::Battlegrounds
 {
+class Battle;
+
 //!
 //! \brief Player class.
 //!
@@ -100,6 +102,7 @@ class Player
     std::function<void(Player&)> upgradeTavernCallback;
     std::function<void()> completeRecruitCallback;
     std::function<Player&(Player&)> getOpponentPlayerCallback;
+    std::function<Battle&()> getBattleCallback;
     std::function<void(Player&)> processDefeatCallback;
 
     std::array<int, 4> heroChoices{ 0, 0, 0, 0 };

--- a/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/AddEnchantmentTask.hpp
+++ b/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/AddEnchantmentTask.hpp
@@ -47,6 +47,7 @@ class AddEnchantmentTask
     //! \return The result of task processing.
     TaskStatus Run(Player& player, Minion& source, Minion& target);
 
+ private:
     std::string_view m_cardID;
     EntityType m_entityType = EntityType::INVALID;
     bool m_useScriptTag = false;

--- a/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/AttackTask.hpp
+++ b/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/AttackTask.hpp
@@ -1,0 +1,51 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_BATTLEGROUNDS_ATTACK_TASK_HPP
+#define ROSETTASTONE_BATTLEGROUNDS_ATTACK_TASK_HPP
+
+#include <Rosetta/Battlegrounds/Conditions/SelfCondition.hpp>
+#include <Rosetta/Common/Enums/TaskEnums.hpp>
+
+namespace RosettaStone::Battlegrounds
+{
+class Card;
+class Minion;
+class Player;
+
+namespace SimpleTasks
+{
+//!
+//! \brief AttackTask class.
+//!
+//! This class represents the task for attacking the opponent minion.
+//!
+class AttackTask
+{
+ public:
+    //! Constructs task with given \p attacker.
+    //! \param attacker The entity type of attacker.
+    explicit AttackTask(EntityType attacker);
+
+    //! Runs task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \param source The source minion.
+    //! \return The result of task processing.
+    TaskStatus Run(Player& player, Minion& source);
+
+    //! Runs task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \param source The source minion.
+    //! \param target The target minion.
+    //! \return The result of task processing.
+    TaskStatus Run(Player& player, Minion& source, Minion& target);
+
+ private:
+    EntityType m_attacker = EntityType::INVALID;
+};
+}  // namespace SimpleTasks
+}  // namespace RosettaStone::Battlegrounds
+
+#endif  // ROSETTASTONE_BATTLEGROUNDS_ATTACK_TASK_HPP

--- a/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/CountTask.hpp
+++ b/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/CountTask.hpp
@@ -45,6 +45,7 @@ class CountTask
     //! \return The result of task processing.
     TaskStatus Run(Player& player, Minion& source, Minion& target);
 
+ private:
     EntityType m_entityType = EntityType::INVALID;
     std::vector<SelfCondition> m_conditions;
     int m_numIndex = 0;

--- a/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/DamageHeroTask.hpp
+++ b/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/DamageHeroTask.hpp
@@ -41,6 +41,7 @@ class DamageHeroTask
     //! \return The result of task processing.
     TaskStatus Run(Player& player, Minion& source, Minion& target);
 
+ private:
     int m_damage = 0;
 };
 }  // namespace SimpleTasks

--- a/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/GetGameTagTask.hpp
+++ b/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/GetGameTagTask.hpp
@@ -45,6 +45,7 @@ class GetGameTagTask
     //! \return The result of task processing.
     TaskStatus Run(Player& player, Minion& source, Minion& target);
 
+ private:
     EntityType m_entityType = EntityType::INVALID;
     GameTag m_gameTag = GameTag::INVALID;
     int m_minionIndex = 0;

--- a/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/IncludeTask.hpp
+++ b/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/IncludeTask.hpp
@@ -26,6 +26,10 @@ namespace SimpleTasks
 class IncludeTask
 {
  public:
+    //! Constructs task with given \p entityType.
+    //! \param entityType The entity type of target to include.
+    explicit IncludeTask(EntityType entityType);
+
     //! Returns a list of minions based on the type of entity.
     //! \param entityType The type of entity.
     //! \param player The player to get hand or battlefield.
@@ -42,6 +46,22 @@ class IncludeTask
     //! \return A list of minions based on the type of entity.
     static std::vector<std::reference_wrapper<Minion>> GetMinions(
         EntityType entityType, Player& player, Minion& source, Minion& target);
+
+    //! Runs task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \param source The source minion.
+    //! \return The result of task processing.
+    TaskStatus Run(Player& player, Minion& source);
+
+    //! Runs task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \param source The source minion.
+    //! \param target The target minion.
+    //! \return The result of task processing.
+    TaskStatus Run(Player& player, Minion& source, Minion& target);
+
+ private:
+    EntityType m_entityType = EntityType::INVALID;
 };
 }  // namespace SimpleTasks
 }  // namespace RosettaStone::Battlegrounds

--- a/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/IncludeTask.hpp
+++ b/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/IncludeTask.hpp
@@ -33,6 +33,15 @@ class IncludeTask
     //! \return A list of minions based on the type of entity.
     static std::vector<std::reference_wrapper<Minion>> GetMinions(
         EntityType entityType, Player& player, Minion& source);
+
+    //! Returns a list of minions based on the type of entity.
+    //! \param entityType The type of entity.
+    //! \param player The player to get hand or battlefield.
+    //! \param source The source that indicates source minion.
+    //! \param target The source that indicates target minion.
+    //! \return A list of minions based on the type of entity.
+    static std::vector<std::reference_wrapper<Minion>> GetMinions(
+        EntityType entityType, Player& player, Minion& source, Minion& target);
 };
 }  // namespace SimpleTasks
 }  // namespace RosettaStone::Battlegrounds

--- a/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/RandomTask.hpp
+++ b/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/RandomTask.hpp
@@ -43,6 +43,7 @@ class RandomTask
     //! \return The result of task processing.
     TaskStatus Run(Player& player, Minion& source, Minion& target);
 
+ private:
     EntityType m_entityType = EntityType::INVALID;
     int m_amount = 0;
 };

--- a/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/ReduceTavernCostTask.hpp
+++ b/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/ReduceTavernCostTask.hpp
@@ -1,0 +1,53 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_BATTLEGROUNDS_REDUCE_TAVERN_COST_TASK_HPP
+#define ROSETTASTONE_BATTLEGROUNDS_REDUCE_TAVERN_COST_TASK_HPP
+
+#include <Rosetta/Common/Enums/TaskEnums.hpp>
+
+namespace RosettaStone::Battlegrounds
+{
+class Card;
+class Minion;
+class Player;
+
+namespace SimpleTasks
+{
+//!
+//! \brief ReduceTavernCostTask class.
+//!
+//! This class represents the task for reducing the cost of specific button
+//! in Tavern.
+//!
+class ReduceTavernCostTask
+{
+ public:
+    //! Constructs task with given \p button and \p cost.
+    //! \param button A specific button in Tavern.
+    //! \param cost The value of cost to reduce.
+    explicit ReduceTavernCostTask(TavernButton button, int cost);
+
+    //! Runs task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \param source The source minion.
+    //! \return The result of task processing.
+    TaskStatus Run(Player& player, Minion& source);
+
+    //! Runs task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \param source The source minion.
+    //! \param target The target minion.
+    //! \return The result of task processing.
+    TaskStatus Run(Player& player, Minion& source, Minion& target);
+
+ private:
+    TavernButton m_tavernButton;
+    int m_cost = 0;
+};
+}  // namespace SimpleTasks
+}  // namespace RosettaStone::Battlegrounds
+
+#endif  // ROSETTASTONE_BATTLEGROUNDS_REDUCE_TAVERN_COST_TASK_HPP

--- a/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/SetGameTagTask.hpp
+++ b/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/SetGameTagTask.hpp
@@ -1,0 +1,55 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_BATTLEGROUNDS_SET_GAME_TAG_TASK_HPP
+#define ROSETTASTONE_BATTLEGROUNDS_SET_GAME_TAG_TASK_HPP
+
+#include <Rosetta/Common/Enums/CardEnums.hpp>
+#include <Rosetta/Common/Enums/TaskEnums.hpp>
+
+namespace RosettaStone::Battlegrounds
+{
+class Card;
+class Minion;
+class Player;
+
+namespace SimpleTasks
+{
+//!
+//! \brief SetGameTagTask class.
+//!
+//! This class represents the task for setting game tag to minions.
+//!
+class SetGameTagTask
+{
+ public:
+    //! Constructs task with given \p entityType, \p tag and \p amount.
+    //! \param entityType The entity type of target to set game tag.
+    //! \param tag A game tag to set.
+    //! \param amount A value of game tag to set.
+    explicit SetGameTagTask(EntityType entityType, GameTag tag, int amount);
+
+    //! Runs task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \param source The source minion.
+    //! \return The result of task processing.
+    TaskStatus Run(Player& player, Minion& source);
+
+    //! Runs task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \param source The source minion.
+    //! \param target The target minion.
+    //! \return The result of task processing.
+    TaskStatus Run(Player& player, Minion& source, Minion& target);
+
+ private:
+    EntityType m_entityType = EntityType::INVALID;
+    GameTag m_gameTag = GameTag::INVALID;
+    int m_amount = 0;
+};
+}  // namespace SimpleTasks
+}  // namespace RosettaStone::Battlegrounds
+
+#endif  // ROSETTASTONE_BATTLEGROUNDS_SET_GAME_TAG_TASK_HPP

--- a/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/SummonTask.hpp
+++ b/Includes/Rosetta/Battlegrounds/Tasks/SimpleTasks/SummonTask.hpp
@@ -39,8 +39,11 @@ class SummonTask
     //! \param cardID The card ID to summon.
     //! \param amount The number of minions to summon.
     //! \param side The side of summoned minion.
+    //! \param addToStack The flag that indicates
+    //! whether the summon entity should add to stack.
     explicit SummonTask(const std::string_view& cardID, int amount,
-                        SummonSide side = SummonSide::DEFAULT);
+                        SummonSide side = SummonSide::DEFAULT,
+                        bool addToStack = false);
 
     //! Returns the position of minion to summon.
     //! \param source The source minion.
@@ -64,6 +67,7 @@ class SummonTask
     std::string_view m_cardID;
     SummonSide m_side = SummonSide::DEFAULT;
     int m_amount = 1;
+    bool m_addToStack = false;
 };
 }  // namespace SimpleTasks
 }  // namespace RosettaStone::Battlegrounds

--- a/Includes/Rosetta/Battlegrounds/Tasks/TaskType.hpp
+++ b/Includes/Rosetta/Battlegrounds/Tasks/TaskType.hpp
@@ -13,6 +13,7 @@
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/DamageHeroTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/GetGameTagTask.hpp>
+#include <Rosetta/Battlegrounds/Tasks/SimpleTasks/IncludeTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/ReduceTavernCostTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/RepeatNumberEndTask.hpp>
@@ -26,8 +27,9 @@ namespace RosettaStone::Battlegrounds
 using namespace SimpleTasks;
 using TaskType =
     std::variant<AddEnchantmentTask, AttackTask, CountTask, DamageHeroTask,
-                 DamageTask, GetGameTagTask, RandomTask, ReduceTavernCostTask,
-                 RepeatNumberEndTask, RepeatNumberStartTask, SummonTask>;
+                 DamageTask, GetGameTagTask, IncludeTask, RandomTask,
+                 ReduceTavernCostTask, RepeatNumberEndTask,
+                 RepeatNumberStartTask, SummonTask>;
 }  // namespace RosettaStone::Battlegrounds
 
 #endif  // ROSETTASTONE_BATTLEGROUNDS_TASK_TYPE_HPP

--- a/Includes/Rosetta/Battlegrounds/Tasks/TaskType.hpp
+++ b/Includes/Rosetta/Battlegrounds/Tasks/TaskType.hpp
@@ -8,6 +8,7 @@
 #define ROSETTASTONE_BATTLEGROUNDS_TASK_TYPE_HPP
 
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
+#include <Rosetta/Battlegrounds/Tasks/SimpleTasks/AttackTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/CountTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/DamageHeroTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/DamageTask.hpp>
@@ -24,8 +25,8 @@ namespace RosettaStone::Battlegrounds
 {
 using namespace SimpleTasks;
 using TaskType =
-    std::variant<AddEnchantmentTask, CountTask, DamageHeroTask, DamageTask,
-                 GetGameTagTask, RandomTask, ReduceTavernCostTask,
+    std::variant<AddEnchantmentTask, AttackTask, CountTask, DamageHeroTask,
+                 DamageTask, GetGameTagTask, RandomTask, ReduceTavernCostTask,
                  RepeatNumberEndTask, RepeatNumberStartTask, SummonTask>;
 }  // namespace RosettaStone::Battlegrounds
 

--- a/Includes/Rosetta/Battlegrounds/Tasks/TaskType.hpp
+++ b/Includes/Rosetta/Battlegrounds/Tasks/TaskType.hpp
@@ -18,6 +18,7 @@
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/ReduceTavernCostTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/RepeatNumberEndTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/RepeatNumberStartTask.hpp>
+#include <Rosetta/Battlegrounds/Tasks/SimpleTasks/SetGameTagTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/SummonTask.hpp>
 
 #include <variant>
@@ -29,7 +30,7 @@ using TaskType =
     std::variant<AddEnchantmentTask, AttackTask, CountTask, DamageHeroTask,
                  DamageTask, GetGameTagTask, IncludeTask, RandomTask,
                  ReduceTavernCostTask, RepeatNumberEndTask,
-                 RepeatNumberStartTask, SummonTask>;
+                 RepeatNumberStartTask, SetGameTagTask, SummonTask>;
 }  // namespace RosettaStone::Battlegrounds
 
 #endif  // ROSETTASTONE_BATTLEGROUNDS_TASK_TYPE_HPP

--- a/Includes/Rosetta/Battlegrounds/Tasks/TaskType.hpp
+++ b/Includes/Rosetta/Battlegrounds/Tasks/TaskType.hpp
@@ -13,6 +13,7 @@
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/GetGameTagTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/RandomTask.hpp>
+#include <Rosetta/Battlegrounds/Tasks/SimpleTasks/ReduceTavernCostTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/RepeatNumberEndTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/RepeatNumberStartTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/SummonTask.hpp>
@@ -24,8 +25,8 @@ namespace RosettaStone::Battlegrounds
 using namespace SimpleTasks;
 using TaskType =
     std::variant<AddEnchantmentTask, CountTask, DamageHeroTask, DamageTask,
-                 GetGameTagTask, RandomTask, RepeatNumberEndTask,
-                 RepeatNumberStartTask, SummonTask>;
+                 GetGameTagTask, RandomTask, ReduceTavernCostTask,
+                 RepeatNumberEndTask, RepeatNumberStartTask, SummonTask>;
 }  // namespace RosettaStone::Battlegrounds
 
 #endif  // ROSETTASTONE_BATTLEGROUNDS_TASK_TYPE_HPP

--- a/Includes/Rosetta/Battlegrounds/Triggers/Trigger.hpp
+++ b/Includes/Rosetta/Battlegrounds/Triggers/Trigger.hpp
@@ -51,10 +51,16 @@ class Trigger
     //! \param condition the condition of the trigger.
     void SetCondition(SelfCondition&& condition);
 
+    //! Validates triggers related to the current sequence at once before the
+    //! sequence starts.
+    //! \param owner The owner of trigger.
+    //! \param source The source of trigger.
+    void Validate(Minion& owner, Minion& source);
+
     //! Runs trigger logic internally.
-    //! \param player The player to run trigger.
-    //! \param source The source minion.
-    void Run(Player& player, Minion& source);
+    //! \param owner The owner of trigger.
+    //! \param source The source of trigger.
+    void Run(Minion& owner, Minion& source);
 
  private:
     TriggerType m_triggerType = TriggerType::NONE;
@@ -62,6 +68,8 @@ class Trigger
 
     std::vector<TaskType> m_tasks;
     std::optional<SelfCondition> m_condition;
+
+    bool m_isValidated = false;
 };
 }  // namespace RosettaStone::Battlegrounds
 

--- a/Includes/Rosetta/Battlegrounds/Zones/FieldZone.hpp
+++ b/Includes/Rosetta/Battlegrounds/Zones/FieldZone.hpp
@@ -90,6 +90,10 @@ class FieldZone
     //! \return true if this zone is full, false otherwise.
     bool IsFull() const;
 
+    //! Returns all minions in this zone.
+    //! \return All minions in this zone.
+    std::vector<std::reference_wrapper<Minion>> GetAll();
+
     //! Runs \p functor on each minion.
     //! \param functor A function to run for each minion.
     template <typename Functor>

--- a/Includes/Rosetta/Common/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/TaskEnums.hpp
@@ -75,6 +75,13 @@ enum class RelaSign
     GEQ,  //!< Greater equal.
     LEQ   //!< Lesser equal.
 };
+
+//! \brief An enumerator for identifying the button of Tavern in Battlegrounds.
+enum class TavernButton
+{
+    UPGRADE,
+    REFRESH,
+};
 }  // namespace RosettaStone
 
 #endif  // ROSETTASTONE_TASK_ENUMS_HPP

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -13,6 +13,7 @@
 #include <Rosetta/Battlegrounds/Cards/CardDef.hpp>
 #include <Rosetta/Battlegrounds/Cards/CardDefs.hpp>
 #include <Rosetta/Battlegrounds/Cards/Cards.hpp>
+#include <Rosetta/Battlegrounds/Cards/TargetingPredicates.hpp>
 #include <Rosetta/Battlegrounds/Conditions/SelfCondition.hpp>
 #include <Rosetta/Battlegrounds/Enchants/Effect.hpp>
 #include <Rosetta/Battlegrounds/Enchants/Effects.hpp>

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -33,6 +33,7 @@
 #include <Rosetta/Battlegrounds/Models/Spell.hpp>
 #include <Rosetta/Battlegrounds/Models/Tavern.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
+#include <Rosetta/Battlegrounds/Tasks/SimpleTasks/AttackTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/CountTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/DamageHeroTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/DamageTask.hpp>

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -39,6 +39,7 @@
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/GetGameTagTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/IncludeTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/RandomTask.hpp>
+#include <Rosetta/Battlegrounds/Tasks/SimpleTasks/ReduceTavernCostTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/RepeatNumberEndTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/RepeatNumberStartTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/SummonTask.hpp>

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -43,6 +43,7 @@
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/ReduceTavernCostTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/RepeatNumberEndTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/RepeatNumberStartTask.hpp>
+#include <Rosetta/Battlegrounds/Tasks/SimpleTasks/SetGameTagTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/SimpleTasks/SummonTask.hpp>
 #include <Rosetta/Battlegrounds/Tasks/TaskStack.hpp>
 #include <Rosetta/Battlegrounds/Tasks/TaskType.hpp>

--- a/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
+++ b/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
@@ -196,10 +196,14 @@ void BattlegroundsCardsGen::AddTier6Minions(
 void BattlegroundsCardsGen::AddTokenMinions(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------- MINION - BATTLEGROUNDS
     // [CFM_315t] Tabbycat (*) - COST:1 [ATK:1/HP:1]
     // - Race: Beast, Set: Gangs
     // --------------------------------------------------------
+    power.ClearData();
+    cards.emplace("CFM_315t", CardDef{ power });
 }
 
 void BattlegroundsCardsGen::AddEnchantments(

--- a/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
+++ b/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
@@ -11,6 +11,8 @@
 
 namespace RosettaStone::Battlegrounds
 {
+using PlayReqs = std::map<PlayReq, int>;
+
 void BattlegroundsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
 }
@@ -191,6 +193,31 @@ void BattlegroundsCardsGen::AddTier1Minions(
     power.ClearData();
     power.AddBattlecryTask(SummonTask{ "EX1_506a", 1, SummonSide::RIGHT });
     cards.emplace("EX1_506", CardDef{ power });
+
+    // --------------------------------- MINION - BATTLEGROUNDS
+    // [UNG_073] Rockpool Hunter - TIER:1 [ATK:2/HP:3]
+    // - Race: Murloc, Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a friendly Murloc +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_WITH_RACE = 14
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddBattlecryTask(
+        AddEnchantmentTask{ "UNG_073e", EntityType::TARGET });
+    cards.emplace(
+        "UNG_073",
+        CardDef{ power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },
+                                  { PlayReq::REQ_MINION_TARGET, 0 },
+                                  { PlayReq::REQ_TARGET_WITH_RACE, 14 },
+                                  { PlayReq::REQ_FRIENDLY_TARGET, 0 } } });
 }
 
 void BattlegroundsCardsGen::AddTier2Minions(
@@ -301,6 +328,16 @@ void BattlegroundsCardsGen::AddEnchantments(
     power.ClearData();
     power.AddEnchant(Enchant{ std::vector<Effect>{ Effects::AttackN(1) } });
     cards.emplace("EX1_509e", CardDef{ power });
+
+    // ---------------------------- ENCHANTMENT - BATTLEGROUNDS
+    // [UNG_073e] Trained (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: +1/+1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("UNG_073e"));
+    cards.emplace("UNG_073e", CardDef{ power });
 }
 
 void BattlegroundsCardsGen::AddAll(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
+++ b/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
@@ -26,7 +26,7 @@ void BattlegroundsCardsGen::AddTier1Minions(
 
     // --------------------------------- MINION - BATTLEGROUNDS
     // [CFM_315] Alleycat - TIER:1 [ATK:1/HP:1]
-    // - Race: Beast, Set: Gangs, Rarity: Common
+    // - Race: Beast, Set: Gangs
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Summon a 1/1 Cat.
     // --------------------------------------------------------
@@ -39,7 +39,7 @@ void BattlegroundsCardsGen::AddTier1Minions(
 
     // --------------------------------- MINION - BATTLEGROUNDS
     // [EX1_531] Scavenging Hyena - TIER:1 [ATK:2/HP:2]
-    // - Race: Beast, Set: Expert1, Rarity: Common
+    // - Race: Beast, Set: Expert1
     // --------------------------------------------------------
     // Text: Whenever a friendly Beast dies, gain +2/+1.
     // --------------------------------------------------------
@@ -54,7 +54,7 @@ void BattlegroundsCardsGen::AddTier1Minions(
 
     // --------------------------------- MINION - BATTLEGROUNDS
     // [YOD_026] Fiendish Servant - TIER:1 [ATK:2/HP:1]
-    // - Race: Demon, Set: YoD, Rarity: Common
+    // - Race: Demon, Set: YoD
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Give this minion's Attack
     //       to a random friendly minion.
@@ -69,7 +69,7 @@ void BattlegroundsCardsGen::AddTier1Minions(
 
     // --------------------------------- MINION - BATTLEGROUNDS
     // [LOOT_013] Vulgar Homunculus - TIER:1 [ATK:2/HP:4]
-    // - Race: Demon, Set: Lootapalooza, Rarity: Common
+    // - Race: Demon, Set: Lootapalooza
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     //       <b>Battlecry:</b> Deal 2 damage to your hero.
@@ -163,6 +163,21 @@ void BattlegroundsCardsGen::AddTier1Minions(
     power.GetTrigger().value().SetTasks(std::vector<TaskType>{
         AddEnchantmentTask{ "GVG_076a", EntityType::SOURCE } });
     cards.emplace("GVG_103", CardDef{ power });
+
+    // --------------------------------- MINION - BATTLEGROUNDS
+    // [EX1_509] Murloc Tidecaller - TIER:1 [ATK:1/HP:2]
+    // - Race: Murloc, Set: Expert1
+    // --------------------------------------------------------
+    // Text: Whenever you summon a Murloc, gain +1 Attack.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(Trigger{ TriggerType::SUMMON });
+    power.GetTrigger().value().SetTriggerSource(TriggerSource::FRIENDLY);
+    power.GetTrigger().value().SetTasks(std::vector<TaskType>{
+        AddEnchantmentTask{ "EX1_509e", EntityType::SOURCE } });
+    power.GetTrigger().value().SetCondition(
+        SelfCondition{ SelfCondition::IsRace(Race::MURLOC) });
+    cards.emplace("EX1_509", CardDef{ power });
 }
 
 void BattlegroundsCardsGen::AddTier2Minions(
@@ -256,6 +271,16 @@ void BattlegroundsCardsGen::AddEnchantments(
     power.ClearData();
     power.AddEnchant(Enchant{ std::vector<Effect>{ Effects::AttackN(1) } });
     cards.emplace("GVG_076a", CardDef{ power });
+
+    // ---------------------------- ENCHANTMENT - BATTLEGROUNDS
+    // [EX1_509e] Blarghghl (*) - COST:0
+    // - Set: Expert1
+    // --------------------------------------------------------
+    // Text: Increased Attack.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchant{ std::vector<Effect>{ Effects::AttackN(1) } });
+    cards.emplace("EX1_509e", CardDef{ power });
 }
 
 void BattlegroundsCardsGen::AddAll(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
+++ b/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
@@ -218,6 +218,20 @@ void BattlegroundsCardsGen::AddTier1Minions(
                                   { PlayReq::REQ_MINION_TARGET, 0 },
                                   { PlayReq::REQ_TARGET_WITH_RACE, 14 },
                                   { PlayReq::REQ_FRIENDLY_TARGET, 0 } } });
+
+    // --------------------------------- MINION - BATTLEGROUNDS
+    // [BGS_055] Deck Swabbie - TIER:1 [ATK:2/HP:2]
+    // - Race: Pirate, Set: Battlegrounds
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Reduce the cost of upgrading
+    //       Bob's Tavern by (1).
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddBattlecryTask(ReduceTavernCostTask{ TavernButton::UPGRADE, 1 });
+    cards.emplace("BGS_055", CardDef{ power });
 }
 
 void BattlegroundsCardsGen::AddTier2Minions(

--- a/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
+++ b/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
@@ -261,6 +261,26 @@ void BattlegroundsCardsGen::AddTier1Minions(
     // --------------------------------------------------------
     power.ClearData();
     cards.emplace("ICC_038", CardDef{ power });
+
+    // --------------------------------- MINION - BATTLEGROUNDS
+    // [OG_221] Selfless Hero - TIER:1 [ATK:2/HP:1]
+    // - Set: Og
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Give a random friendly minion
+    //       <b>Divine Shield</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DIVINE_SHIELD = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(IncludeTask{ EntityType::MINIONS });
+    power.AddDeathrattleTask(RandomTask{ EntityType::STACK, 1 });
+    power.AddDeathrattleTask(
+        SetGameTagTask{ EntityType::STACK, GameTag::DIVINE_SHIELD, 1 });
+    cards.emplace("OG_221", CardDef{ power });
 }
 
 void BattlegroundsCardsGen::AddTier2Minions(

--- a/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
+++ b/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
@@ -193,7 +193,7 @@ void BattlegroundsCardsGen::AddTier6Minions(
 {
 }
 
-void BattlegroundsCardsGen::AddMinionsNonCollect(
+void BattlegroundsCardsGen::AddTokenMinions(
     std::map<std::string, CardDef>& cards)
 {
     // --------------------------------- MINION - BATTLEGROUNDS
@@ -202,7 +202,7 @@ void BattlegroundsCardsGen::AddMinionsNonCollect(
     // --------------------------------------------------------
 }
 
-void BattlegroundsCardsGen::AddSpellsNonCollect(
+void BattlegroundsCardsGen::AddEnchantments(
     std::map<std::string, CardDef>& cards)
 {
 }
@@ -219,7 +219,7 @@ void BattlegroundsCardsGen::AddAll(std::map<std::string, CardDef>& cards)
     AddTier5Minions(cards);
     AddTier6Minions(cards);
 
-    AddMinionsNonCollect(cards);
-    AddSpellsNonCollect(cards);
+    AddTokenMinions(cards);
+    AddEnchantments(cards);
 }
 }  // namespace RosettaStone::Battlegrounds

--- a/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
+++ b/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
@@ -178,6 +178,19 @@ void BattlegroundsCardsGen::AddTier1Minions(
     power.GetTrigger().value().SetCondition(
         SelfCondition{ SelfCondition::IsRace(Race::MURLOC) });
     cards.emplace("EX1_509", CardDef{ power });
+
+    // --------------------------------- MINION - BATTLEGROUNDS
+    // [EX1_506] Murloc Tidehunter - TIER:1 [ATK:2/HP:1]
+    // - Race: Murloc, Set: Core
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon a 1/1 Murloc Scout.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddBattlecryTask(SummonTask{ "EX1_506a", 1, SummonSide::RIGHT });
+    cards.emplace("EX1_506", CardDef{ power });
 }
 
 void BattlegroundsCardsGen::AddTier2Minions(
@@ -223,6 +236,13 @@ void BattlegroundsCardsGen::AddTokenMinions(
     // --------------------------------------------------------
     power.ClearData();
     cards.emplace("BOT_445t", CardDef{ power });
+
+    // --------------------------------- MINION - BATTLEGROUNDS
+    // [EX1_506a] Murloc Scout (*) - TIER:1 [ATK:1/HP:1]
+    // - Race: Murloc, Set: Core
+    // --------------------------------------------------------
+    power.ClearData();
+    cards.emplace("EX1_506a", CardDef{ power });
 }
 
 void BattlegroundsCardsGen::AddEnchantments(

--- a/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
+++ b/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
@@ -232,6 +232,22 @@ void BattlegroundsCardsGen::AddTier1Minions(
     power.ClearData();
     power.AddBattlecryTask(ReduceTavernCostTask{ TavernButton::UPGRADE, 1 });
     cards.emplace("BGS_055", CardDef{ power });
+
+    // --------------------------------- MINION - BATTLEGROUNDS
+    // [BGS_061] Scallywag - TIER:1 [ATK:2/HP:1]
+    // - Race: Pirate, Set: Battlegrounds
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon a 1/1 Pirate.
+    //       It attacks immediately.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        SummonTask{ "BGS_061t", 1, SummonSide::DEATHRATTLE, true });
+    power.AddDeathrattleTask(AttackTask{ EntityType::STACK });
+    cards.emplace("BGS_061", CardDef{ power });
 }
 
 void BattlegroundsCardsGen::AddTier2Minions(
@@ -284,6 +300,13 @@ void BattlegroundsCardsGen::AddTokenMinions(
     // --------------------------------------------------------
     power.ClearData();
     cards.emplace("EX1_506a", CardDef{ power });
+
+    // --------------------------------- MINION - BATTLEGROUNDS
+    // [BGS_061t] Sky Pirate (*) - TIER:1 [ATK:1/HP:1]
+    // - Race: Pirate, Set: Battlegrounds
+    // --------------------------------------------------------
+    power.ClearData();
+    cards.emplace("BGS_061t", CardDef{ power });
 }
 
 void BattlegroundsCardsGen::AddEnchantments(

--- a/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
+++ b/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
@@ -148,6 +148,21 @@ void BattlegroundsCardsGen::AddTier1Minions(
     power.AddDeathrattleTask(
         SummonTask{ "BOT_445t", 1, SummonSide::DEATHRATTLE });
     cards.emplace("BOT_445", CardDef{ power });
+
+    // --------------------------------- MINION - BATTLEGROUNDS
+    // [GVG_103] Micro Machine - TIER:1 [ATK:1/HP:2]
+    // - Race: Mechanical, Set: Gvg
+    // --------------------------------------------------------
+    // Text: At the start of each turn, gain +1 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(Trigger{ TriggerType::TURN_START });
+    power.GetTrigger().value().SetTasks(std::vector<TaskType>{
+        AddEnchantmentTask{ "GVG_076a", EntityType::SOURCE } });
+    cards.emplace("GVG_103", CardDef{ power });
 }
 
 void BattlegroundsCardsGen::AddTier2Minions(
@@ -231,6 +246,16 @@ void BattlegroundsCardsGen::AddEnchantments(
     power.AddEnchant(Enchant{
         std::vector<Effect>{ Effects::AttackN(2), Effects::HealthN(2) } });
     cards.emplace("BGS_004e", CardDef{ power });
+
+    // ---------------------------- ENCHANTMENT - BATTLEGROUNDS
+    // [GVG_076a] Pistons (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Increased Attack.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchant{ std::vector<Effect>{ Effects::AttackN(1) } });
+    cards.emplace("GVG_076a", CardDef{ power });
 }
 
 void BattlegroundsCardsGen::AddAll(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
+++ b/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
@@ -52,17 +52,6 @@ void BattlegroundsCardsGen::AddTier1Minions(
         SelfCondition{ SelfCondition::IsRace(Race::BEAST) });
     cards.emplace("EX1_531", CardDef{ power });
 
-    // ---------------------------- ENCHANTMENT - BATTLEGROUNDS
-    // [EX1_531e] Well Fed (*) - COST:0
-    // - Set: Expert1
-    // --------------------------------------------------------
-    // Text: Increased Attack and Health.
-    // --------------------------------------------------------
-    power.ClearData();
-    power.AddEnchant(Enchant{
-        std::vector<Effect>{ Effects::AttackN(2), Effects::HealthN(1) } });
-    cards.emplace("EX1_531e", CardDef{ power });
-
     // --------------------------------- MINION - BATTLEGROUNDS
     // [YOD_026] Fiendish Servant - TIER:1 [ATK:2/HP:1]
     // - Race: Demon, Set: YoD, Rarity: Common
@@ -77,16 +66,6 @@ void BattlegroundsCardsGen::AddTier1Minions(
     power.AddDeathrattleTask(
         AddEnchantmentTask{ "Yod_026e", EntityType::STACK, true });
     cards.emplace("YOD_026", CardDef{ power });
-
-    // ---------------------------- ENCHANTMENT - BATTLEGROUNDS
-    // [Yod_026e] Servant's Sacrifice (*) - COST:0
-    // - Set: YoD
-    // --------------------------------------------------------
-    // Text: Increased Attack.
-    // --------------------------------------------------------
-    power.ClearData();
-    power.AddEnchant(Enchant{ Enchants::AddAttackScriptTag });
-    cards.emplace("Yod_026e", CardDef(power));
 
     // --------------------------------- MINION - BATTLEGROUNDS
     // [LOOT_013] Vulgar Homunculus - TIER:1 [ATK:2/HP:4]
@@ -123,17 +102,6 @@ void BattlegroundsCardsGen::AddTier1Minions(
     power.GetTrigger().value().SetCondition(
         SelfCondition{ SelfCondition::IsRace(Race::DEMON) });
     cards.emplace("BGS_004", CardDef{ power });
-
-    // ---------------------------- ENCHANTMENT - BATTLEGROUNDS
-    // [BGS_004e] Wrath Woven (*) - COST:0
-    // - Set: Battlegrounds
-    // --------------------------------------------------------
-    // Text: Increased stats.
-    // --------------------------------------------------------
-    power.ClearData();
-    power.AddEnchant(Enchant{
-        std::vector<Effect>{ Effects::AttackN(2), Effects::HealthN(2) } });
-    cards.emplace("BGS_004e", CardDef{ power });
 
     // --------------------------------- MINION - BATTLEGROUNDS
     // [BGS_039] Dragonspawn Lieutenant - TIER:1 [ATK:2/HP:2]
@@ -209,6 +177,39 @@ void BattlegroundsCardsGen::AddTokenMinions(
 void BattlegroundsCardsGen::AddEnchantments(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
+    // ---------------------------- ENCHANTMENT - BATTLEGROUNDS
+    // [EX1_531e] Well Fed (*) - COST:0
+    // - Set: Expert1
+    // --------------------------------------------------------
+    // Text: Increased Attack and Health.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchant{
+        std::vector<Effect>{ Effects::AttackN(2), Effects::HealthN(1) } });
+    cards.emplace("EX1_531e", CardDef{ power });
+
+    // ---------------------------- ENCHANTMENT - BATTLEGROUNDS
+    // [Yod_026e] Servant's Sacrifice (*) - COST:0
+    // - Set: YoD
+    // --------------------------------------------------------
+    // Text: Increased Attack.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchant{ Enchants::AddAttackScriptTag });
+    cards.emplace("Yod_026e", CardDef(power));
+
+    // ---------------------------- ENCHANTMENT - BATTLEGROUNDS
+    // [BGS_004e] Wrath Woven (*) - COST:0
+    // - Set: Battlegrounds
+    // --------------------------------------------------------
+    // Text: Increased stats.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchant{
+        std::vector<Effect>{ Effects::AttackN(2), Effects::HealthN(2) } });
+    cards.emplace("BGS_004e", CardDef{ power });
 }
 
 void BattlegroundsCardsGen::AddAll(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
+++ b/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
@@ -248,6 +248,19 @@ void BattlegroundsCardsGen::AddTier1Minions(
         SummonTask{ "BGS_061t", 1, SummonSide::DEATHRATTLE, true });
     power.AddDeathrattleTask(AttackTask{ EntityType::STACK });
     cards.emplace("BGS_061", CardDef{ power });
+
+    // --------------------------------- MINION - BATTLEGROUNDS
+    // [ICC_038] Righteous Protector - TIER:1 [ATK:1/HP:1]
+    // - Set: Icecrown
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b> <b>Divine Shield</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - DIVINE_SHIELD = 1
+    // - TAUNT = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    cards.emplace("ICC_038", CardDef{ power });
 }
 
 void BattlegroundsCardsGen::AddTier2Minions(

--- a/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
+++ b/Sources/Rosetta/Battlegrounds/CardSets/BattlegroundsCardsGen.cpp
@@ -134,6 +134,20 @@ void BattlegroundsCardsGen::AddTier1Minions(
     power.AddStartCombatTask(DamageTask{ EntityType::STACK, 1 });
     power.AddStartCombatTask(RepeatNumberEndTask{});
     cards.emplace("BGS_019", CardDef{ power });
+
+    // --------------------------------- MINION - BATTLEGROUNDS
+    // [BOT_445] Mecharoo - TIER:1 [ATK:1/HP:1]
+    // - Race: Mechanical, Set: Boomsday
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon a 1/1 Jo-E Bot.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        SummonTask{ "BOT_445t", 1, SummonSide::DEATHRATTLE });
+    cards.emplace("BOT_445", CardDef{ power });
 }
 
 void BattlegroundsCardsGen::AddTier2Minions(
@@ -167,11 +181,18 @@ void BattlegroundsCardsGen::AddTokenMinions(
     Power power;
 
     // --------------------------------- MINION - BATTLEGROUNDS
-    // [CFM_315t] Tabbycat (*) - COST:1 [ATK:1/HP:1]
+    // [CFM_315t] Tabbycat (*) - TIER:1 [ATK:1/HP:1]
     // - Race: Beast, Set: Gangs
     // --------------------------------------------------------
     power.ClearData();
     cards.emplace("CFM_315t", CardDef{ power });
+
+    // --------------------------------- MINION - BATTLEGROUNDS
+    // [BOT_445t] Jo-E Bot (*) - TIER:1 [ATK:1/HP:1]
+    // - Race: Mechanical, Set: Boomsday
+    // --------------------------------------------------------
+    power.ClearData();
+    cards.emplace("BOT_445t", CardDef{ power });
 }
 
 void BattlegroundsCardsGen::AddEnchantments(

--- a/Sources/Rosetta/Battlegrounds/Cards/Card.cpp
+++ b/Sources/Rosetta/Battlegrounds/Cards/Card.cpp
@@ -30,6 +30,7 @@ void Card::Initialize()
                 break;
             case PlayReq::REQ_FRIENDLY_TARGET:
                 friendlyType = FriendlyType::FRIENDLY;
+                break;
             case PlayReq::REQ_TARGET_WITH_RACE:
             {
                 const Race race = static_cast<Race>(requirement.second);

--- a/Sources/Rosetta/Battlegrounds/Cards/Card.cpp
+++ b/Sources/Rosetta/Battlegrounds/Cards/Card.cpp
@@ -172,4 +172,18 @@ bool Card::IsTier6MinionInPool() const
 
     return false;
 }
+
+bool Card::IsPlayableByCardReq(Player& player) const
+{
+    for (const auto& playReq : playRequirements)
+    {
+        switch (playReq.first)
+        {
+            default:
+                break;
+        }
+    }
+
+    return true;
+}
 }  // namespace RosettaStone::Battlegrounds

--- a/Sources/Rosetta/Battlegrounds/Cards/Card.cpp
+++ b/Sources/Rosetta/Battlegrounds/Cards/Card.cpp
@@ -173,14 +173,30 @@ bool Card::IsTier6MinionInPool() const
     return false;
 }
 
-bool Card::IsPlayableByCardReq(Player& player) const
+bool Card::IsPlayableByCardReq([[maybe_unused]] Player& player) const
 {
-    for (const auto& playReq : playRequirements)
+    //for (const auto& playReq : playRequirements)
+    //{
+    //    switch (playReq.first)
+    //    {
+    //        default:
+    //            break;
+    //    }
+    //}
+
+    return true;
+}
+
+bool Card::TargetingRequirements(Minion& target) const
+{
+    if (!targetingPredicate.empty())
     {
-        switch (playReq.first)
+        for (const auto& predicate : targetingPredicate)
         {
-            default:
-                break;
+            if (!predicate(target))
+            {
+                return false;
+            }
         }
     }
 

--- a/Sources/Rosetta/Battlegrounds/Cards/Card.cpp
+++ b/Sources/Rosetta/Battlegrounds/Cards/Card.cpp
@@ -6,11 +6,62 @@
 
 #include <Rosetta/Battlegrounds/Cards/Card.hpp>
 #include <Rosetta/Common/Constants.hpp>
+#include <Rosetta/Common/Enums/TargetingEnums.hpp>
 
 #include <algorithm>
 
 namespace RosettaStone::Battlegrounds
 {
+void Card::Initialize()
+{
+    bool needsTarget = false;
+    CharacterType characterType = CharacterType::CHARACTERS;
+    FriendlyType friendlyType = FriendlyType::ALL;
+
+    for (auto& requirement : playRequirements)
+    {
+        switch (requirement.first)
+        {
+            case PlayReq::REQ_TARGET_IF_AVAILABLE:
+                needsTarget = true;
+                break;
+            case PlayReq::REQ_MINION_TARGET:
+                characterType = CharacterType::MINIONS;
+                break;
+            case PlayReq::REQ_FRIENDLY_TARGET:
+                friendlyType = FriendlyType::FRIENDLY;
+            case PlayReq::REQ_TARGET_WITH_RACE:
+            {
+                const Race race = static_cast<Race>(requirement.second);
+                targetingPredicate.emplace_back(
+                    TargetingPredicates::ReqTargetWithRace(race));
+            }
+            break;
+            default:
+                continue;
+        }
+    }
+
+    if (needsTarget)
+    {
+        switch (characterType)
+        {
+            case CharacterType::MINIONS:
+                switch (friendlyType)
+                {
+                    case FriendlyType::FRIENDLY:
+                        targetingType = TargetingType::FRIENDLY_MINIONS;
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            default:
+                break;
+        }
+    }
+}
+
 CardType Card::GetCardType() const
 {
     return static_cast<CardType>(gameTags.at(GameTag::CARDTYPE));

--- a/Sources/Rosetta/Battlegrounds/Cards/CardDef.cpp
+++ b/Sources/Rosetta/Battlegrounds/Cards/CardDef.cpp
@@ -6,9 +6,11 @@
 
 #include <Rosetta/Battlegrounds/Cards/CardDef.hpp>
 
+#include <utility>
+
 namespace RosettaStone::Battlegrounds
 {
-CardDef::CardDef(Power _power) : power(_power)
+CardDef::CardDef(Power _power) : power(std::move(_power))
 {
     // Do nothing
 }

--- a/Sources/Rosetta/Battlegrounds/Cards/CardDef.cpp
+++ b/Sources/Rosetta/Battlegrounds/Cards/CardDef.cpp
@@ -14,4 +14,10 @@ CardDef::CardDef(Power _power) : power(std::move(_power))
 {
     // Do nothing
 }
+
+CardDef::CardDef(Power _power, std::map<PlayReq, int> _playReqs)
+    : power(std::move(_power)), playReqs(std::move(_playReqs))
+{
+    // Do nothing
+}
 }  // namespace RosettaStone::Battlegrounds

--- a/Sources/Rosetta/Battlegrounds/Cards/Cards.cpp
+++ b/Sources/Rosetta/Battlegrounds/Cards/Cards.cpp
@@ -30,6 +30,8 @@ Cards::Cards()
 
     for (auto& card : m_cards)
     {
+        card.Initialize();
+
         if (card.GetCardType() == CardType::HERO && card.isCurHero)
         {
             m_curHeroes.at(heroIdx) = card;

--- a/Sources/Rosetta/Battlegrounds/Cards/TargetingPredicates.cpp
+++ b/Sources/Rosetta/Battlegrounds/Cards/TargetingPredicates.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <Rosetta/Battlegrounds/Cards/TargetingPredicates.hpp>
+#include <Rosetta/Battlegrounds/Models/Minion.hpp>
+
+#include <stdexcept>
+
+namespace RosettaStone::Battlegrounds
+{
+TargetingPredicate TargetingPredicates::ReqMurlocTarget()
+{
+    return [](Minion& minion) { return minion.GetRace() == Race::MURLOC; };
+}
+
+TargetingPredicate TargetingPredicates::ReqTargetWithRace(Race race)
+{
+    switch (race)
+    {
+        case Race::MURLOC:
+            return ReqMurlocTarget();
+        default:
+            throw std::invalid_argument(
+                "TargetingPredicates::ReqTargetWithRace() - "
+                "Race is not implemented!");
+    }
+}
+}  // namespace RosettaStone::Battlegrounds

--- a/Sources/Rosetta/Battlegrounds/Enchants/Enchants.cpp
+++ b/Sources/Rosetta/Battlegrounds/Enchants/Enchants.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <Rosetta/Battlegrounds/Cards/Cards.hpp>
+#include <Rosetta/Battlegrounds/Enchants/Enchants.hpp>
+
+#include <regex>
+
+namespace RosettaStone::Battlegrounds
+{
+Enchant Enchants::GetEnchantFromText(const std::string& cardID)
+{
+    std::vector<Effect> effects;
+
+    static std::regex attackHealthRegex(
+        R"(([\+\-][[:digit:]]+)/([\+\-][[:digit:]]+))");
+
+    const auto card = Cards::FindCardByID(cardID);
+    const std::string text = card.text;
+    std::smatch values;
+
+    if (std::regex_search(text, values, attackHealthRegex))
+    {
+        effects.emplace_back(Effects::AttackN(std::stoi(values[1].str())));
+        effects.emplace_back(Effects::HealthN(std::stoi(values[2].str())));
+    }
+
+    return Enchant{ effects, false };
+}
+}  // namespace RosettaStone::Battlegrounds

--- a/Sources/Rosetta/Battlegrounds/Enchants/Power.cpp
+++ b/Sources/Rosetta/Battlegrounds/Enchants/Power.cpp
@@ -11,6 +11,7 @@ namespace RosettaStone::Battlegrounds
 void Power::ClearData()
 {
     m_battlecryTask.clear();
+    m_startCombatTask.clear();
     m_deathrattleTask.clear();
     m_enchant.reset();
     m_trigger.reset();

--- a/Sources/Rosetta/Battlegrounds/Games/Game.cpp
+++ b/Sources/Rosetta/Battlegrounds/Games/Game.cpp
@@ -52,10 +52,13 @@ void Game::Start()
 
     // Create callback to purchase a minion in Tavern
     auto purchaseMinionCallback = [](Player& player, std::size_t tavernIdx) {
-        player.hand.Add(
-            player.tavern.fieldZone.Remove(player.tavern.fieldZone[tavernIdx]),
-            -1);
+        Minion minion =
+            player.tavern.fieldZone.Remove(player.tavern.fieldZone[tavernIdx]);
+        player.hand.Add(minion, -1);
     };
+
+    // Create callback to get next card index
+    auto getNextCardIndexCallback = [this]() -> int { return m_cardIndex++; };
 
     // Create callback to return a minion to the minion pool
     auto returnMinionCallback = [this](int poolIdx) {
@@ -157,6 +160,7 @@ void Game::Start()
         player.selectHeroCallback = selectHeroCallback;
         player.prepareTavernMinionsCallback = prepareTavernMinionsCallback;
         player.purchaseMinionCallback = purchaseMinionCallback;
+        player.getNextCardIndexCallback = getNextCardIndexCallback;
         player.returnMinionCallback = returnMinionCallback;
         player.clearTavernMinionsCallback = clearTavernMinionsCallback;
         player.upgradeTavernCallback = upgradeTavernCallback;

--- a/Sources/Rosetta/Battlegrounds/Games/Game.cpp
+++ b/Sources/Rosetta/Battlegrounds/Games/Game.cpp
@@ -267,8 +267,15 @@ void Game::Combat()
     // Simulates a battle for each pair
     for (const auto& pair : m_playerFightPair)
     {
-        Battle battle(m_gameState.players.at(std::get<0>(pair)),
-                      m_gameState.players.at(std::get<1>(pair)));
+        Player& player1 = m_gameState.players.at(std::get<0>(pair));
+        Player& player2 = m_gameState.players.at(std::get<1>(pair));
+
+        Battle battle(player1, player2);
+
+        // Create callback to get battle
+        player1.getBattleCallback = [&]() -> Battle& { return battle; };
+        player2.getBattleCallback = [&]() -> Battle& { return battle; };
+
         battle.Run();
     }
 

--- a/Sources/Rosetta/Battlegrounds/Loaders/InternalCardLoader.cpp
+++ b/Sources/Rosetta/Battlegrounds/Loaders/InternalCardLoader.cpp
@@ -16,6 +16,7 @@ void InternalCardLoader::Load(std::array<Card, NUM_ALL_CARDS>& cards)
         const auto cardDef = CardDefs::GetInstance().FindCardDefByID(card.id);
 
         card.power = cardDef.power;
+        card.playRequirements = cardDef.playReqs;
     }
 }
 }  // namespace RosettaStone::Battlegrounds

--- a/Sources/Rosetta/Battlegrounds/Models/Battle.cpp
+++ b/Sources/Rosetta/Battlegrounds/Models/Battle.cpp
@@ -77,6 +77,31 @@ void Battle::Run()
 
     while (!IsDone())
     {
+        if (m_turn == Turn::PLAYER1)
+        {
+            m_p1Field.ForEachAlive([&](MinionData& aliveMinion) {
+                aliveMinion.value().ActivateTrigger(TriggerType::TURN_START, {},
+                                                    m_player1);
+            });
+
+            m_p2Field.ForEachAlive([&](MinionData& aliveMinion) {
+                aliveMinion.value().ActivateTrigger(TriggerType::TURN_START, {},
+                                                    m_player2);
+            });
+        }
+        else
+        {
+            m_p2Field.ForEachAlive([&](MinionData& aliveMinion) {
+                aliveMinion.value().ActivateTrigger(TriggerType::TURN_START, {},
+                                                    m_player2);
+            });
+
+            m_p1Field.ForEachAlive([&](MinionData& aliveMinion) {
+                aliveMinion.value().ActivateTrigger(TriggerType::TURN_START, {},
+                                                    m_player1);
+            });
+        }
+
         const bool curAttackSuccess = Attack();
         if (!prevAttackSuccess && !curAttackSuccess)
         {

--- a/Sources/Rosetta/Battlegrounds/Models/Battle.cpp
+++ b/Sources/Rosetta/Battlegrounds/Models/Battle.cpp
@@ -79,26 +79,42 @@ void Battle::Run()
     {
         if (m_turn == Turn::PLAYER1)
         {
-            m_p1Field.ForEachAlive([&](MinionData& aliveMinion) {
-                aliveMinion.value().ActivateTrigger(TriggerType::TURN_START, {},
-                                                    m_player1);
+            m_p1Field.ForEachAlive([&](MinionData& owner) {
+                m_p1Field.ForEachAlive([&](MinionData& minion) {
+                    {
+                        owner.value().ActivateTrigger(TriggerType::TURN_START,
+                                                      minion.value());
+                    };
+                });
             });
 
-            m_p2Field.ForEachAlive([&](MinionData& aliveMinion) {
-                aliveMinion.value().ActivateTrigger(TriggerType::TURN_START, {},
-                                                    m_player2);
+            m_p2Field.ForEachAlive([&](MinionData& owner) {
+                m_p2Field.ForEachAlive([&](MinionData& minion) {
+                    {
+                        owner.value().ActivateTrigger(TriggerType::TURN_START,
+                                                      minion.value());
+                    };
+                });
             });
         }
         else
         {
-            m_p2Field.ForEachAlive([&](MinionData& aliveMinion) {
-                aliveMinion.value().ActivateTrigger(TriggerType::TURN_START, {},
-                                                    m_player2);
+            m_p2Field.ForEachAlive([&](MinionData& owner) {
+                m_p2Field.ForEachAlive([&](MinionData& minion) {
+                    {
+                        owner.value().ActivateTrigger(TriggerType::TURN_START,
+                                                      minion.value());
+                    };
+                });
             });
 
-            m_p1Field.ForEachAlive([&](MinionData& aliveMinion) {
-                aliveMinion.value().ActivateTrigger(TriggerType::TURN_START, {},
-                                                    m_player1);
+            m_p1Field.ForEachAlive([&](MinionData& owner) {
+                m_p1Field.ForEachAlive([&](MinionData& minion) {
+                    {
+                        owner.value().ActivateTrigger(TriggerType::TURN_START,
+                                                      minion.value());
+                    };
+                });
             });
         }
 
@@ -238,7 +254,6 @@ void Battle::ProcessDestroy(bool beforeAttack)
         });
     }
 
-    Player& curPlayer = m_turn == Turn::PLAYER1 ? m_player1 : m_player2;
     // A variable to check a minion at the index of next attacker is destroyed
     bool isAttackerDestroyed = false;
 
@@ -268,13 +283,11 @@ void Battle::ProcessDestroy(bool beforeAttack)
             }
 
             m_p1Field.ForEachAlive([&](MinionData& aliveMinion) {
-                aliveMinion.value().ActivateTrigger(
-                    TriggerType::DEATH, { TriggerSource::FRIENDLY }, curPlayer);
+                aliveMinion.value().ActivateTrigger(TriggerType::DEATH, minion);
             });
 
             m_p2Field.ForEachAlive([&](MinionData& aliveMinion) {
-                aliveMinion.value().ActivateTrigger(
-                    TriggerType::DEATH, { TriggerSource::ENEMY }, curPlayer);
+                aliveMinion.value().ActivateTrigger(TriggerType::DEATH, minion);
             });
 
             minion.SetLastFieldPos(minion.GetZonePosition());
@@ -301,13 +314,11 @@ void Battle::ProcessDestroy(bool beforeAttack)
             }
 
             m_p1Field.ForEachAlive([&](MinionData& aliveMinion) {
-                aliveMinion.value().ActivateTrigger(
-                    TriggerType::DEATH, { TriggerSource::ENEMY }, curPlayer);
+                aliveMinion.value().ActivateTrigger(TriggerType::DEATH, minion);
             });
 
             m_p2Field.ForEachAlive([&](MinionData& aliveMinion) {
-                aliveMinion.value().ActivateTrigger(
-                    TriggerType::DEATH, { TriggerSource::FRIENDLY }, curPlayer);
+                aliveMinion.value().ActivateTrigger(TriggerType::DEATH, minion);
             });
 
             minion.SetLastFieldPos(minion.GetZonePosition());

--- a/Sources/Rosetta/Battlegrounds/Models/Battle.cpp
+++ b/Sources/Rosetta/Battlegrounds/Models/Battle.cpp
@@ -252,6 +252,7 @@ void Battle::ProcessDestroy(bool beforeAttack)
                     TriggerType::DEATH, { TriggerSource::ENEMY }, curPlayer);
             });
 
+            minion.SetLastFieldPos(minion.GetZonePosition());
             removedMinion = m_p1Field.Remove(minion);
         }
         else
@@ -284,6 +285,7 @@ void Battle::ProcessDestroy(bool beforeAttack)
                     TriggerType::DEATH, { TriggerSource::FRIENDLY }, curPlayer);
             });
 
+            minion.SetLastFieldPos(minion.GetZonePosition());
             removedMinion = m_p2Field.Remove(minion);
         }
 

--- a/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
+++ b/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
@@ -215,6 +215,21 @@ bool Minion::HasAnyValidPlayTargets(Player& player) const
     return false;
 }
 
+bool Minion::CheckTargetingType([[maybe_unused]] Minion& target)
+{
+    switch (m_card.targetingType)
+    {
+        case TargetingType::NONE:
+            return false;
+        case TargetingType::FRIENDLY_MINIONS:
+            return true;
+        default:
+            break;
+    }
+
+    return true;
+}
+
 void Minion::ActivateTrigger(TriggerType type, Minion& source)
 {
     auto& trigger = m_card.power.GetTrigger();

--- a/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
+++ b/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
@@ -173,9 +173,7 @@ bool Minion::IsDestroyed() const
     return m_isDestroyed;
 }
 
-void Minion::ActivateTrigger(TriggerType type,
-                             std::initializer_list<TriggerSource> sources,
-                             Player& player)
+void Minion::ActivateTrigger(TriggerType type, Minion& source)
 {
     auto& trigger = m_card.power.GetTrigger();
     if (!trigger.has_value())
@@ -188,20 +186,7 @@ void Minion::ActivateTrigger(TriggerType type,
         return;
     }
 
-    if (trigger.value().GetTriggerSource() == TriggerSource::NONE)
-    {
-        trigger.value().Run(player, *this);
-    }
-    else
-    {
-        for (const auto& source : sources)
-        {
-            if (trigger.value().GetTriggerSource() == source)
-            {
-                trigger.value().Run(player, *this);
-            }
-        }
-    }
+    trigger.value().Run(*this, source);
 }
 
 void Minion::ActivateTask(PowerType type, Player& player)

--- a/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
+++ b/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
@@ -215,6 +215,45 @@ bool Minion::HasAnyValidPlayTargets(Player& player) const
     return false;
 }
 
+bool Minion::IsValidPlayTarget(Player& player, int targetIdx)
+{
+    if (targetIdx == -1)
+    {
+        if (m_card.mustHaveToTargetToPlay)
+        {
+            return false;
+        }
+
+        if (m_card.targetingType == TargetingType::NONE)
+        {
+            return true;
+        }
+
+        if (!HasAnyValidPlayTargets(player))
+        {
+            return true;
+        }
+
+        return false;
+    }
+    else
+    {
+        Minion& target = player.recruitField[targetIdx];
+
+        if (!CheckTargetingType(target))
+        {
+            return false;
+        }
+
+        if (m_card.TargetingRequirements(target))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool Minion::CheckTargetingType([[maybe_unused]] Minion& target)
 {
     switch (m_card.targetingType)

--- a/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
+++ b/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
@@ -173,6 +173,33 @@ bool Minion::IsDestroyed() const
     return m_isDestroyed;
 }
 
+bool Minion::HasAnyValidPlayTargets(Player& player) const
+{
+    bool friendlyMinions = false;
+    
+    switch (m_card.targetingType)
+    {
+        case TargetingType::FRIENDLY_MINIONS:
+            friendlyMinions = true;
+            break;
+        default:
+            break;
+    }
+
+    if (friendlyMinions)
+    {
+        for (auto& minion : player.recruitField.GetAll())
+        {
+            if (m_card.TargetingRequirements(minion))
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 void Minion::ActivateTrigger(TriggerType type, Minion& source)
 {
     auto& trigger = m_card.power.GetTrigger();

--- a/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
+++ b/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
@@ -180,7 +180,7 @@ bool Minion::IsPlayableByCardReq(Player& player) const
         return false;
     }
 
-    if (!m_card.mustHaveToTargetToPlay && !HasAnyValidPlayTargets(player))
+    if (m_card.mustHaveToTargetToPlay && !HasAnyValidPlayTargets(player))
     {
         return false;
     }

--- a/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
+++ b/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
@@ -178,11 +178,18 @@ void Minion::ActivateTrigger(TriggerType type,
         return;
     }
 
-    for (const auto& source : sources)
+    if (trigger.value().GetTriggerSource() == TriggerSource::NONE)
     {
-        if (trigger.value().GetTriggerSource() == source)
+        trigger.value().Run(player, *this);
+    }
+    else
+    {
+        for (const auto& source : sources)
         {
-            trigger.value().Run(player, *this);
+            if (trigger.value().GetTriggerSource() == source)
+            {
+                trigger.value().Run(player, *this);
+            }
         }
     }
 }

--- a/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
+++ b/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
@@ -69,6 +69,18 @@ int Minion::GetGameTag(GameTag tag) const
     }
 }
 
+void Minion::SetGameTag(GameTag tag, int value)
+{
+    switch (tag)
+    {
+        case GameTag::DIVINE_SHIELD:
+            m_hasDivineShield = value == 1 ? true : false;
+            break;
+        default:
+            break;
+    }
+}
+
 Race Minion::GetRace() const
 {
     return m_card.GetRace();

--- a/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
+++ b/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
@@ -38,6 +38,16 @@ Minion::Minion(Card card, int poolIdx)
     }
 }
 
+int Minion::GetIndex() const
+{
+    return m_index;
+}
+
+void Minion::SetIndex(int index)
+{
+    m_index = index;
+}
+
 int Minion::GetPoolIndex() const
 {
     return m_poolIdx;

--- a/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
+++ b/Sources/Rosetta/Battlegrounds/Models/Minion.cpp
@@ -173,6 +173,21 @@ bool Minion::IsDestroyed() const
     return m_isDestroyed;
 }
 
+bool Minion::IsPlayableByCardReq(Player& player) const
+{
+    if (!m_card.IsPlayableByCardReq(player))
+    {
+        return false;
+    }
+
+    if (!m_card.mustHaveToTargetToPlay && !HasAnyValidPlayTargets(player))
+    {
+        return false;
+    }
+
+    return true;
+}
+
 bool Minion::HasAnyValidPlayTargets(Player& player) const
 {
     bool friendlyMinions = false;

--- a/Sources/Rosetta/Battlegrounds/Models/Player.cpp
+++ b/Sources/Rosetta/Battlegrounds/Models/Player.cpp
@@ -60,13 +60,8 @@ void Player::PlayCard(std::size_t handIdx, std::size_t fieldIdx, int targetIdx)
         }
 
         recruitField.ForEachAlive([&](MinionData& aliveMinion) {
-            if (aliveMinion.value().GetZonePosition() !=
-                static_cast<int>(fieldIdx))
-            {
-                aliveMinion.value().ActivateTrigger(
-                    TriggerType::AFTER_PLAY_MINION,
-                    { TriggerSource::MINIONS_EXCEPT_SELF }, *this);
-            }
+            aliveMinion.value().ActivateTrigger(TriggerType::AFTER_PLAY_MINION,
+                                                minion);
         });
     }
     else

--- a/Sources/Rosetta/Battlegrounds/Models/Player.cpp
+++ b/Sources/Rosetta/Battlegrounds/Models/Player.cpp
@@ -49,6 +49,14 @@ void Player::PlayCard(std::size_t handIdx, std::size_t fieldIdx, int targetIdx)
             return;
         }
 
+        // Check if we can play this card and the target is valid
+        if (!std::get<Minion>(hand[handIdx]).IsPlayableByCardReq(*this) ||
+            !std::get<Minion>(hand[handIdx])
+                 .IsValidPlayTarget(*this, targetIdx))
+        {
+            return;
+        }
+
         CardData card = hand.Remove(hand[handIdx]);
 
         auto minion = std::get<Minion>(card);

--- a/Sources/Rosetta/Battlegrounds/Models/Player.cpp
+++ b/Sources/Rosetta/Battlegrounds/Models/Player.cpp
@@ -49,15 +49,40 @@ void Player::PlayCard(std::size_t handIdx, std::size_t fieldIdx, int targetIdx)
         minion.getPlayerCallback = [&]() -> Player& { return *this; };
         minion.SetIndex(getNextCardIndexCallback());
 
+        Player& opponent = getOpponentPlayerCallback(*this);
+
         if (targetIdx == -1)
         {
             recruitField.Add(minion, fieldIdx);
+
+            recruitField.ForEachAlive([&](MinionData& aliveMinion) {
+                aliveMinion.value().ActivateTrigger(TriggerType::SUMMON,
+                                                    minion);
+            });
+
+            opponent.recruitField.ForEachAlive([&](MinionData& aliveMinion) {
+                aliveMinion.value().ActivateTrigger(TriggerType::SUMMON,
+                                                    minion);
+            });
+
             minion.ActivateTask(PowerType::POWER, *this);
         }
         else
         {
             Minion& target = recruitField[targetIdx];
+
             recruitField.Add(minion, fieldIdx);
+
+            recruitField.ForEachAlive([&](MinionData& aliveMinion) {
+                aliveMinion.value().ActivateTrigger(TriggerType::SUMMON,
+                                                    minion);
+            });
+
+            opponent.recruitField.ForEachAlive([&](MinionData& aliveMinion) {
+                aliveMinion.value().ActivateTrigger(TriggerType::SUMMON,
+                                                    minion);
+            });
+
             minion.ActivateTask(PowerType::POWER, *this, target);
         }
 

--- a/Sources/Rosetta/Battlegrounds/Models/Player.cpp
+++ b/Sources/Rosetta/Battlegrounds/Models/Player.cpp
@@ -46,6 +46,8 @@ void Player::PlayCard(std::size_t handIdx, std::size_t fieldIdx, int targetIdx)
     if (std::holds_alternative<Minion>(card))
     {
         auto minion = std::get<Minion>(card);
+        minion.getPlayerCallback = [&]() -> Player& { return *this; };
+        minion.SetIndex(getNextCardIndexCallback());
 
         if (targetIdx == -1)
         {

--- a/Sources/Rosetta/Battlegrounds/Models/Player.cpp
+++ b/Sources/Rosetta/Battlegrounds/Models/Player.cpp
@@ -41,10 +41,16 @@ void Player::PurchaseMinion(std::size_t idx)
 
 void Player::PlayCard(std::size_t handIdx, std::size_t fieldIdx, int targetIdx)
 {
-    auto card = hand.Remove(hand[handIdx]);
-
-    if (std::holds_alternative<Minion>(card))
+    if (std::holds_alternative<Minion>(hand[handIdx]))
     {
+        // Check the field is full
+        if (recruitField.IsFull())
+        {
+            return;
+        }
+
+        CardData card = hand.Remove(hand[handIdx]);
+
         auto minion = std::get<Minion>(card);
         minion.getPlayerCallback = [&]() -> Player& { return *this; };
         minion.SetIndex(getNextCardIndexCallback());

--- a/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/AddEnchantmentTask.cpp
+++ b/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/AddEnchantmentTask.cpp
@@ -39,9 +39,10 @@ TaskStatus AddEnchantmentTask::Run(Player& player, Minion& source)
 }
 
 TaskStatus AddEnchantmentTask::Run(Player& player, Minion& source,
-                                   [[maybe_unused]] Minion& target)
+                                   Minion& target)
 {
-    auto minions = IncludeTask::GetMinions(m_entityType, player, source);
+    auto minions =
+        IncludeTask::GetMinions(m_entityType, player, source, target);
     Card enchantmentCard = Cards::FindCardByID(m_cardID);
 
     for (auto& minion : minions)

--- a/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/AttackTask.cpp
+++ b/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/AttackTask.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <Rosetta/Battlegrounds/Models/Battle.hpp>
+#include <Rosetta/Battlegrounds/Models/Minion.hpp>
+#include <Rosetta/Battlegrounds/Models/Player.hpp>
+#include <Rosetta/Battlegrounds/Tasks/SimpleTasks/AttackTask.hpp>
+#include <Rosetta/Battlegrounds/Tasks/SimpleTasks/IncludeTask.hpp>
+
+namespace RosettaStone::Battlegrounds::SimpleTasks
+{
+AttackTask::AttackTask(EntityType attacker) : m_attacker(attacker)
+{
+    // Do nothing
+}
+
+TaskStatus AttackTask::Run(Player& player, Minion& source)
+{
+    Battle& battle = player.getBattleCallback();
+
+    auto attackers = IncludeTask::GetMinions(m_attacker, player, source);
+    for (auto& attacker : attackers)
+    {
+        Minion& battleTarget = battle.GetProperTarget(attacker);
+        battleTarget.TakeDamage(attacker);
+        attacker.get().TakeDamage(battleTarget);
+
+        battle.ProcessDestroy(false);
+    }
+
+    return TaskStatus::COMPLETE;
+}
+
+TaskStatus AttackTask::Run(Player& player, Minion& source, Minion& target)
+{
+    Battle& battle = player.getBattleCallback();
+
+    auto attackers =
+        IncludeTask::GetMinions(m_attacker, player, source, target);
+    for (auto& attacker : attackers)
+    {
+        Minion& battleTarget = battle.GetProperTarget(attacker);
+        battleTarget.TakeDamage(attacker);
+        attacker.get().TakeDamage(battleTarget);
+
+        battle.ProcessDestroy(false);
+    }
+
+    return TaskStatus::COMPLETE;
+}
+}  // namespace RosettaStone::Battlegrounds::SimpleTasks

--- a/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/GetGameTagTask.cpp
+++ b/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/GetGameTagTask.cpp
@@ -32,10 +32,10 @@ TaskStatus GetGameTagTask::Run(Player& player, Minion& source)
     return TaskStatus::COMPLETE;
 }
 
-TaskStatus GetGameTagTask::Run(Player& player, Minion& source,
-                               [[maybe_unused]] Minion& target)
+TaskStatus GetGameTagTask::Run(Player& player, Minion& source, Minion& target)
 {
-    auto minions = IncludeTask::GetMinions(m_entityType, player, source);
+    auto minions =
+        IncludeTask::GetMinions(m_entityType, player, source, target);
     if (minions.empty())
     {
         return TaskStatus::STOP;

--- a/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/IncludeTask.cpp
+++ b/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/IncludeTask.cpp
@@ -21,6 +21,8 @@ std::vector<std::reference_wrapper<Minion>> IncludeTask::GetMinions(
         case EntityType::SOURCE:
             minions.emplace_back(source);
             break;
+        case EntityType::TARGET:
+            break;
         case EntityType::MINIONS:
             player.GetField().ForEachAlive([&](MinionData& minion) {
                 minions.emplace_back(minion.value());

--- a/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/IncludeTask.cpp
+++ b/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/IncludeTask.cpp
@@ -11,6 +11,11 @@
 
 namespace RosettaStone::Battlegrounds::SimpleTasks
 {
+IncludeTask::IncludeTask(EntityType entityType) : m_entityType(entityType)
+{
+    // Do nothing
+}
+
 std::vector<std::reference_wrapper<Minion>> IncludeTask::GetMinions(
     EntityType entityType, Player& player, Minion& source)
 {
@@ -72,5 +77,21 @@ std::vector<std::reference_wrapper<Minion>> IncludeTask::GetMinions(
     }
 
     return minions;
+}
+
+TaskStatus IncludeTask::Run(Player& player, Minion& source)
+{
+    const auto minions = GetMinions(m_entityType, player, source);
+    player.taskStack.minions = minions;
+
+    return TaskStatus::COMPLETE;
+}
+
+TaskStatus IncludeTask::Run(Player& player, Minion& source, Minion& target)
+{
+    const auto minions = GetMinions(m_entityType, player, source, target);
+    player.taskStack.minions = minions;
+
+    return TaskStatus::COMPLETE;
 }
 }  // namespace RosettaStone::Battlegrounds::SimpleTasks

--- a/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/IncludeTask.cpp
+++ b/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/IncludeTask.cpp
@@ -12,7 +12,7 @@
 namespace RosettaStone::Battlegrounds::SimpleTasks
 {
 std::vector<std::reference_wrapper<Minion>> IncludeTask::GetMinions(
-    EntityType entityType, [[maybe_unused]] Player& player, Minion& source)
+    EntityType entityType, Player& player, Minion& source)
 {
     std::vector<std::reference_wrapper<Minion>> minions;
 
@@ -44,6 +44,25 @@ std::vector<std::reference_wrapper<Minion>> IncludeTask::GetMinions(
         break;
         case EntityType::STACK:
             minions = player.taskStack.minions;
+            break;
+        default:
+            throw std::invalid_argument(
+                "IncludeTask::GetEntities() - Invalid entity type");
+    }
+
+    return minions;
+}
+
+std::vector<std::reference_wrapper<Minion>> IncludeTask::GetMinions(
+    EntityType entityType, [[maybe_unused]] Player& player,
+    [[maybe_unused]] Minion& source, Minion& target)
+{
+    std::vector<std::reference_wrapper<Minion>> minions;
+
+    switch (entityType)
+    {
+        case EntityType::TARGET:
+            minions.emplace_back(target);
             break;
         default:
             throw std::invalid_argument(

--- a/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/ReduceTavernCostTask.cpp
+++ b/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/ReduceTavernCostTask.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <Rosetta/Battlegrounds/Models/Minion.hpp>
+#include <Rosetta/Battlegrounds/Models/Player.hpp>
+#include <Rosetta/Battlegrounds/Tasks/SimpleTasks/ReduceTavernCostTask.hpp>
+
+namespace RosettaStone::Battlegrounds::SimpleTasks
+{
+ReduceTavernCostTask::ReduceTavernCostTask(TavernButton button, int cost)
+    : m_tavernButton(button), m_cost(cost)
+{
+    // Do nothing
+}
+
+TaskStatus ReduceTavernCostTask::Run(Player& player,
+                                     [[maybe_unused]] Minion& source)
+{
+    if (m_tavernButton == TavernButton::UPGRADE)
+    {
+        player.coinToUpgradeTavern -= m_cost;
+
+        if (player.coinToUpgradeTavern < 0)
+        {
+            player.coinToUpgradeTavern = 0;
+        }
+    }
+
+    return TaskStatus::COMPLETE;
+}
+
+TaskStatus ReduceTavernCostTask::Run(Player& player,
+                                     [[maybe_unused]] Minion& source,
+                                     [[maybe_unused]] Minion& target)
+{
+    if (m_tavernButton == TavernButton::UPGRADE)
+    {
+        player.coinToUpgradeTavern -= m_cost;
+
+        if (player.coinToUpgradeTavern < 0)
+        {
+            player.coinToUpgradeTavern = 0;
+        }
+    }
+
+    return TaskStatus::COMPLETE;
+}
+}  // namespace RosettaStone::Battlegrounds::SimpleTasks

--- a/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/SetGameTagTask.cpp
+++ b/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/SetGameTagTask.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <Rosetta/Battlegrounds/Models/Minion.hpp>
+#include <Rosetta/Battlegrounds/Models/Player.hpp>
+#include <Rosetta/Battlegrounds/Tasks/SimpleTasks/IncludeTask.hpp>
+#include <Rosetta/Battlegrounds/Tasks/SimpleTasks/SetGameTagTask.hpp>
+
+namespace RosettaStone::Battlegrounds::SimpleTasks
+{
+SetGameTagTask::SetGameTagTask(EntityType entityType, GameTag tag, int amount)
+    : m_entityType(entityType), m_gameTag(tag), m_amount(amount)
+{
+    // Do nothing
+}
+
+TaskStatus SetGameTagTask::Run(Player& player, Minion& source)
+{
+    auto minions = IncludeTask::GetMinions(m_entityType, player, source);
+
+    for (auto& minion : minions)
+    {
+        minion.get().SetGameTag(m_gameTag, m_amount);
+    }
+
+    return TaskStatus::COMPLETE;
+}
+
+TaskStatus SetGameTagTask::Run(Player& player, Minion& source, Minion& target)
+{
+    auto minions = IncludeTask::GetMinions(m_entityType, player, source);
+
+    for (auto& minion : minions)
+    {
+        minion.get().SetGameTag(m_gameTag, m_amount);
+    }
+
+    return TaskStatus::COMPLETE;
+}
+}  // namespace RosettaStone::Battlegrounds::SimpleTasks

--- a/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/SummonTask.cpp
+++ b/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/SummonTask.cpp
@@ -13,8 +13,8 @@
 namespace RosettaStone::Battlegrounds::SimpleTasks
 {
 SummonTask::SummonTask(const std::string_view& cardID, int amount,
-                       SummonSide side)
-    : m_cardID(cardID), m_side(side), m_amount(amount)
+                       SummonSide side, bool addToStack)
+    : m_cardID(cardID), m_side(side), m_amount(amount), m_addToStack(addToStack)
 {
     // Do nothing
 }
@@ -69,7 +69,7 @@ int SummonTask::GetPosition(Minion& source, SummonSide side)
 
 TaskStatus SummonTask::Run(Player& player, Minion& source)
 {
-    Card card = Cards::FindCardByID(m_cardID);
+    const Card card = Cards::FindCardByID(m_cardID);
 
     for (int i = 0; i < m_amount; ++i)
     {
@@ -88,6 +88,11 @@ TaskStatus SummonTask::Run(Player& player, Minion& source)
     }
 
     player.GetField().Add(summonMinion, summonPos);
+
+    if (m_addToStack)
+    {
+        player.taskStack.minions.emplace_back(player.GetField()[summonPos]);
+    }
 
     return TaskStatus::COMPLETE;
 }
@@ -95,7 +100,7 @@ TaskStatus SummonTask::Run(Player& player, Minion& source)
 TaskStatus SummonTask::Run(Player& player, Minion& source,
                            [[maybe_unused]] Minion& target)
 {
-    Card card = Cards::FindCardByID(m_cardID);
+    const Card card = Cards::FindCardByID(m_cardID);
 
     for (int i = 0; i < m_amount; ++i)
     {
@@ -114,6 +119,11 @@ TaskStatus SummonTask::Run(Player& player, Minion& source,
     }
 
     player.GetField().Add(summonMinion, summonPos);
+
+    if (m_addToStack)
+    {
+        player.taskStack.minions.emplace_back(player.GetField()[summonPos]);
+    }
 
     return TaskStatus::COMPLETE;
 }

--- a/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/SummonTask.cpp
+++ b/Sources/Rosetta/Battlegrounds/Tasks/SimpleTasks/SummonTask.cpp
@@ -54,6 +54,11 @@ int SummonTask::GetPosition(Minion& source, SummonSide side)
             }
             break;
         }
+        case SummonSide::DEATHRATTLE:
+        {
+            summonPos = source.GetLastFieldPos();
+            break;
+        }
         default:
             throw std::invalid_argument(
                 "SummonTask::Impl() - Invalid summon side");

--- a/Sources/Rosetta/Battlegrounds/Zones/FieldZone.cpp
+++ b/Sources/Rosetta/Battlegrounds/Zones/FieldZone.cpp
@@ -131,4 +131,20 @@ bool FieldZone::IsFull() const
 {
     return m_count == MAX_FIELD_SIZE;
 }
+
+std::vector<std::reference_wrapper<Minion>> FieldZone::GetAll()
+{
+    std::vector<std::reference_wrapper<Minion>> result;
+    result.reserve(m_count);
+
+    for (int i = 0; i < m_count; ++i)
+    {
+        if (m_minions[i].has_value() && !m_minions[i].value().IsDestroyed())
+        {
+            result.emplace_back(m_minions[i].value());
+        }
+    }
+
+    return result;
+}
 }  // namespace RosettaStone::Battlegrounds

--- a/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
+++ b/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
@@ -643,3 +643,58 @@ TEST_CASE("[Battlegrounds : Minion] - BGS_055 : Deck Swabbie")
     CHECK_EQ(player1.currentTier, 2);
     CHECK_EQ(player1.coinToUpgradeTavern, 7);
 }
+
+// --------------------------------- MINION - BATTLEGROUNDS
+// [BGS_061] Scallywag - TIER:1 [ATK:2/HP:1]
+// - Race: Pirate, Set: Battlegrounds
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Summon a 1/1 Pirate.
+//       It attacks immediately.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Battlegrounds : Minion] - BGS_061 : Scallywag")
+{
+    Game game;
+    game.Start();
+
+    Player& player1 = game.GetGameState().players[0];
+    Player& player2 = game.GetGameState().players[1];
+
+    Minion minion1(Cards::FindCardByID("BGS_061"));
+    Minion minion2(Cards::FindCardByID("BGS_061"));
+    Minion minion3(Cards::FindCardByID("LOOT_013"));
+
+    player1.hero.Initialize(Cards::FindCardByDbfID(58536));
+    player2.hero.Initialize(Cards::FindCardByDbfID(58536));
+
+    game.SetPlayerPair(0, 1);
+
+    player1.hand.Add(minion1);
+    player1.hand.Add(minion2);
+    player1.PlayCard(0, 0);
+    player1.PlayCard(0, 0);
+
+    player2.hand.Add(minion3);
+    player2.PlayCard(0, 0);
+
+    player1.isInCombat = true;
+    player2.isInCombat = true;
+
+    Battle battle(player1, player2);
+    battle.Initialize();
+
+    player1.getBattleCallback = [&]() -> Battle& { return battle; };
+    player2.getBattleCallback = [&]() -> Battle& { return battle; };
+
+    CHECK_EQ(battle.GetPlayer1Field().GetCount(), 2);
+    CHECK_EQ(battle.GetPlayer2Field().GetCount(), 1);
+    CHECK_EQ(battle.GetPlayer2Field()[0].GetHealth(), 4);
+
+    battle.Attack();
+
+    CHECK_EQ(battle.GetPlayer1Field().GetCount(), 1);
+    CHECK_EQ(battle.GetPlayer2Field().GetCount(), 1);
+    CHECK_EQ(battle.GetPlayer2Field()[0].GetHealth(), 1);
+}

--- a/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
+++ b/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
@@ -276,3 +276,56 @@ TEST_CASE("[Battlegrounds : Minion] - BGS_019 : Red Whelp")
     CHECK_EQ(battle.GetPlayer2Field()[0].GetAttack(), 2);
     CHECK_EQ(battle.GetPlayer2Field()[0].GetHealth(), 1);
 }
+
+// --------------------------------- MINION - BATTLEGROUNDS
+// [BOT_445] Mecharoo - TIER:1 [ATK:1/HP:1]
+// - Race: Mechanical, Set: Boomsday
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Summon a 1/1 Jo-E Bot.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Battlegrounds : Minion] - BOT_445 : Mecharoo")
+{
+    Game game;
+    game.Start();
+
+    Player& player1 = game.GetGameState().players[0];
+    Player& player2 = game.GetGameState().players[1];
+
+    Minion minion1(Cards::FindCardByID("BOT_445"));
+    Minion minion2(Cards::FindCardByID("BOT_445"));
+    Minion minion3(Cards::FindCardByID("BOT_445"));
+
+    player1.hero.Initialize(Cards::FindCardByDbfID(58536));
+    player2.hero.Initialize(Cards::FindCardByDbfID(58536));
+
+    player1.hand.Add(minion1);
+    player1.hand.Add(minion2);
+    player1.PlayCard(0, 0);
+    player1.PlayCard(0, 0);
+
+    player2.hand.Add(minion3);
+    player2.PlayCard(0, 0);
+
+    player1.isInCombat = true;
+    player2.isInCombat = true;
+
+    Battle battle(player1, player2);
+    battle.Initialize();
+
+    CHECK_EQ(battle.GetPlayer1Field().GetCount(), 2);
+    CHECK_EQ(battle.GetPlayer1Field()[0].GetName(), "Mecharoo");
+    CHECK_EQ(battle.GetPlayer1Field()[1].GetName(), "Mecharoo");
+    CHECK_EQ(battle.GetPlayer2Field().GetCount(), 1);
+    CHECK_EQ(battle.GetPlayer2Field()[0].GetName(), "Mecharoo");
+
+    battle.Attack();
+
+    CHECK_EQ(battle.GetPlayer1Field().GetCount(), 2);
+    CHECK_EQ(battle.GetPlayer1Field()[0].GetName(), "Jo-E Bot");
+    CHECK_EQ(battle.GetPlayer1Field()[1].GetName(), "Mecharoo");
+    CHECK_EQ(battle.GetPlayer2Field().GetCount(), 1);
+    CHECK_EQ(battle.GetPlayer2Field()[0].GetName(), "Jo-E Bot");
+}

--- a/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
+++ b/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
@@ -8,6 +8,7 @@
 
 #include <Rosetta/Battlegrounds/Cards/Cards.hpp>
 #include <Rosetta/Battlegrounds/Games/Game.hpp>
+#include <Rosetta/Battlegrounds/Managers/GameManager.hpp>
 #include <Rosetta/Battlegrounds/Models/Battle.hpp>
 
 using namespace RosettaStone;
@@ -593,4 +594,52 @@ TEST_CASE("[Battlegrounds : Minion] - UNG_073 : Rockpool Hunter")
     CHECK_EQ(player1.recruitField[1].GetHealth(), 3);
     CHECK_EQ(player1.recruitField[2].GetAttack(), 2);
     CHECK_EQ(player1.recruitField[2].GetHealth(), 3);
+}
+
+// --------------------------------- MINION - BATTLEGROUNDS
+// [BGS_055] Deck Swabbie - TIER:1 [ATK:2/HP:2]
+// - Race: Pirate, Set: Battlegrounds
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Reduce the cost of upgrading
+//       Bob's Tavern by (1).
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Battlegrounds : Minion] - BGS_055 : Deck Swabbie")
+{
+    Game game;
+    game.Start();
+
+    Player& player1 = game.GetGameState().players[0];
+    Player& player2 = game.GetGameState().players[1];
+
+    Minion minion1(Cards::FindCardByID("BGS_055"));
+    Minion minion2(Cards::FindCardByID("BGS_055"));
+
+    player1.hero.Initialize(Cards::FindCardByDbfID(58536));
+    player2.hero.Initialize(Cards::FindCardByDbfID(58536));
+
+    game.GetGameState().nextPhase = Phase::RECRUIT;
+    GameManager::ProcessNextPhase(game, game.GetGameState().nextPhase);
+
+    game.SetPlayerPair(0, 1);
+
+    player1.hand.Add(minion1);
+    player1.hand.Add(minion2);
+
+    CHECK_EQ(player1.currentTier, 1);
+    CHECK_EQ(player1.coinToUpgradeTavern, 5);
+
+    player1.PlayCard(0, 0);
+    CHECK_EQ(player1.coinToUpgradeTavern, 4);
+
+    player1.PlayCard(0, 1);
+    CHECK_EQ(player1.coinToUpgradeTavern, 3);
+
+    player1.remainCoin = 10;
+
+    player1.UpgradeTavern();
+    CHECK_EQ(player1.currentTier, 2);
+    CHECK_EQ(player1.coinToUpgradeTavern, 7);
 }

--- a/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
+++ b/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
@@ -390,13 +390,22 @@ TEST_CASE("[Battlegrounds : Minion] - GVG_103 : Micro Machine")
     auto& p1Field = const_cast<FieldZone&>(battle.GetPlayer1Field());
     auto& p2Field = const_cast<FieldZone&>(battle.GetPlayer2Field());
 
-    p1Field.ForEachAlive([&](MinionData& aliveMinion) {
-        aliveMinion.value().ActivateTrigger(TriggerType::TURN_START, {},
-                                            player1);
+    p1Field.ForEachAlive([&](MinionData& owner) {
+        p1Field.ForEachAlive([&](MinionData& minion) {
+            {
+                owner.value().ActivateTrigger(TriggerType::TURN_START,
+                                              minion.value());
+            };
+        });
     });
-    p2Field.ForEachAlive([&](MinionData& aliveMinion) {
-        aliveMinion.value().ActivateTrigger(TriggerType::TURN_START, {},
-                                            player2);
+
+    p2Field.ForEachAlive([&](MinionData& owner) {
+        p2Field.ForEachAlive([&](MinionData& minion) {
+            {
+                owner.value().ActivateTrigger(TriggerType::TURN_START,
+                                              minion.value());
+            };
+        });
     });
 
     battle.Attack();
@@ -406,13 +415,22 @@ TEST_CASE("[Battlegrounds : Minion] - GVG_103 : Micro Machine")
     CHECK_EQ(battle.GetPlayer2Field().GetCount(), 1);
     CHECK_EQ(battle.GetPlayer2Field()[0].GetAttack(), 2);
 
-    p1Field.ForEachAlive([&](MinionData& aliveMinion) {
-        aliveMinion.value().ActivateTrigger(TriggerType::TURN_START, {},
-                                            player1);
+    p1Field.ForEachAlive([&](MinionData& owner) {
+        p1Field.ForEachAlive([&](MinionData& minion) {
+            {
+                owner.value().ActivateTrigger(TriggerType::TURN_START,
+                                              minion.value());
+            };
+        });
     });
-    p2Field.ForEachAlive([&](MinionData& aliveMinion) {
-        aliveMinion.value().ActivateTrigger(TriggerType::TURN_START, {},
-                                            player2);
+
+    p2Field.ForEachAlive([&](MinionData& owner) {
+        p2Field.ForEachAlive([&](MinionData& minion) {
+            {
+                owner.value().ActivateTrigger(TriggerType::TURN_START,
+                                              minion.value());
+            };
+        });
     });
 
     battle.Attack();

--- a/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
+++ b/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
@@ -329,3 +329,82 @@ TEST_CASE("[Battlegrounds : Minion] - BOT_445 : Mecharoo")
     CHECK_EQ(battle.GetPlayer2Field().GetCount(), 1);
     CHECK_EQ(battle.GetPlayer2Field()[0].GetName(), "Jo-E Bot");
 }
+
+// --------------------------------- MINION - BATTLEGROUNDS
+// [GVG_103] Micro Machine - TIER:1 [ATK:1/HP:2]
+// - Race: Mechanical, Set: Gvg
+// --------------------------------------------------------
+// Text: At the start of each turn, gain +1 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Battlegrounds : Minion] - GVG_103 : Micro Machine")
+{
+    Game game;
+    game.Start();
+
+    Player& player1 = game.GetGameState().players[0];
+    Player& player2 = game.GetGameState().players[1];
+
+    Minion minion1(Cards::FindCardByID("GVG_103"));
+    Minion minion2(Cards::FindCardByID("GVG_103"));
+
+    player1.hero.Initialize(Cards::FindCardByDbfID(58536));
+    player2.hero.Initialize(Cards::FindCardByDbfID(58536));
+
+    player1.hand.Add(minion1);
+    player1.PlayCard(0, 0);
+
+    player2.hand.Add(minion2);
+    player2.PlayCard(0, 0);
+
+    player1.recruitField[0].SetHealth(10);
+    player2.recruitField[0].SetHealth(10);
+
+    player1.isInCombat = true;
+    player2.isInCombat = true;
+
+    Battle battle(player1, player2);
+    battle.Initialize();
+
+    CHECK_EQ(battle.GetPlayer1Field().GetCount(), 1);
+    CHECK_EQ(battle.GetPlayer1Field()[0].GetAttack(), 1);
+    CHECK_EQ(battle.GetPlayer2Field().GetCount(), 1);
+    CHECK_EQ(battle.GetPlayer2Field()[0].GetAttack(), 1);
+
+    auto& p1Field = const_cast<FieldZone&>(battle.GetPlayer1Field());
+    auto& p2Field = const_cast<FieldZone&>(battle.GetPlayer2Field());
+
+    p1Field.ForEachAlive([&](MinionData& aliveMinion) {
+        aliveMinion.value().ActivateTrigger(TriggerType::TURN_START, {},
+                                            player1);
+    });
+    p2Field.ForEachAlive([&](MinionData& aliveMinion) {
+        aliveMinion.value().ActivateTrigger(TriggerType::TURN_START, {},
+                                            player2);
+    });
+
+    battle.Attack();
+
+    CHECK_EQ(battle.GetPlayer1Field().GetCount(), 1);
+    CHECK_EQ(battle.GetPlayer1Field()[0].GetAttack(), 2);
+    CHECK_EQ(battle.GetPlayer2Field().GetCount(), 1);
+    CHECK_EQ(battle.GetPlayer2Field()[0].GetAttack(), 2);
+
+    p1Field.ForEachAlive([&](MinionData& aliveMinion) {
+        aliveMinion.value().ActivateTrigger(TriggerType::TURN_START, {},
+                                            player1);
+    });
+    p2Field.ForEachAlive([&](MinionData& aliveMinion) {
+        aliveMinion.value().ActivateTrigger(TriggerType::TURN_START, {},
+                                            player2);
+    });
+
+    battle.Attack();
+
+    CHECK_EQ(battle.GetPlayer1Field().GetCount(), 1);
+    CHECK_EQ(battle.GetPlayer1Field()[0].GetAttack(), 3);
+    CHECK_EQ(battle.GetPlayer2Field().GetCount(), 1);
+    CHECK_EQ(battle.GetPlayer2Field()[0].GetAttack(), 3);
+}

--- a/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
+++ b/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
@@ -422,3 +422,49 @@ TEST_CASE("[Battlegrounds : Minion] - GVG_103 : Micro Machine")
     CHECK_EQ(battle.GetPlayer2Field().GetCount(), 1);
     CHECK_EQ(battle.GetPlayer2Field()[0].GetAttack(), 3);
 }
+
+// --------------------------------- MINION - BATTLEGROUNDS
+// [EX1_509] Murloc Tidecaller - TIER:1 [ATK:1/HP:2]
+// - Race: Murloc, Set: Expert1
+// --------------------------------------------------------
+// Text: Whenever you summon a Murloc, gain +1 Attack.
+// --------------------------------------------------------
+TEST_CASE("[Battlegrounds : Minion] - EX1_509 : Murloc Tidecaller")
+{
+    Game game;
+    game.Start();
+
+    Player& player1 = game.GetGameState().players[0];
+    Player& player2 = game.GetGameState().players[1];
+
+    Minion minion1(Cards::FindCardByID("EX1_509"));
+    Minion minion2(Cards::FindCardByID("EX1_509"));
+    Minion minion3(Cards::FindCardByID("BGS_039"));
+
+    player1.hero.Initialize(Cards::FindCardByDbfID(58536));
+    player2.hero.Initialize(Cards::FindCardByDbfID(58536));
+
+    game.SetPlayerPair(0, 1);
+
+    player1.hand.Add(minion1);
+    player1.PlayCard(0, 0);
+    CHECK_EQ(player1.recruitField.GetCount(), 1);
+    CHECK_EQ(player1.recruitField[0].GetAttack(), 1);
+    CHECK_EQ(player1.recruitField[0].GetHealth(), 2);
+
+    player1.hand.Add(minion2);
+    player1.PlayCard(0, 1);
+    CHECK_EQ(player1.recruitField.GetCount(), 2);
+    CHECK_EQ(player1.recruitField[0].GetAttack(), 2);
+    CHECK_EQ(player1.recruitField[0].GetHealth(), 2);
+    CHECK_EQ(player1.recruitField[1].GetAttack(), 1);
+    CHECK_EQ(player1.recruitField[1].GetHealth(), 2);
+
+    player1.hand.Add(minion3);
+    player1.PlayCard(0, 2);
+    CHECK_EQ(player1.recruitField.GetCount(), 3);
+    CHECK_EQ(player1.recruitField[0].GetAttack(), 2);
+    CHECK_EQ(player1.recruitField[0].GetHealth(), 2);
+    CHECK_EQ(player1.recruitField[1].GetAttack(), 1);
+    CHECK_EQ(player1.recruitField[1].GetHealth(), 2);
+}

--- a/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
+++ b/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
@@ -713,3 +713,61 @@ TEST_CASE("[Battlegrounds : Minion] - ICC_038 : Righteous Protector")
 {
     // Do nothing
 }
+
+// --------------------------------- MINION - BATTLEGROUNDS
+// [OG_221] Selfless Hero - TIER:1 [ATK:2/HP:1]
+// - Set: Og
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Give a random friendly minion
+//       <b>Divine Shield</b>.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+// RefTag:
+// - DIVINE_SHIELD = 1
+// --------------------------------------------------------
+TEST_CASE("[Battlegrounds : Minion] - OG_221 : Selfless Hero")
+{
+    Game game;
+    game.Start();
+
+    Player& player1 = game.GetGameState().players[0];
+    Player& player2 = game.GetGameState().players[1];
+
+    Minion minion1(Cards::FindCardByID("OG_221"));
+    Minion minion2(Cards::FindCardByID("BGS_061"));
+    Minion minion3(Cards::FindCardByID("LOOT_013"));
+
+    player1.hero.Initialize(Cards::FindCardByDbfID(58536));
+    player2.hero.Initialize(Cards::FindCardByDbfID(58536));
+
+    game.SetPlayerPair(0, 1);
+
+    player1.hand.Add(minion1);
+    player1.hand.Add(minion2);
+    player1.PlayCard(0, 0);
+    player1.PlayCard(0, 1);
+
+    player2.hand.Add(minion3);
+    player2.PlayCard(0, 0);
+
+    player1.isInCombat = true;
+    player2.isInCombat = true;
+
+    Battle battle(player1, player2);
+    battle.Initialize();
+
+    player1.getBattleCallback = [&]() -> Battle& { return battle; };
+    player2.getBattleCallback = [&]() -> Battle& { return battle; };
+
+    CHECK_EQ(battle.GetPlayer1Field().GetCount(), 2);
+    CHECK_EQ(battle.GetPlayer2Field().GetCount(), 1);
+    CHECK_EQ(battle.GetPlayer1Field()[1].HasDivineShield(), false);
+
+    battle.Attack();
+
+    CHECK_EQ(battle.GetPlayer1Field().GetCount(), 1);
+    CHECK_EQ(battle.GetPlayer2Field().GetCount(), 1);
+    CHECK_EQ(battle.GetPlayer1Field()[0].HasDivineShield(), true);
+}

--- a/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
+++ b/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
@@ -486,3 +486,48 @@ TEST_CASE("[Battlegrounds : Minion] - EX1_509 : Murloc Tidecaller")
     CHECK_EQ(player1.recruitField[1].GetAttack(), 1);
     CHECK_EQ(player1.recruitField[1].GetHealth(), 2);
 }
+
+// --------------------------------- MINION - BATTLEGROUNDS
+// [EX1_506] Murloc Tidehunter - TIER:1 [ATK:2/HP:1]
+// - Race: Murloc, Set: Core
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Summon a 1/1 Murloc Scout.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Battlegrounds : Minion] - EX1_506 : Murloc Tidehunter")
+{
+    Game game;
+    game.Start();
+
+    Player& player1 = game.GetGameState().players[0];
+    Player& player2 = game.GetGameState().players[1];
+
+    Minion minion1(Cards::FindCardByID("EX1_506"));
+    Minion minion2(Cards::FindCardByID("EX1_506"));
+
+    player1.hero.Initialize(Cards::FindCardByDbfID(58536));
+    player2.hero.Initialize(Cards::FindCardByDbfID(58536));
+
+    game.SetPlayerPair(0, 1);
+
+    player1.hand.Add(minion1);
+    player1.hand.Add(minion2);
+    CHECK_EQ(player1.hand.GetCount(), 2);
+    CHECK_EQ(player1.recruitField.GetCount(), 0);
+
+    player1.PlayCard(0, 0);
+    CHECK_EQ(player1.hand.GetCount(), 1);
+    CHECK_EQ(player1.recruitField.GetCount(), 2);
+    CHECK_EQ(player1.recruitField[0].GetName(), "Murloc Tidehunter");
+    CHECK_EQ(player1.recruitField[1].GetName(), "Murloc Scout");
+
+    player1.PlayCard(0, 1);
+    CHECK_EQ(player1.hand.GetCount(), 0);
+    CHECK_EQ(player1.recruitField.GetCount(), 4);
+    CHECK_EQ(player1.recruitField[0].GetName(), "Murloc Tidehunter");
+    CHECK_EQ(player1.recruitField[1].GetName(), "Murloc Tidehunter");
+    CHECK_EQ(player1.recruitField[2].GetName(), "Murloc Scout");
+    CHECK_EQ(player1.recruitField[3].GetName(), "Murloc Scout");
+}

--- a/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
+++ b/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
@@ -531,3 +531,66 @@ TEST_CASE("[Battlegrounds : Minion] - EX1_506 : Murloc Tidehunter")
     CHECK_EQ(player1.recruitField[2].GetName(), "Murloc Scout");
     CHECK_EQ(player1.recruitField[3].GetName(), "Murloc Scout");
 }
+
+// --------------------------------- MINION - BATTLEGROUNDS
+// [UNG_073] Rockpool Hunter - TIER:1 [ATK:2/HP:3]
+// - Race: Murloc, Set: Ungoro
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give a friendly Murloc +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// - REQ_MINION_TARGET = 0
+// - REQ_TARGET_WITH_RACE = 14
+// - REQ_FRIENDLY_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Battlegrounds : Minion] - UNG_073 : Rockpool Hunter")
+{
+    Game game;
+    game.Start();
+
+    Player& player1 = game.GetGameState().players[0];
+    Player& player2 = game.GetGameState().players[1];
+
+    Minion minion1(Cards::FindCardByID("UNG_073"));
+    Minion minion2(Cards::FindCardByID("BGS_039"));
+    Minion minion3(Cards::FindCardByID("UNG_073"));
+
+    player1.hero.Initialize(Cards::FindCardByDbfID(58536));
+    player2.hero.Initialize(Cards::FindCardByDbfID(58536));
+
+    game.SetPlayerPair(0, 1);
+
+    player1.hand.Add(minion1);
+    player1.hand.Add(minion2);
+    player1.hand.Add(minion3);
+
+    player1.PlayCard(0, 0);
+    CHECK_EQ(player1.recruitField[0].GetAttack(), 2);
+    CHECK_EQ(player1.recruitField[0].GetHealth(), 3);
+
+    player1.PlayCard(0, 1);
+    CHECK_EQ(player1.recruitField[1].GetAttack(), 2);
+    CHECK_EQ(player1.recruitField[1].GetHealth(), 3);
+
+    player1.PlayCard(0, 0, 1);
+    CHECK_EQ(player1.hand.GetCount(), 1);
+    CHECK_EQ(player1.recruitField.GetCount(), 2);
+    CHECK_EQ(player1.recruitField[0].GetAttack(), 2);
+    CHECK_EQ(player1.recruitField[0].GetHealth(), 3);
+    CHECK_EQ(player1.recruitField[1].GetAttack(), 2);
+    CHECK_EQ(player1.recruitField[1].GetHealth(), 3);
+
+    player1.PlayCard(0, 0, 0);
+    CHECK_EQ(player1.hand.GetCount(), 0);
+    CHECK_EQ(player1.recruitField.GetCount(), 3);
+    CHECK_EQ(player1.recruitField[0].GetAttack(), 3);
+    CHECK_EQ(player1.recruitField[0].GetHealth(), 4);
+    CHECK_EQ(player1.recruitField[1].GetAttack(), 2);
+    CHECK_EQ(player1.recruitField[1].GetHealth(), 3);
+    CHECK_EQ(player1.recruitField[2].GetAttack(), 2);
+    CHECK_EQ(player1.recruitField[2].GetHealth(), 3);
+}

--- a/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
+++ b/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
@@ -698,3 +698,18 @@ TEST_CASE("[Battlegrounds : Minion] - BGS_061 : Scallywag")
     CHECK_EQ(battle.GetPlayer2Field().GetCount(), 1);
     CHECK_EQ(battle.GetPlayer2Field()[0].GetHealth(), 1);
 }
+
+// --------------------------------- MINION - BATTLEGROUNDS
+// [ICC_038] Righteous Protector - TIER:1 [ATK:1/HP:1]
+// - Set: Icecrown
+// --------------------------------------------------------
+// Text: <b>Taunt</b> <b>Divine Shield</b>
+// --------------------------------------------------------
+// GameTag:
+// - DIVINE_SHIELD = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Battlegrounds : Minion] - ICC_038 : Righteous Protector")
+{
+    // Do nothing
+}

--- a/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
+++ b/Tests/UnitTests/Battlegrounds/CardSets/BattlegroundsCardsGenTests.cpp
@@ -35,6 +35,8 @@ TEST_CASE("[Battlegrounds : Minion] - CFM_315 : Alleycat")
     player1.hero.Initialize(Cards::FindCardByDbfID(58536));
     player2.hero.Initialize(Cards::FindCardByDbfID(58536));
 
+    game.SetPlayerPair(0, 1);
+
     player1.hand.Add(minion1);
     CHECK_EQ(player1.hand.GetCount(), 1);
     CHECK_EQ(player1.recruitField.GetCount(), 0);
@@ -66,6 +68,8 @@ TEST_CASE("[Battlegrounds : Minion] - EX1_531 : Scavenging Hyena")
 
     player1.hero.Initialize(Cards::FindCardByDbfID(58536));
     player2.hero.Initialize(Cards::FindCardByDbfID(58536));
+
+    game.SetPlayerPair(0, 1);
 
     player1.hand.Add(minion1);
     player1.hand.Add(minion2);
@@ -115,6 +119,8 @@ TEST_CASE("[Battlegrounds : Minion] - YOD_026 : Fiendish Servant")
 
     player1.hero.Initialize(Cards::FindCardByDbfID(58536));
     player2.hero.Initialize(Cards::FindCardByDbfID(58536));
+
+    game.SetPlayerPair(0, 1);
 
     player1.hand.Add(minion1);
     player1.hand.Add(minion2);
@@ -169,6 +175,8 @@ TEST_CASE("[Battlegrounds : Minion] - LOOT_013 : Vulgar Homunculus")
     player1.hero.Initialize(Cards::FindCardByDbfID(58536));
     player2.hero.Initialize(Cards::FindCardByDbfID(58536));
 
+    game.SetPlayerPair(0, 1);
+
     CHECK_EQ(player1.hero.health, 40);
 
     player1.hand.Add(minion1);
@@ -199,6 +207,8 @@ TEST_CASE("[Battlegrounds : Minion] - BGS_004 : Wrath Weaver")
 
     player1.hero.Initialize(Cards::FindCardByDbfID(58536));
     player2.hero.Initialize(Cards::FindCardByDbfID(58536));
+
+    game.SetPlayerPair(0, 1);
 
     CHECK_EQ(player1.hero.health, 40);
 
@@ -255,6 +265,8 @@ TEST_CASE("[Battlegrounds : Minion] - BGS_019 : Red Whelp")
     player1.hero.Initialize(Cards::FindCardByDbfID(58536));
     player2.hero.Initialize(Cards::FindCardByDbfID(58536));
 
+    game.SetPlayerPair(0, 1);
+
     player1.hand.Add(minion1);
     player1.hand.Add(minion2);
     player1.hand.Add(minion3);
@@ -264,8 +276,6 @@ TEST_CASE("[Battlegrounds : Minion] - BGS_019 : Red Whelp")
 
     player2.hand.Add(minion4);
     player2.PlayCard(0, 0);
-
-    game.SetPlayerPair(0, 1);
 
     player1.isInCombat = true;
     player2.isInCombat = true;
@@ -300,6 +310,8 @@ TEST_CASE("[Battlegrounds : Minion] - BOT_445 : Mecharoo")
 
     player1.hero.Initialize(Cards::FindCardByDbfID(58536));
     player2.hero.Initialize(Cards::FindCardByDbfID(58536));
+
+    game.SetPlayerPair(0, 1);
 
     player1.hand.Add(minion1);
     player1.hand.Add(minion2);
@@ -352,6 +364,8 @@ TEST_CASE("[Battlegrounds : Minion] - GVG_103 : Micro Machine")
 
     player1.hero.Initialize(Cards::FindCardByDbfID(58536));
     player2.hero.Initialize(Cards::FindCardByDbfID(58536));
+
+    game.SetPlayerPair(0, 1);
 
     player1.hand.Add(minion1);
     player1.PlayCard(0, 0);

--- a/Tests/UnitTests/Battlegrounds/Games/GameTests.cpp
+++ b/Tests/UnitTests/Battlegrounds/Games/GameTests.cpp
@@ -95,17 +95,17 @@ TEST_CASE("[Game] - Basic")
     CHECK_EQ(static_cast<int>(minions.size()),
              game.GetGameState().minionPool.GetCount() - 3 * 8);
 
-    player1.remainCoin = 10;
+    player1.remainCoin = 7;
 
     player1.PurchaseMinion(0);
     CHECK_EQ(player1.hand.GetCount(), 1);
     CHECK_EQ(player1.tavern.fieldZone.GetCount(), 2);
-    CHECK_EQ(player1.remainCoin, 7);
+    CHECK_EQ(player1.remainCoin, 4);
 
     player1.PurchaseMinion(0);
     CHECK_EQ(player1.hand.GetCount(), 2);
     CHECK_EQ(player1.tavern.fieldZone.GetCount(), 1);
-    CHECK_EQ(player1.remainCoin, 4);
+    CHECK_EQ(player1.remainCoin, 1);
 
     player1.PlayCard(0, 0);
     player1.PlayCard(0, 1);
@@ -119,18 +119,24 @@ TEST_CASE("[Game] - Basic")
 
     player1.UpgradeTavern();
     CHECK_EQ(player1.currentTier, 1);
-    CHECK_EQ(player1.remainCoin, 4);
+    CHECK_EQ(player1.remainCoin, 1);
 
     player1.remainCoin = 10;
 
     player1.UpgradeTavern();
     CHECK_EQ(player1.currentTier, 2);
-    CHECK_EQ(player1.remainCoin, 5);
+
+    const bool check1 = player1.remainCoin == 5 || player1.remainCoin == 6 ||
+                        player1.remainCoin == 7 || player1.remainCoin == 8;
+    CHECK(check1);
 
     player1.RefreshTavern();
     CHECK_EQ(player1.hand.GetCount(), 0);
     CHECK_EQ(player1.tavern.fieldZone.GetCount(), 4);
-    CHECK_EQ(player1.remainCoin, 4);
+
+    const bool check2 = player1.remainCoin == 4 || player1.remainCoin == 5 ||
+                        player1.remainCoin == 6 || player1.remainCoin == 7;
+    CHECK(check2);
 
     const std::size_t numMinions =
         GetNumMinionsCanPurchase(player1.currentTier);


### PR DESCRIPTION
This revision includes:
- Implement 9 Tier 1 cards of Hearthstone: Battlegrounds
  - Mecharoo (BOT_445)
  - Micro Machine (GVG_103)
  - Murloc Tidecaller (EX1_509)
  - Murloc Tidehunter (EX1_506)
  - Rockpool Hunter (UNG_073)
  - Deck Swabbie (BGS_055)
  - Scallywag (BGS_061)
  - Righteous Protector (ICC_038)
  - Selfless Hero (OG_221)
- Add some tasks for Hearthstone: Battlegrounds
  - AttackTask
  - IncludeTask
  - ReduceTavernCostTask
  - SetGameTagTask