### PR TITLE
Implement 10 YEAR_OF_THE_DRAGON cards

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -913,9 +913,9 @@ DRAGONS | DRG_660 | Galakrond, the Unspeakable | O
 
 Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
-YEAR_OF_THE_DRAGON | YOD_001 | Rising Winds |  
+YEAR_OF_THE_DRAGON | YOD_001 | Rising Winds | O
 YEAR_OF_THE_DRAGON | YOD_003 | Winged Guardian | O
-YEAR_OF_THE_DRAGON | YOD_004 | Chopshop Copter |  
+YEAR_OF_THE_DRAGON | YOD_004 | Chopshop Copter | O
 YEAR_OF_THE_DRAGON | YOD_005 | Fresh Scent | O
 YEAR_OF_THE_DRAGON | YOD_006 | Escaped Manasaber |  
 YEAR_OF_THE_DRAGON | YOD_007 | Animated Avalanche | O
@@ -924,32 +924,32 @@ YEAR_OF_THE_DRAGON | YOD_009 | The Amazing Reno |
 YEAR_OF_THE_DRAGON | YOD_010 | Shotbot | O
 YEAR_OF_THE_DRAGON | YOD_012 | Air Raid | O
 YEAR_OF_THE_DRAGON | YOD_013 | Cleric of Scales |  
-YEAR_OF_THE_DRAGON | YOD_014 | Aeon Reaver |  
+YEAR_OF_THE_DRAGON | YOD_014 | Aeon Reaver | O
 YEAR_OF_THE_DRAGON | YOD_015 | Dark Prophecy |  
 YEAR_OF_THE_DRAGON | YOD_016 | Skyvateer | O
 YEAR_OF_THE_DRAGON | YOD_017 | Shadow Sculptor |  
 YEAR_OF_THE_DRAGON | YOD_018 | Waxmancy |  
-YEAR_OF_THE_DRAGON | YOD_020 | Explosive Evolution |  
-YEAR_OF_THE_DRAGON | YOD_022 | Risky Skipper |  
+YEAR_OF_THE_DRAGON | YOD_020 | Explosive Evolution | O
+YEAR_OF_THE_DRAGON | YOD_022 | Risky Skipper | O
 YEAR_OF_THE_DRAGON | YOD_023 | Boom Squad |  
-YEAR_OF_THE_DRAGON | YOD_024 | Bomb Wrangler |  
+YEAR_OF_THE_DRAGON | YOD_024 | Bomb Wrangler | O
 YEAR_OF_THE_DRAGON | YOD_025 | Twisted Knowledge | O
 YEAR_OF_THE_DRAGON | YOD_026 | Fiendish Servant |  
 YEAR_OF_THE_DRAGON | YOD_027 | Chaos Gazer |  
 YEAR_OF_THE_DRAGON | YOD_028 | Skydiving Instructor |  
 YEAR_OF_THE_DRAGON | YOD_029 | Hailbringer |  
-YEAR_OF_THE_DRAGON | YOD_030 | Licensed Adventurer |  
+YEAR_OF_THE_DRAGON | YOD_030 | Licensed Adventurer | O
 YEAR_OF_THE_DRAGON | YOD_032 | Frenzied Felwing |  
 YEAR_OF_THE_DRAGON | YOD_033 | Boompistol Bully |  
-YEAR_OF_THE_DRAGON | YOD_035 | Grand Lackey Erkh |  
+YEAR_OF_THE_DRAGON | YOD_035 | Grand Lackey Erkh | O
 YEAR_OF_THE_DRAGON | YOD_036 | Rotnest Drake | O
 YEAR_OF_THE_DRAGON | YOD_038 | Sky Gen'ral Kragg |  
-YEAR_OF_THE_DRAGON | YOD_040 | Steel Beetle |  
-YEAR_OF_THE_DRAGON | YOD_041 | Eye of the Storm |  
+YEAR_OF_THE_DRAGON | YOD_040 | Steel Beetle | O
+YEAR_OF_THE_DRAGON | YOD_041 | Eye of the Storm | O
 YEAR_OF_THE_DRAGON | YOD_042 | The Fist of Ra-den |  
 YEAR_OF_THE_DRAGON | YOD_043 | Scalelord | O
 
