### PR TITLE
Update Hearthstone Patch 18.0.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,36 @@
+# Sources
+*.c     text diff=c
+*.cc    text diff=cpp
+*.cxx   text diff=cpp
+*.cpp   text diff=cpp
+*.c++   text diff=cpp
+*.hpp   text diff=cpp
+*.h     text diff=c
+*.h++   text diff=cpp
+*.hh    text diff=cpp
+
+# Compiled Object files
+*.slo   binary
+*.lo    binary
+*.o     binary
+*.obj   binary
+
+# Precompiled Headers
+*.gch   binary
+*.pch   binary
+
+# Compiled Dynamic libraries
+*.so    binary
+*.dylib binary
+*.dll   binary
+
+# Compiled Static libraries
+*.lai   binary
+*.la    binary
+*.a     binary
+*.lib   binary
+
+# Executables
+*.exe   binary
+*.out   binary
+*.app   binary

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -994,12 +994,12 @@ BLACK_TEMPLE | BT_127 | Imprisoned Satyr |
 BLACK_TEMPLE | BT_128 | Fungal Fortunes |  
 BLACK_TEMPLE | BT_129 | Germination |  
 BLACK_TEMPLE | BT_130 | Overgrowth | O
-BLACK_TEMPLE | BT_131 | Ysiel Windsinger |  
+BLACK_TEMPLE | BT_131 | Ysiel Windsinger | O
 BLACK_TEMPLE | BT_132 | Ironbark |  
 BLACK_TEMPLE | BT_133 | Marsh Hydra |  
 BLACK_TEMPLE | BT_134 | Bogbeam |  
 BLACK_TEMPLE | BT_135 | Glowfly Swarm |  
-BLACK_TEMPLE | BT_136 | Archspore Msshi'fn | O  
+BLACK_TEMPLE | BT_136 | Archspore Msshi'fn | O
 BLACK_TEMPLE | BT_138 | Bloodboil Brute |  
 BLACK_TEMPLE | BT_140 | Bonechewer Raider |  
 BLACK_TEMPLE | BT_155 | Scrapyard Colossus | O
@@ -1077,7 +1077,7 @@ BLACK_TEMPLE | BT_723 | Rocket Augmerchant |
 BLACK_TEMPLE | BT_724 | Ethereal Augmerchant |  
 BLACK_TEMPLE | BT_726 | Dragonmaw Sky Stalker | O
 BLACK_TEMPLE | BT_727 | Soulbound Ashtongue |  
-BLACK_TEMPLE | BT_728 | Disguised Wanderer |  
+BLACK_TEMPLE | BT_728 | Disguised Wanderer | O
 BLACK_TEMPLE | BT_729 | Waste Warden |  
 BLACK_TEMPLE | BT_730 | Overconfident Orc |  
 BLACK_TEMPLE | BT_731 | Infectious Sporeling |  
@@ -1091,7 +1091,7 @@ BLACK_TEMPLE | BT_781 | Bulwark of Azzinoth |
 BLACK_TEMPLE | BT_850 | Magtheridon |  
 BLACK_TEMPLE | BT_934 | Imprisoned Antaen |  
 
-- Progress: 8% (11 of 135 Cards)
+- Progress: 20% (28 of 135 Cards)
 
 ## Scholomance Academy
 
@@ -1102,7 +1102,7 @@ SCHOLOMANCE | SCH_126 | Disciplinarian Gandling |
 SCHOLOMANCE | SCH_133 | Wolpertinger |  
 SCHOLOMANCE | SCH_135 | Turalyon, the Tenured |  
 SCHOLOMANCE | SCH_136 | Power Word: Feast |  
-SCHOLOMANCE | SCH_137 | Frazzled Freshman | O 
+SCHOLOMANCE | SCH_137 | Frazzled Freshman | O
 SCHOLOMANCE | SCH_138 | Blessing of Authority |  
 SCHOLOMANCE | SCH_139 | Devout Pupil |  
 SCHOLOMANCE | SCH_140 | Flesh Giant |  
@@ -1223,14 +1223,14 @@ SCHOLOMANCE | SCH_703 | Soulciologist Malicia |
 SCHOLOMANCE | SCH_704 | Soulshard Lapidary |  
 SCHOLOMANCE | SCH_705 | Vilefiend Trainer |  
 SCHOLOMANCE | SCH_706 | Plagiarize | O
-SCHOLOMANCE | SCH_707 | Fishy Flyer | O  
-SCHOLOMANCE | SCH_708 | Sneaky Delinquent | O  
-SCHOLOMANCE | SCH_709 | Smug Senior | O  
-SCHOLOMANCE | SCH_710 | Ogremancer | O 
-SCHOLOMANCE | SCH_711 | Plagued Protodrake | O  
+SCHOLOMANCE | SCH_707 | Fishy Flyer | O
+SCHOLOMANCE | SCH_708 | Sneaky Delinquent | O
+SCHOLOMANCE | SCH_709 | Smug Senior | O
+SCHOLOMANCE | SCH_710 | Ogremancer | O
+SCHOLOMANCE | SCH_711 | Plagued Protodrake | O
 SCHOLOMANCE | SCH_712 | Judicious Junior | O
 SCHOLOMANCE | SCH_713 | Cult Neophyte |  
 SCHOLOMANCE | SCH_714 | Educated Elekk |  
 SCHOLOMANCE | SCH_717 | Keymaster Alabaster |  
 
-- Progress: 1% (2 of 135 Cards)
+- Progress: 8% (12 of 135 Cards)

--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -106,7 +106,7 @@ constexpr int MAX_SECERT_SIZE = 5;
 constexpr int NUM_BATTLEGROUNDS_PLAYERS = 8;
 
 //! The number of heroes in Battlegrounds.
-constexpr int NUM_BATTLEGROUNDS_HEROES = 45;
+constexpr int NUM_BATTLEGROUNDS_HEROES = 44;
 
 //! The number of heroes on the selection list in Battlegrounds.
 constexpr int NUM_HEROES_ON_SELECTION_LIST = 4;
@@ -133,19 +133,19 @@ constexpr int NUM_COPIES_OF_EACH_TIER6_MINIONS = 7;
 constexpr int NUM_TIER1_MINIONS = 16;
 
 //! The number of tier 2 minions in Battlegrounds.
-constexpr int NUM_TIER2_MINIONS = 20;
+constexpr int NUM_TIER2_MINIONS = 19;
 
 //! The number of tier 3 minions in Battlegrounds.
 constexpr int NUM_TIER3_MINIONS = 23;
 
 //! The number of tier 4 minions in Battlegrounds.
-constexpr int NUM_TIER4_MINIONS = 19;
+constexpr int NUM_TIER4_MINIONS = 20;
 
 //! The number of tier 5 minions in Battlegrounds.
 constexpr int NUM_TIER5_MINIONS = 17;
 
 //! The number of tier 6 minions in Battlegrounds.
-constexpr int NUM_TIER6_MINIONS = 14;
+constexpr int NUM_TIER6_MINIONS = 12;
 
 //! A list of Tier 1 minion dbfIDs in Battlegrounds.
 // Alleycat (40426)
@@ -170,7 +170,6 @@ constexpr std::array<int, NUM_TIER1_MINIONS> TIER1_MINIONS = {
 };
 
 //! A list of Tier 2 minion dbfIDs in Battlegrounds.
-// Arcane Cannon (62188)
 // Freedealing Gambler (61049)
 // Glyph Guardian (61029)
 // Harvest Golem (778)
