### PR TITLE
Implement 5 BLACK_TEMPLE cards

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -1060,7 +1060,7 @@ BLACK_TEMPLE | BT_514 | Immolation Aura |
 BLACK_TEMPLE | BT_601 | Skull of Gul'dan |  
 BLACK_TEMPLE | BT_701 | Spymistress |  
 BLACK_TEMPLE | BT_702 | Ashtongue Slayer |  
-BLACK_TEMPLE | BT_703 | Cursed Vagrant |  
+BLACK_TEMPLE | BT_703 | Cursed Vagrant | O
 BLACK_TEMPLE | BT_707 | Ambush |  
 BLACK_TEMPLE | BT_709 | Dirty Tricks |  
 BLACK_TEMPLE | BT_710 | Greyheart Sage |  

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -1005,7 +1005,7 @@ BLACK_TEMPLE | BT_140 | Bonechewer Raider |
 BLACK_TEMPLE | BT_155 | Scrapyard Colossus | O
 BLACK_TEMPLE | BT_156 | Imprisoned Vilefiend | O
 BLACK_TEMPLE | BT_159 | Terrorguard Escapee | O
-BLACK_TEMPLE | BT_160 | Rustsworn Cultist |  
+BLACK_TEMPLE | BT_160 | Rustsworn Cultist | O
 BLACK_TEMPLE | BT_163 | Nagrand Slam |  
 BLACK_TEMPLE | BT_187 | Kayn Sunfury |  
 BLACK_TEMPLE | BT_188 | Shadowjeweler Hanar |  

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -1055,7 +1055,7 @@ BLACK_TEMPLE | BT_486 | Pit Commander |
 BLACK_TEMPLE | BT_491 | Spectral Sight |  
 BLACK_TEMPLE | BT_493 | Priestess of Fury |  
 BLACK_TEMPLE | BT_496 | Furious Felfin |  
-BLACK_TEMPLE | BT_509 | Fel Summoner |  
+BLACK_TEMPLE | BT_509 | Fel Summoner | O
 BLACK_TEMPLE | BT_514 | Immolation Aura |  
 BLACK_TEMPLE | BT_601 | Skull of Gul'dan |  
 BLACK_TEMPLE | BT_701 | Spymistress |  
@@ -1086,7 +1086,7 @@ BLACK_TEMPLE | BT_733 | Mo'arg Artificer |
 BLACK_TEMPLE | BT_734 | Supreme Abyssal |  
 BLACK_TEMPLE | BT_735 | Al'ar |  
 BLACK_TEMPLE | BT_737 | Maiev Shadowsong |  
-BLACK_TEMPLE | BT_761 | Coilfang Warlord |  
+BLACK_TEMPLE | BT_761 | Coilfang Warlord | O
 BLACK_TEMPLE | BT_781 | Bulwark of Azzinoth |  
 BLACK_TEMPLE | BT_850 | Magtheridon |  
 BLACK_TEMPLE | BT_934 | Imprisoned Antaen |  

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -1039,7 +1039,7 @@ BLACK_TEMPLE | BT_292 | Hand of A'dal |
 BLACK_TEMPLE | BT_300 | Hand of Gul'dan |  
 BLACK_TEMPLE | BT_301 | Nightshade Matron |  
 BLACK_TEMPLE | BT_302 | The Dark Portal |  
-BLACK_TEMPLE | BT_304 | Enhanced Dreadlord |  
+BLACK_TEMPLE | BT_304 | Enhanced Dreadlord | O
 BLACK_TEMPLE | BT_305 | Imprisoned Scrap Imp |  
 BLACK_TEMPLE | BT_306 | Shadow Council |  
 BLACK_TEMPLE | BT_307 | Darkglare |  

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -2040,6 +2040,15 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     //  - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<IncludeTask>(EntityType::MINIONS_NOSOURCE));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsMinion()) }));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("BT_160e", EntityType::STACK));
+    cards.emplace("BT_160", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BT_190] Replicat-o-tron - COST: 4 [ATK: 3/HP: 3]
@@ -2430,11 +2439,18 @@ void BlackTempleCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Summon a 1/1 Demon.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("BT_160t", SummonSide::DEATHRATTLE));
+    cards.emplace("BT_160e", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BT_160t] Rusted Devil - COST: 1 [ATK: 1/HP: 1]
     //  - Race: DEMON, Set: BLACK_TEMPLE
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("BT_160t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [BT_187e] Death's Dance - COST: 0

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -1825,8 +1825,6 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
             SelfCondition::IsRace(Race::DEMON)) }));
     power.AddDeathrattleTask(
         std::make_shared<RandomTask>(EntityType::STACK, 1));