-- Progress: 28% (10 of 35 Cards)
+- Progress: 57% (20 of 35 Cards)
 
 ## Ashes of Outland
 

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -100,6 +100,10 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsTreant();
 
+    //! SelfCondition wrapper for checking it is Lackey.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsLackey();
+
     //! SelfCondition wrapper for checking race of entity is \p race.
     //! \param race The race for checking.
     //! \return Generated SelfCondition for intended purpose.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Adventures
 
-  * 28% Galakrond's Awakening (10 of 35 cards)
+  * 57% Galakrond's Awakening (20 of 35 cards)
   * 0% One Night in Karazhan (0 of 45 Cards)
   * 0% The League of Explorers (0 of 45 Cards)
   * 0% Blackrock Mountain (0 of 31 Cards)

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -2022,7 +2022,7 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
                 {
                     randomMinionTask->Run();
                     Playable* left = stack.playables[0];
-                    Playable* right = nullptr;
+                    Playable* right;
                     do
                     {
                         randomMinionTask->Run();

--- a/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
@@ -12,12 +12,14 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/CopyTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageNumberTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DestroyTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FlagTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/GetGameTagTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
@@ -421,6 +423,8 @@ void YoDCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 
 void YoDCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- MINION - PRIEST
     // [YOD_013] Cleric of Scales - COST:1 [ATK:1/HP:1]
     // - Set: YoD, Rarity: Rare
@@ -443,6 +447,18 @@ void YoDCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<GetGameTagTask>(EntityType::SOURCE, GameTag::ATK));
+    power.AddPowerTask(std::make_shared<DamageNumberTask>(EntityType::TARGET));
+    cards.emplace(
+        "YOD_014",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ----------------------------------------- SPELL - PRIEST
     // [YOD_015] Dark Prophecy - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
@@ -699,6 +699,11 @@ void YoDCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TAKE_DAMAGE));
+    power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    power.GetTrigger()->tasks = { std::make_shared<SummonTask>("GVG_110t", 1) };
+    cards.emplace("YOD_024", CardDef(power));
 }
 
 void YoDCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
@@ -21,6 +21,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SetGameTagTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonCopyTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/TransformMinionTask.hpp>
 
 using namespace RosettaStone::PlayMode::SimpleTasks;
 
@@ -531,6 +532,17 @@ void YoDCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Transform a minion into a random one that costs (3) more.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<TransformMinionTask>(EntityType::TARGET, 3));
+    cards.emplace(
+        "YOD_020",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [YOD_041] Eye of the Storm - COST:10

--- a/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
@@ -7,6 +7,7 @@
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddCardTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/AddLackeyTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddStackToTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ConditionTask.hpp>
@@ -809,6 +810,13 @@ void YoDCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_PLAY_MINION));
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    power.GetTrigger()->condition =
+        std::make_shared<SelfCondition>(SelfCondition::IsLackey());
+    power.GetTrigger()->tasks = { std::make_shared<AddLackeyTask>(1) };
+    cards.emplace("YOD_035", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [YOD_038] Sky Gen'ral Kragg - COST:4 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
@@ -6,6 +6,7 @@
 #include <Rosetta/PlayMode/CardSets/YoDCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/CopyTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DestroyTask.hpp>
@@ -106,6 +107,13 @@ void YoDCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::Has5MoreCostSpellInHand()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<ArmorTask>(5) }));
+    cards.emplace("YOD_040", CardDef(power));
 }
 
 void YoDCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
@@ -5,6 +5,7 @@
 
 #include <Rosetta/PlayMode/CardSets/YoDCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/AddCardTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddStackToTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
@@ -712,6 +713,8 @@ void YoDCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)
 
 void YoDCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - NEUTRAL
     // [YOD_006] Escaped Manasaber - COST:4 [ATK:3/HP:5]
     // - Race: Beast, Faction: Neutral, Set: YoD, Rarity: Epic
@@ -764,12 +767,17 @@ void YoDCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
-    // PlayReq:
-    // - REQ_NUM_MINION_SLOTS = 1
-    // --------------------------------------------------------
     // RefTag:
     // - QUEST = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::HERO, SelfCondList{ std::make_shared<SelfCondition>(