@@ -182,17 +181,17 @@ constexpr std::array<int, NUM_TIER1_MINIONS> TIER1_MINIONS = {
 // Murloc Warleader (1063)
 // Nathrezim Overseer (59186)
 // Old Murk-Eye (736)
+// Pack Leader (59940)
 // Pogo-Hopper (60122)
 // Rabid Saurolisk (62162)
-// Rat Pack (40428)
 // Southsea Captain (680)
 // Spawn of N'Zoth (38797)
 // Steward of Time (60621)
 // Unstable Ghoul (1808)
 // Waxrider Togwaggle (60559)
 constexpr std::array<int, NUM_TIER2_MINIONS> TIER2_MINIONS = {
-    62188, 61049, 61029, 778,   59937, 49279, 39481, 63435, 2016, 1063,
-    59186, 736,   60122, 62162, 40428, 680,   38797, 60621, 1808, 60559
+    61049, 61029, 778,   59937, 49279, 39481, 63435, 2016, 1063, 59186,
+    736,   59940, 60122, 62162, 680,   38797, 60621, 1808, 60559
 };
 
 //! A list of Tier 3 minion dbfIDs in Battlegrounds.
@@ -209,8 +208,8 @@ constexpr std::array<int, NUM_TIER2_MINIONS> TIER2_MINIONS = {
 // Infested Wolf (38734)
 // Khadgar (52502)
 // Monstrous Macaw (62230)
-// Pack Leader (59940)
 // Piloted Shredder (60048)
+// Rat Pack (40428)
 // Replicating Menace (48536)
 // Salty Looter (62734)
 // Screwjank Clunker (2023)
@@ -221,7 +220,7 @@ constexpr std::array<int, NUM_TIER2_MINIONS> TIER2_MINIONS = {
 // Yo-Ho-Ogre (61060)
 constexpr std::array<int, NUM_TIER3_MINIONS> TIER3_MINIONS = {
     61053, 60558, 453,   40391, 2518,  61930, 56393, 60552,
-    1003,  2288,  38734, 52502, 62230, 59940, 60048, 48536,
+    1003,  2288,  38734, 52502, 62230, 60048, 40428, 48536,
     62734, 2023,  57742, 59660, 962,   60626, 61060
 };
 
@@ -238,6 +237,7 @@ constexpr std::array<int, NUM_TIER3_MINIONS> TIER3_MINIONS = {
 // Iron Sensei (1992)
 // Mechano-Egg (49169)
 // Menagerie Jug (63487)
+// Primalfin Lookout (60028)
 // Ripsnarl Captain (61056)
 // Savannah Highmane (1261)
 // Security Rover (48100)
@@ -246,8 +246,8 @@ constexpr std::array<int, NUM_TIER3_MINIONS> TIER3_MINIONS = {
 // Toxfin (52277)
 // Virmen Sensei (40641)
 constexpr std::array<int, NUM_TIER4_MINIONS> TIER4_MINIONS = {
-    48993, 45392, 43358, 42442, 763,   61072, 2068,  61066, 60498, 1992,
-    49169, 63487, 61056, 1261,  48100, 54835, 61048, 52277, 40641
+    48993, 45392, 43358, 42442, 763,  61072, 2068,  61066, 60498, 1992,
+    49169, 63487, 60028, 61056, 1261, 48100, 54835, 61048, 52277, 40641
 };
 
 //! A list of Tier 5 minion dbfIDs in Battlegrounds.
@@ -260,9 +260,9 @@ constexpr std::array<int, NUM_TIER4_MINIONS> TIER4_MINIONS = {
 // King Bagurgle (60247)
 // Lightfang Enforcer (59707)
 // Mal'Ganis (1986)
+// Mama Bear (60036)
 // Murozond (60637)
 // Nat Pagle, Extreme Angler (61046)
-// Primalfin Lookout (60028)
 // Razorgore, the Untamed (60561)
 // Seabreaker Goliath (62458)
 // Sneed's Old Shredder (59682)
@@ -270,7 +270,7 @@ constexpr std::array<int, NUM_TIER4_MINIONS> TIER4_MINIONS = {
 // Voidlord (46056)
 constexpr std::array<int, NUM_TIER5_MINIONS> TIER5_MINIONS = {
     59714, 1915,  2949,  61989, 49973, 2074,  60247, 59707, 1986,
-    60637, 61046, 60028, 60561, 62458, 59682, 43022, 46056
+    60036, 60637, 61046, 60561, 62458, 59682, 43022, 46056
 };
 
 //! A list of Tier 6 minion dbfIDs in Battlegrounds.
@@ -279,18 +279,16 @@ constexpr std::array<int, NUM_TIER5_MINIONS> TIER5_MINIONS = {
 // Foe Reaper 4000 (2081)
 // Goldrinn, the Great Wolf (59955)
 // Kangor's Apprentice (59935)
-// Gentle Megasaur (56465)
 // Ghastcoiler (52041)
 // Imp Mama (61028)
 // Kalecgos, Arcane Aspect (60630)
 // Maexxna (1791)
-// Mama Bear (60036)
 // Nadina the Red (60629)
 // The Tide Razor (62232)
 // Zapp Slywick (60040)
 constexpr std::array<int, NUM_TIER6_MINIONS> TIER6_MINIONS = {
-    61444, 61047, 2081, 59955, 59935, 56465, 52041,
-    61028, 60630, 1791, 60036, 60629, 62232, 60040
+    61444, 61047, 2081, 59955, 59935, 52041,
+    61028, 60630, 1791, 60629, 62232, 60040
 };
 
 //! The total number of tier minions in Battlegrounds Tavern.

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Expansions
 
-  * 1% Scholomance Academy (2 of 135 cards)
-  * 8% Ashes of Outland (11 of 135 cards)
+  * 8% Scholomance Academy (12 of 135 cards)
+  * 20% Ashes of Outland (28 of 135 cards)
   * **100% Descent of Dragons (140 of 140 cards)**
   * 57% Saviors of Uldum (78 of 135 cards)
   * **100% Rise of Shadows (136 of 136 cards)**

--- a/Resources/cards.collectible.json
+++ b/Resources/cards.collectible.json
@@ -7184,7 +7184,7 @@
         "name": "Kael'thas Sunstrider",
         "rarity": "LEGENDARY",
         "set": "BLACK_TEMPLE",
-        "text": "Every third spell you cast each turn costs (0).",
+        "text": "Every third spell you cast each turn costs (1).",
         "type": "MINION"
     },
     {
@@ -9266,7 +9266,7 @@
         "race": "BEAST",
         "rarity": "EPIC",
         "set": "GANGS",
-        "techLevel": 2,
+        "techLevel": 3,
         "text": "[x]<b>Deathrattle:</b> Summon a\nnumber of 1/1 Rats equal\n to this minion's Attack.",
         "type": "MINION"
     },
@@ -40244,7 +40244,7 @@
         "attack": 1,
         "cardClass": "PRIEST",
         "collectible": true,
-        "cost": 2,
+        "cost": 3,
         "dbfId": 59643,
         "elite": true,
         "flavor": "\"…and that's how I ended up with a Murloc Cultural Studies major.\"",

--- a/Resources/cards.json
+++ b/Resources/cards.json
@@ -3630,7 +3630,7 @@
         "name": "Pack Leader",
         "rarity": "RARE",
         "set": "BATTLEGROUNDS",
-        "techLevel": 3,
+        "techLevel": 2,
         "text": "Whenever you summon a Beast, give it +3 Attack.",
         "type": "MINION"
     },
@@ -3660,7 +3660,7 @@
         "rarity": "LEGENDARY",
         "set": "BATTLEGROUNDS",
         "techLevel": 6,
-        "text": "<b>Deathrattle:</b> Give your Beasts +4/+4.",
+        "text": "<b>Deathrattle:</b> Give your Beasts +5/+5.",
         "type": "MINION"
     },
     {
@@ -3669,7 +3669,7 @@
         "id": "BGS_018e",
         "name": "Soul of the Beast",
         "set": "BATTLEGROUNDS",
-        "text": "+4/+4.",
+        "text": "+5/+5.",
         "type": "ENCHANTMENT"
     },
     {
@@ -3706,17 +3706,17 @@
         "race": "MURLOC",
         "rarity": "COMMON",
         "set": "BATTLEGROUNDS",
-        "techLevel": 5,
+        "techLevel": 4,
         "text": "<b>Battlecry:</b> If you control another Murloc, <b>Discover</b> a Murloc.",
         "type": "MINION"
     },
     {
-        "attack": 5,
+        "attack": 4,
         "battlegroundsPremiumDbfId": 60038,
         "cardClass": "NEUTRAL",
         "cost": 8,
         "dbfId": 60036,
-        "health": 5,
+        "health": 4,
         "id": "BGS_021",
         "mechanics": [
             "TRIGGER_VISUAL"
@@ -3725,8 +3725,8 @@
         "race": "BEAST",
         "rarity": "EPIC",
         "set": "BATTLEGROUNDS",
-        "techLevel": 6,
-        "text": "Whenever you summon a Beast, give it +5/+5.",
+        "techLevel": 5,
+        "text": "Whenever you summon a Beast, give it +4/+4.",
         "type": "MINION"
     },
     {
@@ -3735,7 +3735,7 @@
         "id": "BGS_021e",
         "name": "Rampage",
         "set": "BATTLEGROUNDS",
-        "text": "+5/+5.",
+        "text": "+4/+4.",
         "type": "ENCHANTMENT"
     },
     {
@@ -4260,14 +4260,14 @@
         "elite": true,
         "health": 5,
         "id": "BGS_046",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
         "name": "Nat Pagle, Extreme Angler",
         "race": "PIRATE",
-        "referencedTags": [
-            "OVERKILL"
-        ],
         "set": "BATTLEGROUNDS",
         "techLevel": 5,
-        "text": "<b>Overkill:</b> Summon a 0/2 Treasure Chest.",
+        "text": "[x]When this attacks and kills\na minion, add a random\nminion to your hand.",
         "type": "MINION"
     },
     {
@@ -4654,7 +4654,7 @@
         "type": "MINION"
     },
     {
-        "attack": 3,
+        "attack": 4,
         "battlegroundsPremiumDbfId": 62165,
         "cardClass": "HUNTER",
         "cost": 3,
@@ -4702,12 +4702,12 @@
         "type": "MINION"
     },
     {
-        "attack": 3,
+        "attack": 4,
         "battlegroundsPremiumDbfId": 62231,
         "cardClass": "NEUTRAL",
         "cost": 3,
         "dbfId": 62230,
-        "health": 2,
+        "health": 3,
         "id": "BGS_078",
         "mechanics": [
             "TRIGGER_VISUAL"
@@ -15824,7 +15824,7 @@
         "name": "Kael'thas Sunstrider",
         "rarity": "LEGENDARY",
         "set": "BLACK_TEMPLE",
-        "text": "Every third spell you cast each turn costs (0).",
+        "text": "Every third spell you cast each turn costs (1).",
         "type": "MINION"
     },
     {
@@ -15833,7 +15833,7 @@
         "id": "BT_255e",
         "name": "Sunstrider",
         "set": "BLACK_TEMPLE",
-        "text": "Costs (0).",
+        "text": "Costs (1).",
         "type": "ENCHANTMENT"
     },
     {
@@ -20122,7 +20122,7 @@
         "race": "BEAST",
         "rarity": "EPIC",
         "set": "GANGS",
-        "techLevel": 2,
+        "techLevel": 3,
         "text": "[x]<b>Deathrattle:</b> Summon a\nnumber of 1/1 Rats equal\n to this minion's Attack.",
         "type": "MINION"
     },
@@ -90939,7 +90939,7 @@
         "attack": 1,
         "cardClass": "PRIEST",
         "collectible": true,
-        "cost": 2,
+        "cost": 3,
         "dbfId": 59643,
         "elite": true,
         "flavor": "\"…and that's how I ended up with a Murloc Cultural Studies major.\"",
@@ -95839,7 +95839,6 @@
         "type": "HERO"
     },
     {
-        "battlegroundsHero": true,
         "cardClass": "NEUTRAL",
         "dbfId": 61913,
         "health": 40,
@@ -95997,7 +95996,7 @@
         "id": "TB_BaconShop_HP_011",
         "name": "Galakrond's Greed",
         "set": "BATTLEGROUNDS",
-        "text": "[x]<b>Hero Power</b>\nReplace a minion in Bob's\nTavern with a minion from\na higher Tavern Tier.",
+        "text": "[x]<b>Hero Power</b>\nReplace a minion in Bob's\nTavern with one from a higher\nTavern Tier and <b>Freeze</b> it.",
         "type": "HERO_POWER"
     },
     {
@@ -96134,7 +96133,7 @@
     },
     {
         "cardClass": "NEUTRAL",
-        "cost": 1,
+        "cost": 0,
         "dbfId": 58040,
         "id": "TB_BaconShop_HP_024",
         "name": "Reborn Rites",
@@ -96488,7 +96487,7 @@
     },
     {
         "cardClass": "NEUTRAL",
-        "cost": 2,
+        "cost": 0,
         "dbfId": 60216,
         "id": "TB_BaconShop_HP_046",
         "name": "Gonna Be Rich!",
@@ -96882,7 +96881,7 @@
         "id": "TB_BaconShop_HP_074",
         "name": "Buried Treasure",
         "set": "BATTLEGROUNDS",
-        "text": "[x]<b>Hero Power</b>\n Dig for a Golden minion!\n<i>(4 Digs left.)</i>",
+        "text": "[x]<b>Hero Power</b>\n Dig for a Golden minion!\n<i>(5 Digs left.)</i>",
         "type": "HERO_POWER"
     },
     {
@@ -97358,7 +97357,7 @@
         "race": "BEAST",
         "rarity": "EPIC",
         "set": "BATTLEGROUNDS",
-        "techLevel": 2,
+        "techLevel": 3,
         "text": "[x]<b>Deathrattle:</b> Summon a\nnumber of 2/2 Rats equal\n to this minion's Attack.",
         "type": "MINION"
     },
@@ -98689,7 +98688,7 @@
         "rarity": "LEGENDARY",
         "set": "BATTLEGROUNDS",
         "techLevel": 6,
-        "text": "<b>Deathrattle:</b> Give your Beasts +8/+8.",
+        "text": "<b>Deathrattle:</b> Give your Beasts +10/+10.",
         "type": "MINION"
     },
     {
@@ -98698,7 +98697,7 @@
         "id": "TB_BaconUps_085e",
         "name": "Soul of the Beast",
         "set": "BATTLEGROUNDS",
-        "text": "+8/+8.",
+        "text": "+10/+10.",
         "type": "ENCHANTMENT"
     },
     {
@@ -98715,7 +98714,7 @@
         "name": "Pack Leader",
         "rarity": "RARE",
         "set": "BATTLEGROUNDS",
-        "techLevel": 3,
+        "techLevel": 2,
         "text": "Whenever you summon a Beast, give it +6 Attack.",
         "type": "MINION"
     },
@@ -98791,17 +98790,17 @@
         "race": "MURLOC",
         "rarity": "COMMON",
         "set": "BATTLEGROUNDS",
-        "techLevel": 5,
+        "techLevel": 4,
         "text": "<b>Battlecry:</b> If you control another Murloc, <b>Discover</b> two Murlocs.",
         "type": "MINION"
     },
     {
-        "attack": 10,
+        "attack": 8,
         "battlegroundsNormalDbfId": 60036,
         "cardClass": "NEUTRAL",
         "cost": 8,
         "dbfId": 60038,
-        "health": 10,
+        "health": 8,
         "id": "TB_BaconUps_090",
         "mechanics": [
             "TRIGGER_VISUAL"
@@ -98810,8 +98809,8 @@
         "race": "BEAST",
         "rarity": "EPIC",
         "set": "BATTLEGROUNDS",
-        "techLevel": 6,
-        "text": "Whenever you summon a Beast, give it +10/+10.",
+        "techLevel": 5,
+        "text": "Whenever you summon a Beast, give it +8/+8.",
         "type": "MINION"
     },
     {
@@ -98820,7 +98819,7 @@
         "id": "TB_BaconUps_090e",
         "name": "Rampage",
         "set": "BATTLEGROUNDS",
-        "text": "+10/+10.",
+        "text": "+8/+8.",
         "type": "ENCHANTMENT"
     },
     {
@@ -99508,7 +99507,7 @@
         "type": "ENCHANTMENT"
     },
     {
-        "attack": 6,
+        "attack": 8,
         "battlegroundsNormalDbfId": 62162,
         "cardClass": "HUNTER",
         "cost": 3,
@@ -99624,14 +99623,14 @@
         "elite": true,
         "health": 10,
         "id": "TB_BaconUps_132",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
         "name": "Nat Pagle, Extreme Angler",
         "race": "PIRATE",
-        "referencedTags": [
-            "OVERKILL"
-        ],
         "set": "BATTLEGROUNDS",
         "techLevel": 5,
-        "text": "<b>Overkill:</b> Summon a 0/2 Golden Treasure Chest.",
+        "text": "[x]When this attacks and kills\na minion, add 2 random\nminions to your hand.",
         "type": "MINION"
     },
     {
@@ -99698,12 +99697,12 @@
         "type": "ENCHANTMENT"
     },
     {
-        "attack": 6,
+        "attack": 8,
         "battlegroundsNormalDbfId": 62230,
         "cardClass": "NEUTRAL",
         "cost": 3,
         "dbfId": 62231,
-        "health": 4,
+        "health": 6,
         "id": "TB_BaconUps_135",
         "mechanics": [
             "TRIGGER_VISUAL"

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -2168,7 +2168,7 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [BT_255] Kael'thas Sunstrider - COST: 7 [ATK: 4/HP: 7]
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: Every third spell you cast each turn costs (0).
+    // Text: Every third spell you cast each turn costs (1).
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -20,8 +20,8 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/HealTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ManaCrystalTask.hpp>
-#include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomMinionTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SetGameTagTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonCopyTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonOpTask.hpp>
@@ -570,8 +570,8 @@ void BlackTempleCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     //  - FREEZE = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(
-        EntityType::TARGET, GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::TARGET,
+                                                        GameTag::FROZEN, 1));
     power.AddPowerTask(std::make_shared<SummonTask>("CS2_033", 2));
     cards.emplace("BT_072",
                   CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
@@ -860,7 +860,8 @@ void BlackTempleCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // Text: Give a minion +1/+2. Summon a copy of it.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<AddEnchantmentTask>("BT_253e", EntityType::TARGET));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("BT_253e", EntityType::TARGET));
     power.AddPowerTask(std::make_shared<SummonCopyTask>(EntityType::TARGET));
     cards.emplace(
         "BT_253",
@@ -905,7 +906,6 @@ void BlackTempleCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
         "BT_257",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
                                  { PlayReq::REQ_MINION_TARGET, 0 } }));
-
 
     // ---------------------------------------- MINION - PRIEST
     // [BT_258] Imprisoned Homunculus - COST: 1 [ATK: 2/HP: 5]

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -51,21 +51,17 @@ void BlackTempleCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ------------------------------- HERO_POWER - DEMONHUNTER
-    // [BT_429p] Demonic Blast - COST: 1
+    // [BT_429p] Demonic Blast - COST:1
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
-    // Text: <b>Hero Power</b>
-    //       Deal 4 damage.
-    //       <i>(Two uses left!)</i>
+    // Text: <b>Hero Power</b> Deal 4 damage. (Two uses left!)
     // --------------------------------------------------------
 
     // ------------------------------- HERO_POWER - DEMONHUNTER
-    // [BT_429p2] Demonic Blast - COST: 1
+    // [BT_429p2] Demonic Blast - COST:1
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
-    // Text: <b>Hero Power</b>
-    //       Deal 4 damage.
-    //       <i>(Last use!)</i>
+    // Text: <b>Hero Power</b> Deal 4 damage. (Last use!)
     // --------------------------------------------------------
 }
 
@@ -74,24 +70,22 @@ void BlackTempleCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ----------------------------------------- MINION - DRUID
-    // [BT_127] Imprisoned Satyr - COST: 3 [ATK: 3/HP: 3]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Common
+    // [BT_127] Imprisoned Satyr - COST:3 [ATK:3/HP:3]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Dormant</b> for 2 turns.
-    //       When this awakens, reduce
-    //       the Cost of a random minion
-    //       in your hand by (5).
+    // Text: <b>Dormant</b> for 2 turns. When this awakens,
+    //       reduce the Cost of a random minion in your hand by (5).
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [BT_128] Fungal Fortunes - COST: 3
+    // [BT_128] Fungal Fortunes - COST:3
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Draw 3 cards. Discard any minions drawn.
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [BT_129] Germination - COST: 4
+    // [BT_129] Germination - COST:4
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Summon a copy of a friendly minion.
@@ -112,7 +106,7 @@ void BlackTempleCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_130", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
-    // [BT_131] Ysiel Windsinger - COST: 9 [ATK: 5/HP: 5]
+    // [BT_131] Ysiel Windsinger - COST:9 [ATK:5/HP:5]
     // - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: Your spells cost (1).
@@ -131,7 +125,7 @@ void BlackTempleCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_131", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
-    // [BT_132] Ironbark - COST: 2
+    // [BT_132] Ironbark - COST:2
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Give a minion +1/+3 and <b>Taunt</b>.
@@ -142,13 +136,11 @@ void BlackTempleCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [BT_133] Marsh Hydra - COST: 7 [ATK: 7/HP: 7]
-    //  - Race: BEAST, Set: BLACK_TEMPLE, Rarity: Epic
+    // [BT_133] Marsh Hydra - COST:7 [ATK:7/HP:7]
+    //  - Race: Beast, Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Rush</b>
-    //       After this attacks, add a
-    //       random 8-Cost minion
-    //       to your hand.
+    // Text: <b>Rush</b> After this attacks,
+    //       add a random 8-Cost minion to your hand.
     // --------------------------------------------------------
     // GameTag:
     //  - RUSH = 1
@@ -156,7 +148,7 @@ void BlackTempleCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [BT_134] Bogbeam - COST: 3
+    // [BT_134] Bogbeam - COST:3
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: Deal 3 damage to a minion.
@@ -164,20 +156,18 @@ void BlackTempleCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [BT_135] Glowfly Swarm - COST: 5
+    // [BT_135] Glowfly Swarm - COST:5
     //  - Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
     // Text: Summon a 2/2 Glowfly for each spell in your hand.
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [BT_136] Archspore Msshi'fn - COST: 3 [ATK: 3/HP: 4]
+    // [BT_136] Archspore Msshi'fn - COST:3 [ATK:3/HP:4]
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>
-    //       <b>Deathrattle:</b> Shuffle
-    //       'Msshi'fn Prime'
-    //       into your deck.
+    // Text: <b>Taunt</b> <b>Deathrattle:</b> Shuffle
+    //       'Msshi'fn Prime' into your deck.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -196,31 +186,30 @@ void BlackTempleCardsGen::AddDruidNonCollect(
     Power power;
 
     // ------------------------------------ ENCHANTMENT - DRUID
-    // [BT_127e] Imprisoned Satyr - COST: 0
+    // [BT_127e] Imprisoned Satyr - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Costs (5) less.
     // --------------------------------------------------------
 
     // ------------------------------------ ENCHANTMENT - DRUID
-    // [BT_132e] Ironbark - COST: 0
+    // [BT_132e] Ironbark - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: +1/+3 and <b>Taunt</b>.
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [BT_135t] Glowfly - COST: 2 [ATK: 2/HP: 2]
-    //  - Race: BEAST, Set: BLACK_TEMPLE
+    // [BT_135t] Glowfly - COST:2 [ATK:2/HP:2]
+    //  - Race: Beast, Set: BLACK_TEMPLE
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [BT_136t] Msshi'fn Prime - COST: 10 [ATK: 9/HP: 9]
+    // [BT_136t] Msshi'fn Prime - COST:10 [ATK:9/HP:9]
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>
-    //       <b>Choose One -</b> Summon a 9/9 Fungal Giant with <b>Taunt</b>; or
-    //       <b>Rush</b>.
+    // Text: <b>Taunt</b> <b>Choose One -</b> Summon a
+    //       9/9 Fungal Giant with <b>Taunt</b>; or <b>Rush</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -236,7 +225,7 @@ void BlackTempleCardsGen::AddDruidNonCollect(
                   CardDef(power, ChooseCardIDs{ "BT_136ta", "BT_136tb" }));
 
     // ------------------------------------------ SPELL - DRUID
-    // [BT_136ta] Msshi'fn Pro'tec - COST: 10
+    // [BT_136ta] Msshi'fn Pro'tec - COST:10
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Summon a 9/9 Guardian with <b>Taunt</b>.
@@ -251,7 +240,7 @@ void BlackTempleCardsGen::AddDruidNonCollect(
     cards.emplace("BT_136ta", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
-    // [BT_136tb] Msshi'fn At'tac - COST: 10
+    // [BT_136tb] Msshi'fn At'tac - COST:10
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Summon a 9/9 Bruiser with <b>Rush</b>.
@@ -266,7 +255,7 @@ void BlackTempleCardsGen::AddDruidNonCollect(
     cards.emplace("BT_136tb", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
-    // [BT_136tt] Fungal Guardian - COST: 10 [ATK: 9/HP: 9]
+    // [BT_136tt] Fungal Guardian - COST:10 [ATK:9/HP:9]
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -280,7 +269,7 @@ void BlackTempleCardsGen::AddDruidNonCollect(
     cards.emplace("BT_136tt", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
-    // [BT_136tt2] Fungal Bruiser - COST: 10 [ATK: 9/HP: 9]
+    // [BT_136tt2] Fungal Bruiser - COST:10 [ATK:9/HP:9]
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -294,7 +283,7 @@ void BlackTempleCardsGen::AddDruidNonCollect(
     cards.emplace("BT_136tt2", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
-    // [BT_136tt3] Fungal Gargantuan - COST: 10 [ATK: 9/HP: 9]
+    // [BT_136tt3] Fungal Gargantuan - COST:10 [ATK:9/HP:9]
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -315,28 +304,26 @@ void BlackTempleCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ----------------------------------------- SPELL - HUNTER
-    // [BT_163] Nagrand Slam - COST: 10
+    // [BT_163] Nagrand Slam - COST:10
     //  - Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
     // Text: Summon four 3/5 Clefthoofs that attack random enemies.
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [BT_201] Augmented Porcupine - COST: 3 [ATK: 2/HP: 4]
-    //  - Race: BEAST, Set: BLACK_TEMPLE, Rarity: Epic
+    // [BT_201] Augmented Porcupine - COST:3 [ATK:2/HP:4]
+    //  - Race: Beast, Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Deathrattle</b>: Deal this
-    //       minion's Attack damage
-    //       randomly split among
-    //       all enemies.
+    // Text: <b>Deathrattle</b>: Deal this minion's Attack damage
+    //       randomly split among all enemies.
     // --------------------------------------------------------
     // GameTag:
     //  - DEATHRATTLE = 1
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [BT_202] Helboar - COST: 1 [ATK: 2/HP: 1]
-    //  - Race: BEAST, Set: BLACK_TEMPLE, Rarity: Common
+    // [BT_202] Helboar - COST:1 [ATK:2/HP:1]
+    //  - Race: Beast, Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Give a random Beast in your hand +1/+1.
     // --------------------------------------------------------
@@ -345,31 +332,29 @@ void BlackTempleCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - HUNTER
-    // [BT_203] Pack Tactics - COST: 2
+    // [BT_203] Pack Tactics - COST:2
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Secret:</b> When a friendly minion is attacked, summon a 3/3
-    // copy.
+    // Text: <b>Secret:</b> When a friendly minion is attacked,
+    //       summon a 3/3 copy.
     // --------------------------------------------------------
     // GameTag:
     //  - SECRET = 1
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - HUNTER
-    // [BT_205] Scrap Shot - COST: 4
+    // [BT_205] Scrap Shot - COST:4
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Deal 3 damage.
-    //       Give a random Beast in your hand +3/+3.
+    // Text: Deal 3 damage. Give a random Beast in your hand +3/+3.
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [BT_210] Zixor, Apex Predator - COST: 3 [ATK: 2/HP: 4]
-    //  - Race: BEAST, Set: BLACK_TEMPLE, Rarity: Legendary
+    // [BT_210] Zixor, Apex Predator - COST:3 [ATK:2/HP:4]
+    //  - Race: Beast, Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Rush</b>
-    //       <b>Deathrattle:</b> Shuffle 'Zixor
-    //       Prime' into your deck.
+    //       <b>Deathrattle:</b> Shuffle 'Zixor Prime' into your deck.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -378,20 +363,19 @@ void BlackTempleCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [BT_211] Imprisoned Felmaw - COST: 2 [ATK: 5/HP: 4]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Common
+    // [BT_211] Imprisoned Felmaw - COST:2 [ATK:5/HP:4]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Dormant</b> for 2 turns.
-    //       When this awakens,
-    //         attack a random enemy.
+    //       When this awakens, attack a random enemy.
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [BT_212] Mok'Nathal Lion - COST: 4 [ATK: 5/HP: 2]
-    //  - Race: BEAST, Set: BLACK_TEMPLE, Rarity: Rare
+    // [BT_212] Mok'Nathal Lion - COST:4 [ATK:5/HP:2]
+    //  - Race: Beast, Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Rush</b>. <b>Battlecry:</b> Choose a friendly minion. Gain a
-    // copy of its <b>Deathrattle</b>.
+    // Text: <b>Rush</b>. <b>Battlecry:</b> Choose a friendly minion.
+    //       Gain a copy of its <b>Deathrattle</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -402,15 +386,14 @@ void BlackTempleCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - HUNTER
-    // [BT_213] Scavenger's Ingenuity - COST: 2
+    // [BT_213] Scavenger's Ingenuity - COST:2
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Draw a Beast.
-    //       Give it +2/+2.
+    // Text: Draw a Beast. Give it +2/+2.
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [BT_214] Beastmaster Leoroxx - COST: 8 [ATK: 5/HP: 5]
+    // [BT_214] Beastmaster Leoroxx - COST:8 [ATK:5/HP:5]
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Summon 3 Beasts from your hand.
@@ -427,31 +410,30 @@ void BlackTempleCardsGen::AddHunterNonCollect(
     Power power;
 
     // ---------------------------------------- MINION - HUNTER
-    // [BT_163t] Clefthoof - COST: 4 [ATK: 3/HP: 5]
-    //  - Race: BEAST, Set: BLACK_TEMPLE
+    // [BT_163t] Clefthoof - COST:4 [ATK:3/HP:5]
+    //  - Race: Beast, Set: BLACK_TEMPLE
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - HUNTER
-    // [BT_202e] Scent of Blood - COST: 0
+    // [BT_202e] Scent of Blood - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - HUNTER
-    // [BT_203e] Packmate - COST: 0
+    // [BT_203e] Packmate - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Attack and Health set to 3.
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [BT_210t] Zixor Prime - COST: 8 [ATK: 4/HP: 4]
-    //  - Race: BEAST, Set: BLACK_TEMPLE
+    // [BT_210t] Zixor Prime - COST:8 [ATK:4/HP:4]
+    //  - Race: Beast, Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Rush</b>
-    //       <b>Battlecry:</b> Summon 3
-    //       copies of this minion.
+    //       <b>Battlecry:</b> Summon 3 copies of this minion.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -465,35 +447,33 @@ void BlackTempleCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ------------------------------------------- SPELL - MAGE
-    // [BT_002] Incanter's Flow - COST: 2
+    // [BT_002] Incanter's Flow - COST:2
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: Reduce the Cost of spells in your deck by (1).
     // --------------------------------------------------------
 
     // ------------------------------------------- SPELL - MAGE
-    // [BT_003] Netherwind Portal - COST: 3
+    // [BT_003] Netherwind Portal - COST:3
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Secret:</b> After your opponent casts a spell, summon a random
-    //       4-Cost minion.
+    // Text: <b>Secret:</b> After your opponent casts a spell,
+    //       summon a random 4-Cost minion.
     // --------------------------------------------------------
     // GameTag:
     //  - SECRET = 1
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [BT_004] Imprisoned Observer - COST: 3 [ATK: 4/HP: 5]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Rare
+    // [BT_004] Imprisoned Observer - COST:3 [ATK:4/HP:5]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Dormant</b> for 2 turns.
-    //       When this awakens,
-    //       deal 2 damage to all
-    //       enemy minions.
+    //       When this awakens, deal 2 damage to all enemy minions.
     // --------------------------------------------------------
 
     // ------------------------------------------- SPELL - MAGE
-    // [BT_006] Evocation - COST: 1
+    // [BT_006] Evocation - COST:1
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: Fill your hand with random Mage spells.
@@ -503,7 +483,7 @@ void BlackTempleCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     //  - ELITE = 1
 
     // ------------------------------------------ MINION - MAGE
-    // [BT_014] Starscryer - COST: 2 [ATK: 3/HP: 1]
+    // [BT_014] Starscryer - COST:2 [ATK:3/HP:1]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Draw a spell.
@@ -521,18 +501,18 @@ void BlackTempleCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_014", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
-    // [BT_021] Font of Power - COST: 1
+    // [BT_021] Font of Power - COST:1
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Discover</b> a Mage minion. If your deck has no minions, keep
-    // all 3.
+    // Text: <b>Discover</b> a Mage minion.
+    //       If your deck has no minions, keep all 3.
     // --------------------------------------------------------
     // GameTag:
     //  - DISCOVER = 1
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [BT_022] Apexis Smuggler - COST: 2 [ATK: 2/HP: 3]
+    // [BT_022] Apexis Smuggler - COST:2 [ATK:2/HP:3]
     //  - Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
     // Text: After you play a <b>Secret</b>, <b>Discover</b> a spell.
@@ -546,13 +526,11 @@ void BlackTempleCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [BT_028] Astromancer Solarian - COST: 2 [ATK: 3/HP: 2]
+    // [BT_028] Astromancer Solarian - COST:2 [ATK:3/HP:2]
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Spell Damage +1</b>
-    //       <b>Deathrattle:</b> Shuffle
-    //       'Solarian Prime'
-    //       into your deck.
+    // Text: <b>Spell Damage +1</b> <b>Deathrattle:</b> Shuffle
+    //       'Solarian Prime' into your deck.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -561,7 +539,7 @@ void BlackTempleCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------- SPELL - MAGE
-    // [BT_072] Deep Freeze - COST: 8
+    // [BT_072] Deep Freeze - COST:8
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Freeze</b> an enemy. Summon two 3/6 Water Elementals.
@@ -578,11 +556,11 @@ void BlackTempleCardsGen::AddMage(std::map<std::string, CardDef>& cards)
                                            { PlayReq::REQ_ENEMY_TARGET, 0 } }));
 
     // ------------------------------------------- SPELL - MAGE
-    // [BT_291] Apexis Blast - COST: 5
+    // [BT_291] Apexis Blast - COST:5
     //  - Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: Deal 5 damage.
-    //       If your deck has no minions, summon a random 5-Cost minion.
+    // Text: Deal 5 damage. If your deck has no minions,
+    //       summon a random 5-Cost minion.
     // --------------------------------------------------------
 }
 
@@ -592,26 +570,26 @@ void BlackTempleCardsGen::AddMageNonCollect(
     Power power;
 
     // ------------------------------------- ENCHANTMENT - MAGE
-    // [BT_002e] Incanter's Flow - COST: 0
+    // [BT_002e] Incanter's Flow - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Costs (1) less.
     // --------------------------------------------------------
 
     // ------------------------------------- ENCHANTMENT - MAGE
-    // [BT_006e] Evocation - COST: 0
+    // [BT_006e] Evocation - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Discards at the end of your turn.
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [BT_028t] Solarian Prime - COST: 7 [ATK: 7/HP: 7]
-    //  - Race: DEMON, Set: BLACK_TEMPLE
+    // [BT_028t] Solarian Prime - COST:7 [ATK:7/HP:7]
+    //  - Race: Demon, Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Spell Damage +1</b>
-    //       <b>Battlecry:</b> Cast 5 random Mage spells <i>(targets enemies if
-    //       possible)</i>.
+    //       <b>Battlecry:</b> Cast 5 random Mage spells
+    //       (targets enemies if possible).
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -625,19 +603,19 @@ void BlackTempleCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     Power power;
 
     // --------------------------------------- MINION - PALADIN
-    // [BT_009] Imprisoned Sungill - COST: 1 [ATK: 2/HP: 1]
-    //  - Race: MURLOC, Set: BLACK_TEMPLE, Rarity: Rare
+    // [BT_009] Imprisoned Sungill - COST:1 [ATK:2/HP:1]
+    //  - Race: Murloc, Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Dormant</b> for 2 turns.
-    //       When this awakens, summon two 1/1
-    //       Murlocs.
+    // Text: <b>Dormant</b> for 2 turns. When this awakens,
+    //       summon two 1/1 Murlocs.
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [BT_011] Libram of Justice - COST: 5
+    // [BT_011] Libram of Justice - COST:5
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Equip a 1/4 weapon. Change the Health of all enemy minions to 1.
+    // Text: Equip a 1/4 weapon.
+    //       Change the Health of all enemy minions to 1.
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(std::make_shared<WeaponTask>("BT_011t"));
@@ -646,23 +624,22 @@ void BlackTempleCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_011", CardDef(power));
 
     // --------------------------------------- WEAPON - PALADIN
-    // [BT_018] Underlight Angling Rod - COST: 3
+    // [BT_018] Underlight Angling Rod - COST:3
     //  - Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: After your Hero attacks, add a random Murloc to your hand.
+    // Text: After your Hero attacks,
+    //       add a random Murloc to your hand.
     // --------------------------------------------------------
     // GameTag:
     //  - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [BT_019] Murgur Murgurgle - COST: 2 [ATK: 2/HP: 1]
-    //  - Race: MURLOC, Set: BLACK_TEMPLE, Rarity: Legendary
+    // [BT_019] Murgur Murgurgle - COST:2 [ATK:2/HP:1]
+    //  - Race: Murloc, Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Divine Shield</b>
-    //       <b>Deathrattle:</b> Shuffle
-    //       'Murgurgle Prime'
-    //       into your deck.
+    // Text: <b>Divine Shield</b> <b>Deathrattle:</b> Shuffle
+    //       'Murgurgle Prime' into your deck.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -671,21 +648,22 @@ void BlackTempleCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [BT_020] Aldor Attendant - COST: 1 [ATK: 1/HP: 3]
+    // [BT_020] Aldor Attendant - COST:1 [ATK:1/HP:3]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Reduce the Cost of your Librams by (1) this game.
+    // Text: <b>Battlecry:</b> Reduce the Cost of your Librams
+    //       by (1) this game.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [BT_024] Libram of Hope - COST: 9
+    // [BT_024] Libram of Hope - COST:9
     //  - Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: Restore 8 Health. Summon an 8/8 Guardian with <b>Taunt</b>
-    // and <b>Divine Shield</b>.
+    // Text: Restore 8 Health. Summon an 8/8 Guardian
+    //       with <b>Taunt</b> and <b>Divine Shield</b>.
     // --------------------------------------------------------
     // RefTag:
     //  - DIVINE_SHIELD = 1
@@ -700,24 +678,22 @@ void BlackTempleCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ---------------------------------------- SPELL - PALADIN
-    // [BT_025] Libram of Wisdom - COST: 2
+    // [BT_025] Libram of Wisdom - COST:2
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Give a minion +1/+1
-    //       and "<b>Deathrattle:</b> Add
-    //       a 'Libram of Wisdom'
-    //       spell to your hand."
+    // Text: Give a minion +1/+1 and "<b>Deathrattle:</b>
+    //       Add a 'Libram of Wisdom' spell to your hand."
     // --------------------------------------------------------
     // RefTag:
     //  - DEATHRATTLE = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [BT_026] Aldor Truthseeker - COST: 5 [ATK: 4/HP: 6]
+    // [BT_026] Aldor Truthseeker - COST:5 [ATK:4/HP:6]
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>. <b>Battlecry:</b> Reduce the Cost of your Librams by
-    // (2) this game.
+    // Text: <b>Taunt</b>. <b>Battlecry:</b> Reduce the Cost of
+    //       your Librams by (2) this game.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -725,21 +701,18 @@ void BlackTempleCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [BT_292] Hand of A'dal - COST: 2
+    // [BT_292] Hand of A'dal - COST:2
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Give a minion +2/+2.
-    //       Draw a card.
+    // Text: Give a minion +2/+2. Draw a card.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [BT_334] Lady Liadrin - COST: 7 [ATK: 4/HP: 6]
+    // [BT_334] Lady Liadrin - COST:7 [ATK:4/HP:6]
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Add a copy of
-    //       each spell you cast on
-    //       friendly characters this
-    //       game to your hand.
+    // Text: <b>Battlecry:</b> Add a copy of each spell you cast
+    //       on friendly characters this game to your hand.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -753,12 +726,12 @@ void BlackTempleCardsGen::AddPaladinNonCollect(
     Power power;
 
     // --------------------------------------- MINION - PALADIN
-    // [BT_009t] Sungill Streamrunner - COST: 1 [ATK: 1/HP: 1]
-    //  - Race: MURLOC, Set: BLACK_TEMPLE
+    // [BT_009t] Sungill Streamrunner - COST:1 [ATK:1/HP:1]
+    //  - Race: Murloc, Set: BLACK_TEMPLE
     // --------------------------------------------------------
 
     // --------------------------------------- WEAPON - PALADIN
-    // [BT_011t] Overdue Justice - COST: 1
+    // [BT_011t] Overdue Justice - COST:1
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     power.ClearData();
@@ -766,12 +739,12 @@ void BlackTempleCardsGen::AddPaladinNonCollect(
     cards.emplace("BT_011t", CardDef(power));
 
     // --------------------------------------- MINION - PALADIN
-    // [BT_019t] Murgurgle Prime - COST: 8 [ATK: 6/HP: 3]
-    //  - Race: MURLOC, Set: BLACK_TEMPLE
+    // [BT_019t] Murgurgle Prime - COST:8 [ATK:6/HP:3]
+    //  - Race: Murloc, Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Divine Shield</b>
-    //       <b>Battlecry:</b> Summon 4 random Murlocs. Give them <b>Divine
-    //       Shield</b>.
+    //       <b>Battlecry:</b> Summon 4 random Murlocs.
+    //       Give them <b>Divine Shield</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -780,11 +753,10 @@ void BlackTempleCardsGen::AddPaladinNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [BT_024t] Ancient Guardian - COST: 8 [ATK: 8/HP: 8]
+    // [BT_024t] Ancient Guardian - COST:8 [ATK:8/HP:8]
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>
-    //       <b>Divine Shield</b>
+    // Text: <b>Taunt</b> <b>Divine Shield</b>
     // --------------------------------------------------------
     // GameTag:
     //  - DIVINE_SHIELD = 1
@@ -795,14 +767,15 @@ void BlackTempleCardsGen::AddPaladinNonCollect(
     cards.emplace("BT_024t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - PALADIN
-    // [BT_025e] Light's Wisdom - COST: 0
+    // [BT_025e] Light's Wisdom - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
-    // Text: +1/+1. <b>Deathrattle:</b> Add 'Libram of Wisdom' to your hand.
+    // Text: +1/+1. <b>Deathrattle:</b> Add
+    //       'Libram of Wisdom' to your hand.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - PALADIN
-    // [BT_292e] Hand of A'dal - COST: 0
+    // [BT_292e] Hand of A'dal - COST:0
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: +2/+2.
@@ -814,13 +787,11 @@ void BlackTempleCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ---------------------------------------- MINION - PRIEST
-    // [BT_197] Reliquary of Souls - COST: 1 [ATK: 1/HP: 3]
+    // [BT_197] Reliquary of Souls - COST:1 [ATK:1/HP:3]
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Lifesteal</b>
-    //       <b>Deathrattle:</b> Shuffle
-    //       'Reliquary Prime'
-    //       into your deck.
+    // Text: <b>Lifesteal</b> <b>Deathrattle:</b> Shuffle
+    //       'Reliquary Prime' into your deck.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -829,16 +800,17 @@ void BlackTempleCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - PRIEST
-    // [BT_198] Soul Mirror - COST: 7
+    // [BT_198] Soul Mirror - COST:7
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: Summon copies of enemy minions. They attack their copies.
+    // Text: Summon copies of enemy minions.
+    //       They attack their copies.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
 
     // ----------------------------------------- SPELL - PRIEST
-    // [BT_252] Renew - COST: 1
+    // [BT_252] Renew - COST:1
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: Restore 3 Health. <b>Discover</b> a spell.
@@ -854,7 +826,7 @@ void BlackTempleCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ----------------------------------------- SPELL - PRIEST
-    // [BT_253] Psyche Split - COST: 5
+    // [BT_253] Psyche Split - COST:5
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Give a minion +1/+2. Summon a copy of it.
@@ -869,29 +841,29 @@ void BlackTempleCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
                                  { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ---------------------------------------- MINION - PRIEST
-    // [BT_254] Sethekk Veilweaver - COST: 2 [ATK: 2/HP: 3]
+    // [BT_254] Sethekk Veilweaver - COST:2 [ATK:2/HP:3]
     //  - Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: After you cast a spell on
-    //       a minion, add a Priest
-    //       spell to your hand.
+    // Text: After you cast a spell on a minion,
+    //       add a Priest spell to your hand.
     // --------------------------------------------------------
     // GameTag:
     //  - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [BT_256] Dragonmaw Overseer - COST: 3 [ATK: 2/HP: 2]
+    // [BT_256] Dragonmaw Overseer - COST:3 [ATK:2/HP:2]
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: At the end of your turn, give another friendly minion +2/+2.
+    // Text: At the end of your turn,
+    //       give another friendly minion +2/+2.
     // --------------------------------------------------------
     // GameTag:
     //  - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - PRIEST
-    // [BT_257] Apotheosis - COST: 3
+    // [BT_257] Apotheosis - COST:3
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: Give a minion +2/+3 and <b>Lifesteal</b>.
@@ -908,11 +880,10 @@ void BlackTempleCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
                                  { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ---------------------------------------- MINION - PRIEST
-    // [BT_258] Imprisoned Homunculus - COST: 1 [ATK: 2/HP: 5]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Common
+    // [BT_258] Imprisoned Homunculus - COST:1 [ATK:2/HP:5]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Dormant</b> for 2 turns.
-    //       <b>Taunt</b>
+    // Text: <b>Dormant</b> for 2 turns. <b>Taunt</b>
     // --------------------------------------------------------
     // GameTag:
     //  - TAUNT = 1
@@ -942,11 +913,11 @@ void BlackTempleCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_258", CardDef(power));
 
     // ---------------------------------------- MINION - PRIEST
-    // [BT_262] Dragonmaw Sentinel - COST: 2 [ATK: 1/HP: 4]
+    // [BT_262] Dragonmaw Sentinel - COST:2 [ATK:1/HP:4]
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> If you're holding a Dragon, gain +1 Attack and
-    // <b>Lifesteal</b>.
+    // Text: <b>Battlecry:</b> If you're holding a Dragon,
+    //       gain +1 Attack and <b>Lifesteal</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -956,12 +927,11 @@ void BlackTempleCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [BT_341] Skeletal Dragon - COST: 7 [ATK: 4/HP: 9]
-    //  - Race: DRAGON, Set: BLACK_TEMPLE, Rarity: Epic
+    // [BT_341] Skeletal Dragon - COST:7 [ATK:4/HP:9]
+    //  - Race: Dragon, Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>
-    //       At the end of your turn, add
-    //       a Dragon to your hand.
+    // Text: <b>Taunt</b> At the end of your turn,
+    //       add a Dragon to your hand.
     // --------------------------------------------------------
     // GameTag:
     //  - TAUNT = 1
@@ -975,12 +945,11 @@ void BlackTempleCardsGen::AddPriestNonCollect(
     Power power;
 
     // ---------------------------------------- MINION - PRIEST
-    // [BT_197t] Reliquary Prime - COST: 7 [ATK: 6/HP: 8]
+    // [BT_197t] Reliquary Prime - COST:7 [ATK:6/HP:8]
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
-    // Text: <b><b>Taunt</b>, Lifesteal</b>
-    //       Only you can target this with
-    //       spells and Hero Powers.
+    // Text: <b>Taunt</b>, <b>Lifesteal</b>
+    //       Only you can target this with spells and Hero Powers.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -989,7 +958,7 @@ void BlackTempleCardsGen::AddPriestNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - PRIEST
-    // [BT_253e] Twin Vision - COST: 0
+    // [BT_253e] Twin Vision - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: +1/+2.
@@ -999,14 +968,14 @@ void BlackTempleCardsGen::AddPriestNonCollect(
     cards.emplace("BT_253e", CardDef(power));
 
     // ----------------------------------- ENCHANTMENT - PRIEST
-    // [BT_256e] Booted - COST: 0
+    // [BT_256e] Booted - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Stats increased.
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - PRIEST
-    // [BT_257e] Apotheosis - COST: 0
+    // [BT_257e] Apotheosis - COST:0
     //  - Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
     // Text: +2/+3 and <b>Lifesteal</b>.
@@ -1016,7 +985,7 @@ void BlackTempleCardsGen::AddPriestNonCollect(
     cards.emplace("BT_257e", CardDef(power));
 
     // ----------------------------------- ENCHANTMENT - PRIEST
-    // [BT_262e] Nether Sight - COST: 0
+    // [BT_262e] Nether Sight - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: +1 Attack and <b>Lifesteal</b>.
@@ -1028,25 +997,22 @@ void BlackTempleCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ------------------------------------------ SPELL - ROGUE
-    // [BT_042] Bamboozle - COST: 2
+    // [BT_042] Bamboozle - COST:2
     //  - Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Secret:</b> When one of
-    //       your minions is attacked,
-    //       transform it into a random
-    //       one that costs (3) more.
+    // Text: <b>Secret:</b> When one of your minions is attacked,
+    //       transform it into a random one that costs (3) more.
     // --------------------------------------------------------
     // GameTag:
     //  - SECRET = 1
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [BT_188] Shadowjeweler Hanar - COST: 2 [ATK: 1/HP: 4]
+    // [BT_188] Shadowjeweler Hanar - COST:2 [ATK:1/HP:4]
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: After you play a <b>Secret</b>,
-    //       <b>Discover</b> a <b>Secret</b> from
-    //       a different class.
+    // Text: After you play a <b>Secret</b>, <b>Discover</b>
+    //       a <b>Secret</b> from a different class.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -1058,7 +1024,7 @@ void BlackTempleCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [BT_701] Spymistress - COST: 1 [ATK: 3/HP: 1]
+    // [BT_701] Spymistress - COST:1 [ATK:3/HP:1]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Stealth</b>
@@ -1068,11 +1034,11 @@ void BlackTempleCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [BT_702] Ashtongue Slayer - COST: 2 [ATK: 3/HP: 2]
+    // [BT_702] Ashtongue Slayer - COST:2 [ATK:3/HP:2]
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Give a <b><b>Stealth</b>ed</b> minion +3 Attack
-    // and <b>Immune</b> this turn.
+    // Text: <b>Battlecry:</b> Give a <b>Stealthed</b> minion
+    //       +3 Attack and <b>Immune</b> this turn.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -1083,7 +1049,7 @@ void BlackTempleCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [BT_703] Cursed Vagrant - COST: 7 [ATK: 7/HP: 5]
+    // [BT_703] Cursed Vagrant - COST:7 [ATK:7/HP:5]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Summon a 7/5 Shadow with <b>Stealth</b>.
@@ -1100,13 +1066,11 @@ void BlackTempleCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_703", CardDef(power));
 
     // ------------------------------------------ SPELL - ROGUE
-    // [BT_707] Ambush - COST: 2
+    // [BT_707] Ambush - COST:2
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Secret:</b> After your
-    //       opponent plays a minion,
-    //       summon a 2/3 Ambusher
-    //       with <b>Poisonous</b>.
+    // Text: <b>Secret:</b> After your opponent plays a minion,
+    //       summon a 2/3 Ambusher with <b>Poisonous</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - SECRET = 1
@@ -1116,11 +1080,10 @@ void BlackTempleCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - ROGUE
-    // [BT_709] Dirty Tricks - COST: 2
+    // [BT_709] Dirty Tricks - COST:2
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Secret:</b> After your
-    //       opponent casts a spell,
+    // Text: <b>Secret:</b> After your opponent casts a spell,
     //       draw 2 cards.
     // --------------------------------------------------------
     // GameTag:
@@ -1128,12 +1091,11 @@ void BlackTempleCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [BT_710] Greyheart Sage - COST: 3 [ATK: 3/HP: 3]
+    // [BT_710] Greyheart Sage - COST:3 [ATK:3/HP:3]
     //  - Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> If you control
-    //       a <b><b>Stealth</b>ed</b> minion,
-    //       draw 2 cards.
+    //       a <b>Stealthed</b> minion, draw 2 cards.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -1143,13 +1105,11 @@ void BlackTempleCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [BT_711] Blackjack Stunner - COST: 1 [ATK: 1/HP: 2]
+    // [BT_711] Blackjack Stunner - COST:1 [ATK:1/HP:2]
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> If you control a
-    //       <b>Secret</b>, return a minion
-    //       to its owner's hand.
-    //       It costs (1) more.
+    // Text: <b>Battlecry:</b> If you control a <b>Secret</b>,
+    //       return a minion to its owner's hand. It costs (1) more.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -1159,12 +1119,11 @@ void BlackTempleCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [BT_713] Akama - COST: 3 [ATK: 3/HP: 4]
+    // [BT_713] Akama - COST:3 [ATK:3/HP:4]
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Stealth</b>
-    //       <b>Deathrattle:</b> Shuffle 'Akama
-    //       Prime' into your deck.
+    // Text: <b>Stealth</b> <b>Deathrattle:</b> Shuffle
+    //       'Akama Prime' into your deck.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -1179,21 +1138,21 @@ void BlackTempleCardsGen::AddRogueNonCollect(
     Power power;
 
     // ------------------------------------ ENCHANTMENT - ROGUE
-    // [BT_212e] Stalking - COST: 0
+    // [BT_212e] Stalking - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Copied <b>Deathrattle</b> from {0}.
     // --------------------------------------------------------
 
     // ------------------------------------ ENCHANTMENT - ROGUE
-    // [BT_702e] Guile of the Ashtongue - COST: 0
+    // [BT_702e] Guile of the Ashtongue - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: +3 Attack and <b>Immune</b> this turn.
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [BT_703t] Cursed Shadow - COST: 7 [ATK: 7/HP: 5]
+    // [BT_703t] Cursed Shadow - COST:7 [ATK:7/HP:5]
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Stealth</b>
@@ -1206,7 +1165,7 @@ void BlackTempleCardsGen::AddRogueNonCollect(
     cards.emplace("BT_703t", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
-    // [BT_707t] Broken Ambusher - COST: 2 [ATK: 2/HP: 3]
+    // [BT_707t] Broken Ambusher - COST:2 [ATK:2/HP:3]
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Poisonous</b>
@@ -1216,10 +1175,10 @@ void BlackTempleCardsGen::AddRogueNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [BT_713t] Akama Prime - COST: 6 [ATK: 6/HP: 5]
+    // [BT_713t] Akama Prime - COST:6 [ATK:6/HP:5]
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
-    // Text: Permanently <b><b>Stealth</b>ed</b>.
+    // Text: Permanently <b>Stealthed</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -1232,12 +1191,10 @@ void BlackTempleCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ----------------------------------------- SPELL - SHAMAN
-    // [BT_100] Serpentshrine Portal - COST: 3
+    // [BT_100] Serpentshrine Portal - COST:3
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Deal 3 damage.
-    //       Summon a random
-    //       3-Cost minion.
+    // Text: Deal 3 damage. Summon a random 3-Cost minion.
     //       <b>Overload:</b> (1)
     // --------------------------------------------------------
     // GameTag:
@@ -1254,44 +1211,44 @@ void BlackTempleCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ----------------------------------------- SPELL - SHAMAN
-    // [BT_101] Vivid Spores - COST: 4
+    // [BT_101] Vivid Spores - COST:4
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Give your minions "<b>Deathrattle:</b> Resummon this minion."
+    // Text: Give your minions
+    //       "<b>Deathrattle:</b> Resummon this minion."
     // --------------------------------------------------------
     // RefTag:
     //  - DEATHRATTLE = 1
     // --------------------------------------------------------
 
     // ---------------------------------------- WEAPON - SHAMAN
-    // [BT_102] Boggspine Knuckles - COST: 5
+    // [BT_102] Boggspine Knuckles - COST:5
     //  - Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: After your hero attacks, transform your minions into random ones
-    // that cost (1) more.
+    // Text: After your hero attacks, transform your minions
+    //       into random ones that cost (1) more.
     // --------------------------------------------------------
     // GameTag:
     //  - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [BT_106] Bogstrok Clacker - COST: 3 [ATK: 3/HP: 3]
+    // [BT_106] Bogstrok Clacker - COST:3 [ATK:3/HP:3]
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Transform adjacent minions into random minions
-    // that cost (1) more.
+    // Text: <b>Battlecry:</b> Transform adjacent minions
+    //       into random minions that cost (1) more.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [BT_109] Lady Vashj - COST: 3 [ATK: 4/HP: 3]
+    // [BT_109] Lady Vashj - COST:3 [ATK:4/HP:3]
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Spell Damage +1</b>
-    //       <b>Deathrattle:</b> Shuffle 'Vashj
-    //       Prime' into your deck.
+    // Text: <b>Spell Damage +1</b> <b>Deathrattle:</b> Shuffle
+    //       'Vashj Prime' into your deck.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -1300,16 +1257,15 @@ void BlackTempleCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - SHAMAN
-    // [BT_110] Torrent - COST: 4
+    // [BT_110] Torrent - COST:4
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Deal 8 damage to a
-    //       minion. Costs (3) less if
-    //       you cast a spell last turn.
+    // Text: Deal 8 damage to a minion.
+    //       Costs (3) less if you cast a spell last turn.
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - SHAMAN
-    // [BT_113] Totemic Reflection - COST: 3
+    // [BT_113] Totemic Reflection - COST:3
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: Give a minion +2/+2.
@@ -1317,22 +1273,21 @@ void BlackTempleCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [BT_114] Shattered Rumbler - COST: 5 [ATK: 5/HP: 6]
-    //  - Race: ELEMENTAL, Set: BLACK_TEMPLE, Rarity: Epic
+    // [BT_114] Shattered Rumbler - COST:5 [ATK:5/HP:6]
+    //  - Race: Elemental, Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> If you cast a spell last turn, deal 2 damage to
-    // all other minions.
+    // Text: <b>Battlecry:</b> If you cast a spell last turn,
+    //       deal 2 damage to all other minions.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [BT_115] Marshspawn - COST: 3 [ATK: 3/HP: 4]
-    //  - Race: ELEMENTAL, Set: BLACK_TEMPLE, Rarity: Common
+    // [BT_115] Marshspawn - COST:3 [ATK:3/HP:4]
+    //  - Race: Elemental, Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> If you cast
-    //       a spell last turn,
+    // Text: <b>Battlecry:</b> If you cast a spell last turn,
     //       <b>Discover</b> a spell.
     // --------------------------------------------------------
     // GameTag:
@@ -1343,13 +1298,11 @@ void BlackTempleCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [BT_230] The Lurker Below - COST: 6 [ATK: 6/HP: 5]
-    //  - Race: BEAST, Set: BLACK_TEMPLE, Rarity: Legendary
+    // [BT_230] The Lurker Below - COST:6 [ATK:6/HP:5]
+    //  - Race: Beast, Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Deal 3 damage
-    //       to an enemy minion. If it
-    //       dies, repeat on one of
-    //       its neighbors.
+    // Text: <b>Battlecry:</b> Deal 3 damage to an enemy minion.
+    //       If it dies, repeat on one of its neighbors.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -1363,7 +1316,7 @@ void BlackTempleCardsGen::AddShamanNonCollect(
     Power power;
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
-    // [BT_101e] Glowcapped - COST: 0
+    // [BT_101e] Glowcapped - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Resummon this minion.
@@ -1373,12 +1326,11 @@ void BlackTempleCardsGen::AddShamanNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [BT_109t] Vashj Prime - COST: 7 [ATK: 5/HP: 4]
+    // [BT_109t] Vashj Prime - COST:7 [ATK:5/HP:4]
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
-    // Text: <b>Spell Damage +1</b>
-    //       <b>Battlecry:</b> Draw 3 spells.
-    //          Reduce their Cost by (3).   
+    // Text: <b>Spell Damage +1</b> <b>Battlecry:</b> Draw 3 spells.
+    //       Reduce their Cost by (3).   
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -1387,7 +1339,7 @@ void BlackTempleCardsGen::AddShamanNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
-    // [BT_109te] Vashj Prime - COST: 0
+    // [BT_109te] Vashj Prime - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Cost (3) less.
@@ -1399,12 +1351,11 @@ void BlackTempleCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     Power power;
 
     // --------------------------------------- MINION - WARLOCK
-    // [BT_196] Keli'dan the Breaker - COST: 6 [ATK: 3/HP: 3]
+    // [BT_196] Keli'dan the Breaker - COST:6 [ATK:3/HP:3]
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Destroy a minion.
-    //       If drawn this turn, instead
-    //       destroy all minions
+    //       If drawn this turn, instead destroy all minions
     //       except this one.
     // --------------------------------------------------------
     // GameTag:
@@ -1413,27 +1364,26 @@ void BlackTempleCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARLOCK
-    // [BT_199] Unstable Felbolt - COST: 1
+    // [BT_199] Unstable Felbolt - COST:1
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Deal 3 damage to an enemy minion and a random friendly one.
+    // Text: Deal 3 damage to an enemy minion
+    //       and a random friendly one.
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARLOCK
-    // [BT_300] Hand of Gul'dan - COST: 6
+    // [BT_300] Hand of Gul'dan - COST:6
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: When you play
-    //       or discard this,
-    //       draw 3 cards.
+    // Text: When you play or discard this, draw 3 cards.
     // --------------------------------------------------------
     // GameTag:
     //  - InvisibleDeathrattle = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [BT_301] Nightshade Matron - COST: 4 [ATK: 5/HP: 5]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Common
+    // [BT_301] Nightshade Matron - COST:4 [ATK:5/HP:5]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Rush</b>
     //       <b>Battlecry:</b> Discard your highest Cost card.
@@ -1444,19 +1394,18 @@ void BlackTempleCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARLOCK
-    // [BT_302] The Dark Portal - COST: 4
+    // [BT_302] The Dark Portal - COST:4
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Draw a minion. If you have at least 8 cards in hand, it costs (5)
-    // less.
+    // Text: Draw a minion. If you have at least 8 cards in hand,
+    //       it costs (5) less.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [BT_304] Enhanced Dreadlord - COST: 8 [ATK: 5/HP: 7]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Rare
+    // [BT_304] Enhanced Dreadlord - COST:8 [ATK:5/HP:7]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>
-    //       <b>Deathrattle:</b> Summon a 5/5
+    // Text: <b>Taunt</b> <b>Deathrattle:</b> Summon a 5/5
     //       Dreadlord with <b>Lifesteal</b>.
     // --------------------------------------------------------
     // GameTag:
@@ -1472,26 +1421,23 @@ void BlackTempleCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_304", CardDef(power));
 
     // --------------------------------------- MINION - WARLOCK
-    // [BT_305] Imprisoned Scrap Imp - COST: 2 [ATK: 3/HP: 3]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Rare
+    // [BT_305] Imprisoned Scrap Imp - COST:2 [ATK:3/HP:3]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Dormant</b> for 2 turns.
-    //       When this awakens,
+    // Text: <b>Dormant</b> for 2 turns. When this awakens,
     //       give all minions in your hand +2/+1.
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARLOCK
-    // [BT_306] Shadow Council - COST: 1
+    // [BT_306] Shadow Council - COST:1
     //  - Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: Replace your hand
-    //       with random Demons.
-    //       Give them +2/+2.
+    // Text: Replace your hand with random Demons. Give them +2/+2.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [BT_307] Darkglare - COST: 3 [ATK: 3/HP: 4]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Epic
+    // [BT_307] Darkglare - COST:3 [ATK:3/HP:4]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
     // Text: After your hero takes damage, refresh 2 Mana Crystals.
     // --------------------------------------------------------
@@ -1500,13 +1446,11 @@ void BlackTempleCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [BT_309] Kanrethad Ebonlocke - COST: 2 [ATK: 3/HP: 2]
+    // [BT_309] Kanrethad Ebonlocke - COST:2 [ATK:3/HP:2]
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: Your Demons cost (1) less.
-    //       <b>Deathrattle:</b> Shuffle
-    //       'Kanrethad Prime'
-    //       into your deck.
+    // Text: Your Demons cost (1) less. <b>Deathrattle:</b> Shuffle
+    //       'Kanrethad Prime' into your deck.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -1521,8 +1465,8 @@ void BlackTempleCardsGen::AddWarlockNonCollect(
     Power power;
 
     // --------------------------------------- MINION - WARLOCK
-    // [BT_304t] Desperate Dreadlord - COST: 5 [ATK: 5/HP: 5]
-    //  - Race: DEMON, Set: BLACK_TEMPLE
+    // [BT_304t] Desperate Dreadlord - COST:5 [ATK:5/HP:5]
+    //  - Race: Demon, Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Lifesteal</b>
     // --------------------------------------------------------
@@ -1534,24 +1478,25 @@ void BlackTempleCardsGen::AddWarlockNonCollect(
     cards.emplace("BT_304t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - WARLOCK
-    // [BT_305e] Scrap Weapons - COST: 0
+    // [BT_305e] Scrap Weapons - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: +2/+1.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - WARLOCK
-    // [BT_306e] Ritual Summons - COST: 0
+    // [BT_306e] Ritual Summons - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [BT_309t] Kanrethad Prime - COST: 8 [ATK: 7/HP: 6]
-    //  - Race: DEMON, Set: BLACK_TEMPLE
+    // [BT_309t] Kanrethad Prime - COST:8 [ATK:7/HP:6]
+    //  - Race: Demon, Set: BLACK_TEMPLE
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Summon 3 friendly Demons that died this game.
+    // Text: <b>Battlecry:</b> Summon 3 friendly Demons
+    //       that died this game.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -1564,7 +1509,7 @@ void BlackTempleCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ---------------------------------------- SPELL - WARRIOR
-    // [BT_117] Bladestorm - COST: 3
+    // [BT_117] Bladestorm - COST:3
     //  - Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
     // Text: Deal 1 damage to all minions. Repeat until one dies.
@@ -1603,7 +1548,7 @@ void BlackTempleCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_117", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
-    // [BT_120] Warmaul Challenger - COST: 3 [ATK: 1/HP: 10]
+    // [BT_120] Warmaul Challenger - COST:3 [ATK:1/HP:10]
     //  - Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Choose an enemy minion.
@@ -1649,22 +1594,19 @@ void BlackTempleCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
                                  { PlayReq::REQ_ENEMY_TARGET, 0 } }));
 
     // --------------------------------------- MINION - WARRIOR
-    // [BT_121] Imprisoned Gan'arg - COST: 1 [ATK: 2/HP: 2]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Common
+    // [BT_121] Imprisoned Gan'arg - COST:1 [ATK:2/HP:2]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Dormant</b> for 2 turns.
-    //       When this awakens,
-    //       equip a 3/2 Axe.
+    //       When this awakens, equip a 3/2 Axe.
     // --------------------------------------------------------
 
-    // ----------------------------------------- MINION - WARRIOR
+    // --------------------------------------- MINION - WARRIOR
     // [BT_123] Kargath Bladefist - COST:4 [ATK:4/HP:4]
     // - Set: BLACK_TEMPLE, Rarity: LEGENDARY
     // --------------------------------------------------------
-    // Text: <b>Rush</b>
-    //       <b>Deathrattle:</b> Shuffle
-    //       'Kargath Prime'
-    //       into your deck.
+    // Text: <b>Rush</b> <b>Deathrattle:</b> Shuffle
+    //       'Kargath Prime' into your deck.
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
@@ -1676,12 +1618,11 @@ void BlackTempleCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
         std::make_shared<AddCardTask>(EntityType::DECK, "BT_123t"));
     cards.emplace("BT_123", CardDef(power));
 
-    // ----------------------------------------- SPELL - WARRIOR
+    // ---------------------------------------- SPELL - WARRIOR
     // [BT_124] Corsair Cache - COST:2
     // - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Draw a weapon.
-    //       Give it +1 Durability.
+    // Text: Draw a weapon. Give it +1 Durability.
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::DECK));
@@ -1694,22 +1635,21 @@ void BlackTempleCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_124", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
-    // [BT_138] Bloodboil Brute - COST: 7 [ATK: 5/HP: 8]
+    // [BT_138] Bloodboil Brute - COST:7 [ATK:5/HP:8]
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Rush</b>
-    //       Costs (1) less for each damaged minion.
+    // Text: <b>Rush</b> Costs (1) less for each damaged minion.
     // --------------------------------------------------------
     // GameTag:
     //  - RUSH = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [BT_140] Bonechewer Raider - COST: 3 [ATK: 3/HP: 3]
+    // [BT_140] Bonechewer Raider - COST:3 [ATK:3/HP:3]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> If there is a damaged minion, gain +1/+1 and
-    // <b>Rush</b>.
+    // Text: <b>Battlecry:</b> If there is a damaged minion,
+    //       gain +1/+1 and <b>Rush</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -1719,18 +1659,18 @@ void BlackTempleCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARRIOR
-    // [BT_233] Sword and Board - COST: 1
+    // [BT_233] Sword and Board - COST:1
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: Deal 2 damage to a minion. Gain 2 Armor.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [BT_249] Scrap Golem - COST: 5 [ATK: 4/HP: 5]
-    //  - Race: MECHANICAL, Set: BLACK_TEMPLE, Rarity: Rare
+    // [BT_249] Scrap Golem - COST:5 [ATK:4/HP:5]
+    //  - Race: Mechanical, Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>. <b>Deathrattle</b>: Gain Armor equal to this minion's
-    // Attack.
+    // Text: <b>Taunt</b>. <b>Deathrattle</b>: Gain Armor
+    //       equal to this minion's Attack.
     // --------------------------------------------------------
     // GameTag:
     //  - DEATHRATTLE = 1
@@ -1738,12 +1678,11 @@ void BlackTempleCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- WEAPON - WARRIOR
-    // [BT_781] Bulwark of Azzinoth - COST: 3
+    // [BT_781] Bulwark of Azzinoth - COST:3
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: Whenever your hero would
-    //       take damage, this loses
-    //        1 Durability instead.
+    // Text: Whenever your hero would take damage,
+    //       this loses 1 Durability instead.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -1756,12 +1695,12 @@ void BlackTempleCardsGen::AddWarriorNonCollect(
 {
     Power power;
 
-    // ----------------------------------------- MINION - WARRIOR
+    // --------------------------------------- MINION - WARRIOR
     // [BT_123t] Kargath Prime - COST:8 [ATK:10/HP:10]
     // - Set: BLACK_TEMPLE
     // --------------------------------------------------------
-    // Text: <b>Rush</b>. Whenever this attacks and kills a minion, gain 10
-    // Armor.
+    // Text: <b>Rush</b>. Whenever this attacks
+    //       and kills a minion, gain 10 Armor.
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
@@ -1783,7 +1722,7 @@ void BlackTempleCardsGen::AddWarriorNonCollect(
     };
     cards.emplace("BT_123t", CardDef(power));
 
-    // ----------------------------------------- ENCHANTMENT - WARRIOR
+    // ---------------------------------- ENCHANTMENT - WARRIOR
     // [BT_124e] Void Sharpened
     // - Set: BLACK_TEMPLE
     // --------------------------------------------------------
@@ -1800,11 +1739,10 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [BT_187] Kayn Sunfury - COST: 4 [ATK: 3/HP: 4]
+    // [BT_187] Kayn Sunfury - COST:4 [ATK:3/HP:4]
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Charge</b>
-    //       All friendly attacks ignore <b>Taunt</b>.
+    // Text: <b>Charge</b> All friendly attacks ignore <b>Taunt</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -1816,7 +1754,7 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [BT_321] Netherwalker - COST: 2 [ATK: 2/HP: 2]
+    // [BT_321] Netherwalker - COST:2 [ATK:2/HP:2]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> <b>Discover</b> a Demon.
@@ -1827,11 +1765,10 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [BT_423] Ashtongue Battlelord - COST: 4 [ATK: 3/HP: 5]
+    // [BT_423] Ashtongue Battlelord - COST:4 [ATK:3/HP:5]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>
-    //       <b>Lifesteal</b>
+    // Text: <b>Taunt</b> <b>Lifesteal</b>
     // --------------------------------------------------------
     // GameTag:
     //  - LIFESTEAL = 1
@@ -1839,17 +1776,18 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------ SPELL - DEMONHUNTER
-    // [BT_429] Metamorphosis - COST: 5
+    // [BT_429] Metamorphosis - COST:5
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: Swap your Hero Power to "Deal 4 damage." After 2 uses, swap it
-    // back.
+    // Text: Swap your Hero Power to "Deal 4 damage."
+    //       After 2 uses, swap it back.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
+    // --------------------------------------------------------
 
     // ----------------------------------- WEAPON - DEMONHUNTER
-    // [BT_430] Warglaives of Azzinoth - COST: 6
+    // [BT_430] Warglaives of Azzinoth - COST:6
     //  - Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
     // Text: After attacking a minion, your hero may attack again.
@@ -1859,7 +1797,7 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [BT_480] Crimson Sigil Runner - COST: 1 [ATK: 1/HP: 1]
+    // [BT_480] Crimson Sigil Runner - COST:1 [ATK:1/HP:1]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Outcast:</b> Draw a card.
@@ -1869,11 +1807,11 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [BT_486] Pit Commander - COST: 9 [ATK: 7/HP: 9]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Epic
+    // [BT_486] Pit Commander - COST:9 [ATK:7/HP:9]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>
-    //       At the end of your turn, summon a Demon from your deck.
+    // Text: <b>Taunt</b> At the end of your turn,
+    //       summon a Demon from your deck.
     // --------------------------------------------------------
     // GameTag:
     //  - TAUNT = 1
@@ -1881,34 +1819,32 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------ SPELL - DEMONHUNTER
-    // [BT_491] Spectral Sight - COST: 2
+    // [BT_491] Spectral Sight - COST:2
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Draw a card.
-    //       <b>Outcast:</b> Draw another.
+    // Text: Draw a card. <b>Outcast:</b> Draw another.
     // --------------------------------------------------------
     // GameTag:
     //  - OUTCAST = 1
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [BT_493] Priestess of Fury - COST: 7 [ATK: 6/HP: 5]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Rare
+    // [BT_493] Priestess of Fury - COST:7 [ATK:6/HP:5]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: At the end of your turn, deal 6 damage randomly split among all
-    // enemies.
+    // Text: At the end of your turn,
+    //       deal 6 damage randomly split among all enemies.
     // --------------------------------------------------------
     // GameTag:
     //  - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [BT_496] Furious Felfin - COST: 2 [ATK: 3/HP: 2]
-    //  - Race: MURLOC, Set: BLACK_TEMPLE, Rarity: Rare
+    // [BT_496] Furious Felfin - COST:2 [ATK:3/HP:2]
+    //  - Race: Murloc, Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> If your hero
-    //       attacked this turn, gain
-    //       +1 Attack and <b>Rush</b>.
+    // Text: <b>Battlecry:</b> If your hero attacked this turn,
+    //       gain +1 Attack and <b>Rush</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -1918,7 +1854,7 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [BT_509] Fel Summoner - COST: 6 [ATK: 8/HP: 3]
+    // [BT_509] Fel Summoner - COST:6 [ATK:8/HP:3]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Summon a random Demon from your hand.
@@ -1936,30 +1872,28 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_509", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
-    // [BT_514] Immolation Aura - COST: 2
+    // [BT_514] Immolation Aura - COST:2
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: Deal 1 damage to all minions twice.
     // --------------------------------------------------------
 
     // ------------------------------------ SPELL - DEMONHUNTER
-    // [BT_601] Skull of Gul'dan - COST: 6
+    // [BT_601] Skull of Gul'dan - COST:6
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Draw 3 cards.
-    //       <b>Outcast:</b> Reduce their Cost by (3).
+    // Text: Draw 3 cards. <b>Outcast:</b> Reduce their Cost by (3).
     // --------------------------------------------------------
     // GameTag:
     //  - OUTCAST = 1
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [BT_761] Coilfang Warlord - COST: 8 [ATK: 9/HP: 5]
+    // [BT_761] Coilfang Warlord - COST:8 [ATK:9/HP:5]
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Rush</b>
-    //       <b>Deathrattle:</b> Summon a
-    //        5/9 Warlord with <b>Taunt</b>.
+    // Text: <b>Rush</b> <b>Deathrattle:</b> Summon a
+    //       5/9 Warlord with <b>Taunt</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - DEATHRATTLE = 1
@@ -1974,13 +1908,11 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_761", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [BT_934] Imprisoned Antaen - COST: 6 [ATK: 10/HP: 6]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Rare
+    // [BT_934] Imprisoned Antaen - COST:6 [ATK:10/HP:6]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Dormant</b> for 2 turns.
-    //       When this awakens, deal
-    //       10 damage randomly split
-    //       among all enemies.
+    // Text: <b>Dormant</b> for 2 turns. When this awakens,
+    //       deal 10 damage randomly split among all enemies.
     // --------------------------------------------------------
 }
 
@@ -1990,14 +1922,14 @@ void BlackTempleCardsGen::AddDemonHunterNonCollect(
     Power power;
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
-    // [BT_512e3] Branded - COST: 0
+    // [BT_512e3] Branded - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Takes 1 damage at the end of each turn.
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [BT_761t] Conchguard Warlord - COST: 8 [ATK: 5/HP: 9]
+    // [BT_761t] Conchguard Warlord - COST:8 [ATK:5/HP:9]
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -2015,7 +1947,7 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     Power power;
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_008] Rustsworn Initiate - COST: 2 [ATK: 2/HP: 2]
+    // [BT_008] Rustsworn Initiate - COST:2 [ATK:2/HP:2]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Summon a 1/1 Impcaster with
@@ -2033,8 +1965,8 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_008", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_010] Felfin Navigator - COST: 4 [ATK: 4/HP: 4]
-    //  - Race: MURLOC, Set: BLACK_TEMPLE, Rarity: Common
+    // [BT_010] Felfin Navigator - COST:4 [ATK:4/HP:4]
+    //  - Race: Murloc, Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give your other Murlocs +1/+1.
     // --------------------------------------------------------
@@ -2052,13 +1984,11 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_010", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_126] Teron Gorefiend - COST: 3 [ATK: 3/HP: 4]
+    // [BT_126] Teron Gorefiend - COST:3 [ATK:3/HP:4]
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Destroy all
-    //       other friendly minions.
-    //       <b>Deathrattle:</b> Resummon
-    //       them with +1/+1.
+    // Text: <b>Battlecry:</b> Destroy all other friendly minions.
+    //       <b>Deathrattle:</b> Resummon them with +1/+1.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -2067,13 +1997,11 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_155] Scrapyard Colossus - COST: 10 [ATK: 7/HP: 7]
-    //  - Race: ELEMENTAL, Set: BLACK_TEMPLE, Rarity: Rare
+    // [BT_155] Scrapyard Colossus - COST:10 [ATK:7/HP:7]
+    //  - Race: Elemental, Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>
-    //       <b>Deathrattle:</b> Summon a
-    //       7/7 Felcracked Colossus
-    //       with <b>Taunt</b>.
+    // Text: <b>Taunt</b> <b>Deathrattle:</b> Summon a
+    //       7/7 Felcracked Colossus with <b>Taunt</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - DEATHRATTLE = 1
@@ -2085,11 +2013,10 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_155", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_156] Imprisoned Vilefiend - COST: 2 [ATK: 3/HP: 5]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Common
+    // [BT_156] Imprisoned Vilefiend - COST:2 [ATK:3/HP:5]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Dormant</b> for 2 turns.
-    //       <b>Rush</b>
+    // Text: <b>Dormant</b> for 2 turns. <b>Rush</b>
     // --------------------------------------------------------
     // GameTag:
     //  - RUSH = 1
@@ -2119,10 +2046,11 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_156", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_159] Terrorguard Escapee - COST: 3 [ATK: 3/HP: 7]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Common
+    // [BT_159] Terrorguard Escapee - COST:3 [ATK:3/HP:7]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Summon three 1/1 Huntresses for your opponent.
+    // Text: <b>Battlecry:</b> Summon three 1/1 Huntresses
+    //       for your opponent.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -2132,12 +2060,11 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_159", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_160] Rustsworn Cultist - COST: 4 [ATK: 3/HP: 3]
+    // [BT_160] Rustsworn Cultist - COST:4 [ATK:3/HP:3]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Give your
-    //       other minions "<b>Deathrattle:</b>
-    //       Summon a 1/1 Demon."
+    // Text: <b>Battlecry:</b> Give your other minions
+    //       "<b>Deathrattle:</b> Summon a 1/1 Demon."
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -2153,17 +2080,18 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_160", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_190] Replicat-o-tron - COST: 4 [ATK: 3/HP: 3]
-    //  - Race: MECHANICAL, Set: BLACK_TEMPLE, Rarity: Epic
+    // [BT_190] Replicat-o-tron - COST:4 [ATK:3/HP:3]
+    //  - Race: Mechanical, Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: At the end of your turn, transform a neighbor into a copy of this.
+    // Text: At the end of your turn,
+    //       transform a neighbor into a copy of this.
     // --------------------------------------------------------
     // GameTag:
     //  - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_255] Kael'thas Sunstrider - COST: 7 [ATK: 4/HP: 7]
+    // [BT_255] Kael'thas Sunstrider - COST:7 [ATK:4/HP:7]
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: Every third spell you cast each turn costs (1).
@@ -2174,7 +2102,7 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_714] Frozen Shadoweaver - COST: 3 [ATK: 4/HP: 3]
+    // [BT_714] Frozen Shadoweaver - COST:3 [ATK:4/HP:3]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> <b>Freeze</b> an enemy.
@@ -2187,12 +2115,11 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_715] Bonechewer Brawler - COST: 2 [ATK: 2/HP: 3]
+    // [BT_715] Bonechewer Brawler - COST:2 [ATK:2/HP:3]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>
-    //       Whenever this minion takes
-    //        damage, gain +2 Attack.
+    // Text: <b>Taunt</b> Whenever this minion takes damage,
+    //       gain +2 Attack.
     // --------------------------------------------------------
     // GameTag:
     //  - TAUNT = 1
@@ -2200,12 +2127,11 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_716] Bonechewer Vanguard - COST: 7 [ATK: 4/HP: 10]
+    // [BT_716] Bonechewer Vanguard - COST:7 [ATK:4/HP:10]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>
-    //       Whenever this minion takes
-    //       damage, gain +2 Attack.
+    // Text: <b>Taunt</b> Whenever this minion takes damage,
+    //       gain +2 Attack.
     // --------------------------------------------------------
     // GameTag:
     //  - TAUNT = 1
@@ -2213,12 +2139,11 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_717] Burrowing Scorpid - COST: 4 [ATK: 5/HP: 2]
-    //  - Race: BEAST, Set: BLACK_TEMPLE, Rarity: Common
+    // [BT_717] Burrowing Scorpid - COST:4 [ATK:5/HP:2]
+    //  - Race: Beast, Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Deal 2 damage.
-    //       If that kills the target,
-    //       gain <b>Stealth</b>.
+    //       If that kills the target, gain <b>Stealth</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -2228,7 +2153,7 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_720] Ruststeed Raider - COST: 5 [ATK: 1/HP: 8]
+    // [BT_720] Ruststeed Raider - COST:5 [ATK:1/HP:8]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>, <b>Rush</b>
@@ -2241,23 +2166,22 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_721] Blistering Rot - COST: 3 [ATK: 1/HP: 2]
+    // [BT_721] Blistering Rot - COST:3 [ATK:1/HP:2]
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
     // Text: At the end of your turn,
-    //       summon a Rot with stats
-    //       equal to this minion's.
+    //       summon a Rot with stats equal to this minion's.
     // --------------------------------------------------------
     // GameTag:
     //  - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_722] Guardian Augmerchant - COST: 1 [ATK: 2/HP: 1]
+    // [BT_722] Guardian Augmerchant - COST:1 [ATK:2/HP:1]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Deal 1 damage to a minion and give it <b>Divine
-    // Shield</b>.
+    // Text: <b>Battlecry:</b> Deal 1 damage to a minion and
+    //       give it <b>Divine Shield</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -2267,11 +2191,11 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_723] Rocket Augmerchant - COST: 1 [ATK: 2/HP: 1]
+    // [BT_723] Rocket Augmerchant - COST:1 [ATK:2/HP:1]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Deal 1 damage to a minion and give it
-    // <b>Rush</b>.
+    // Text: <b>Battlecry:</b> Deal 1 damage to a minion and
+    //       give it <b>Rush</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -2281,11 +2205,11 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_724] Ethereal Augmerchant - COST: 1 [ATK: 2/HP: 1]
+    // [BT_724] Ethereal Augmerchant - COST:1 [ATK:2/HP:1]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Deal 1 damage to a minion and give it <b>Spell
-    // Damage +1</b>.
+    // Text: <b>Battlecry:</b> Deal 1 damage to a minion and
+    //       give it <b>Spell Damage +1</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -2295,8 +2219,8 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_726] Dragonmaw Sky Stalker - COST: 6 [ATK: 5/HP: 6]
-    //  - Race: DRAGON, Set: BLACK_TEMPLE, Rarity: Common
+    // [BT_726] Dragonmaw Sky Stalker - COST:6 [ATK:5/HP:6]
+    //  - Race: Dragon, Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Summon a 3/4 Dragonrider.
     // --------------------------------------------------------
@@ -2309,19 +2233,19 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_726", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_727] Soulbound Ashtongue - COST: 1 [ATK: 1/HP: 4]
+    // [BT_727] Soulbound Ashtongue - COST:1 [ATK:1/HP:4]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Whenever this minion takes damage, also deal that amount to your
-    // hero.
+    // Text: Whenever this minion takes damage,
+    //       also deal that amount to your hero.
     // --------------------------------------------------------
     // GameTag:
     //  - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_728] Disguised Wanderer - COST: 4 [ATK: 3/HP: 3]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Common
+    // [BT_728] Disguised Wanderer - COST:4 [ATK:3/HP:3]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Summon a 9/1 Inquisitor.
     // --------------------------------------------------------
@@ -2334,70 +2258,68 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("BT_728", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_729] Waste Warden - COST: 5 [ATK: 3/HP: 3]
+    // [BT_729] Waste Warden - COST:5 [ATK:3/HP:3]
     //  - Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Deal 3 damage to
-    //       a minion and all others of
-    //       the same minion type.
+    // Text: <b>Battlecry:</b> Deal 3 damage to a minion and
+    //       all others of the same minion type.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_730] Overconfident Orc - COST: 3 [ATK: 1/HP: 6]
+    // [BT_730] Overconfident Orc - COST:3 [ATK:1/HP:6]
     //  - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>
-    //       While at full Health,
-    //       this has +2 Attack.
+    // Text: <b>Taunt</b> While at full Health, this has +2 Attack.
     // --------------------------------------------------------
     // GameTag:
     //  - TAUNT = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_731] Infectious Sporeling - COST: 1 [ATK: 1/HP: 2]
+    // [BT_731] Infectious Sporeling - COST:1 [ATK:1/HP:2]
     //  - Set: BLACK_TEMPLE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: After this damages a minion, turn it into an Infectious Sporeling.
+    // Text: After this damages a minion,
+    //       turn it into an Infectious Sporeling.
     // --------------------------------------------------------
     // GameTag:
     //  - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_732] Scavenging Shivarra - COST: 6 [ATK: 6/HP: 3]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Common
+    // [BT_732] Scavenging Shivarra - COST:6 [ATK:6/HP:3]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Deal 6 damage randomly split among all other
-    // minions.
+    // Text: <b>Battlecry:</b> Deal 6 damage randomly split
+    //       among all other minions.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_733] Mo'arg Artificer - COST: 2 [ATK: 2/HP: 4]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Epic
+    // [BT_733] Mo'arg Artificer - COST:2 [ATK:2/HP:4]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
     // Text: All minions take double damage from spells.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_734] Supreme Abyssal - COST: 8 [ATK: 12/HP: 12]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Common
+    // [BT_734] Supreme Abyssal - COST:8 [ATK:12/HP:12]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
     // Text: Can't attack heroes.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_735] Al'ar - COST: 5 [ATK: 7/HP: 3]
-    //  - Race: ELEMENTAL, Set: BLACK_TEMPLE, Rarity: Legendary
+    // [BT_735] Al'ar - COST:5 [ATK:7/HP:3]
+    //  - Race: Elemental, Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Deathrattle</b>: Summon a
-    //        0/3 Ashes of Al'ar that resurrects this minion on your next turn.
+    // Text: <b>Deathrattle</b>: Summon a 0/3 Ashes of Al'ar
+    //       that resurrects this minion on your next turn.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -2405,7 +2327,7 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_737] Maiev Shadowsong - COST: 4 [ATK: 4/HP: 3]
+    // [BT_737] Maiev Shadowsong - COST:4 [ATK:4/HP:3]
     //  - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Choose a minion.
@@ -2417,13 +2339,12 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_850] Magtheridon - COST: 4 [ATK: 12/HP: 12]
-    //  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Legendary
+    // [BT_850] Magtheridon - COST:4 [ATK:12/HP:12]
+    //  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Dormant</b>. <b>Battlecry:</b> Summon
-    //       three 1/3 enemy Warders.
-    //       When they die, destroy all
-    //       minions and awaken.
+    // Text: <b>Dormant</b>.
+    //       <b>Battlecry:</b> Summon three 1/3 enemy Warders.
+    //       When they die, destroy all minions and awaken.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -2437,8 +2358,8 @@ void BlackTempleCardsGen::AddNeutralNonCollect(
     Power power;
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_008t] Impcaster - COST: 1 [ATK: 1/HP: 1]
-    //  - Race: DEMON, Set: BLACK_TEMPLE
+    // [BT_008t] Impcaster - COST:1 [ATK:1/HP:1]
+    //  - Race: Demon, Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Spell Damage +1</b>
     // --------------------------------------------------------
@@ -2450,7 +2371,7 @@ void BlackTempleCardsGen::AddNeutralNonCollect(
     cards.emplace("BT_008t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_010e] Felfin Fueled - COST: 0
+    // [BT_010e] Felfin Fueled - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: +1/+1.
@@ -2460,7 +2381,7 @@ void BlackTempleCardsGen::AddNeutralNonCollect(
     cards.emplace("BT_010e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_011e] Judgment of Justice - COST: 0
+    // [BT_011e] Judgment of Justice - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Health changed to 1.
@@ -2470,57 +2391,57 @@ void BlackTempleCardsGen::AddNeutralNonCollect(
     cards.emplace("BT_011e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_020e] Aldor Attendant - COST: 0
+    // [BT_020e] Aldor Attendant - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Reduced Cost.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_026e] Aldor Truthseeker - COST: 0
+    // [BT_026e] Aldor Truthseeker - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Reduced Cost.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_113e] Totemly Awesome - COST: 0
+    // [BT_113e] Totemly Awesome - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_126e] Shadowy Construct - COST: 0
+    // [BT_126e] Shadowy Construct - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Destroyed {0}.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_126e2] Vengeful Spirit - COST: 0
+    // [BT_126e2] Vengeful Spirit - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_129e] Mitosis - COST: 0
+    // [BT_129e] Mitosis - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_140e] Worg-mounted - COST: 0
+    // [BT_140e] Worg-mounted - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: +1/+1 and <b>Rush</b>.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_155t] Felcracked Colossus - COST: 7 [ATK: 7/HP: 7]
-    //  - Race: ELEMENTAL, Set: BLACK_TEMPLE
+    // [BT_155t] Felcracked Colossus - COST:7 [ATK:7/HP:7]
+    //  - Race: Elemental, Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------
@@ -2532,7 +2453,7 @@ void BlackTempleCardsGen::AddNeutralNonCollect(
     cards.emplace("BT_155t", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_159t] Huntress - COST: 1 [ATK: 1/HP: 1]
+    // [BT_159t] Huntress - COST:1 [ATK:1/HP:1]
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     power.ClearData();
@@ -2540,7 +2461,7 @@ void BlackTempleCardsGen::AddNeutralNonCollect(
     cards.emplace("BT_159t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_160e] Rustsworn Pact - COST: 0
+    // [BT_160e] Rustsworn Pact - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Summon a 1/1 Demon.
@@ -2551,15 +2472,15 @@ void BlackTempleCardsGen::AddNeutralNonCollect(
     cards.emplace("BT_160e", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_160t] Rusted Devil - COST: 1 [ATK: 1/HP: 1]
-    //  - Race: DEMON, Set: BLACK_TEMPLE
+    // [BT_160t] Rusted Devil - COST:1 [ATK:1/HP:1]
+    //  - Race: Demon, Set: BLACK_TEMPLE
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
     cards.emplace("BT_160t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_187e] Death's Dance - COST: 0
+    // [BT_187e] Death's Dance - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Your attacks ignore <b>Taunt</b>.
@@ -2569,14 +2490,14 @@ void BlackTempleCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_187e2] Death's Dance - COST: 0
+    // [BT_187e2] Death's Dance - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Kayn is letting this ignore <b>Taunt</b>.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_196e] Come Closer - COST: 0
+    // [BT_196e] Come Closer - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Drawn this turn.
@@ -2587,77 +2508,77 @@ void BlackTempleCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_205e] Scrapmetal Claws - COST: 0
+    // [BT_205e] Scrapmetal Claws - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: +3/+3.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_213e] Pack Tactics - COST: 0
+    // [BT_213e] Pack Tactics - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_255e] Sunstrider - COST: 0
+    // [BT_255e] Sunstrider - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Costs (0).
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_302e] Dark Portal - COST: 0
+    // [BT_302e] Dark Portal - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Costs (5) less.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_309e] Black Harvest - COST: 0
+    // [BT_309e] Black Harvest - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Costs (1) less.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_496e] Finned and Furious - COST: 0
+    // [BT_496e] Finned and Furious - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: +1 Attack and <b>Rush</b>.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_601e] Embrace Power - COST: 0
+    // [BT_601e] Embrace Power - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Costs (3) less.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_711e] Stunned - COST: 0
+    // [BT_711e] Stunned - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Costs (1) more.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_715e] Brawling - COST: 0
+    // [BT_715e] Brawling - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Increased Attack.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_716e] Victorious - COST: 0
+    // [BT_716e] Victorious - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: Increased Attack.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_720e] Ride Eternal - COST: 0
+    // [BT_720e] Ride Eternal - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: +4 Attack this turn.
@@ -2667,19 +2588,19 @@ void BlackTempleCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_721t] Living Rot - COST: 1 [ATK: 1/HP: 1]
+    // [BT_721t] Living Rot - COST:1 [ATK:1/HP:1]
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_724e] Ethereal Augment - COST: 0
+    // [BT_724e] Ethereal Augment - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Spell Damage +1</b>.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_726t] Dragonrider - COST: 3 [ATK: 3/HP: 4]
+    // [BT_726t] Dragonrider - COST:3 [ATK:3/HP:4]
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     power.ClearData();
@@ -2687,15 +2608,15 @@ void BlackTempleCardsGen::AddNeutralNonCollect(
     cards.emplace("BT_726t", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_728t] Rustsworn Inquisitor - COST: 4 [ATK: 9/HP: 1]
-    //  - Race: DEMON, Set: BLACK_TEMPLE
+    // [BT_728t] Rustsworn Inquisitor - COST:4 [ATK:9/HP:1]
+    //  - Race: Demon, Set: BLACK_TEMPLE
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
     cards.emplace("BT_728t", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_735t] Ashes of Al'ar - COST: 1 [ATK: 0/HP: 3]
+    // [BT_735t] Ashes of Al'ar - COST:1 [ATK:0/HP:3]
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: At the start of your turn, transform this into Al'ar.
@@ -2706,7 +2627,7 @@ void BlackTempleCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_737e] Imprisoned - COST: 0
+    // [BT_737e] Imprisoned - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Dormant</b>. Awaken in 2 turns.
@@ -2716,7 +2637,7 @@ void BlackTempleCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [BT_850e] Imprisoned - COST: 0
+    // [BT_850e] Imprisoned - COST:0
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
     // Text: <b>Dormant</b>. Awaken after 3 Warders die.
@@ -2726,12 +2647,11 @@ void BlackTempleCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_850t] Hellfire Warder - COST: 1 [ATK: 1/HP: 3]
+    // [BT_850t] Hellfire Warder - COST:1 [ATK:1/HP:3]
     //  - Set: BLACK_TEMPLE
     // --------------------------------------------------------
-    // Text: <i>(Magtheridon will destroy
-    //       all minions and awaken
-    //       after 3 Warders die.)</i>
+    // Text: (Magtheridon will destroy all minions and awaken
+    //       after 3 Warders die.)
     // --------------------------------------------------------
 }
 

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -15,10 +15,8 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.hpp>
-#include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FlagTask.hpp>
-#include <Rosetta/PlayMode/Tasks/SimpleTasks/GetGameTagTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/HealTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ManaCrystalTask.hpp>

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -719,7 +719,7 @@ void ScholomanceCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [SCH_159] Mindrender Illucia - COST: 2 [ATK: 1/HP: 3]
+    // [SCH_159] Mindrender Illucia - COST: 3 [ATK: 1/HP: 3]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Swap hands and decks with your opponent until

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -5,6 +5,7 @@
 
 #include <Rosetta/PlayMode/Actions/Generic.hpp>
 #include <Rosetta/PlayMode/CardSets/ScholomanceCardsGen.hpp>
+#include <Rosetta/PlayMode/Conditions/RelaCondition.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddCardTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
@@ -22,8 +23,15 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 
 namespace RosettaStone::PlayMode
 {
-using TagValues = std::vector<TagValue>;
 using GameTags = std::map<GameTag, int>;
+using TagValues = std::vector<TagValue>;
+using PlayReqs = std::map<PlayReq, int>;
+using ChooseCardIDs = std::vector<std::string>;
+using Entourages = std::vector<std::string>;
+using TaskList = std::vector<std::shared_ptr<ITask>>;
+using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
+using RelaCondList = std::vector<std::shared_ptr<RelaCondition>>;
+using EffectList = std::vector<std::shared_ptr<IEffect>>;
 
 void ScholomanceCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
@@ -38,14 +46,14 @@ void ScholomanceCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ----------------------------------------- MINION - DRUID
-    // [SCH_242] Gibberling - COST: 1 [ATK: 1/HP: 1]
+    // [SCH_242] Gibberling - COST:1 [ATK:1/HP:1]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Spellburst:</b> Summon a Gibberling.
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [SCH_333] Nature Studies - COST: 1
+    // [SCH_333] Nature Studies - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Discover</b> a spell. Your next one costs (1) less.
@@ -55,7 +63,7 @@ void ScholomanceCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [SCH_427] Lightning Bloom - COST: 0
+    // [SCH_427] Lightning Bloom - COST:0
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: Gain 2 Mana Crystals this turn only.
@@ -66,25 +74,26 @@ void ScholomanceCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [SCH_606] Partner Assignment - COST: 1
+    // [SCH_606] Partner Assignment - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Add a random 2-Cost and 3-Cost Beast to your hand.
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [SCH_609] Survival of the Fittest - COST: 10
+    // [SCH_609] Survival of the Fittest - COST:10
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: Give +4/+4 to all minions in your hand, deck, and battlefield.
+    // Text: Give +4/+4 to all minions in your hand,
+    //       deck, and battlefield.
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [SCH_612] Runic Carvings - COST: 6
+    // [SCH_612] Runic Carvings - COST:6
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Choose One -</b> Summon four 2/2 Treant Totems; or
-    // <b>Overload:</b> (2) to summon them with <b>Rush</b>.
+    //       <b>Overload:</b> (2) to summon them with <b>Rush</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - CHOOSE_ONE = 1
@@ -95,13 +104,11 @@ void ScholomanceCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [SCH_613] Groundskeeper - COST: 4 [ATK: 4/HP: 5]
+    // [SCH_613] Groundskeeper - COST:4 [ATK:4/HP:5]
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>
-    //       <b>Battlecry:</b> If you're holding a
-    //       spell that costs (5) or more,
-    //       restore 5 Health.
+    // Text: <b>Taunt</b> <b>Battlecry:</b> If you're holding a
+    //       spell that costs (5) or more, restore 5 Health.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -109,7 +116,7 @@ void ScholomanceCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [SCH_614] Forest Warden Omu - COST: 6 [ATK: 5/HP: 4]
+    // [SCH_614] Forest Warden Omu - COST:6 [ATK:5/HP:4]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Spellburst:</b> Refresh your Mana Crystals.
@@ -118,11 +125,10 @@ void ScholomanceCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     //  - ELITE = 1
 
     // ----------------------------------------- MINION - DRUID
-    // [SCH_616] Twilight Runner - COST: 5 [ATK: 5/HP: 4]
-    //  - Race: BEAST, Set: SCHOLOMANCE, Rarity: Rare
+    // [SCH_616] Twilight Runner - COST:5 [ATK:5/HP:4]
+    //  - Race: Beast, Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Stealth</b>
-    //       Whenever this attacks, draw 2 cards.
+    // Text: <b>Stealth</b> Whenever this attacks, draw 2 cards.
     // --------------------------------------------------------
     // GameTag:
     //  - STEALTH = 1
@@ -136,14 +142,14 @@ void ScholomanceCardsGen::AddDruidNonCollect(
     Power power;
 
     // ------------------------------------ ENCHANTMENT - DRUID
-    // [SCH_182e] Outspoken - COST: 0
+    // [SCH_182e] Outspoken - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Increased stats.
     // --------------------------------------------------------
 
     // ------------------------------------ ENCHANTMENT - DRUID
-    // [SCH_333e] Nature Studies - COST: 0
+    // [SCH_333e] Nature Studies - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Your next spell costs (1) less.
@@ -153,28 +159,28 @@ void ScholomanceCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
 
     // ------------------------------------ ENCHANTMENT - DRUID
-    // [SCH_333e2] Studying Nature - COST: 0
+    // [SCH_333e2] Studying Nature - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Costs (1) less.
     // --------------------------------------------------------
 
     // ------------------------------------ ENCHANTMENT - DRUID
-    // [SCH_609e] Survival of the Fittest - COST: 0
+    // [SCH_609e] Survival of the Fittest - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: +4/+4.
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [SCH_612a] Call to Aid - COST: 6
+    // [SCH_612a] Call to Aid - COST:6
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Summon four 2/2 Treant Totems.
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [SCH_612b] Alarm the Forest - COST: 6
+    // [SCH_612b] Alarm the Forest - COST:6
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Summon four 2/2 Treant Totems with <b>Rush</b>.
@@ -188,12 +194,12 @@ void ScholomanceCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [SCH_612t] Treant Totem - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_612t] Treant Totem - COST:2 [ATK:2/HP:2]
     //  - Race: TOTEM, Set: SCHOLOMANCE
     // --------------------------------------------------------
 
     // ------------------------------------ ENCHANTMENT - DRUID
-    // [SCH_617e] Adorable - COST: 0
+    // [SCH_617e] Adorable - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: +1/+1.
@@ -205,8 +211,8 @@ void ScholomanceCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ---------------------------------------- MINION - HUNTER
-    // [SCH_133] Wolpertinger - COST: 1 [ATK: 1/HP: 1]
-    //  - Race: BEAST, Set: SCHOLOMANCE, Rarity: Common
+    // [SCH_133] Wolpertinger - COST:1 [ATK:1/HP:1]
+    //  - Race: Beast, Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Summon a copy of this.
     // --------------------------------------------------------
@@ -215,19 +221,18 @@ void ScholomanceCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [SCH_239] Krolusk Barkstripper - COST: 4 [ATK: 3/HP: 5]
-    //  - Race: BEAST, Set: SCHOLOMANCE, Rarity: Epic
+    // [SCH_239] Krolusk Barkstripper - COST:4 [ATK:3/HP:5]
+    //  - Race: Beast, Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Spellburst:</b> Destroy a random enemy minion.
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [SCH_244] Teacher's Pet - COST: 5 [ATK: 4/HP: 5]
-    //  - Race: BEAST, Set: SCHOLOMANCE, Rarity: Rare
+    // [SCH_244] Teacher's Pet - COST:5 [ATK:4/HP:5]
+    //  - Race: Beast, Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
-    //       <b>Deathrattle:</b> Summon a
-    //       random 3-Cost Beast.
+    //       <b>Deathrattle:</b> Summon a random 3-Cost Beast.
     // --------------------------------------------------------
     // GameTag:
     //  - DEATHRATTLE = 1
@@ -235,11 +240,11 @@ void ScholomanceCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - HUNTER
-    // [SCH_300] Carrion Studies - COST: 1
+    // [SCH_300] Carrion Studies - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Discover</b> a <b>Deathrattle</b> minion. Your next one costs
-    // (1) less.
+    // Text: <b>Discover</b> a <b>Deathrattle</b> minion.
+    //       Your next one costs (1) less.
     // --------------------------------------------------------
     // GameTag:
     //  - DISCOVER = 1
@@ -249,8 +254,8 @@ void ScholomanceCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [SCH_340] Bloated Python - COST: 3 [ATK: 1/HP: 2]
-    //  - Race: BEAST, Set: SCHOLOMANCE, Rarity: Rare
+    // [SCH_340] Bloated Python - COST:3 [ATK:1/HP:2]
+    //  - Race: Beast, Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Summon a 4/4 Hapless Handler.
     // --------------------------------------------------------
@@ -259,7 +264,7 @@ void ScholomanceCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [SCH_539] Professor Slate - COST: 3 [ATK: 3/HP: 4]
+    // [SCH_539] Professor Slate - COST:3 [ATK:3/HP:4]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: Your spells are <b>Poisonous</b>.
@@ -273,21 +278,19 @@ void ScholomanceCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - HUNTER
-    // [SCH_604] Overwhelm - COST: 1
+    // [SCH_604] Overwhelm - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Deal 2 damage to a minion. Deal one more damage for each Beast you
-    // control.
+    // Text: Deal 2 damage to a minion.
+    //       Deal one more damage for each Beast you control.
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [SCH_607] Shan'do Wildclaw - COST: 3 [ATK: 3/HP: 3]
+    // [SCH_607] Shan'do Wildclaw - COST:3 [ATK:3/HP:3]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Choose One -</b> Give Beasts
-    //       in your deck +1/+1; or
-    //       Transform into a copy
-    //       of a friendly Beast.
+    // Text: <b>Choose One -</b> Give Beasts in your deck +1/+1;
+    //       or Transform into a copy of a friendly Beast.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -295,21 +298,22 @@ void ScholomanceCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - HUNTER
-    // [SCH_610] Guardian Animals - COST: 7
+    // [SCH_610] Guardian Animals - COST:7
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: Summon two Beasts that cost (5) or less from your deck. Give them
-    // <b>Rush</b>.
+    // Text: Summon two Beasts that cost (5) or less from your deck.
+    //       Give them <b>Rush</b>.
     // --------------------------------------------------------
     // RefTag:
     //  - RUSH = 1
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - HUNTER
-    // [SCH_617] Adorable Infestation - COST: 1
+    // [SCH_617] Adorable Infestation - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Give a minion +1/+1. Summon a 1/1 Cub. Add a Cub to your hand.
+    // Text: Give a minion +1/+1. Summon a 1/1 Cub.
+    //       Add a Cub to your hand.
     // --------------------------------------------------------
 }
 
@@ -319,33 +323,33 @@ void ScholomanceCardsGen::AddHunterNonCollect(
     Power power;
 
     // ---------------------------------------- MINION - HUNTER
-    // [SCH_340t] Hapless Handler - COST: 4 [ATK: 4/HP: 4]
+    // [SCH_340t] Hapless Handler - COST:4 [ATK:4/HP:4]
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - HUNTER
-    // [SCH_538e] Ace Hunter's Lesson - COST: 0
+    // [SCH_538e] Ace Hunter's Lesson - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: <b>Immune</b> while attacking.
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - HUNTER
-    // [SCH_600t3e] Kolek's Call - COST: 0
+    // [SCH_600t3e] Kolek's Call - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Kolek is granting this minion +1 Attack.
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - HUNTER
-    // [SCH_607a] Transfiguration - COST: 3
+    // [SCH_607a] Transfiguration - COST:3
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Transform into a copy of a friendly Beast.
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - HUNTER
-    // [SCH_607b] Rile the Herd - COST: 3
+    // [SCH_607b] Rile the Herd - COST:3
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Give Beasts in your deck +1/+1.
@@ -355,19 +359,19 @@ void ScholomanceCardsGen::AddHunterNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - HUNTER
-    // [SCH_607e] Riled Up - COST: 0
+    // [SCH_607e] Riled Up - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [SCH_617t] Marsuul Cub - COST: 1 [ATK: 1/HP: 1]
-    //  - Race: BEAST, Set: SCHOLOMANCE
+    // [SCH_617t] Marsuul Cub - COST:1 [ATK:1/HP:1]
+    //  - Race: Beast, Set: SCHOLOMANCE
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - HUNTER
-    // [SCH_618e] Blood of Innocents - COST: 0
+    // [SCH_618e] Blood of Innocents - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: +1/+1.
@@ -379,22 +383,22 @@ void ScholomanceCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ------------------------------------------ MINION - MAGE
-    // [SCH_241] Firebrand - COST: 3 [ATK: 3/HP: 4]
+    // [SCH_241] Firebrand - COST:3 [ATK:3/HP:4]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b><b>Spellburst</b>:</b> Deal 4 damage randomly split among
-    // all enemy minions.
+    // Text: <b>Spellburst</b>: Deal 4 damage randomly split
+    //       among all enemy minions.
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [SCH_243] Wyrm Weaver - COST: 5 [ATK: 3/HP: 6]
+    // [SCH_243] Wyrm Weaver - COST:5 [ATK:3/HP:6]
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Spellburst:</b> Summon two 1/3 Mana Wyrms.
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [SCH_310] Lab Partner - COST: 1 [ATK: 1/HP: 3]
+    // [SCH_310] Lab Partner - COST:1 [ATK:1/HP:3]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Spell Damage +1</b>
@@ -404,29 +408,28 @@ void ScholomanceCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------- SPELL - MAGE
-    // [SCH_348] Combustion - COST: 3
+    // [SCH_348] Combustion - COST:3
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: Deal 4 damage to
-    //       a minion. Any excess
-    //       damages both neighbors.
+    // Text: Deal 4 damage to a minion.
+    //       Any excess damages both neighbors.
     // --------------------------------------------------------
     // GameTag:
     //  - ImmuneToSpellpower = 1
     // --------------------------------------------------------
 
     // ------------------------------------------- SPELL - MAGE
-    // [SCH_353] Cram Session - COST: 2
+    // [SCH_353] Cram Session - COST:2
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Draw 1 cards <i>(improved by <b>Spell Damage</b>)</i>.
+    // Text: Draw 1 cards (improved by <b>Spell Damage</b>).
     // --------------------------------------------------------
     // RefTag:
     //  - SPELLPOWER = 1
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [SCH_400] Mozaki, Master Duelist - COST: 5 [ATK: 3/HP: 8]
+    // [SCH_400] Mozaki, Master Duelist - COST:5 [ATK:3/HP:8]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: After you cast a spell, gain <b>Spell Damage +1</b>.
@@ -446,7 +449,7 @@ void ScholomanceCardsGen::AddMageNonCollect(
     Power power;
 
     // ------------------------------------- ENCHANTMENT - MAGE
-    // [SCH_400e2] Magic Master - COST: 0
+    // [SCH_400e2] Magic Master - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: <b>Spell Damage +1</b>
@@ -458,12 +461,11 @@ void ScholomanceCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     Power power;
 
     // --------------------------------------- MINION - PALADIN
-    // [SCH_135] Turalyon, the Tenured - COST: 8 [ATK: 3/HP: 12]
+    // [SCH_135] Turalyon, the Tenured - COST:8 [ATK:3/HP:12]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Rush</b>. Whenever this attacks
-    //       a minion, set the defender's
-    //       Attack and Health to 3.
+    // Text: <b>Rush</b>. Whenever this attacks a minion,
+    //       set the defender's Attack and Health to 3.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -472,20 +474,19 @@ void ScholomanceCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [SCH_138] Blessing of Authority - COST: 5
+    // [SCH_138] Blessing of Authority - COST:5
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Give a minion +8/+8. It can't attack heroes this turn.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [SCH_139] Devout Pupil - COST: 6 [ATK: 4/HP: 5]
+    // [SCH_139] Devout Pupil - COST:6 [ATK:4/HP:5]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Divine Shield, Taunt</b>
-    //       Costs (1) less for each spell
-    //       you've cast on friendly
-    //       characters this game.
+    //       Costs (1) less for each spell you've cast on
+    //       friendly characters this game.
     // --------------------------------------------------------
     // GameTag:
     //  - DIVINE_SHIELD = 1
@@ -493,63 +494,66 @@ void ScholomanceCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [SCH_141] High Abbess Alura - COST: 4 [ATK: 3/HP: 6]
+    // [SCH_141] High Abbess Alura - COST:4 [ATK:3/HP:6]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Spellburst:</b> Cast a spell from your deck <i>(targets this if
-    // possible)</i>.
+    // Text: <b>Spellburst:</b> Cast a spell from your deck
+    //       (targets this if possible).
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
+    // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [SCH_149] Argent Braggart - COST: 2 [ATK: 1/HP: 1]
+    // [SCH_149] Argent Braggart - COST:2 [ATK:1/HP:1]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Gain Attack and Health to match the highest in
-    // the battlefield.
+    // Text: <b>Battlecry:</b> Gain Attack and Health to match
+    //       the highest in the battlefield.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [SCH_247] First Day of School - COST: 0
+    // [SCH_247] First Day of School - COST:0
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: Add 2 random 1-Cost minions to your hand.
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [SCH_250] Wave of Apathy - COST: 1
+    // [SCH_250] Wave of Apathy - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Set the Attack of all enemy minions to 1 until your next turn.
+    // Text: Set the Attack of all enemy minions to 1
+    //       until your next turn.
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [SCH_302] Gift of Luminance - COST: 3
+    // [SCH_302] Gift of Luminance - COST:3
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Give a minion <b>Divine Shield</b>, then summon a 1/1 copy of it.
+    // Text: Give a minion <b>Divine Shield</b>,
+    //       then summon a 1/1 copy of it.
     // --------------------------------------------------------
     // RefTag:
     //  - DIVINE_SHIELD = 1
     // --------------------------------------------------------
 
     // --------------------------------------- WEAPON - PALADIN
-    // [SCH_523] Ceremonial Maul - COST: 3
+    // [SCH_523] Ceremonial Maul - COST:3
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Spellburst</b>: Summon a Student with <b>Taunt</b> and stats
-    // equal to the spell's Cost.
+    // Text: <b>Spellburst</b>: Summon a Student with <b>Taunt</b>
+    //       and stats equal to the spell's Cost.
     // --------------------------------------------------------
     // RefTag:
     //  - TAUNT = 1
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [SCH_524] Shield of Honor - COST: 1
+    // [SCH_524] Shield of Honor - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: Give a damaged minion +3 Attack and <b>Divine Shield</b>.
@@ -559,13 +563,11 @@ void ScholomanceCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [SCH_526] Lord Barov - COST: 3 [ATK: 3/HP: 2]
+    // [SCH_526] Lord Barov - COST:3 [ATK:3/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Set the Health
-    //       of all other minions to 1.
-    //       <b>Deathrattle:</b> Deal 1 damage
-    //       to all minions.
+    // Text: <b>Battlecry:</b> Set the Health of all other minions to 1.
+    //       <b>Deathrattle:</b> Deal 1 damage to all minions.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -574,7 +576,7 @@ void ScholomanceCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [SCH_532] Goody Two-Shields - COST: 3 [ATK: 4/HP: 2]
+    // [SCH_532] Goody Two-Shields - COST:3 [ATK:4/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Divine Shield</b>
@@ -585,11 +587,11 @@ void ScholomanceCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [SCH_533] Commencement - COST: 7
+    // [SCH_533] Commencement - COST:7
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Summon a minion from your deck. Give it <b>Taunt</b> and <b>Divine
-    // Shield</b>.
+    // Text: Summon a minion from your deck.
+    //       Give it <b>Taunt</b> and <b>Divine Shield</b>.
     // --------------------------------------------------------
     // RefTag:
     //  - DIVINE_SHIELD = 1
@@ -597,7 +599,7 @@ void ScholomanceCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [SCH_712] Judicious Junior - COST: 6 [ATK: 4/HP: 9]
+    // [SCH_712] Judicious Junior - COST:6 [ATK:4/HP:9]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Lifesteal</b>
@@ -616,21 +618,21 @@ void ScholomanceCardsGen::AddPaladinNonCollect(
     Power power;
 
     // ---------------------------------- ENCHANTMENT - PALADIN
-    // [SCH_135e] Schooled - COST: 0
+    // [SCH_135e] Schooled - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: 3/3.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - PALADIN
-    // [SCH_138e] Blessing of Authority - COST: 0
+    // [SCH_138e] Blessing of Authority - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: +8/+8.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - PALADIN
-    // [SCH_138e2] Honorable Intentions - COST: 0
+    // [SCH_138e2] Honorable Intentions - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Can't attack heroes this turn.
@@ -640,14 +642,14 @@ void ScholomanceCardsGen::AddPaladinNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - PALADIN
-    // [SCH_149e] Best of the Best - COST: 0
+    // [SCH_149e] Best of the Best - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Increased stats.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [SCH_523t] Honor Student - COST: 1 [ATK: 1/HP: 1]
+    // [SCH_523t] Honor Student - COST:1 [ATK:1/HP:1]
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -657,7 +659,7 @@ void ScholomanceCardsGen::AddPaladinNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - PALADIN
-    // [SCH_533e] Graduated - COST: 0
+    // [SCH_533e] Graduated - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: <b>Taunt</b>, <b>Divine Shield</b>.
@@ -669,25 +671,22 @@ void ScholomanceCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ---------------------------------------- MINION - PRIEST
-    // [SCH_120] Cabal Acolyte - COST: 4 [ATK: 2/HP: 6]
+    // [SCH_120] Cabal Acolyte - COST:4 [ATK:2/HP:6]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>
-    //       <b>Spellburst:</b> Gain control
-    //       of a random enemy minion
-    //       with 2 or less Attack.
+    // Text: <b>Taunt</b> <b>Spellburst:</b> Gain control
+    //       of a random enemy minion with 2 or less Attack.
     // --------------------------------------------------------
     // GameTag:
     //  - TAUNT = 1
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [SCH_126] Disciplinarian Gandling - COST: 4 [ATK: 3/HP: 6]
+    // [SCH_126] Disciplinarian Gandling - COST:4 [ATK:3/HP:6]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: After you play a minion,
-    //       destroy it and summon a
-    //       4/4 Failed Student.
+    //       destroy it and summon a 4/4 Failed Student.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -695,15 +694,15 @@ void ScholomanceCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - PRIEST
-    // [SCH_136] Power Word: Feast - COST: 2
+    // [SCH_136] Power Word: Feast - COST:2
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Give a minion +2/+2. Restore it to full Health at the end of this
-    // turn.
+    // Text: Give a minion +2/+2.
+    //       Restore it to full Health at the end of this turn.
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [SCH_137] Frazzled Freshman - COST: 1 [ATK: 1/HP: 4]
+    // [SCH_137] Frazzled Freshman - COST:1 [ATK:1/HP:4]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     power.ClearData();
@@ -711,19 +710,19 @@ void ScholomanceCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     cards.emplace("SCH_137", CardDef(power));
 
     // ---------------------------------------- MINION - PRIEST
-    // [SCH_140] Flesh Giant - COST: 8 [ATK: 8/HP: 8]
+    // [SCH_140] Flesh Giant - COST:8 [ATK:8/HP:8]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: Costs (1) less for each time your hero's Health changed during your
-    // turns.
+    // Text: Costs (1) less for each time your hero's Health changed
+    //       during your turns.
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [SCH_159] Mindrender Illucia - COST: 3 [ATK: 1/HP: 3]
+    // [SCH_159] Mindrender Illucia - COST:3 [ATK:1/HP:3]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Swap hands and decks with your opponent until
-    // your next turn.
+    // Text: <b>Battlecry:</b> Swap hands and decks with your opponent
+    //       until your next turn.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -731,41 +730,40 @@ void ScholomanceCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - PRIEST
-    // [SCH_233] Draconic Studies - COST: 1
+    // [SCH_233] Draconic Studies - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Discover</b> a Dragon. Your
-    //       next one costs (1) less.
+    // Text: <b>Discover</b> a Dragon. Your next one costs (1) less.
     // --------------------------------------------------------
     // GameTag:
     //  - DISCOVER = 1
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - PRIEST
-    // [SCH_512] Initiation - COST: 6
+    // [SCH_512] Initiation - COST:6
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Deal 4 damage to a minion. If that kills it, summon a new copy.
+    // Text: Deal 4 damage to a minion. If that kills it,
+    //       summon a new copy.
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [SCH_513] Brittlebone Destroyer - COST: 4 [ATK: 3/HP: 3]
+    // [SCH_513] Brittlebone Destroyer - COST:4 [ATK:3/HP:3]
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> If your hero's
-    //       Health changed this turn,
-    //       destroy a minion.
+    // Text: <b>Battlecry:</b> If your hero's Health
+    //       changed this turn, destroy a minion.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - PRIEST
-    // [SCH_514] Raise Dead - COST: 0
+    // [SCH_514] Raise Dead - COST:0
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Deal 3 damage to your hero. Return two friendly minions that died
-    // this game to your hand.
+    // Text: Deal 3 damage to your hero. Return two friendly minions
+    //       that died this game to your hand.
     // --------------------------------------------------------
 }
 
@@ -775,36 +773,37 @@ void ScholomanceCardsGen::AddPriestNonCollect(
     Power power;
 
     // ---------------------------------------- MINION - PRIEST
-    // [SCH_126t] Failed Student - COST: 4 [ATK: 4/HP: 4]
+    // [SCH_126t] Failed Student - COST:4 [ATK:4/HP:4]
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - PRIEST
-    // [SCH_136e] Power Word: Feast - COST: 0
+    // [SCH_136e] Power Word: Feast - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - PRIEST
-    // [SCH_136e2] Famished - COST: 0
+    // [SCH_136e2] Famished - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Restores full health at end of turn.
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - PRIEST
-    // [SCH_159e] Mind Swap - COST: 0
+    // [SCH_159e] Mind Swap - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
-    // Text: At the start of your turn, swap both players hands and decks.
+    // Text: At the start of your turn,
+    //       swap both players hands and decks.
     // --------------------------------------------------------
     // GameTag:
     //  - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - PRIEST
-    // [SCH_233e] Draconic Studies - COST: 0
+    // [SCH_233e] Draconic Studies - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Your next Dragon costs (1) less.
@@ -814,21 +813,21 @@ void ScholomanceCardsGen::AddPriestNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - PRIEST
-    // [SCH_233e2] Studying Dragons - COST: 0
+    // [SCH_233e2] Studying Dragons - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Costs (1) less.
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - PRIEST
-    // [SCH_250e] Apathetic - COST: 0
+    // [SCH_250e] Apathetic - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Attack reduced to 1 until next turn.
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - PRIEST
-    // [SCH_302e] Student of the Light - COST: 0
+    // [SCH_302e] Student of the Light - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: 1/1.
@@ -840,11 +839,11 @@ void ScholomanceCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ----------------------------------------- MINION - ROGUE
-    // [SCH_234] Shifty Sophomore - COST: 4 [ATK: 4/HP: 4]
+    // [SCH_234] Shifty Sophomore - COST:4 [ATK:4/HP:4]
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Stealth</b>
-    //       <b>Spellburst:</b> Add a <b>Combo</b> card to your hand.
+    // Text: <b>Stealth</b> <b>Spellburst:</b> Add a
+    //       <b>Combo</b> card to your hand.
     // --------------------------------------------------------
     // GameTag:
     //  - STEALTH = 1
@@ -860,19 +859,19 @@ void ScholomanceCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     cards.emplace("SCH_234", CardDef(power));
 
     // ------------------------------------------ SPELL - ROGUE
-    // [SCH_305] Secret Passage - COST: 1
+    // [SCH_305] Secret Passage - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: Replace your hand with 5 cards from your deck. Swap back next turn.
+    // Text: Replace your hand with 5 cards from your deck.
+    //       Swap back next turn.
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [SCH_426] Infiltrator Lilian - COST: 4 [ATK: 4/HP: 2]
+    // [SCH_426] Infiltrator Lilian - COST:4 [ATK:4/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Stealth</b>
-    //       <b>Deathrattle:</b> Summon a 4/2 Forsaken Lilian
-    //       that attacks a random enemy.
+    // Text: <b>Stealth</b> <b>Deathrattle:</b> Summon a
+    //       4/2 Forsaken Lilian that attacks a random enemy.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -893,7 +892,7 @@ void ScholomanceCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     cards.emplace("SCH_426", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
-    // [SCH_519] Vulpera Toxinblade - COST: 3 [ATK: 3/HP: 3]
+    // [SCH_519] Vulpera Toxinblade - COST:3 [ATK:3/HP:3]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: Your weapon has +2 Attack.
@@ -903,7 +902,7 @@ void ScholomanceCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- WEAPON - ROGUE
-    // [SCH_622] Self-Sharpening Sword - COST: 3
+    // [SCH_622] Self-Sharpening Sword - COST:3
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
     // Text: After your hero attacks, gain +1 Attack.
@@ -919,7 +918,7 @@ void ScholomanceCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     cards.emplace("SCH_622", CardDef(power));
 
     // ------------------------------------------ SPELL - ROGUE
-    // [SCH_706] Plagiarize - COST: 2
+    // [SCH_706] Plagiarize - COST:2
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Secret:</b> At the end of your opponent's turn,
@@ -959,43 +958,43 @@ void ScholomanceCardsGen::AddRogueNonCollect(
     Power power;
 
     // ------------------------------------ ENCHANTMENT - ROGUE
-    // [SCH_305e] Secret Exit - COST: 0
+    // [SCH_305e] Secret Exit - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
 
     // ------------------------------------ ENCHANTMENT - ROGUE
-    // [SCH_305e2] Secret Entrance - COST: 0
+    // [SCH_305e2] Secret Entrance - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
 
     // ------------------------------------ ENCHANTMENT - ROGUE
-    // [SCH_305e3] Secret Passage Player Enchantment - COST: 0
+    // [SCH_305e3] Secret Passage Player Enchantment - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
 
     // ------------------------------------ ENCHANTMENT - ROGUE
-    // [SCH_351e] Illusion - COST: 0
-    //  - Set: SCHOLOMANCE
-    // --------------------------------------------------------
-    // Text: This might be an illusion that dies when it takes damage.
-    // --------------------------------------------------------
-
-    // ------------------------------------ ENCHANTMENT - ROGUE
-    // [SCH_351e2] Illusion - COST: 0
+    // [SCH_351e] Illusion - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: This might be an illusion that dies when it takes damage.
     // --------------------------------------------------------
 
     // ------------------------------------ ENCHANTMENT - ROGUE
-    // [SCH_352e] Potion of Illusion - COST: 0
+    // [SCH_351e2] Illusion - COST:0
+    //  - Set: SCHOLOMANCE
+    // --------------------------------------------------------
+    // Text: This might be an illusion that dies when it takes damage.
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - ROGUE
+    // [SCH_352e] Potion of Illusion - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: 1/1.
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [SCH_426t] Forsaken Lilian - COST: 4 [ATK: 4/HP: 2]
+    // [SCH_426t] Forsaken Lilian - COST:4 [ATK:4/HP:2]
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // GameTag:
@@ -1005,7 +1004,7 @@ void ScholomanceCardsGen::AddRogueNonCollect(
     cards.emplace("SCH_426t", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - ROGUE
-    // [SCH_622e] Honed Edge - COST: 0
+    // [SCH_622e] Honed Edge - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: +1 Attack.
@@ -1020,24 +1019,25 @@ void ScholomanceCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ---------------------------------------- MINION - SHAMAN
-    // [SCH_236] Diligent Notetaker - COST: 2 [ATK: 2/HP: 3]
+    // [SCH_236] Diligent Notetaker - COST:2 [ATK:2/HP:3]
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Spellburst:</b> Return the spell to your hand.
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - SHAMAN
-    // [SCH_271] Molten Blast - COST: 3
+    // [SCH_271] Molten Blast - COST:3
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Deal 2 damage. Summon that many 1/1 Elementals.
     // --------------------------------------------------------
 
     // ---------------------------------------- WEAPON - SHAMAN
-    // [SCH_301] Rune Dagger - COST: 2
+    // [SCH_301] Rune Dagger - COST:2
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: After your hero attacks, gain <b>Spell Damage +1</b> this turn.
+    // Text: After your hero attacks,
+    //       gain <b>Spell Damage +1</b> this turn.
     // --------------------------------------------------------
     // GameTag:
     //  - TRIGGER_VISUAL = 1
@@ -1047,12 +1047,11 @@ void ScholomanceCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [SCH_507] Instructor Fireheart - COST: 3 [ATK: 3/HP: 3]
+    // [SCH_507] Instructor Fireheart - COST:3 [ATK:3/HP:3]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> <b>Discover</b> a spell
-    //       that costs (1) or more.
-    //       If you play it this turn,
+    //       that costs (1) or more. If you play it this turn,
     //       repeat this effect.
     // --------------------------------------------------------
     // GameTag:
@@ -1064,7 +1063,7 @@ void ScholomanceCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - SHAMAN
-    // [SCH_535] Tidal Wave - COST: 8
+    // [SCH_535] Tidal Wave - COST:8
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Lifesteal</b>
@@ -1076,7 +1075,7 @@ void ScholomanceCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [SCH_615] Totem Goliath - COST: 5 [ATK: 4/HP: 5]
+    // [SCH_615] Totem Goliath - COST:5 [ATK:4/HP:5]
     //  - Race: TOTEM, Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Summon all four basic Totems.
@@ -1096,12 +1095,12 @@ void ScholomanceCardsGen::AddShamanNonCollect(
     Power power;
 
     // ---------------------------------------- MINION - SHAMAN
-    // [SCH_271t] Molten Elemental - COST: 1 [ATK: 1/HP: 1]
-    //  - Race: ELEMENTAL, Set: SCHOLOMANCE
+    // [SCH_271t] Molten Elemental - COST:1 [ATK:1/HP:1]
+    //  - Race: Elemental, Set: SCHOLOMANCE
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
-    // [SCH_507e] Hot Streak! - COST: 0
+    // [SCH_507e] Hot Streak! - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: If played this turn, <b>Discover</b> another spell.
@@ -1116,13 +1115,11 @@ void ScholomanceCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     Power power;
 
     // --------------------------------------- MINION - WARLOCK
-    // [SCH_147] Boneweb Egg - COST: 2 [ATK: 0/HP: 2]
+    // [SCH_147] Boneweb Egg - COST:2 [ATK:0/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Deathrattle:</b> Summon
-    //       two 2/1 Spiders. If you
-    //       discard this, trigger its
-    //       <b>Deathrattle</b>.
+    // Text: <b>Deathrattle:</b> Summon two 2/1 Spiders.
+    //       If you discard this, trigger its <b>Deathrattle</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - DEATHRATTLE = 1
@@ -1130,7 +1127,7 @@ void ScholomanceCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARLOCK
-    // [SCH_158] Demonic Studies - COST: 1
+    // [SCH_158] Demonic Studies - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Discover</b> a Demon. Your next one costs (1) less.
@@ -1140,10 +1137,11 @@ void ScholomanceCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [SCH_181] Archwitch Willow - COST: 9 [ATK: 7/HP: 7]
+    // [SCH_181] Archwitch Willow - COST:9 [ATK:7/HP:7]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Summon a random Demon from your hand and deck.
+    // Text: <b>Battlecry:</b> Summon a random Demon
+    //       from your hand and deck.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -1151,21 +1149,19 @@ void ScholomanceCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARLOCK
-    // [SCH_307] School Spirits - COST: 3
+    // [SCH_307] School Spirits - COST:3
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Deal 2 damage to all
-    //       minions. Shuffle 2 Soul
-    //       Fragments into your deck.
+    // Text: Deal 2 damage to all minions.
+    //       Shuffle 2 Soul Fragments into your deck.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [SCH_343] Void Drinker - COST: 5 [ATK: 4/HP: 5]
-    //  - Race: DEMON, Set: SCHOLOMANCE, Rarity: Epic
+    // [SCH_343] Void Drinker - COST:5 [ATK:4/HP:5]
+    //  - Race: Demon, Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Taunt</b>. <b>Battlecry:</b> Destroy
-    //       a Soul Fragment in your
-    //       deck to gain +3/+3.
+    //       a Soul Fragment in your deck to gain +3/+3.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -1173,19 +1169,19 @@ void ScholomanceCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [SCH_517] Shadowlight Scholar - COST: 3 [ATK: 3/HP: 4]
+    // [SCH_517] Shadowlight Scholar - COST:3 [ATK:3/HP:4]
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Destroy a Soul Fragment in your deck to deal 3
-    // damage.
+    // Text: <b>Battlecry:</b> Destroy a Soul Fragment in your deck
+    //       to deal 3 damage.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [SCH_700] Spirit Jailer - COST: 1 [ATK: 1/HP: 3]
-    //  - Race: DEMON, Set: SCHOLOMANCE, Rarity: Common
+    // [SCH_700] Spirit Jailer - COST:1 [ATK:1/HP:3]
+    //  - Race: Demon, Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Shuffle 2 Soul Fragments into your deck.
     // --------------------------------------------------------
@@ -1194,20 +1190,18 @@ void ScholomanceCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARLOCK
-    // [SCH_701] Soul Shear - COST: 2
+    // [SCH_701] Soul Shear - COST:2
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Deal 3 damage to a
-    //       minion. Shuffle 2 Soul
-    //       Fragments into your deck.
+    // Text: Deal 3 damage to a minion.
+    //       Shuffle 2 Soul Fragments into your deck.
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARLOCK
-    // [SCH_702] Felosophy - COST: 1
+    // [SCH_702] Felosophy - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: Copy the lowest Cost
-    //       Demon in your hand.
+    // Text: Copy the lowest Cost Demon in your hand.
     //       <b>Outcast:</b> Give both +1/+1.
     // --------------------------------------------------------
     // GameTag:
@@ -1215,11 +1209,11 @@ void ScholomanceCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [SCH_703] Soulciologist Malicia - COST: 7 [ATK: 5/HP: 5]
+    // [SCH_703] Soulciologist Malicia - COST:7 [ATK:5/HP:5]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> For each Soul Fragment in your deck, summon a 3/3
-    // Soul with <b>Rush</b>.@ <i>(@)</i>
+    // Text: <b>Battlecry:</b> For each Soul Fragment in your deck,
+    //       summon a 3/3 Soul with <b>Rush</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -1236,12 +1230,12 @@ void ScholomanceCardsGen::AddWarlockNonCollect(
     Power power;
 
     // --------------------------------------- MINION - WARLOCK
-    // [SCH_147t] Boneweb Spider - COST: 1 [ATK: 2/HP: 1]
-    //  - Race: BEAST, Set: SCHOLOMANCE
+    // [SCH_147t] Boneweb Spider - COST:1 [ATK:2/HP:1]
+    //  - Race: Beast, Set: SCHOLOMANCE
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - WARLOCK
-    // [SCH_158e] Demonic Studies - COST: 0
+    // [SCH_158e] Demonic Studies - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Your next Demon costs (1) less.
@@ -1251,25 +1245,25 @@ void ScholomanceCardsGen::AddWarlockNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARLOCK
-    // [SCH_307t] Soul Fragment - COST: 0
+    // [SCH_307t] Soul Fragment - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: <b>Casts When Drawn</b>
-    //       Restore #2 Health to your hero.
+    //       Restore 2 Health to your hero.
     // --------------------------------------------------------
     // GameTag:
     //  - TOPDECK = 1
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - WARLOCK
-    // [SCH_343e] Soul Powered - COST: 0
+    // [SCH_343e] Soul Powered - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: +3/+3.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [SCH_703t] Released Soul - COST: 3 [ATK: 3/HP: 3]
+    // [SCH_703t] Released Soul - COST:3 [ATK:3/HP:3]
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -1284,10 +1278,11 @@ void ScholomanceCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ---------------------------------------- SPELL - WARRIOR
-    // [SCH_237] Athletic Studies - COST: 1
+    // [SCH_237] Athletic Studies - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Discover</b> a <b>Rush</b> minion. Your next one costs (1) less.
+    // Text: <b>Discover</b> a <b>Rush</b> minion.
+    //       Your next one costs (1) less.
     // --------------------------------------------------------
     // GameTag:
     //  - DISCOVER = 1
@@ -1297,21 +1292,19 @@ void ScholomanceCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- WEAPON - WARRIOR
-    // [SCH_238] Reaper's Scythe - COST: 4
+    // [SCH_238] Reaper's Scythe - COST:4
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Spellburst</b>: Also
-    //       damages adjacent
+    // Text: <b>Spellburst</b>: Also damages adjacent
     //       minions this turn.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [SCH_317] Playmaker - COST: 3 [ATK: 4/HP: 3]
+    // [SCH_317] Playmaker - COST:3 [ATK:4/HP:3]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: After you play a <b>Rush</b>
-    //       minion, summon a copy
-    //        with 1 Health remaining.
+    // Text: After you play a <b>Rush</b> minion,
+    //       summon a copy with 1 Health remaining.
     // --------------------------------------------------------
     // GameTag:
     //  - TRIGGER_VISUAL = 1
@@ -1321,18 +1314,18 @@ void ScholomanceCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [SCH_337] Troublemaker - COST: 8 [ATK: 6/HP: 8]
+    // [SCH_337] Troublemaker - COST:8 [ATK:6/HP:8]
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: At the end of your turn, summon two 3/3 Ruffians that attack random
-    // enemies.
+    // Text: At the end of your turn,
+    //       summon two 3/3 Ruffians that attack random enemies.
     // --------------------------------------------------------
     // GameTag:
     //  - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARRIOR
-    // [SCH_525] In Formation! - COST: 2
+    // [SCH_525] In Formation! - COST:2
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: Add 2 random <b>Taunt</b> minions to your hand.
@@ -1342,7 +1335,7 @@ void ScholomanceCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [SCH_621] Rattlegore - COST: 9 [ATK: 9/HP: 9]
+    // [SCH_621] Rattlegore - COST:9 [ATK:9/HP:9]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Resummon this with -1/-1.
@@ -1359,7 +1352,7 @@ void ScholomanceCardsGen::AddWarriorNonCollect(
     Power power;
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
-    // [SCH_237e] Athletic Studies - COST: 0
+    // [SCH_237e] Athletic Studies - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Your next <b>Rush</b> minion costs (1) less.
@@ -1369,14 +1362,14 @@ void ScholomanceCardsGen::AddWarriorNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
-    // [SCH_237e2] Studying Athletics - COST: 0
+    // [SCH_237e2] Studying Athletics - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Costs (1) less.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
-    // [SCH_238e] Reaping - COST: 0
+    // [SCH_238e] Reaping - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Damages minions next to whomever your hero attacks.
@@ -1386,19 +1379,19 @@ void ScholomanceCardsGen::AddWarriorNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [SCH_337t] Ruffian - COST: 3 [ATK: 3/HP: 3]
+    // [SCH_337t] Ruffian - COST:3 [ATK:3/HP:3]
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
-    // [SCH_425e] Sharpened - COST: 0
+    // [SCH_425e] Sharpened - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
-    // [SCH_526e] A Common Peasant - COST: 0
+    // [SCH_526e] A Common Peasant - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Health changed to 1.
@@ -1410,7 +1403,7 @@ void ScholomanceCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ----------------------------------- WEAPON - DEMONHUNTER
-    // [SCH_252] Marrowslicer - COST: 4
+    // [SCH_252] Marrowslicer - COST:4
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Shuffle 2 Soul Fragments into your deck.
@@ -1420,19 +1413,19 @@ void ScholomanceCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------ SPELL - DEMONHUNTER
-    // [SCH_253] Cycle of Hatred - COST: 7
+    // [SCH_253] Cycle of Hatred - COST:7
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Deal 3 damage to all minions. Summon a 3/3 Spirit for every minion
-    // killed.
+    // Text: Deal 3 damage to all minions. Summon a 3/3 Spirit
+    //       for every minion killed.
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [SCH_276] Magehunter - COST: 3 [ATK: 2/HP: 3]
+    // [SCH_276] Magehunter - COST:3 [ATK:2/HP:3]
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Rush</b>
-    //       Whenever this attacks a minion, <b>Silence</b> it.
+    // Text: <b>Rush</b> Whenever this attacks a minion,
+    //       <b>Silence</b> it.
     // --------------------------------------------------------
     // GameTag:
     //  - RUSH = 1
@@ -1443,21 +1436,21 @@ void ScholomanceCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------- WEAPON - DEMONHUNTER
-    // [SCH_279] Trueaim Crescent - COST: 1
+    // [SCH_279] Trueaim Crescent - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: After your Hero attacks a minion, your minions attack it too.
+    // Text: After your Hero attacks a minion,
+    //       your minions attack it too.
     // --------------------------------------------------------
     // GameTag:
     //  - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [SCH_354] Ancient Void Hound - COST: 9 [ATK: 10/HP: 10]
-    //  - Race: DEMON, Set: SCHOLOMANCE, Rarity: Epic
+    // [SCH_354] Ancient Void Hound - COST:9 [ATK:10/HP:10]
+    //  - Race: Demon, Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: At the end of your turn,
-    //       steal 1 Attack and Health
+    // Text: At the end of your turn, steal 1 Attack and Health
     //       from all enemy minions.
     // --------------------------------------------------------
     // GameTag:
@@ -1465,42 +1458,40 @@ void ScholomanceCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [SCH_355] Shardshatter Mystic - COST: 3 [ATK: 3/HP: 2]
+    // [SCH_355] Shardshatter Mystic - COST:3 [ATK:3/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Destroy a Soul Fragment in your deck to deal 3
-    // damage to all other minions.
+    // Text: <b>Battlecry:</b> Destroy a Soul Fragment
+    //       in your deck to deal 3 damage to all other minions.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // ------------------------------------ SPELL - DEMONHUNTER
-    // [SCH_356] Glide - COST: 4
+    // [SCH_356] Glide - COST:4
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Shuffle your hand into
-    //       your deck. Draw 4 cards.
-    //       <b>Outcast:</b> Your opponent
-    //       does the same.
+    // Text: Shuffle your hand into your deck. Draw 4 cards.
+    //       <b>Outcast:</b> Your opponent does the same.
     // --------------------------------------------------------
     // GameTag:
     //  - OUTCAST = 1
     // --------------------------------------------------------
 
     // ------------------------------------ SPELL - DEMONHUNTER
-    // [SCH_357] Fel Guardians - COST: 7
+    // [SCH_357] Fel Guardians - COST:7
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Summon three 1/2 Demons with <b>Taunt</b>. Costs (1) less whenever
-    // a friendly minion dies.
+    // Text: Summon three 1/2 Demons with <b>Taunt</b>.
+    //       Costs (1) less whenever a friendly minion dies.
     // --------------------------------------------------------
     // RefTag:
     //  - TAUNT = 1
     // --------------------------------------------------------
 
     // ------------------------------------ SPELL - DEMONHUNTER
-    // [SCH_422] Double Jump - COST: 1
+    // [SCH_422] Double Jump - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: Draw an <b>Outcast</b> card from your deck.
@@ -1510,7 +1501,7 @@ void ScholomanceCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [SCH_538] Ace Hunter Kreen - COST: 3 [ATK: 2/HP: 4]
+    // [SCH_538] Ace Hunter Kreen - COST:3 [ATK:2/HP:4]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: Your other characters are <b>Immune</b> while attacking.
@@ -1524,20 +1515,18 @@ void ScholomanceCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------ SPELL - DEMONHUNTER
-    // [SCH_600] Demon Companion - COST: 1
+    // [SCH_600] Demon Companion - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Summon a random Demon Companion.
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [SCH_603] Star Student Stelina - COST: 4 [ATK: 4/HP: 3]
+    // [SCH_603] Star Student Stelina - COST:4 [ATK:4/HP:3]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Outcast:</b> Look at 3 cards
-    //       in your opponent's hand.
-    //       Shuffle one of them
-    //       into their deck.
+    // Text: <b>Outcast:</b> Look at 3 cards in your opponent's hand.
+    //       Shuffle one of them into their deck.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -1545,28 +1534,26 @@ void ScholomanceCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [SCH_618] Blood Herald - COST: 5 [ATK: 1/HP: 1]
+    // [SCH_618] Blood Herald - COST:5 [ATK:1/HP:1]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Whenever a friendly minion dies while this is in your hand, gain
-    // +1/+1.
+    // Text: Whenever a friendly minion dies while
+    //       this is in your hand, gain +1/+1.
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [SCH_704] Soulshard Lapidary - COST: 5 [ATK: 5/HP: 5]
+    // [SCH_704] Soulshard Lapidary - COST:5 [ATK:5/HP:5]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Destroy a Soul
-    //       Fragment in your deck to
-    //       give your hero +5 Attack
-    //       this turn.
+    // Text: <b>Battlecry:</b> Destroy a Soul Fragment in your deck
+    //       to give your hero +5 Attack this turn.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [SCH_705] Vilefiend Trainer - COST: 4 [ATK: 5/HP: 4]
+    // [SCH_705] Vilefiend Trainer - COST:4 [ATK:5/HP:4]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Outcast:</b> Summon two 1/1 Demons.
@@ -1582,26 +1569,26 @@ void ScholomanceCardsGen::AddDemonHunterNonCollect(
     Power power;
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [SCH_253t] Spirit of Vengeance - COST: 3 [ATK: 3/HP: 3]
+    // [SCH_253t] Spirit of Vengeance - COST:3 [ATK:3/HP:3]
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
-    // [SCH_354e] Siphoned - COST: 0
+    // [SCH_354e] Siphoned - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Reduced Attack and Health.
     // --------------------------------------------------------
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
-    // [SCH_354e2] Void Siphon - COST: 0
+    // [SCH_354e2] Void Siphon - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Increased Attack and Health.
     // --------------------------------------------------------
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
-    // [SCH_354e2a] Void Siphon - COST: 0
+    // [SCH_354e2a] Void Siphon - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Increased Attack.
@@ -1611,7 +1598,7 @@ void ScholomanceCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
-    // [SCH_354e2b] Void Siphon - COST: 0
+    // [SCH_354e2b] Void Siphon - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Increased Health.
@@ -1621,7 +1608,7 @@ void ScholomanceCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
-    // [SCH_354ea] Siphoned - COST: 0
+    // [SCH_354ea] Siphoned - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Reduced Attack.
@@ -1631,7 +1618,7 @@ void ScholomanceCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
-    // [SCH_354eb] Siphoned - COST: 0
+    // [SCH_354eb] Siphoned - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Reduced Health.
@@ -1641,15 +1628,15 @@ void ScholomanceCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
-    // [SCH_357e] Soul Infused - COST: 0
+    // [SCH_357e] Soul Infused - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Costs less.
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [SCH_357t] Soulfed Felhound - COST: 1 [ATK: 1/HP: 2]
-    //  - Race: DEMON, Set: SCHOLOMANCE
+    // [SCH_357t] Soulfed Felhound - COST:1 [ATK:1/HP:2]
+    //  - Race: Demon, Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------
@@ -1658,8 +1645,8 @@ void ScholomanceCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [SCH_600t1] Reffuh - COST: 1 [ATK: 2/HP: 1]
-    //  - Race: DEMON, Set: SCHOLOMANCE
+    // [SCH_600t1] Reffuh - COST:1 [ATK:2/HP:1]
+    //  - Race: Demon, Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: <b>Charge</b>
     // --------------------------------------------------------
@@ -1668,8 +1655,8 @@ void ScholomanceCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [SCH_600t2] Shima - COST: 1 [ATK: 2/HP: 2]
-    //  - Race: DEMON, Set: SCHOLOMANCE
+    // [SCH_600t2] Shima - COST:1 [ATK:2/HP:2]
+    //  - Race: Demon, Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------
@@ -1678,8 +1665,8 @@ void ScholomanceCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [SCH_600t3] Kolek - COST: 1 [ATK: 1/HP: 2]
-    //  - Race: DEMON, Set: SCHOLOMANCE
+    // [SCH_600t3] Kolek - COST:1 [ATK:1/HP:2]
+    //  - Race: Demon, Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Your other minions have +1 Attack.
     // --------------------------------------------------------
@@ -1688,14 +1675,14 @@ void ScholomanceCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
-    // [SCH_702e] Felosophically Inclined - COST: 0
+    // [SCH_702e] Felosophically Inclined - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: +1/+1
     // --------------------------------------------------------
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
-    // [SCH_704e] Soul Rage - COST: 0
+    // [SCH_704e] Soul Rage - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: +5 Attack this turn.
@@ -1705,8 +1692,8 @@ void ScholomanceCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [SCH_705t] Snarling Vilefiend - COST: 1 [ATK: 1/HP: 1]
-    //  - Race: DEMON, Set: SCHOLOMANCE
+    // [SCH_705t] Snarling Vilefiend - COST:1 [ATK:1/HP:1]
+    //  - Race: Demon, Set: SCHOLOMANCE
     // --------------------------------------------------------
 }
 
@@ -1724,7 +1711,7 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     Power power;
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_142] Voracious Reader - COST: 2 [ATK: 1/HP: 3]
+    // [SCH_142] Voracious Reader - COST:2 [ATK:1/HP:3]
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
     // Text: At the end of your turn, draw until you have 3 cards.
@@ -1734,8 +1721,8 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_143] Divine Rager - COST: 4 [ATK: 5/HP: 1]
-    //  - Race: ELEMENTAL, Set: SCHOLOMANCE, Rarity: Common
+    // [SCH_143] Divine Rager - COST:4 [ATK:5/HP:1]
+    //  - Race: Elemental, Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Divine Shield</b>
     // --------------------------------------------------------
@@ -1744,15 +1731,16 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_145] Desk Imp - COST: 0 [ATK: 1/HP: 1]
-    //  - Race: DEMON, Set: SCHOLOMANCE, Rarity: Common
+    // [SCH_145] Desk Imp - COST:0 [ATK:1/HP:1]
+    //  - Race: Demon, Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_146] Robes of Protection - COST: 3 [ATK: 2/HP: 4]
+    // [SCH_146] Robes of Protection - COST:3 [ATK:2/HP:4]
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Your minions have "Can't be targeted by spells or Hero Powers."
+    // Text: Your minions have "Can't be targeted by spells
+    //       or Hero Powers."
     // --------------------------------------------------------
     // GameTag:
     //  - AURA = 1
@@ -1761,29 +1749,29 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_157] Enchanted Cauldron - COST: 3 [ATK: 1/HP: 6]
+    // [SCH_157] Enchanted Cauldron - COST:3 [ATK:1/HP:6]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b><b>Spellburst</b>:</b> Cast a random spell of the same Cost.
+    // Text: <b>Spellburst</b>:> Cast a random spell of the same Cost.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_160] Wandmaker - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_160] Wandmaker - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Add a 1-Cost spell from your class to your hand.
+    // Text: <b>Battlecry:</b> Add a 1-Cost spell
+    //       from your class to your hand.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_162] Vectus - COST: 5 [ATK: 4/HP: 4]
+    // [SCH_162] Vectus - COST:5 [ATK:4/HP:4]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Summon two
-    //       1/1 Whelps. Each gains a
-    //       <b>Deathrattle</b> from your minions
+    // Text: <b>Battlecry:</b> Summon two 1/1 Whelps.
+    //       Each gains a <b>Deathrattle</b> from your minions
     //       that died this game.
     // --------------------------------------------------------
     // GameTag:
@@ -1795,13 +1783,11 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_182] Speaker Gidra - COST: 3 [ATK: 1/HP: 4]
+    // [SCH_182] Speaker Gidra - COST:3 [ATK:1/HP:4]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b><b>Rush</b>, Windfury</b>
-    //       <b><b>Spellburst</b>:</b> Gain Attack
-    //       and Health equal to
-    //       the spell's Cost.
+    // Text: <b>Rush</b>, Windfury</b> <b>Spellburst</b>:
+    //       Gain Attack and Health equal to the spell's Cost.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -1810,27 +1796,29 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: This has different effects based on which game board you're on.
+    // Text: This has different effects based on
+    //       which game board you're on.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_224] Headmaster Kel'Thuzad - COST: 5 [ATK: 4/HP: 6]
+    // [SCH_224] Headmaster Kel'Thuzad - COST:5 [ATK:4/HP:6]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Spellburst:</b> If the spell destroys any minions, summon them.
+    // Text: <b>Spellburst:</b> If the spell destroys any minions,
+    //       summon them.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_230] Onyx Magescribe - COST: 6 [ATK: 4/HP: 9]
-    //  - Race: DRAGON, Set: SCHOLOMANCE, Rarity: Common
+    // [SCH_230] Onyx Magescribe - COST:6 [ATK:4/HP:9]
+    //  - Race: Dragon, Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Spellburst:</b> Add 2 random spells from your class to your
-    // hand.
+    // Text: <b>Spellburst:</b> Add 2 random spells
+    //       from your class to your hand.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
@@ -1848,8 +1836,8 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("SCH_231", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_232] Crimson Hothead - COST: 4 [ATK: 3/HP: 6]
-    //  - Race: DRAGON, Set: SCHOLOMANCE, Rarity: Common
+    // [SCH_232] Crimson Hothead - COST:4 [ATK:3/HP:6]
+    //  - Race: Dragon, Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Spellburst:</b> Gain +1 Attack and <b>Taunt</b>.
     // --------------------------------------------------------
@@ -1858,18 +1846,16 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [SCH_235] Devolving Missiles - COST: 1
+    // [SCH_235] Devolving Missiles - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: Shoot three missiles
-    //       at random enemy minions
-    //       that transform them into
-    //       ones that cost (1) less.
+    // Text: Shoot three missiles at random enemy minions
+    //       that transform them into ones that cost (1) less.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_245] Steward of Scrolls - COST: 5 [ATK: 4/HP: 4]
-    //  - Race: ELEMENTAL, Set: SCHOLOMANCE, Rarity: Common
+    // [SCH_245] Steward of Scrolls - COST:5 [ATK:4/HP:4]
+    //  - Race: Elemental, Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Spell Damage +1</b>
     //       <b>Battlecry:</b> <b>Discover</b> a spell.
@@ -1881,24 +1867,22 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_248] Pen Flinger - COST: 1 [ATK: 1/HP: 1]
+    // [SCH_248] Pen Flinger - COST:1 [ATK:1/HP:1]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Deal 1 damage. <b>Spellburst:</b> Return this
-    // to your hand.
+    // Text: <b>Battlecry:</b> Deal 1 damage.
+    //       <b>Spellburst:</b> Return this to your hand.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // --------------------------------------- WEAPON - NEUTRAL
-    // [SCH_259] Sphere of Sapience - COST: 1
+    // [SCH_259] Sphere of Sapience - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: At the start of your turn,
-    //       look at your top card. You
-    //       can put it on the bottom
-    //        and lose 1 Durability.
+    // Text: At the start of your turn, look at your top card.
+    //       You can put it on the bottom and lose 1 Durability.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -1906,11 +1890,11 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [SCH_270] Primordial Studies - COST: 1
+    // [SCH_270] Primordial Studies - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Discover</b> a <b>Spell Damage</b> minion. Your next one costs
-    // (1) less.
+    // Text: <b>Discover</b> a <b>Spell Damage</b> minion.
+    //       Your next one costs (1) less.
     // --------------------------------------------------------
     // GameTag:
     //  - DISCOVER = 1
@@ -1920,12 +1904,11 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_273] Ras Frostwhisper - COST: 5 [ATK: 3/HP: 6]
+    // [SCH_273] Ras Frostwhisper - COST:5 [ATK:3/HP:6]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: At the end of your turn,
-    //       deal 1 damage to all enemies <i>(improved by <b>Spell
-    //       Damage</b>)</i>.
+    // Text: At the end of your turn, deal 1 damage
+    //       to all enemies (improved by <b>Spell Damage</b>).
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -1936,18 +1919,18 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_283] Manafeeder Panthara - COST: 2 [ATK: 2/HP: 3]
-    //  - Race: BEAST, Set: SCHOLOMANCE, Rarity: Common
+    // [SCH_283] Manafeeder Panthara - COST:2 [ATK:2/HP:3]
+    //  - Race: Beast, Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> If you've used your Hero Power this turn, draw a
-    // card.
+    // Text: <b>Battlecry:</b> If you've used your Hero Power
+    //       this turn, draw a card.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_311] Animated Broomstick - COST: 1 [ATK: 1/HP: 1]
+    // [SCH_311] Animated Broomstick - COST:1 [ATK:1/HP:1]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -1959,7 +1942,7 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_312] Tour Guide - COST: 1 [ATK: 1/HP: 1]
+    // [SCH_312] Tour Guide - COST:1 [ATK:1/HP:1]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Your next Hero Power costs (0).
@@ -1969,14 +1952,14 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_313] Wretched Tutor - COST: 4 [ATK: 2/HP: 5]
+    // [SCH_313] Wretched Tutor - COST:4 [ATK:2/HP:5]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Spellburst:</b> Deal 2 damage to all other minions.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_350] Wand Thief - COST: 1 [ATK: 1/HP: 2]
+    // [SCH_350] Wand Thief - COST:1 [ATK:1/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Combo:</b> <b>Discover</b> a Mage spell.
@@ -1987,13 +1970,11 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_351] Jandice Barov - COST: 5 [ATK: 2/HP: 1]
+    // [SCH_351] Jandice Barov - COST:5 [ATK:2/HP:1]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Summon two
-    //       random 5-Cost minions.
-    //       Secretly pick one that dies
-    //        when it takes damage.
+    // Text: <b>Battlecry:</b> Summon two random 5-Cost minions.
+    //       Secretly pick one that dies when it takes damage.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -2001,14 +1982,15 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [SCH_352] Potion of Illusion - COST: 4
+    // [SCH_352] Potion of Illusion - COST:4
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: Add 1/1 copies of your minions to your hand. They cost (1).
+    // Text: Add 1/1 copies of your minions to your hand.
+    //       They cost (1).
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_425] Doctor Krastinov - COST: 5 [ATK: 4/HP: 4]
+    // [SCH_425] Doctor Krastinov - COST:5 [ATK:4/HP:4]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -2021,12 +2003,11 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_428] Lorekeeper Polkelt - COST: 4 [ATK: 4/HP: 5]
+    // [SCH_428] Lorekeeper Polkelt - COST:4 [ATK:4/HP:5]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Reorder your deck
-    //       from the highest Cost card
-    //       to the lowest Cost card.
+    // Text: <b>Battlecry:</b> Reorder your deck from the highest
+    //       Cost card to the lowest Cost card.
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -2034,10 +2015,11 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [SCH_509] Brain Freeze - COST: 1
+    // [SCH_509] Brain Freeze - COST:1
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Freeze</b> a minion. <b>Combo:</b> Also deal 3 damage to it.
+    // Text: <b>Freeze</b> a minion.
+    //       <b>Combo:</b> Also deal 3 damage to it.
     // --------------------------------------------------------
     // GameTag:
     //  - COMBO = 1
@@ -2047,33 +2029,33 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [SCH_521] Coerce - COST: 3
+    // [SCH_521] Coerce - COST:3
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Destroy a damaged minion. <b>Combo:</b> Destroy any minion.
+    // Text: Destroy a damaged minion.
+    //       <b>Combo:</b> Destroy any minion.
     // --------------------------------------------------------
     // GameTag:
     //  - COMBO = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_522] Steeldancer - COST: 4 [ATK: 4/HP: 4]
+    // [SCH_522] Steeldancer - COST:4 [ATK:4/HP:4]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Summon a random
-    //       minion with Cost equal to
-    //       your weapon's Attack.
+    // Text: <b>Battlecry:</b> Summon a random minion with Cost
+    //       equal to your weapon's Attack.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_530] Sorcerous Substitute - COST: 6 [ATK: 6/HP: 6]
+    // [SCH_530] Sorcerous Substitute - COST:6 [ATK:6/HP:6]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> If you have <b>Spell Damage</b>, summon a copy of
-    // this.
+    // Text: <b>Battlecry:</b> If you have <b>Spell Damage</b>,
+    //       summon a copy of this.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -2083,39 +2065,37 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_537] Trick Totem - COST: 2 [ATK: 0/HP: 3]
+    // [SCH_537] Trick Totem - COST:2 [ATK:0/HP:3]
     //  - Race: TOTEM, Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: At the end of your turn, cast a random spell that costs (3) or
-    // less.
+    // Text: At the end of your turn,
+    //       cast a random spell that costs (3) or less.
     // --------------------------------------------------------
     // GameTag:
     //  - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_605] Lake Thresher - COST: 5 [ATK: 4/HP: 6]
-    //  - Race: BEAST, Set: SCHOLOMANCE, Rarity: Common
+    // [SCH_605] Lake Thresher - COST:5 [ATK:4/HP:6]
+    //  - Race: Beast, Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: Also damages the minions next to whomever
     //       this attacks.
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [SCH_623] Cutting Class - COST: 5
+    // [SCH_623] Cutting Class - COST:5
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Draw 2 cards.
-    //       Costs (1) less per Attack
-    //       of your weapon.
+    // Text: Draw 2 cards. Costs (1) less per Attack of your weapon.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_707] Fishy Flyer - COST: 4 [ATK: 4/HP: 3]
-    //  - Race: MURLOC, Set: SCHOLOMANCE, Rarity: Common
+    // [SCH_707] Fishy Flyer - COST:4 [ATK:4/HP:3]
+    //  - Race: Murloc, Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Rush</b>. <b>Deathrattle:</b> Add a 4/3 Ghost with <b>Rush</b>
-    // to your hand.
+    // Text: <b>Rush</b>. <b>Deathrattle:</b> Add a 4/3 Ghost
+    //       with <b>Rush</b> to your hand.
     // --------------------------------------------------------
     // GameTag:
     //  - DEATHRATTLE = 1
@@ -2127,11 +2107,11 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("SCH_707", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_708] Sneaky Delinquent - COST: 2 [ATK: 3/HP: 1]
+    // [SCH_708] Sneaky Delinquent - COST:2 [ATK:3/HP:1]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Stealth</b>. <b>Deathrattle:</b> Add a 3/1 Ghost with
-    // <b>Stealth</b> to your hand.
+    // Text: <b>Stealth</b>. <b>Deathrattle:</b> Add a 3/1 Ghost
+    //       with <b>Stealth</b> to your hand.
     // --------------------------------------------------------
     // GameTag:
     //  - DEATHRATTLE = 1
@@ -2143,11 +2123,11 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("SCH_708", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_709] Smug Senior - COST: 6 [ATK: 5/HP: 7]
+    // [SCH_709] Smug Senior - COST:6 [ATK:5/HP:7]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>. <b>Deathrattle:</b> Add a 5/7 Ghost with <b>Taunt</b>
-    // to your hand.
+    // Text: <b>Taunt</b>. <b>Deathrattle:</b> Add a 5/7 Ghost
+    //       with <b>Taunt</b> to your hand.
     // --------------------------------------------------------
     // GameTag:
     //  - DEATHRATTLE = 1
@@ -2159,12 +2139,11 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("SCH_709", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_710] Ogremancer - COST: 5 [ATK: 3/HP: 7]
+    // [SCH_710] Ogremancer - COST:5 [ATK:3/HP:7]
     //  - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Whenever your opponent
-    //       casts a spell, summon a 2/2
-    //       Skeleton with <b>Taunt</b>.
+    // Text: Whenever your opponent casts a spell,
+    //       summon a 2/2 Skeleton with <b>Taunt</b>.
     // --------------------------------------------------------
     // GameTag:
     //  - TRIGGER_VISUAL = 1
@@ -2180,8 +2159,8 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("SCH_710", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_711] Plagued Protodrake - COST: 8 [ATK: 8/HP: 8]
-    //  - Race: DRAGON, Set: SCHOLOMANCE, Rarity: Common
+    // [SCH_711] Plagued Protodrake - COST:8 [ATK:8/HP:8]
+    //  - Race: Dragon, Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Summon a random 7-Cost minion.
     // --------------------------------------------------------
@@ -2195,23 +2174,22 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("SCH_711", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_713] Cult Neophyte - COST: 2 [ATK: 3/HP: 2]
+    // [SCH_713] Cult Neophyte - COST:2 [ATK:3/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Your opponent's spells cost (1) more next turn.
+    // Text: <b>Battlecry:</b> Your opponent's spells cost (1)
+    //       more next turn.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_714] Educated Elekk - COST: 3 [ATK: 3/HP: 4]
-    //  - Race: BEAST, Set: SCHOLOMANCE, Rarity: Epic
+    // [SCH_714] Educated Elekk - COST:3 [ATK:3/HP:4]
+    //  - Race: Beast, Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: Whenever a spell is played,
-    //       this minion remembers it.
-    //       <b>Deathrattle:</b> Shuffle the
-    //       spells into your deck.
+    // Text: Whenever a spell is played, this minion remembers it.
+    //       <b>Deathrattle:</b> Shuffle the spells into your deck.
     // --------------------------------------------------------
     // GameTag:
     //  - DEATHRATTLE = 1
@@ -2219,12 +2197,11 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_717] Keymaster Alabaster - COST: 7 [ATK: 6/HP: 8]
+    // [SCH_717] Keymaster Alabaster - COST:7 [ATK:6/HP:8]
     //  - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: Whenever your opponent
-    //        draws a card, add a copy to
-    //        your hand that costs (1).
+    // Text: Whenever your opponent draws a card,
+    //       add a copy to your hand that costs (1).
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -2238,7 +2215,7 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     Power power;
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_146e] Protected - COST: 0
+    // [SCH_146e] Protected - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Can't be targeted by spells or Hero Powers.
@@ -2249,29 +2226,29 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_158e2] Studying Demons - COST: 0
+    // [SCH_158e2] Studying Demons - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Costs (1) less.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_162e] Experimental Plague - COST: 0
+    // [SCH_162e] Experimental Plague - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Copied <b>Deathrattle</b> from {0}.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_162t] Plagued Hatchling - COST: 1 [ATK: 1/HP: 1]
-    //  - Race: DRAGON, Set: SCHOLOMANCE
+    // [SCH_162t] Plagued Hatchling - COST:1 [ATK:1/HP:1]
+    //  - Race: Dragon, Set: SCHOLOMANCE
     // --------------------------------------------------------
     // RefTag:
     //  - DEATHRATTLE = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Divine Shield</b>
@@ -2281,28 +2258,29 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t10] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t10] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Spend all your Mana. Summon a random minion of
-    // that Cost.
+    // Text: <b>Battlecry:</b> Spend all your Mana.
+    //       Summon a random minion of that Cost.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t11] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t11] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Add a <b>Karazhan</b> Portal spell to your hand.
+    // Text: <b>Battlecry:</b> Add a <b>Karazhan</b> Portal spell
+    //       to your hand.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t12] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t12] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give a random minion in your hand +2/+2.
@@ -2312,14 +2290,14 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_199t12e] Supplies from Gadgetzan - COST: 0
+    // [SCH_199t12e] Supplies from Gadgetzan - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t13] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t13] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> <b>Adapt</b>.
@@ -2332,22 +2310,22 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t14] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t14] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Add a random
-    //       <b>Death Knight</b> card to
-    //       your hand.
+    //       <b>Death Knight</b> card to your hand.
     // --------------------------------------------------------
     // GameTag:
     //  - DEATHRATTLE = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t15] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t15] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> <b>Recruit</b> a minion that costs (2) or less.