-    power.AddDeathrattleTask(std::make_shared<GetGameTagTask>(
-        EntityType::STACK, GameTag::ENTITY_ID));
     power.AddDeathrattleTask(std::make_shared<SummonStackTask>(true));
     cards.emplace("BT_509", CardDef(power));
 
@@ -2043,9 +2041,6 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddPowerTask(
         std::make_shared<IncludeTask>(EntityType::MINIONS_NOSOURCE));
-    power.AddPowerTask(std::make_shared<FilterStackTask>(
-        SelfCondList{ std::make_shared<SelfCondition>(
-            SelfCondition::IsMinion()) }));
     power.AddPowerTask(
         std::make_shared<AddEnchantmentTask>("BT_160e", EntityType::STACK));
     cards.emplace("BT_160", CardDef(power));

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -994,6 +994,10 @@ void BlackTempleCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // RefTag:
     //  - STEALTH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("BT_703t", SummonSide::DEATHRATTLE));
+    cards.emplace("BT_703", CardDef(power));
 
     // ------------------------------------------ SPELL - ROGUE
     // [BT_707] Ambush - COST: 2
@@ -1097,6 +1101,9 @@ void BlackTempleCardsGen::AddRogueNonCollect(
     // GameTag:
     //  - STEALTH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("BT_703t", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
     // [BT_707t] Broken Ambusher - COST: 2 [ATK: 2/HP: 3]

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -15,11 +15,13 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FlagTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/GetGameTagTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ManaCrystalTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SetGameTagTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonOpTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
 
 using namespace RosettaStone::PlayMode::SimpleTasks;
@@ -1817,6 +1819,16 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     //  - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(std::make_shared<IncludeTask>(EntityType::HAND));
+    power.AddDeathrattleTask(std::make_shared<FilterStackTask>(SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsRace(Race::DEMON)) }));
+    power.AddDeathrattleTask(
+        std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddDeathrattleTask(std::make_shared<GetGameTagTask>(
+        EntityType::STACK, GameTag::ENTITY_ID));
+    power.AddDeathrattleTask(std::make_shared<SummonStackTask>(true));
+    cards.emplace("BT_509", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [BT_514] Immolation Aura - COST: 2
@@ -1851,6 +1863,10 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     //  - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("BT_761t", SummonSide::DEATHRATTLE));
+    cards.emplace("BT_761", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [BT_934] Imprisoned Antaen - COST: 6 [ATK: 10/HP: 6]
@@ -1884,6 +1900,9 @@ void BlackTempleCardsGen::AddDemonHunterNonCollect(
     // GameTag:
     //  - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("BT_761t", CardDef(power));
 }
 
 void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -1357,6 +1357,10 @@ void BlackTempleCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // RefTag:
     //  - LIFESTEAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("BT_304t", SummonSide::DEATHRATTLE));
+    cards.emplace("BT_304", CardDef(power));
 
     // --------------------------------------- MINION - WARLOCK
     // [BT_305] Imprisoned Scrap Imp - COST: 2 [ATK: 3/HP: 3]
@@ -1416,6 +1420,9 @@ void BlackTempleCardsGen::AddWarlockNonCollect(
     // GameTag:
     //  - LIFESTEAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("BT_304t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - WARLOCK
     // [BT_305e] Scrap Weapons - COST: 0

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -179,8 +179,8 @@ TEST_CASE("[Rogue : Minion] - BT_703 : Cursed Vagrant")
     game.ProcessUntil(Step::MAIN_ACTION);
 
     game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
-    CHECK_EQ(curField[0]->card->name, "Cursed Shadow");
     CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Cursed Shadow");
     CHECK_EQ(curField[0]->GetAttack(), 7);
     CHECK_EQ(curField[0]->GetHealth(), 5);
     CHECK_EQ(curField[0]->HasStealth(), true);
@@ -240,8 +240,8 @@ TEST_CASE("[Warlock : Minion] - BT_304 : Enhanced Dreadlord")
 
     game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
     game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
-    CHECK_EQ(curField[0]->card->name, "Desperate Dreadlord");
     CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Desperate Dreadlord");
     CHECK_EQ(curField[0]->GetAttack(), 5);
     CHECK_EQ(curField[0]->GetHealth(), 5);
     CHECK_EQ(curField[0]->HasLifesteal(), true);

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -909,3 +909,61 @@ TEST_CASE("[Neutral : Minion] - BT_159 : Terrorguard Escapee")
     CHECK_EQ(opField[2]->GetAttack(), 1);
     CHECK_EQ(opField[2]->card->name, "Huntress");
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BT_160] Rustsworn Cultist - COST: 4 [ATK: 3/HP: 3]
+//  - Set: BLACK_TEMPLE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give your
+//       other minions "<b>Deathrattle:</b>
+//       Summon a 1/1 Demon."
+// --------------------------------------------------------
+// GameTag:
+//  - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+//  - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BT_160 : Rustsworn Cultist")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Rustsworn Cultist"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card2));
+    CHECK_EQ(curField[0]->card->name, "Rusted Devil");
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+﻿// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 // We are making my contributions/submissions to this project solely in our
 // personal capacity and are not conveying any rights to any intellectual
@@ -487,6 +487,118 @@ TEST_CASE("[Warrior : Spell] - BT_124 : Corsair Cache")
     CHECK_EQ(curHand.GetCount(), 5);
     CHECK_EQ(dynamic_cast<Weapon*>(curHand[3])->GetDurability(), 2);
     CHECK_EQ(dynamic_cast<Weapon*>(curHand[4])->GetDurability(), 3);
+}
+
+// ----------------------------------- MINION - DEMONHUNTER
+// [BT_509] Fel Summoner - COST: 6 [ATK: 8/HP: 3]
+//  - Set: BLACK_TEMPLE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Summon a random Demon from your hand.
+// --------------------------------------------------------
+// GameTag:
+//  - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - BT_509 : Fel Summoner")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(20);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fel Summoner"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Battlefiend"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ur'zul Horror"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Fel Summoner");
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card5, card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->IsRace((Race::DEMON)), true);
+}
+
+// ----------------------------------- MINION - DEMONHUNTER
+// [BT_761] Coilfang Warlord - COST: 8 [ATK: 9/HP: 5]
+//  - Set: BLACK_TEMPLE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Rush</b>
+//       <b>Deathrattle:</b> Summon a
+//        5/9 Warlord with <b>Taunt</b>.
+// --------------------------------------------------------
+// GameTag:
+//  - DEATHRATTLE = 1
+//  - RUSH = 1
+// --------------------------------------------------------
+// RefTag:
+//  - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - BT_761 : Coilfang Warlord")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Coilfang Warlord"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Coilfang Warlord");
+    CHECK_EQ(curField[0]->HasRush(), true);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField[0]->card->name, "Conchguard Warlord");
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 9);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -240,6 +240,7 @@ TEST_CASE("[Warlock : Minion] - BT_304 : Enhanced Dreadlord")
 
     game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
     game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
     CHECK_EQ(curField.GetCount(), 1);
     CHECK_EQ(curField[0]->card->name, "Desperate Dreadlord");
     CHECK_EQ(curField[0]->GetAttack(), 5);