+                              SelfCondition::IsControllingQuest()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<AddCardTask>(EntityType::HAND,
+                                                      "GAME_005") }));
+    cards.emplace("YOD_030", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [YOD_032] Skydiving Instructor - COST:4 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
@@ -24,6 +24,7 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 namespace RosettaStone::PlayMode
 {
 using PlayReqs = std::map<PlayReq, int>;
+using ChooseCardIDs = std::vector<std::string>;
 using TaskList = std::vector<std::shared_ptr<ITask>>;
 using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
 using EffectList = std::vector<std::shared_ptr<IEffect>>;
@@ -73,6 +74,10 @@ void YoDCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - TWINSPELL_COPY = 56141
     // - TWINSPELL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("YOD_001", CardDef(power, PlayReqs{},
+                                     ChooseCardIDs{ "YOD_001b", "YOD_001c" }));
 
     // ----------------------------------------- MINION - DRUID
     // [YOD_003] Winged Guardian - COST:7 [ATK:6/HP:8]
@@ -105,12 +110,17 @@ void YoDCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 
 void YoDCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------ SPELL - DRUID
     // [YOD_001b] Take Flight (*) - COST:2
     // - Faction: Neutral, Set: YoD
     // --------------------------------------------------------
     // Text: Draw a card.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cards.emplace("YOD_001b", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [YOD_001c] Swoop In (*) - COST:2
@@ -118,11 +128,20 @@ void YoDCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Summon a 3/2 Eagle.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("YOD_001t", SummonSide::SPELL));
+    cards.emplace(
+        "YOD_001c",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ----------------------------------------- MINION - DRUID
     // [YOD_001t] Eagle (*) - COST:2 [ATK:3/HP:2]
     // - Race: Beast, Set: YoD
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("YOD_001t", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [YOD_001ts] Rising Winds (*) - COST:2
@@ -134,6 +153,11 @@ void YoDCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CHOOSE_ONE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace(
+        "YOD_001ts",
+        CardDef(power, PlayReqs{}, ChooseCardIDs{ "YOD_001b", "YOD_001c" }));
 }
 
 void YoDCardsGen::AddHunter(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
@@ -10,6 +10,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/CopyTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DestroyTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawTask.hpp>
@@ -660,6 +661,8 @@ void YoDCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
 
 void YoDCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - WARRIOR
     // [YOD_022] Risky Skipper - COST:1 [ATK:1/HP:3]
     // - Set: YoD, Rarity: Rare
@@ -669,6 +672,12 @@ void YoDCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_PLAY_MINION));
+    power.GetTrigger()->triggerSource = TriggerSource::MINIONS_EXCEPT_SELF;
+    power.GetTrigger()->tasks = { std::make_shared<DamageTask>(
+        EntityType::ALL_MINIONS, 1) };
+    cards.emplace("YOD_022", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [YOD_023] Boom Squad - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
@@ -523,6 +523,8 @@ void YoDCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 
 void YoDCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- SPELL - SHAMAN
     // [YOD_020] Explosive Evolution - COST:2
     // - Set: YoD, Rarity: Common
@@ -546,6 +548,12 @@ void YoDCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("YOD_041t", 3, SummonSide::SPELL));
+    cards.emplace(
+        "YOD_041",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ---------------------------------------- WEAPON - SHAMAN
     // [YOD_042] The Fist of Ra-den - COST:4 [ATK:1/HP:0]
@@ -563,6 +571,8 @@ void YoDCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 
 void YoDCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- MINION - SHAMAN
     // [YOD_041t] Stormblocker (*) - COST:5 [ATK:5/HP:6]
     // - Race: Elemental, Set: YoD
@@ -570,6 +580,9 @@ void YoDCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("YOD_041t", CardDef(power));
 }
 
 void YoDCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
@@ -6,6 +6,7 @@
 #include <Rosetta/PlayMode/CardSets/YoDCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/AddStackToTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/CopyTask.hpp>