+    // Text: <b>Battlecry:</b> <b>Recruit</b> a minion that
+    //       costs (2) or less.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -2357,7 +2335,7 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t16] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t16] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Echo</b>
@@ -2369,12 +2347,11 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t17] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t17] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>. <b>Battlecry:</b> If you
-    //       have 10 Mana Crystals,
-    //       gain +5/+5.
+    // Text: <b>Taunt</b>. <b>Battlecry:</b>
+    //       If you have 10 Mana Crystals, gain +5/+5.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -2382,14 +2359,14 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_199t17e] Omega Transfer - COST: 0
+    // [SCH_199t17e] Omega Transfer - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: +5/+5.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t18] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t18] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -2401,7 +2378,7 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t19] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t19] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Add a <b>Lackey</b> to your hand.
@@ -2411,7 +2388,7 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t2] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t2] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Deal 2 damage.
@@ -2421,7 +2398,7 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t20] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t20] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Reborn</b>
@@ -2431,7 +2408,7 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t21] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t21] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> <b>Discover</b> a Dragon.
@@ -2442,17 +2419,15 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t22] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t22] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Dormant</b> for 2 turns.
-    //       When this awakens, deal
-    //       3 damage to two random
-    //       enemy minions.
+    // Text: <b>Dormant</b> for 2 turns. When this awakens,
+    //       deal 3 damage to two random enemy minions.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t23] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t23] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Add a Dual Class card to your hand.
@@ -2462,7 +2437,7 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t24] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t24] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Add a random weapon to your hand.
@@ -2472,17 +2447,18 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t25] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t25] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Add an <b>Uldum</b> Plague spell to your hand.
+    // Text: <b>Battlecry:</b> Add an <b>Uldum</b> Plague spell
+    //       to your hand.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t3] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t3] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give a friendly minion +1/+2.
@@ -2492,14 +2468,14 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_199t3e] Mark of the Pandaren - COST: 0
+    // [SCH_199t3e] Mark of the Pandaren - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: +1/+2.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t4] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t4] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Stealth</b>
@@ -2511,22 +2487,22 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t5] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t5] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Deathrattle:</b> Add a random <b>Deathrattle</b> minion to
-    // your hand.
+    // Text: <b>Deathrattle:</b> Add a random <b>Deathrattle</b>
+    //       minion to your hand.
     // --------------------------------------------------------
     // GameTag:
     //  - DEATHRATTLE = 1
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t6] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t6] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Battlecry and Deathrattle:</b> Add a <b>Spare Part</b> card to
-    // your hand.
+    // Text: <b>Battlecry and Deathrattle:</b> Add a
+    //       <b>Spare Part</b> card to your hand.
     // --------------------------------------------------------
     // GameTag:
     //  - BATTLECRY = 1
