### PR TITLE
Correct order of value in 'GameTag'

### DIFF
--- a/Includes/Rosetta/Common/Enums/CardEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/CardEnums.hpp
@@ -72,15 +72,15 @@ const std::string FACTION_STR[] = {
 enum class GameTag
 {
 #define X(a) a,
-#include "GameTagCustom.def"
 #include "Rosetta/Common/Enums/GameTag.def"
+#include "GameTagCustom.def"
 #undef X
 };
 
 const std::string GAME_TAG_STR[] = {
 #define X(a) #a,
-#include "GameTagCustom.def"
 #include "Rosetta/Common/Enums/GameTag.def"
+#include "GameTagCustom.def"
 #undef X
 };
 


### PR DESCRIPTION
When 'mechanics' option is blank during command 'Search Card', nothing is searched.
The reason is that default of 'GameTag' is not 'INVALID'.

So fix it by changing order of value in 'GameTag'.
Because default of enum class is first value of that in accordance with 'StrToEnum' function in 'GameEnums.hpp'.

Fixes #449

Repported-by: JinDDeok