@@ -540,7 +541,7 @@ TEST_CASE("[Demon Hunter : Minion] - BT_509 : Fel Summoner")
 
     game.Process(opPlayer, PlayCardTask::SpellTarget(card5, card1));
     CHECK_EQ(curField.GetCount(), 1);
-    CHECK_EQ(curField[0]->IsRace((Race::DEMON)), true);
+    CHECK_EQ(curField[0]->IsRace(Race::DEMON), true);
 }
 
 // ----------------------------------- MINION - DEMONHUNTER
@@ -594,8 +595,8 @@ TEST_CASE("[Demon Hunter : Minion] - BT_761 : Coilfang Warlord")
     game.ProcessUntil(Step::MAIN_ACTION);
 
     game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
-    CHECK_EQ(curField[0]->card->name, "Conchguard Warlord");
     CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Conchguard Warlord");
     CHECK_EQ(curField[0]->GetAttack(), 5);
     CHECK_EQ(curField[0]->GetHealth(), 9);
     CHECK_EQ(curField[0]->HasTaunt(), true);
@@ -952,8 +953,6 @@ TEST_CASE("[Neutral : Minion] - BT_160 : Rustsworn Cultist")
         curPlayer, Cards::FindCardByName("Wolfrider"));
     const auto card3 =
         Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