@@ -2537,25 +2513,25 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t7] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t7] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: At the end of your turn, reduce the Cost of a random card in your
-    // hand by (2).
+    // Text: At the end of your turn, reduce the Cost of
+    //       a random card in your hand by (2).
     // --------------------------------------------------------
     // GameTag:
     //  - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_199t7e] Transfer of Power - COST: 0
+    // [SCH_199t7e] Transfer of Power - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Costs (2) less.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t8] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t8] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Inspire:</b> Draw a card.
@@ -2565,7 +2541,7 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_199t9] Transfer Student - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_199t9] Transfer Student - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> <b>Discover</b> a new basic Hero Power.
@@ -2576,13 +2552,13 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_224e3] Kel'thuzad's Call - COST: 0
+    // [SCH_224e3] Kel'thuzad's Call - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_224t] Mr. Bigglesworth - COST: 0 [ATK: 1/HP: 1]
-    //  - Race: BEAST, Set: SCHOLOMANCE
+    // [SCH_224t] Mr. Bigglesworth - COST:0 [ATK:1/HP:1]
+    //  - Race: Beast, Set: SCHOLOMANCE
     // --------------------------------------------------------
     // GameTag:
     //  - ELITE = 1
@@ -2599,21 +2575,21 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     cards.emplace("SCH_231e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_232e] Fired Up - COST: 0
+    // [SCH_232e] Fired Up - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: +1 Attack and <b>Taunt</b>.
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [SCH_259t] A New Fate - COST: 0
+    // [SCH_259t] A New Fate - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Draw a different card.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_270e] Runic Studies - COST: 0
+    // [SCH_270e] Runic Studies - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Your next <b>Spell Damage</b> minion costs (1) less.
@@ -2623,14 +2599,14 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_270e2] Studying Runes - COST: 0
+    // [SCH_270e2] Studying Runes - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Costs (1) less.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_300e] Carrion Studies - COST: 0
+    // [SCH_300e] Carrion Studies - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Your next <b>Deathrattle</b> minion costs (1) less.
@@ -2640,14 +2616,14 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_300e2] Studying Carrion - COST: 0
+    // [SCH_300e2] Studying Carrion - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Costs (1) less.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_301e] Runic Power - COST: 0
+    // [SCH_301e] Runic Power - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: You have <b>Spell Damage +1</b> this turn.
@@ -2657,51 +2633,51 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [SCH_305d] Secret Passage Dummy - COST: 0
+    // [SCH_305d] Secret Passage Dummy - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Dummy Hook Up SCH 305e3
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_312e] School Tour - COST: 0
+    // [SCH_312e] School Tour - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Your Hero Power costs (0).
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_351a] This is an Illusion. - COST: 0
+    // [SCH_351a] This is an Illusion. - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_351b] This is not an Illusion. - COST: 0
+    // [SCH_351b] This is not an Illusion. - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_519e] Akunda's Bite - COST: 0
+    // [SCH_519e] Akunda's Bite - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: +2 Attack.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_524e] Shield of Honor - COST: 0
+    // [SCH_524e] Shield of Honor - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: +3 Attack and <b>Divine Shield</b>.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_539e] Professor's Poison - COST: 0
+    // [SCH_539e] Professor's Poison - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_707t] Spectral Flyer - COST: 4 [ATK: 4/HP: 3]
-    //  - Race: MURLOC, Set: SCHOLOMANCE
+    // [SCH_707t] Spectral Flyer - COST:4 [ATK:4/HP:3]
+    //  - Race: Murloc, Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: <b>Rush</b>
     // --------------------------------------------------------