@@ -15,6 +16,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FlagTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SetGameTagTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonCopyTask.hpp>
@@ -24,6 +26,7 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 
 namespace RosettaStone::PlayMode
 {
+using TagValues = std::vector<TagValue>;
 using PlayReqs = std::map<PlayReq, int>;
 using ChooseCardIDs = std::vector<std::string>;
 using TaskList = std::vector<std::shared_ptr<ITask>>;
@@ -182,6 +185,18 @@ void YoDCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::DEATH));
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
+        SelfCondition::IsRace(Race::MECHANICAL));
+    power.GetTrigger()->tasks = {
+        std::make_shared<RandomMinionTask>(
+            TagValues{ { GameTag::CARDRACE, static_cast<int>(Race::MECHANICAL),
+                         RelaSign::EQ } }),
+        std::make_shared<AddStackToTask>(EntityType::HAND)
+    };
+    cards.emplace("YOD_004", CardDef(power));
 
     // ----------------------------------------- SPELL - HUNTER
     // [YOD_005] Fresh Scent - COST:2

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -163,6 +163,19 @@ SelfCondition SelfCondition::IsTreant()
         [](Playable* playable) { return playable->card->name == "Treant"; });
 }
 
+SelfCondition SelfCondition::IsLackey()
+{
+    return SelfCondition([](Playable* playable) {
+        const auto minion = dynamic_cast<Minion*>(playable);
+        if (!minion)
+        {
+            return false;
+        }
+
+        return minion->IsLackey();
+    });
+}
+
 SelfCondition SelfCondition::IsRace(Race race)
 {
     return SelfCondition([race](Playable* playable) {

--- a/Sources/Rosetta/PlayMode/Models/Playable.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Playable.cpp
@@ -508,9 +508,8 @@ bool Playable::CheckTargetingType(Card* card, Character* target)
 void Playable::ActivateTask(PowerType type, Character* target, int chooseOne,
                             Playable* chooseBase)
 {
-    // TODO: Remove code '56057' after the card 'Rising Winds' is implemented
     // TODO: Remove code '59542' after the card 'Runic Carvings' is implemented
-    if (HasChooseOne() && (card->dbfID != 56057 && card->dbfID != 59542))
+    if (HasChooseOne() && (card->dbfID != 59542))
     {
         if (player->ChooseBoth() && !card->IsTransformMinion())
         {

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -775,7 +775,7 @@ TEST_CASE("[Neutral : Spell] - SCH_352 : Potion of Illusion")
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Edwin VanCleef"));
     const auto card4 = Generic::DrawCard(
         curPlayer, Cards::FindCardByName("Potion of Illusion"));
-    const auto card5 =
+    [[maybe_unused]] const auto card5 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Edwin VanCleef"));
     const auto card6 = Generic::DrawCard(
         opPlayer, Cards::FindCardByName("Blazing Battlemage"));

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -1054,25 +1054,18 @@ TEST_CASE("[Neutral : Minion] - SCH_522 : Steeldancer")
     const auto card2 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Steeldancer"));
     const auto card3 =
-        Generic::DrawCard(curPlayer, Cards::FindCardByName("Steeldancer"));
-    const auto card4 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Hooked Scimitar"));
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     CHECK_EQ(curField.GetCount(), 2);
     CHECK_EQ(curField[1]->GetCost(), 0);
 
-    game.Process(curPlayer, HeroPowerTask());
-    game.Process(curPlayer, PlayCardTask::Minion(card2));
-    CHECK_EQ(curField.GetCount(), 4);
-    CHECK_EQ(curField[3]->GetCost(), 1);
-
     curPlayer->SetUsedMana(0);
 
-    game.Process(curPlayer, PlayCardTask::Weapon(card4));
-    game.Process(curPlayer, PlayCardTask::Minion(card3));
-    CHECK_EQ(curField.GetCount(), 6);
-    CHECK_EQ(curField[5]->GetCost(), 4);
+    game.Process(curPlayer, PlayCardTask::Weapon(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 4);
+    CHECK_EQ(curField[3]->GetCost(), 4);
 }
 
 // ---------------------------------------- SPELL - NEUTRAL

--- a/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
@@ -930,3 +930,56 @@ TEST_CASE("[Warrior : Minion] - YOD_024 : Bomb Wrangler")
     CHECK_EQ(curField[0]->card->name, "Boom Bot");
     CHECK_EQ(curField[1]->card->name, "Boom Bot");
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [YOD_030] Licensed Adventurer - COST:2 [ATK:2/HP:2]
+// - Faction: Neutral, Set: YoD, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you control a <b>Quest</b>,
+//       add a Coin to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - QUEST = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - YOD_030 : Licensed Adventurer")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Licensed Adventurer"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Licensed Adventurer"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Untapped Potential"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->card->name, "The Coin");
+}

--- a/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
@@ -876,3 +876,57 @@ TEST_CASE("[Warrior : Minion] - YOD_022 : Risky Skipper")
     CHECK_EQ(curField[1]->GetHealth(), 2);
     CHECK_EQ(opField.GetCount(), 0);
 }
+
+// --------------------------------------- MINION - WARRIOR
+// [YOD_024] Bomb Wrangler - COST:3 [ATK:2/HP:3]
+// - Set: YoD, Rarity: Rare
+// --------------------------------------------------------
+// Text: Whenever this minion takes damage, summon a 1/1 Boom Bot.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - YOD_024 : Bomb Wrangler")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bomb Wrangler"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[1]->card->name, "Boom Bot");
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Boom Bot");
+    CHECK_EQ(curField[1]->card->name, "Boom Bot");
+}

--- a/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
@@ -607,6 +607,57 @@ TEST_CASE("[Paladin : Minion] - YOD_043 : Scalelord")
     CHECK_EQ(curField[2]->HasDivineShield(), false);
 }
 
+// ---------------------------------------- MINION - PRIEST
+// [YOD_014] Aeon Reaver - COST:6 [ATK:4/HP:4]
+// - Race: Dragon, Set: YoD, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Deal damage to a minion equal
+//       to its Attack.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - YOD_014 : Aeon Reaver")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Ironbark Protector"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Aeon Reaver"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetHealth(), 8);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::MinionTarget(card2, card1));
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+}
+
 // ----------------------------------------- MINION - ROGUE
 // [YOD_016] Skyvateer - COST:2 [ATK:1/HP:3]
 // - Set: YoD, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
@@ -660,6 +660,55 @@ TEST_CASE("[Rogue : Minion] - YOD_016 : Skyvateer")
 }
 
 // ----------------------------------------- SPELL - SHAMAN
