### PR TITLE
Fix memory leak in SwapAttackHealthTask

### DIFF
--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/SwapAttackHealthTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/SwapAttackHealthTask.cpp
@@ -36,6 +36,9 @@ TaskStatus SwapAttackHealthTask::Impl(Player* player)
 
         attackEffect->ApplyTo(playable);
         healthEffect->ApplyTo(playable);
+
+        delete attackEffect;
+        delete healthEffect;
     }
 
     return TaskStatus::COMPLETE;


### PR DESCRIPTION
The memory allocated by find SwapAttackHealthTask.cpp is not freed.
So, It should free the allocated memory.