@@ -2713,7 +2689,7 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     cards.emplace("SCH_707t", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_708t] Spectral Delinquent - COST: 2 [ATK: 3/HP: 1]
+    // [SCH_708t] Spectral Delinquent - COST:2 [ATK:3/HP:1]
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: <b>Stealth</b>
@@ -2726,7 +2702,7 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     cards.emplace("SCH_708t", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_709t] Spectral Senior - COST: 6 [ATK: 5/HP: 7]
+    // [SCH_709t] Spectral Senior - COST:6 [ATK:5/HP:7]
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -2739,7 +2715,7 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     cards.emplace("SCH_709t", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_710t] Risen Skeleton - COST: 2 [ATK: 2/HP: 2]
+    // [SCH_710t] Risen Skeleton - COST:2 [ATK:2/HP:2]
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -2752,7 +2728,7 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     cards.emplace("SCH_710t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_713e] Spoiled! - COST: 0
+    // [SCH_713e] Spoiled! - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Your spells cost (1) more this turn.
@@ -2762,14 +2738,14 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_713e2] Spoiling - COST: 0
+    // [SCH_713e2] Spoiling - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Costs (1) more.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [SCH_714e] Educated - COST: 0
+    // [SCH_714e] Educated - COST:0
     //  - Set: SCHOLOMANCE
     // --------------------------------------------------------
     // Text: Remembering spell.

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -1083,11 +1083,11 @@ TEST_CASE("[Demon Hunter : Minion] - BT_509 : Fel Summoner")
 
     const auto card1 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Fel Summoner"));