+// [YOD_020] Explosive Evolution - COST:2
+// - Set: YoD, Rarity: Common
+// --------------------------------------------------------
+// Text: Transform a minion into a random one that costs (3) more.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - YOD_020 : Explosive Evolution")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Explosive Evolution"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Explosive Evolution"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Shattered Rumbler"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[0]->GetCost(), 5);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, curField[0]));
+    CHECK_EQ(curField[0]->GetCost(), 8);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, curField[0]));
+    CHECK_EQ(curField[0]->GetCost(), 10);
+}
+
+// ----------------------------------------- SPELL - SHAMAN
 // [YOD_041] Eye of the Storm - COST:10
 // - Set: YoD, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
@@ -133,6 +133,57 @@ TEST_CASE("[Druid : Minion] - YOD_003 : Winged Guardian")
     CHECK_EQ(curField[0]->HasReborn(), false);
 }
 
+// ----------------------------------------- MINION - DRUID
+// [YOD_040] Steel Beetle - COST:2 [ATK:2/HP:3]
+// - Race: Beast, Set: YoD, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you're holding a spell that
+//       costs (5) or more, gain 5 Armor.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - YOD_040 : Steel Beetle")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Steel Beetle"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Steel Beetle"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Gift of the Wild"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [YOD_005] Fresh Scent - COST:2
 // - Set: YoD, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
@@ -659,6 +659,69 @@ TEST_CASE("[Rogue : Minion] - YOD_016 : Skyvateer")
     CHECK_EQ(curField.GetCount(), 0);
 }
 
