### PR TITLE
Fix memory leak in Atk

### DIFF
--- a/Includes/Rosetta/PlayMode/Enchants/Attrs/Atk.hpp
+++ b/Includes/Rosetta/PlayMode/Enchants/Attrs/Atk.hpp
@@ -64,6 +64,7 @@ class Atk : public SelfContainedIntAttr<Atk, Entity>
             const auto effect =
                 new PlayMode::Effect(GameTag::ATK, effectOp, value);
             effect->ApplyTo(entity);
+            delete effect;
         }
     }
 


### PR DESCRIPTION
The memory allocated by find Atk.hpp is not freed.
So, It should free the allocated memory.