-    const auto card2 =
+    [[maybe_unused]] const auto card2 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Battlefiend"));
-    const auto card3 =
+    [[maybe_unused]] const auto card3 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Ur'zul Horror"));
-    const auto card4 =
+    [[maybe_unused]] const auto card4 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
     const auto card5 =
         Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -60,13 +60,66 @@ TEST_CASE("[Druid : Spell] - BT_130 : Overgrowth")
 }
 
 // ----------------------------------------- MINION - DRUID
-// [BT_136] Archspore Msshi'fn - COST: 3 [ATK: 3/HP: 4]
+// [BT_131] Ysiel Windsinger - COST:9 [ATK:5/HP:5]
+// - Set: BLACK_TEMPLE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: Your spells cost (1).
+// --------------------------------------------------------
+// GameTag:
+//  - ELITE = 1
+//  - AURA = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - BT_131 : Ysiel Windsinger")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ysiel Windsinger"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Moonfire"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Silence"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(card2->GetCost(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
+    CHECK_EQ(card2->GetCost(), 0);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 10);
+}
+
+// ----------------------------------------- MINION - DRUID
+// [BT_136] Archspore Msshi'fn - COST:3 [ATK:3/HP:4]
 //  - Set: BLACK_TEMPLE, Rarity: Legendary
 // --------------------------------------------------------
