### PR TITLE
Fix bug by adding the full hand condition in 'ReturnHandTask'

### DIFF
--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/ReturnHandTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/ReturnHandTask.cpp
@@ -7,6 +7,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ReturnHandTask.hpp>
 #include <Rosetta/PlayMode/Zones/FieldZone.hpp>
+#include <Rosetta/PlayMode/Zones/HandZone.hpp>
 
 namespace RosettaStone::PlayMode::SimpleTasks
 {
@@ -22,9 +23,16 @@ TaskStatus ReturnHandTask::Impl(Player* player)
 
     for (auto& playable : playables)
     {
-        playable->zone->Remove(playable);
-        playable->Reset();
-        Generic::AddCardToHand(playable->player, playable);
+        if (playable->player->GetHandZone()->IsFull()) 
+        {
+            playable->Destroy();
+        }
+        else
+        {
+            playable->zone->Remove(playable);
+            playable->Reset();
+            Generic::AddCardToHand(playable->player, playable);
+        }
     }
 
     return TaskStatus::COMPLETE;


### PR DESCRIPTION
This revision includes:
- Fix the bug 'ReturnHandTask' doesn't check a death by the full hand (#452)
  - When a player's hand is full and a minion is returned by 'ReturnHandTask', it should be destroyed because of no space in hand. So fixed it by adding the logic to check full hand condition and destroy minions.