-    const auto card4 =
-        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
 
     game.Process(curPlayer, PlayCardTask::Minion(card2));
     game.Process(curPlayer, PlayCardTask::Minion(card1));
@@ -962,8 +961,8 @@ TEST_CASE("[Neutral : Minion] - BT_160 : Rustsworn Cultist")
     game.ProcessUntil(Step::MAIN_ACTION);
 
     game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card2));
-    CHECK_EQ(curField[0]->card->name, "Rusted Devil");
     CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Rusted Devil");
     CHECK_EQ(curField[0]->GetAttack(), 1);
     CHECK_EQ(curField[0]->GetHealth(), 1);
 }

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -170,8 +170,6 @@ TEST_CASE("[Rogue : Minion] - BT_703 : Cursed Vagrant")
         curPlayer, Cards::FindCardByName("Cursed Vagrant"));
     const auto card2 =
         Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
-    const auto card3 =
-        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     CHECK_EQ(curField.GetCount(), 1);
@@ -181,12 +179,72 @@ TEST_CASE("[Rogue : Minion] - BT_703 : Cursed Vagrant")
     game.ProcessUntil(Step::MAIN_ACTION);
 
     game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
-    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
     CHECK_EQ(curField[0]->card->name, "Cursed Shadow");
     CHECK_EQ(curField.GetCount(), 1);
     CHECK_EQ(curField[0]->GetAttack(), 7);
     CHECK_EQ(curField[0]->GetHealth(), 5);
     CHECK_EQ(curField[0]->HasStealth(), true);
+}
+
+// --------------------------------------- MINION - WARLOCK
+// [BT_304] Enhanced Dreadlord - COST: 8 [ATK: 5/HP: 7]
+//  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Deathrattle:</b> Summon a 5/5
+//       Dreadlord with <b>Lifesteal</b>.
+// --------------------------------------------------------
+// GameTag:
+//  - DEATHRATTLE = 1
+//  - TAUNT = 1
+// --------------------------------------------------------
+// RefTag:
+//  - LIFESTEAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - BT_304 : Enhanced Dreadlord")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Enhanced Dreadlord"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Enhanced Dreadlord");
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
+    CHECK_EQ(curField[0]->card->name, "Desperate Dreadlord");
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+    CHECK_EQ(curField[0]->HasLifesteal(), true);
 }
 
 // ---------------------------------------- SPELL - WARRIOR


### PR DESCRIPTION
This revision includes
- Implementation of 5 BLACK_TEMPLE cards
  - 'Cursed Vagrant' (BT_703)
  - 'Enhanced Dreadlord' (BT_304)
  - 'Fel Summoner' (BT_509)
  - 'Coilfang Warlord' (BT_761)
  - 'Rustsworn Cutlist' (BT_160)