-// Text: <b>Taunt</b>
-//       <b>Deathrattle:</b> Shuffle
-//       'Msshi'fn Prime'
-//       into your deck.
+// Text: <b>Taunt</b> <b>Deathrattle:</b> Shuffle
+//       'Msshi'fn Prime' into your deck.
 // --------------------------------------------------------
 // GameTag:
 //  - ELITE = 1
@@ -152,63 +205,8 @@ TEST_CASE("[Druid : Minion] - BT_136 : Archspore Msshi'fn")
     CHECK_EQ(curField[3]->GetHealth(), 9);
 }
 
-// ----------------------------------------- MINION - DRUID
-// [BT_131] Ysiel Windsinger - COST: 9 [ATK: 5/HP: 5]
-// - Set: BLACK_TEMPLE, Rarity: Legendary
-// --------------------------------------------------------
-// Text: Your spells cost (1).
-// --------------------------------------------------------
-// GameTag:
-//  - ELITE = 1
-//  - AURA = 1
-// --------------------------------------------------------
-TEST_CASE("[Druid : Minion] - BT_131 : Ysiel Windsinger")
-{
-    GameConfig config;
-    config.player1Class = CardClass::DRUID;
-    config.player2Class = CardClass::MAGE;
-    config.startPlayer = PlayerType::PLAYER1;
-    config.doFillDecks = true;
-    config.autoRun = false;
-
-    Game game(config);
-    game.Start();
-    game.ProcessUntil(Step::MAIN_ACTION);
-
-    Player* curPlayer = game.GetCurrentPlayer();
-    Player* opPlayer = game.GetOpponentPlayer();
-
-    curPlayer->SetTotalMana(10);
-    curPlayer->SetUsedMana(0);
-    opPlayer->SetTotalMana(10);
-    opPlayer->SetUsedMana(0);
-
-    const auto card1 =
-        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ysiel Windsinger"));
-    const auto card2 =
-        Generic::DrawCard(curPlayer, Cards::FindCardByName("Moonfire"));
-    const auto card3 =
-        Generic::DrawCard(opPlayer, Cards::FindCardByName("Silence"));
-
-    game.Process(curPlayer, PlayCardTask::Minion(card1));
-    CHECK_EQ(card2->GetCost(), 1);
-
-    game.Process(curPlayer, EndTurnTask());
-    game.ProcessUntil(Step::MAIN_ACTION);
-
-    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
-    CHECK_EQ(card2->GetCost(), 0);
-
-    game.Process(opPlayer, EndTurnTask());
-    game.ProcessUntil(Step::MAIN_ACTION);
-
-    game.Process(curPlayer,
-                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
-    CHECK_EQ(curPlayer->GetRemainingMana(), 10);
-}
-
 // ------------------------------------------ MINION - MAGE
-// [BT_014] Starscryer - COST: 2 [ATK: 3/HP: 1]
+// [BT_014] Starscryer - COST:2 [ATK:3/HP:1]
 //  - Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Deathrattle:</b> Draw a spell.
@@ -270,7 +268,7 @@ TEST_CASE("[Mage : Minion] - BT_014 : Starscryer")
 }
 
 // ------------------------------------------- SPELL - MAGE