+// ----------------------------------------- SPELL - SHAMAN
+// [YOD_041] Eye of the Storm - COST:10
+// - Set: YoD, Rarity: Common
+// --------------------------------------------------------
+// Text: Summon three 5/6 Elementals with <b>Taunt</b>.
+//       <b>Overload:</b> (3)
+// --------------------------------------------------------
+// GameTag:
+// - OVERLOAD = 3
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - YOD_041 : Eye of the Storm")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Eye of the Storm"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[0]->card->name, "Stormblocker");
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+    CHECK_EQ(curField[1]->card->name, "Stormblocker");
+    CHECK_EQ(curField[2]->card->name, "Stormblocker");
+    CHECK_EQ(curPlayer->GetOverloadLocked(), 0);
+    CHECK_EQ(curPlayer->GetOverloadOwed(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetRemainingMana(), 7);
+    CHECK_EQ(curPlayer->GetOverloadLocked(), 3);
+    CHECK_EQ(curPlayer->GetOverloadOwed(), 0);
+}
+
 // ---------------------------------------- SPELL - WARLOCK
 // [YOD_025] Twisted Knowledge - COST:2
 // - Set: YoD, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
@@ -983,3 +983,54 @@ TEST_CASE("[Neutral : Minion] - YOD_030 : Licensed Adventurer")
     CHECK_EQ(curHand.GetCount(), 5);
     CHECK_EQ(curHand[4]->card->name, "The Coin");
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [YOD_035] Grand Lackey Erkh - COST:4 [ATK:2/HP:3]
+// - Faction: Neutral, Set: YoD, Rarity: Legendary
+// --------------------------------------------------------
+// Text: After you play a <b>Lackey</b>,
+//       add a <b>Lackey</b> to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - YOD_035 : Grand Lackey Erkh")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Grand Lackey Erkh"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByID("DAL_614"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curHand.GetCount(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[0])->IsLackey(), true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
@@ -184,6 +184,63 @@ TEST_CASE("[Druid : Minion] - YOD_040 : Steel Beetle")
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
 }
 
+// ---------------------------------------- MINION - HUNTER
+// [YOD_004] Chopshop Copter - COST:3 [ATK:2/HP:4]
+// - Race: Mechanical, Set: YoD, Rarity: Rare
+// --------------------------------------------------------
+// Text: After a friendly Mech dies,
+//       add a random Mech to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - YOD_004 : Chopshop Copter")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Chopshop Copter"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Stonetusk Boar"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Harvest Golem"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curHand.GetCount(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card2));
+    CHECK_EQ(curHand.GetCount(), 0);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card3));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->GetRace(), Race::MECHANICAL);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [YOD_005] Fresh Scent - COST:2
 // - Set: YoD, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
@@ -19,6 +19,55 @@ using namespace PlayMode;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ------------------------------------------ SPELL - DRUID
+// [YOD_001] Rising Winds - COST:2
+// - Set: YoD, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Twinspell</b> <b>Choose One -</b>
+//       Draw a card; or Summon a 3/2 Eagle.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// - TWINSPELL_COPY = 56141
+// - TWINSPELL = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - YOD_001 : Rising Winds")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByID("YOD_001"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1, 1));
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(curHand[4]->card->id, "YOD_001ts");
+
+    game.Process(curPlayer, PlayCardTask::Spell(curHand[4], 2));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Eagle");
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+}
+
 // ----------------------------------------- MINION - DRUID
 // [YOD_003] Winged Guardian - COST:7 [ATK:6/HP:8]
 // - Race: Beast, Set: YoD, Rarity: Rare


### PR DESCRIPTION
This revision includes:
- Implement 10 YEAR_OF_THE_DRAGON cards
  - Rising Wind (YOD_001)
  - Chopshop Copter (YOD_004)
  - Aeon Reaver (YOD_014)
  - Explosive Evolution (YOD_020)
  - Risky Skipper (YOD_022)
  - Bomb Wrangler (YOD_024)
  - Licensed Adventurer (YOD_030)
  - Grand Lackey Erkh (YOD_035)
  - Steel Beetle (YOD_040)
  - Eye of the Storm (YOD_041)
- Add SelfCondition wrappers
  - IsLackey(): SelfCondition wrapper for checking it is Lackey
- Change the logic of transform to consider nearest possible cost
  - Cards that "transform a minion into a random one that costs (1) more/less", like Evolve or Devolve, will now always re-roll the minion, even if no minion exists in the target-cost minion pool. The minion will be re-rolled at the nearest possible cost.
    - References: https://hearthstone.gamepedia.com/Transform