-// [BT_072] Deep Freeze - COST: 8
+// [BT_072] Deep Freeze - COST:8
 //  - Set: BLACK_TEMPLE, Rarity: Rare
 // --------------------------------------------------------
 // Text: <b>Freeze</b> an enemy. Summon two 3/6 Water Elementals.
@@ -320,10 +318,11 @@ TEST_CASE("[Mage : Speel] - BT_072 : Deep Freeze")
 }
 
 // ---------------------------------------- SPELL - PALADIN
-// [BT_011] Libram of Justice - COST: 5
+// [BT_011] Libram of Justice - COST:5
 //  - Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------
-// Text: Equip a 1/4 weapon. Change the Health of all enemy minions to 1.
+// Text: Equip a 1/4 weapon.
+//       Change the Health of all enemy minions to 1.
 // --------------------------------------------------------
 TEST_CASE("[Paladin : Speel] - BT_011 : Libram of Justice")
 {
@@ -373,11 +372,11 @@ TEST_CASE("[Paladin : Speel] - BT_011 : Libram of Justice")
 }
 
 // ---------------------------------------- SPELL - PALADIN
-// [BT_024] Libram of Hope - COST: 9
+// [BT_024] Libram of Hope - COST:9
 //  - Set: BLACK_TEMPLE, Rarity: Epic
 // --------------------------------------------------------
-// Text: Restore 8 Health. Summon an 8/8 Guardian with <b>Taunt</b>
-// and <b>Divine Shield</b>.
+// Text: Restore 8 Health. Summon an 8/8 Guardian
+//       with <b>Taunt</b> and <b>Divine Shield</b>.
 // --------------------------------------------------------
 // RefTag:
 //  - DIVINE_SHIELD = 1
@@ -421,7 +420,7 @@ TEST_CASE("[Paladin : Spell] - BT_024 : Libram of Hope")
 }
 
 // ----------------------------------------- SPELL - PRIEST
-// [BT_252] Renew - COST: 1
+// [BT_252] Renew - COST:1
 //  - Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------
 // Text: Restore 3 Health. <b>Discover</b> a spell.
@@ -468,7 +467,7 @@ TEST_CASE("[Preist : Spell] - BT_252 : Renew")
 }
 
 // ----------------------------------------- SPELL - PRIEST
-// [BT_253] Psyche Split - COST: 5
+// [BT_253] Psyche Split - COST:5
 //  - Set: BLACK_TEMPLE, Rarity: Rare
 // --------------------------------------------------------
 // Text: Give a minion +1/+2. Summon a copy of it.
@@ -514,7 +513,7 @@ TEST_CASE("[Preist : Spell] - BT_253 : Psyche Split")
 }
 
 // ----------------------------------------- SPELL - PRIEST
-// [BT_257] Apotheosis - COST: 3
+// [BT_257] Apotheosis - COST:3
 //  - Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------
 // Text: Give a minion +2/+3 and <b>Lifesteal</b>.
@@ -564,8 +563,7 @@ TEST_CASE("[Preist : Spell] - BT_257 : Apotheosis")
 // [BT_258] Imprisoned Homunculus - COST:1 [ATK:2/HP:5]
 // - Race: Demon, Set: Black Temple, Rarity: Common
 // --------------------------------------------------------
-// Text: <b>Dormant</b> for 2 turns.
-//       <b>Taunt</b>
+// Text: <b>Dormant</b> for 2 turns. <b>Taunt</b>
 // --------------------------------------------------------
 // GameTag:
 // - TAUNT = 1
@@ -635,7 +633,7 @@ TEST_CASE("[Priest : Minion] - BT_258 : Imprisoned Homunculus")
 }
 
 // ----------------------------------------- MINION - ROGUE
-// [BT_703] Cursed Vagrant - COST: 7 [ATK: 7/HP: 5]
+// [BT_703] Cursed Vagrant - COST:7 [ATK:7/HP:5]
 //  - Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Deathrattle:</b> Summon a 7/5 Shadow with <b>Stealth</b>.
@@ -689,12 +687,10 @@ TEST_CASE("[Rogue : Minion] - BT_703 : Cursed Vagrant")
 }
 
 // ----------------------------------------- SPELL - SHAMAN
-// [BT_100] Serpentshrine Portal - COST: 3
+// [BT_100] Serpentshrine Portal - COST:3
 //  - Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------
-// Text: Deal 3 damage.
-//       Summon a random
-//       3-Cost minion.
+// Text: Deal 3 damage. Summon a random 3-Cost minion.
 //       <b>Overload:</b> (1)
 // --------------------------------------------------------
 // GameTag:
@@ -746,11 +742,10 @@ TEST_CASE("[Shaman : Spell] - BT_100 : Serpentshrine Portal")
 }
 
 // --------------------------------------- MINION - WARLOCK
-// [BT_304] Enhanced Dreadlord - COST: 8 [ATK: 5/HP: 7]
-//  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Rare
+// [BT_304] Enhanced Dreadlord - COST:8 [ATK:5/HP:7]
+//  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Rare
 // --------------------------------------------------------
-// Text: <b>Taunt</b>
-//       <b>Deathrattle:</b> Summon a 5/5
+// Text: <b>Taunt</b> <b>Deathrattle:</b> Summon a 5/5
 //       Dreadlord with <b>Lifesteal</b>.
 // --------------------------------------------------------
 // GameTag:
@@ -808,7 +803,7 @@ TEST_CASE("[Warlock : Minion] - BT_304 : Enhanced Dreadlord")
 }
 
 // ---------------------------------------- SPELL - WARRIOR
-// [BT_117] Bladestorm - COST: 3
+// [BT_117] Bladestorm - COST:3
 //  - Set: BLACK_TEMPLE, Rarity: Epic
 // --------------------------------------------------------
 // Text: Deal 1 damage to all minions. Repeat until one dies.
@@ -852,7 +847,7 @@ TEST_CASE("[Warrior : Spell] - BT_117 : Bladestorm")
 }
 
 // --------------------------------------- MINION - WARRIOR
-// [BT_120] Warmaul Challenger - COST: 3 [ATK: 1/HP: 10]
+// [BT_120] Warmaul Challenger - COST:3 [ATK:1/HP:10]
 //  - Set: BLACK_TEMPLE, Rarity: Epic
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Choose an enemy minion.
@@ -908,14 +903,12 @@ TEST_CASE("[Warrior : Minion] - BT_120 : Warmaul Challenger")
     CHECK_EQ(opField.GetCount(), 0);
 }
 
-// ----------------------------------------- MINION - WARRIOR
+// --------------------------------------- MINION - WARRIOR
 // [BT_123] Kargath Bladefist - COST:4 [ATK:4/HP:4]
 // - Set: BLACK_TEMPLE, Rarity: LEGENDARY
 // --------------------------------------------------------
-// Text: <b>Rush</b>
-//       <b>Deathrattle:</b> Shuffle
-//       'Kargath Prime'
-//       into your deck.
+// Text: <b>Rush</b> <b>Deathrattle:</b> Shuffle
+//       'Kargath Prime' into your deck.
 // --------------------------------------------------------
 // GameTag:
 // - ELITE = 1
@@ -1004,12 +997,11 @@ TEST_CASE("[Warrior : Minion] - BT_123 : Kargath Bladefist")
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 20);
 }
 
-// ----------------------------------------- SPELL - WARRIOR
+// ---------------------------------------- SPELL - WARRIOR
 // [BT_124] Corsair Cache - COST:2
 // - Set: BLACK_TEMPLE, Rarity: Rare
 // --------------------------------------------------------
-// Text: Draw a weapon.
-//       Give it +1 Durability.
+// Text: Draw a weapon. Give it +1 Durability.
 // --------------------------------------------------------
 TEST_CASE("[Warrior : Spell] - BT_124 : Corsair Cache")
 {
@@ -1050,10 +1042,10 @@ TEST_CASE("[Warrior : Spell] - BT_124 : Corsair Cache")
 }
 
 // ----------------------------------- MINION - DEMONHUNTER
-// [BT_509] Fel Summoner - COST: 6 [ATK: 8/HP: 3]
+// [BT_509] Fel Summoner - COST:6 [ATK:8/HP:3]
 //  - Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------
-// Text: <b>Deathrattle:</b> Summon a random Demon from your hand.
+// Text: <b>Deathrattle:</b> Summon a random Demon from your hand.
 // --------------------------------------------------------
 // GameTag:
 //  - DEATHRATTLE = 1
@@ -1104,12 +1096,11 @@ TEST_CASE("[Demon Hunter : Minion] - BT_509 : Fel Summoner")
 }
 
 // ----------------------------------- MINION - DEMONHUNTER
-// [BT_761] Coilfang Warlord - COST: 8 [ATK: 9/HP: 5]
+// [BT_761] Coilfang Warlord - COST:8 [ATK:9/HP:5]
 //  - Set: BLACK_TEMPLE, Rarity: Rare
 // --------------------------------------------------------
-// Text: <b>Rush</b>
-//       <b>Deathrattle:</b> Summon a
-//        5/9 Warlord with <b>Taunt</b>.
+// Text: <b>Rush</b> <b>Deathrattle:</b> Summon a
+//       5/9 Warlord with <b>Taunt</b>.
 // --------------------------------------------------------
 // GameTag:
 //  - DEATHRATTLE = 1
@@ -1162,7 +1153,7 @@ TEST_CASE("[Demon Hunter : Minion] - BT_761 : Coilfang Warlord")
 }
 
 // --------------------------------------- MINION - NEUTRAL
-// [BT_008] Rustsworn Initiate - COST: 2 [ATK: 2/HP: 2]
+// [BT_008] Rustsworn Initiate - COST:2 [ATK:2/HP:2]
 //  - Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Deathrattle:</b> Summon a 1/1 Impcaster with
@@ -1217,8 +1208,8 @@ TEST_CASE("[Neutral : Minion] - BT_008 : Rustsworn Initiate")
 }
 
 // --------------------------------------- MINION - NEUTRAL
-// [BT_010] Felfin Navigator - COST: 4 [ATK: 4/HP: 4]
-//  - Race: MURLOC, Set: BLACK_TEMPLE, Rarity: Common
+// [BT_010] Felfin Navigator - COST:4 [ATK:4/HP:4]
+//  - Race: Murloc, Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Give your other Murlocs +1/+1.
 // --------------------------------------------------------
@@ -1285,13 +1276,11 @@ TEST_CASE("[Neutral : Minion] - BT_010 : Felfin Navigator")
 }
 
 // --------------------------------------- MINION - NEUTRAL
-// [BT_155] Scrapyard Colossus - COST: 10 [ATK: 7/HP: 7]
-//  - Race: ELEMENTAL, Set: BLACK_TEMPLE, Rarity: Rare
+// [BT_155] Scrapyard Colossus - COST:10 [ATK:7/HP:7]
+//  - Race: Elemental, Set: BLACK_TEMPLE, Rarity: Rare
 // --------------------------------------------------------
-// Text: <b>Taunt</b>
-//       <b>Deathrattle:</b> Summon a
-//       7/7 Felcracked Colossus
-//       with <b>Taunt</b>.
+// Text: <b>Taunt</b> <b>Deathrattle:</b> Summon a
+//       7/7 Felcracked Colossus with <b>Taunt</b>.
 // --------------------------------------------------------
 // GameTag:
 //  - DEATHRATTLE = 1
@@ -1343,11 +1332,10 @@ TEST_CASE("[Neutral : Minion] - BT_155 : Scrapyard Colossus")
 }
 
 // --------------------------------------- MINION - NEUTRAL
-// [BT_156] Imprisoned Vilefiend - COST: 2 [ATK: 3/HP: 5]
-//  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Common
+// [BT_156] Imprisoned Vilefiend - COST:2 [ATK:3/HP:5]
+//  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------
-// Text: <b>Dormant</b> for 2 turns.
-//       <b>Rush</b>
+// Text: <b>Dormant</b> for 2 turns. <b>Rush</b>
 // --------------------------------------------------------
 // GameTag:
 //  - RUSH = 1
@@ -1417,10 +1405,11 @@ TEST_CASE("[Priest : Minion] - BT_156 : Imprisoned Vilefiend")
 }
 
 // --------------------------------------- MINION - NEUTRAL
-// [BT_159] Terrorguard Escapee - COST: 3 [ATK: 3/HP: 7]
-//  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Common
+// [BT_159] Terrorguard Escapee - COST:3 [ATK:3/HP:7]
+//  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------
-// Text: <b>Battlecry:</b> Summon three 1/1 Huntresses for your opponent.
+// Text: <b>Battlecry:</b> Summon three 1/1 Huntresses
+//       for your opponent.
 // --------------------------------------------------------
 // GameTag:
 //  - BATTLECRY = 1
@@ -1471,12 +1460,11 @@ TEST_CASE("[Neutral : Minion] - BT_159 : Terrorguard Escapee")
 }
 
 // --------------------------------------- MINION - NEUTRAL
-// [BT_160] Rustsworn Cultist - COST: 4 [ATK: 3/HP: 3]
+// [BT_160] Rustsworn Cultist - COST:4 [ATK:3/HP:3]
 //  - Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------
-// Text: <b>Battlecry:</b> Give your
-//       other minions "<b>Deathrattle:</b>
-//       Summon a 1/1 Demon."
+// Text: <b>Battlecry:</b> Give your other minions
+//       "<b>Deathrattle:</b> Summon a 1/1 Demon."
 // --------------------------------------------------------
 // GameTag:
 //  - BATTLECRY = 1
@@ -1527,15 +1515,15 @@ TEST_CASE("[Neutral : Minion] - BT_160 : Rustsworn Cultist")
 }
 
 // --------------------------------------- MINION - NEUTRAL
-// [BT_726] Dragonmaw Sky Stalker - COST: 6 [ATK: 5/HP: 6]
-//  - Race: DRAGON, Set: BLACK_TEMPLE, Rarity: Common
+// [BT_726] Dragonmaw Sky Stalker - COST:6 [ATK:5/HP:6]
+//  - Race: Dragon, Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Deathrattle:</b> Summon a 3/4 Dragonrider.
 // --------------------------------------------------------
 // GameTag:
 //  - DEATHRATTLE = 1
 // --------------------------------------------------------
-TEST_CASE("[Neutral : Minion] - BT_155 : Dragonmaw Sky Stalker")
+TEST_CASE("[Neutral : Minion] - BT_726 : Dragonmaw Sky Stalker")
 {
     GameConfig config;
     config.player1Class = CardClass::PRIEST;
@@ -1577,8 +1565,8 @@ TEST_CASE("[Neutral : Minion] - BT_155 : Dragonmaw Sky Stalker")
 }
 
 // --------------------------------------- MINION - NEUTRAL
-// [BT_728] Disguised Wanderer - COST: 4 [ATK: 3/HP: 3]
-//  - Race: DEMON, Set: BLACK_TEMPLE, Rarity: Common
+// [BT_728] Disguised Wanderer - COST:4 [ATK:3/HP:3]
+//  - Race: Demon, Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Deathrattle:</b> Summon a 9/1 Inquisitor.
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -228,10 +228,8 @@ TEST_CASE("[Mage : Minion] - BT_014 : Starscryer")
     for (int i = 0; i < 10; ++i)
     {
         config.player1Deck[i] = Cards::FindCardByName("Wolfrider");
-        config.player1Deck[i + 10] =
-            Cards::FindCardByName("Starscryer");
-        config.player1Deck[i + 20] =
-            Cards::FindCardByName("Pyroblast");
+        config.player1Deck[i + 10] = Cards::FindCardByName("Starscryer");
+        config.player1Deck[i + 20] = Cards::FindCardByName("Pyroblast");
     }
 
     Game game(config);
@@ -249,8 +247,8 @@ TEST_CASE("[Mage : Minion] - BT_014 : Starscryer")
     auto& curField = *(curPlayer->GetFieldZone());
     auto& opField = *(opPlayer->GetFieldZone());
 
-    const auto card1 = Generic::DrawCard(
-        curPlayer, Cards::FindCardByName("Starscryer"));
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Starscryer"));
     const auto card2 =
         Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
 
@@ -411,7 +409,8 @@ TEST_CASE("[Paladin : Spell] - BT_024 : Libram of Hope")
     const auto card1 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Libram of Hope"));
 
-    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, curPlayer->GetHero()));
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card1, curPlayer->GetHero()));
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 28);
     CHECK_EQ(curField.GetCount(), 1);
     CHECK_EQ(curField[0]->card->name, "Ancient Guardian");
@@ -723,8 +722,8 @@ TEST_CASE("[Shaman : Spell] - BT_100 : Serpentshrine Portal")
 
     auto& curField = *(curPlayer->GetFieldZone());
 
-    const auto card1 =
-        Generic::DrawCard(curPlayer, Cards::FindCardByName("Serpentshrine Portal"));
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Serpentshrine Portal"));
 
     game.Process(curPlayer,
                  PlayCardTask::SpellTarget(card1, opPlayer->GetHero()));

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -70,7 +70,7 @@ TEST_CASE("[PALADIN : Minion] - SCH_712 : Judicious Junior")
 }
 
 // ---------------------------------------- MINION - PRIEST
-// [SCH_137] Frazzled Freshman - COST: 1 [ATK: 1/HP: 4]
+// [SCH_137] Frazzled Freshman - COST:1 [ATK:1/HP:4]
 //  - Set: SCHOLOMANCE, Rarity: Common
 // --------------------------------------------------------
 TEST_CASE("[Priest : Minion] - SCH_137 : Frazzled Freshman")
@@ -104,11 +104,11 @@ TEST_CASE("[Priest : Minion] - SCH_137 : Frazzled Freshman")
 }
 
 // ----------------------------------------- MINION - ROGUE
-// [SCH_234] Shifty Sophomore - COST: 4 [ATK: 4/HP: 4]
+// [SCH_234] Shifty Sophomore - COST:4 [ATK:4/HP:4]
 //  - Set: SCHOLOMANCE, Rarity: Rare
 // --------------------------------------------------------
-// Text: <b>Stealth</b>
-//       <b>Spellburst:</b> Add a <b>Combo</b> card to your hand.
+// Text: <b>Stealth</b> <b>Spellburst:</b> Add a
+//       <b>Combo</b> card to your hand.
 // --------------------------------------------------------
 // GameTag:
 //  - STEALTH = 1
@@ -161,12 +161,11 @@ TEST_CASE("[Rogue : Minion] - SCH_234 : Shifty Sophomore")
 }
 
 // ----------------------------------------- MINION - ROGUE
-// [SCH_426] Infiltrator Lilian - COST: 4 [ATK: 4/HP: 2]
+// [SCH_426] Infiltrator Lilian - COST:4 [ATK:4/HP:2]
 //  - Set: SCHOLOMANCE, Rarity: Legendary
 // --------------------------------------------------------
-// Text: <b>Stealth</b>
-//       <b>Deathrattle:</b> Summon a 4/2 Forsaken Lilian
-//       that attacks a random enemy.
+// Text: <b>Stealth</b> <b>Deathrattle:</b> Summon a
+//       4/2 Forsaken Lilian that attacks a random enemy.
 // --------------------------------------------------------
 // GameTag:
 //  - ELITE = 1
@@ -246,7 +245,7 @@ TEST_CASE("[Rogue : Minion] - SCH_426 : Infiltrator Lilian")
 }
 
 // ----------------------------------------- WEAPON - ROGUE
-// [SCH_622] Self-Sharpening Sword - COST: 3
+// [SCH_622] Self-Sharpening Sword - COST:3
 //  - Set: SCHOLOMANCE, Rarity: Rare
 // --------------------------------------------------------
 // Text: After your hero attacks, gain +1 Attack.
@@ -304,7 +303,7 @@ TEST_CASE("[Rogue : Minion] - SCH_622 : Self-Sharpening Sword")
 }
 
 // ------------------------------------------ SPELL - ROGUE
-// [SCH_706] Plagiarize - COST: 2
+// [SCH_706] Plagiarize - COST:2
 //  - Set: SCHOLOMANCE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Secret:</b> At the end of your opponent's turn,
@@ -420,11 +419,11 @@ TEST_CASE("[Neutral : Minion] - SCH_231 : Intrepid Initiate")
 }
 
 // --------------------------------------- MINION - NEUTRAL
-// [SCH_707] Fishy Flyer - COST: 4 [ATK: 4/HP: 3]
-//  - Race: MURLOC, Set: SCHOLOMANCE, Rarity: Common
+// [SCH_707] Fishy Flyer - COST:4 [ATK:4/HP:3]
+//  - Race: Murloc, Set: SCHOLOMANCE, Rarity: Common
 // --------------------------------------------------------
-// Text: <b>Rush</b>. <b>Deathrattle:</b> Add a 4/3 Ghost with <b>Rush</b>
-// to your hand.
+// Text: <b>Rush</b>. <b>Deathrattle:</b> Add a 4/3 Ghost
+//       with <b>Rush</b> to your hand.
 // --------------------------------------------------------
 // GameTag:
 //  - DEATHRATTLE = 1
@@ -471,11 +470,11 @@ TEST_CASE("[NEUTRAL : Minion] - SCH_707 : Fishy Flyer")
 }
 
 // --------------------------------------- MINION - NEUTRAL
-// [SCH_708] Sneaky Delinquent - COST: 2 [ATK: 3/HP: 1]
+// [SCH_708] Sneaky Delinquent - COST:2 [ATK:3/HP:1]
 //  - Set: SCHOLOMANCE, Rarity: Common
 // --------------------------------------------------------
-// Text: <b>Stealth</b>. <b>Deathrattle:</b> Add a 3/1 Ghost with
-// <b>Stealth</b> to your hand.
+// Text: <b>Stealth</b>. <b>Deathrattle:</b> Add a 3/1 Ghost
+//       with <b>Stealth</b> to your hand.
 // --------------------------------------------------------
 // GameTag:
 //  - DEATHRATTLE = 1
@@ -522,11 +521,11 @@ TEST_CASE("[NEUTRAL : Minion] - SCH_708 : Sneaky Delinquent")
 }
 
 // --------------------------------------- MINION - NEUTRAL
-// [SCH_709] Smug Senior - COST: 6 [ATK: 5/HP: 7]
+// [SCH_709] Smug Senior - COST:6 [ATK:5/HP:7]
 //  - Set: SCHOLOMANCE, Rarity: Common
 // --------------------------------------------------------
-// Text: <b>Taunt</b>. <b>Deathrattle:</b> Add a 5/7 Ghost with <b>Taunt</b>
-// to your hand.
+// Text: <b>Taunt</b>. <b>Deathrattle:</b> Add a 5/7 Ghost
+//       with <b>Taunt</b> to your hand.
 // --------------------------------------------------------
 // GameTag:
 //  - DEATHRATTLE = 1
@@ -573,12 +572,11 @@ TEST_CASE("[NEUTRAL : Minion] - SCH_709 : Smug Senior")
 }
 
 // --------------------------------------- MINION - NEUTRAL
-// [SCH_710] Ogremancer - COST: 5 [ATK: 3/HP: 7]
+// [SCH_710] Ogremancer - COST:5 [ATK:3/HP:7]
 //  - Set: SCHOLOMANCE, Rarity: Common
 // --------------------------------------------------------
-// Text: Whenever your opponent
-//       casts a spell, summon a 2/2
-//       Skeleton with <b>Taunt</b>.
+// Text: Whenever your opponent casts a spell,
+//       summon a 2/2 Skeleton with <b>Taunt</b>.
 // --------------------------------------------------------
 // GameTag:
 //  - TRIGGER_VISUAL = 1
@@ -634,8 +632,8 @@ TEST_CASE("[NEUTRAL : Minion] - SCH_710 : Ogremancer")
 }
 
 // --------------------------------------- MINION - NEUTRAL
-// [SCH_711] Plagued Protodrake - COST: 8 [ATK: 8/HP: 8]
-//  - Race: DRAGON, Set: SCHOLOMANCE, Rarity: Common
+// [SCH_711] Plagued Protodrake - COST:8 [ATK:8/HP:8]
+//  - Race: Dragon, Set: SCHOLOMANCE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Deathrattle:</b> Summon a random 7-Cost minion.
 // --------------------------------------------------------

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,11 +4,11 @@ jobs:
     vmImage: 'vs2017-win2016'
   steps:
   - template: Scripts/azure_pipelines_build_windows_vs2017.yml
-- job: Windows_VS2019
-  pool:
-    vmImage: 'windows-2019'
-  steps:
-  - template: Scripts/azure_pipelines_build_windows_vs2019.yml
+#- job: Windows_VS2019
+#  pool:
+#    vmImage: 'windows-2019'
+#  steps:
+#  - template: Scripts/azure_pipelines_build_windows_vs2019.yml
 - job: Linux
   pool:
     vmImage: 'Ubuntu-16.04'


### PR DESCRIPTION
This revision includes:
- Update Hearthstone Patch 18.0.2 (#485)
  - Card Update
    - Kael’thas Sunstrider: Old: Every third spell you cast each turn costs (0). → New: Every third spell you cast each turn costs (1).
    - Mindrender Illucia: Old: [Cost 2] → New: [Cost 3]
  - Battlegrounds Update
    - Gentle Megasaur has been removed from the Battlegrounds minion pool.
    - Arcane Cannon has been removed from Battlegrounds minion pool.
    - Rat Pack: Old: [Tier 2] → New: [Tier 3]
    - Pack Leader: Old: [Tier 3] → New: [Tier 2]
    - Primalfin Lookout: Old: [Tier 5] → New: [Tier 4]
    - Mama Bear: Old: [Tier 6] 5 Attack, 5 Health. Whenever you summon a Beast, give it +5/+5.→ New: [Tier 5] 4 Attack, 4 Health. Whenever you summon a Beast, give it +4/+4.
    - Lady Vashj has been removed from the Battlegrounds Hero pool.
- Refactor code
  - Add attribute '[[maybe_unused]]' to unused variables
  - Delete unused headers
  - Apply coding convention by clang-format
- Rearrange card comments to improve readability
- Add .gitattributes
- Update card implementation progress