### PR TITLE
Implement 18 DARKMOON_FAIRE cards and keyword 'Corrupt'

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,13 +42,13 @@ jobs:
     - name: Configure Compiler
       run: |
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
-          echo "::set-env name=CC::gcc-${{ matrix.version }}"
-          echo "::set-env name=CXX::g++-${{ matrix.version }}"
+          echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
+          echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
         else
           ls -ls /Applications/
           sudo xcode-select -switch /Applications/Xcode_${{ matrix.version }}.app
-          echo "::set-env name=CC::clang"
-          echo "::set-env name=CXX::clang++"
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
         fi
     - name: Configure Build
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,10 +22,10 @@ jobs:
             compiler: xcode
             version: "12.2"
           # macOS 10.15 + gcc-8
-          - name: "macOS 10.15 + gcc-8"
-            os: macos-10.15
-            compiler: gcc
-            version: "8"
+          #- name: "macOS 10.15 + gcc-8"
+          #  os: macos-10.15
+          #  compiler: gcc
+          #  version: "8"
           # macOS 10.15 + gcc-9
           - name: "macOS 10.15 + gcc-9"
             os: macos-10.15

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -54,11 +54,11 @@ jobs:
     - name: Configure Compiler
       run: |
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
-          echo "::set-env name=CC::gcc-${{ matrix.version }}"
-          echo "::set-env name=CXX::g++-${{ matrix.version }}"
+          echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
+          echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
         else
-          echo "::set-env name=CC::clang-${{ matrix.version }}"
-          echo "::set-env name=CXX::clang++-${{ matrix.version }}"
+          echo "CC=clang-${{ matrix.version }}" >> $GITHUB_ENV
+          echo "CXX=clang++-${{ matrix.version }}" >> $GITHUB_ENV
         fi
     - name: Configure Build
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..

--- a/.github/workflows/ubuntu_codecov.yml
+++ b/.github/workflows/ubuntu_codecov.yml
@@ -29,11 +29,11 @@ jobs:
     - name: Configure Compiler
       run: |
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
-          echo "::set-env name=CC::gcc-${{ matrix.version }}"
-          echo "::set-env name=CXX::g++-${{ matrix.version }}"
+          echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
+          echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
         else
-          echo "::set-env name=CC::clang-${{ matrix.version }}"
-          echo "::set-env name=CXX::clang++-${{ matrix.version }}"
+          echo "CC=clang-${{ matrix.version }}" >> $GITHUB_ENV
+          echo "CXX=clang++-${{ matrix.version }}" >> $GITHUB_ENV
         fi
     - name: Configure Build
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_COVERAGE=ON ..

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Configure Build
       run: mkdir build && cd build && cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DCMAKE_BUILD_TYPE=Release ..
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.1
+      uses: microsoft/setup-msbuild@v1.0.2
     - name: Build
       run: cd build && MSBuild.exe RosettaStone.sln /p:Configuration=Release
     - name: Run Unit Test

--- a/Documents/AbilityList.md
+++ b/Documents/AbilityList.md
@@ -32,7 +32,7 @@
 * [x] Casts When Drawn
 * [x] Charge
 * [ ] Choose Twice
-* [ ] Corrupt
+* [x] Corrupt
 * [x] Counter
 * [x] Dormant
 * [x] Echo

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -1242,18 +1242,18 @@ Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
 DARKMOON_FAIRE | DMF_002 | N'Zoth, God of the Deep |  
 DARKMOON_FAIRE | DMF_004 | Yogg-Saron, Master of Fate |  
-DARKMOON_FAIRE | DMF_044 | Rock Rager |  
+DARKMOON_FAIRE | DMF_044 | Rock Rager | O
 DARKMOON_FAIRE | DMF_053 | Blood of G'huun |  
 DARKMOON_FAIRE | DMF_054 | Insight |  
 DARKMOON_FAIRE | DMF_055 | Idol of Y'Shaarj |  
 DARKMOON_FAIRE | DMF_056 | G'huun the Blood God |  
 DARKMOON_FAIRE | DMF_057 | Lunar Eclipse |  
 DARKMOON_FAIRE | DMF_058 | Solar Eclipse |  
-DARKMOON_FAIRE | DMF_059 | Fizzy Elemental |  
+DARKMOON_FAIRE | DMF_059 | Fizzy Elemental | O
 DARKMOON_FAIRE | DMF_060 | Umbral Owl |  
 DARKMOON_FAIRE | DMF_061 | Faire Arborist |  
 DARKMOON_FAIRE | DMF_062 | Gyreworm |  
-DARKMOON_FAIRE | DMF_064 | Carousel Gryphon |  
+DARKMOON_FAIRE | DMF_064 | Carousel Gryphon | O
 DARKMOON_FAIRE | DMF_065 | Banana Vendor |  
 DARKMOON_FAIRE | DMF_066 | Knife Vendor |  
 DARKMOON_FAIRE | DMF_067 | Prize Vendor |  
@@ -1261,15 +1261,15 @@ DARKMOON_FAIRE | DMF_068 | Optimistic Ogre |
 DARKMOON_FAIRE | DMF_069 | Claw Machine |  
 DARKMOON_FAIRE | DMF_070 | Darkmoon Rabbit |  
 DARKMOON_FAIRE | DMF_071 | Tenwu of the Red Smoke |  
-DARKMOON_FAIRE | DMF_073 | Darkmoon Dirigible |  
+DARKMOON_FAIRE | DMF_073 | Darkmoon Dirigible | O
 DARKMOON_FAIRE | DMF_074 | Silas Darkmoon |  
 DARKMOON_FAIRE | DMF_075 | Guess the Weight |  
-DARKMOON_FAIRE | DMF_078 | Strongman |  
+DARKMOON_FAIRE | DMF_078 | Strongman | O
 DARKMOON_FAIRE | DMF_079 | Inconspicuous Rider |  
-DARKMOON_FAIRE | DMF_080 | Fleethoof Pearltusk |  
+DARKMOON_FAIRE | DMF_080 | Fleethoof Pearltusk | O
 DARKMOON_FAIRE | DMF_081 | K'thir Ritualist |  
 DARKMOON_FAIRE | DMF_082 | Darkmoon Statue |  
-DARKMOON_FAIRE | DMF_083 | Dancing Cobra |  
+DARKMOON_FAIRE | DMF_083 | Dancing Cobra | O
 DARKMOON_FAIRE | DMF_084 | Jewel of N'Zoth |  
 DARKMOON_FAIRE | DMF_085 | Darkmoon Tonk |  
 DARKMOON_FAIRE | DMF_086 | Petting Zoo |  
@@ -1279,7 +1279,7 @@ DARKMOON_FAIRE | DMF_089 | Maxima Blastenheimer |
 DARKMOON_FAIRE | DMF_090 | Don't Feed the Animals |  
 DARKMOON_FAIRE | DMF_091 | Wriggling Horror |  
 DARKMOON_FAIRE | DMF_100 | Confection Cyclone |  
-DARKMOON_FAIRE | DMF_101 | Firework Elemental |  
+DARKMOON_FAIRE | DMF_101 | Firework Elemental | O
 DARKMOON_FAIRE | DMF_102 | Game Master |  
 DARKMOON_FAIRE | DMF_103 | Mask of C'Thun |  
 DARKMOON_FAIRE | DMF_104 | Grand Finale |  
@@ -1291,7 +1291,7 @@ DARKMOON_FAIRE | DMF_109 | Sayge, Seer of Darkmoon |
 DARKMOON_FAIRE | DMF_110 | Fire Breather |  
 DARKMOON_FAIRE | DMF_111 | Man'ari Mosher |  
 DARKMOON_FAIRE | DMF_113 | Free Admission |  
-DARKMOON_FAIRE | DMF_114 | Midway Maniac |  
+DARKMOON_FAIRE | DMF_114 | Midway Maniac | O
 DARKMOON_FAIRE | DMF_115 | Revenant Rascal |  
 DARKMOON_FAIRE | DMF_116 | The Nameless One |  
 DARKMOON_FAIRE | DMF_117 | Cascading Disaster |  
@@ -1304,13 +1304,13 @@ DARKMOON_FAIRE | DMF_123 | Open the Cages |
 DARKMOON_FAIRE | DMF_124 | Horrendous Growth |  
 DARKMOON_FAIRE | DMF_125 | Safety Inspector |  
 DARKMOON_FAIRE | DMF_163 | Carnival Clown |  
-DARKMOON_FAIRE | DMF_174 | Circus Medic |  
-DARKMOON_FAIRE | DMF_184 | Fairground Fool |  
+DARKMOON_FAIRE | DMF_174 | Circus Medic | O
+DARKMOON_FAIRE | DMF_184 | Fairground Fool | O
 DARKMOON_FAIRE | DMF_186 | Auspicious Spirits |  
 DARKMOON_FAIRE | DMF_187 | Palm Reading |  
 DARKMOON_FAIRE | DMF_188 | Y'Shaarj, the Defiler |  
 DARKMOON_FAIRE | DMF_189 | Costumed Entertainer |  
-DARKMOON_FAIRE | DMF_190 | Fantastic Firebird |  
+DARKMOON_FAIRE | DMF_190 | Fantastic Firebird | O
 DARKMOON_FAIRE | DMF_191 | Showstopper |  
 DARKMOON_FAIRE | DMF_194 | Redscale Dragontamer |  
 DARKMOON_FAIRE | DMF_195 | Snack Run |  
@@ -1333,8 +1333,8 @@ DARKMOON_FAIRE | DMF_237 | Carnival Barker |
 DARKMOON_FAIRE | DMF_238 | Hammer of the Naaru |  
 DARKMOON_FAIRE | DMF_240 | Lothraxion the Redeemed |  
 DARKMOON_FAIRE | DMF_241 | High Exarch Yrel |  
-DARKMOON_FAIRE | DMF_244 | Day at the Faire |  
-DARKMOON_FAIRE | DMF_247 | Insatiable Felhound |  
+DARKMOON_FAIRE | DMF_244 | Day at the Faire | O
+DARKMOON_FAIRE | DMF_247 | Insatiable Felhound | O
 DARKMOON_FAIRE | DMF_248 | Felsteel Executioner |  
 DARKMOON_FAIRE | DMF_249 | Acrobatics |  
 DARKMOON_FAIRE | DMF_254 | C'Thun, the Shattered |  
@@ -1344,7 +1344,7 @@ DARKMOON_FAIRE | DMF_513 | Shadow Clone |
 DARKMOON_FAIRE | DMF_514 | Ticket Master |  
 DARKMOON_FAIRE | DMF_515 | Swindle |  
 DARKMOON_FAIRE | DMF_516 | Grand Empress Shek'zara |  
-DARKMOON_FAIRE | DMF_517 | Sweet Tooth |  
+DARKMOON_FAIRE | DMF_517 | Sweet Tooth | O
 DARKMOON_FAIRE | DMF_518 | Malevolent Strike |  
 DARKMOON_FAIRE | DMF_519 | Prize Plunderer |  
 DARKMOON_FAIRE | DMF_520 | Parade Leader |  
@@ -1362,18 +1362,18 @@ DARKMOON_FAIRE | DMF_532 | Circus Amalgam |
 DARKMOON_FAIRE | DMF_533 | Ring Matron |  
 DARKMOON_FAIRE | DMF_534 | Deck of Chaos |  
 DARKMOON_FAIRE | DMF_700 | Revolve |  
-DARKMOON_FAIRE | DMF_701 | Dunk Tank |  
+DARKMOON_FAIRE | DMF_701 | Dunk Tank | O
 DARKMOON_FAIRE | DMF_702 | Stormstrike |  
-DARKMOON_FAIRE | DMF_703 | Pit Master |  
+DARKMOON_FAIRE | DMF_703 | Pit Master | O
 DARKMOON_FAIRE | DMF_704 | Cagematch Custodian |  
 DARKMOON_FAIRE | DMF_705 | Whack-A-Gnoll Hammer |  
 DARKMOON_FAIRE | DMF_706 | Deathmatch Pavilion |  
 DARKMOON_FAIRE | DMF_707 | Magicfin |  
 DARKMOON_FAIRE | DMF_708 | Inara Stormcrash |  
 DARKMOON_FAIRE | DMF_709 | Grand Totem Eys'or |  
-DARKMOON_FAIRE | DMF_730 | Moontouched Amulet |  
+DARKMOON_FAIRE | DMF_730 | Moontouched Amulet | O
 DARKMOON_FAIRE | DMF_732 | Cenarion Ward |  
 DARKMOON_FAIRE | DMF_733 | Kiri, Chosen of Elune |  
 DARKMOON_FAIRE | DMF_734 | Greybough |  
 
-- Progress: 0% (0 of 135 Cards)
+- Progress: 13% (18 of 135 Cards)

--- a/Includes/Rosetta/PlayMode/Cards/CardDef.hpp
+++ b/Includes/Rosetta/PlayMode/Cards/CardDef.hpp
@@ -59,6 +59,14 @@ class CardDef
     explicit CardDef(Power _power, std::map<PlayReq, int> _playReqs,
                      std::vector<std::string> _chooseCardIDs);
 
+    //! Constructs card def with given \p _power, \p _playReqs and
+    //! \p _corruptCardID.
+    //! \param _power The power data.
+    //! \param _playReqs The play requirements data.
+    //! \param _corruptCardID The card ID to change when 'Corrupt' is activated.
+    explicit CardDef(Power _power, std::map<PlayReq, int> _playReqs,
+                     std::string _corruptCardID);
+
     //! Constructs card def with given \p _power, \p _playReqs,
     //! \p _chooseCardIDs and \p _entourages.
     //! \param _power The power data.

--- a/Includes/Rosetta/PlayMode/Cards/CardDef.hpp
+++ b/Includes/Rosetta/PlayMode/Cards/CardDef.hpp
@@ -38,6 +38,11 @@ class CardDef
     //! \param _chooseCardIDs The choose card IDs data.
     explicit CardDef(Power _power, std::vector<std::string> _chooseCardIDs);
 
+    //! Constructs card def with given \p _power and \p _corruptCardID.
+    //! \param _power The power data.
+    //! \param _corruptCardID The card ID to change when 'Corrupt' is activated.
+    explicit CardDef(Power _power, std::string _corruptCardID);
+
     //! Constructs card def with given \p _power, \p _questProgressTotal
     //! and \p _heroPowerDbfID.
     //! \param _power The power data.
@@ -68,6 +73,7 @@ class CardDef
     std::map<PlayReq, int> playReqs;
     std::vector<std::string> chooseCardIDs;
     std::vector<std::string> entourages;
+    std::string corruptCardID;
     int questProgressTotal = 0;
     int heroPowerDbfID = 0;
 };

--- a/Includes/Rosetta/PlayMode/Models/Playable.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Playable.hpp
@@ -103,6 +103,10 @@ class Playable : public Entity
     //! \return The flag that indicates whether it is echo.
     bool IsEcho() const;
 
+    //! Returns the flag that indicates whether it has corrupt.
+    //! \return The flag that indicates whether it has corrupt.
+    bool HasCorrupt() const;
+
     //! Resets the value of the cost.
     void ResetCost();
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Expansions
 
-  * 0% Madness at the Darkmoon Faire (0 of 135 cards)
+  * 13% Madness at the Darkmoon Faire (18 of 135 cards)
   * 24% Scholomance Academy (33 of 135 cards)
   * 25% Ashes of Outland (35 of 135 cards)
   * **100% Descent of Dragons (140 of 140 cards)**

--- a/Scripts/card_comment_gen.py
+++ b/Scripts/card_comment_gen.py
@@ -12,7 +12,7 @@ def cardCommentGen(card):
     str_format = str_format.replace(" ", "-")
     str_format = str_format.replace("#", " ")
     str_format = str_format + comm + \
-        "[" + card['id'] + "] " + card['name'] + " - COST: "
+        "[" + card['id'] + "] " + card['name'] + " - COST:"
     if("cost" in card.keys()):
         str_format = str_format + str(card['cost'])
     else:

--- a/Scripts/card_comment_gen.py
+++ b/Scripts/card_comment_gen.py
@@ -19,7 +19,7 @@ def cardCommentGen(card):
         str_format = str_format + str(0)
     if card['type'] == "MINION":
         str_format = str_format + \
-            " [ATK: " + str(card['attack']) + "/HP: " + \
+            " [ATK:" + str(card['attack']) + "/HP:" + \
             str(card['health']) + "]"
     str_format = str_format + comm + "- "
     if "race" in card.keys():

--- a/Sources/Rosetta/PlayMode/Actions/Generic.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Generic.cpp
@@ -160,6 +160,10 @@ void ChangeEntity(Player* player, Playable* playable, Card* newCard,
     if (playable->card->GetCardType() == newCard->GetCardType())
     {
         playable->card = newCard;
+        for (auto& gameTag : newCard->gameTags)
+        {
+            playable->SetGameTag(gameTag.first, gameTag.second);
+        }
 
         if (playable->costManager != nullptr)
         {

--- a/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
@@ -4,6 +4,7 @@
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 #include <Rosetta/PlayMode/Actions/CastSpell.hpp>
+#include <Rosetta/PlayMode/Actions/Generic.hpp>
 #include <Rosetta/PlayMode/Actions/PlayCard.hpp>
 #include <Rosetta/PlayMode/Cards/Cards.hpp>
 #include <Rosetta/PlayMode/Games/Game.hpp>
@@ -73,6 +74,19 @@ void PlayCard(Player* player, Playable* source, Character* target, int fieldPos,
             player->opponent->GetDeckZone()->GetCount() + 7)
     {
         player->IncreaseNumCardsPlayedThisGameNotStartInDeck();
+    }
+
+    // Process keyword 'Corrupt'
+    for (auto& playable : player->GetHandZone()->GetAll())
+    {
+        if (playable->HasCorrupt() && source->GetCost() > playable->GetCost())
+        {
+            Card* newCard = Cards::FindCardByID(playable->card->id + "t");
+            if (newCard != nullptr)
+            {
+                ChangeEntity(player, playable, newCard, true);
+            }
+        }
     }
 
     // Set card's owner
@@ -190,7 +204,7 @@ void PlayHero(Player* player, Hero* hero, Character* target, int chooseOne)
     // If player has extra battlecry, activate power task again
     if (player->ExtraBattlecry())
     {
-        hero->ActivateTask(PowerType::POWER, target, chooseOne);    
+        hero->ActivateTask(PowerType::POWER, target, chooseOne);
     }
 
     player->game->ProcessTasks();

--- a/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
@@ -81,7 +81,8 @@ void PlayCard(Player* player, Playable* source, Character* target, int fieldPos,
     {
         if (playable->HasCorrupt() && source->GetCost() > playable->GetCost())
         {
-            Card* newCard = Cards::FindCardByID(playable->card->id + "t");
+            Card* newCard = Cards::FindCardByDbfID(
+                playable->GetGameTag(GameTag::CORRUPTEDCARD));
             if (newCard != nullptr)
             {
                 ChangeEntity(player, playable, newCard, true);

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -232,6 +232,8 @@ void DarkmoonFaireCardsGen::AddDruidNonCollect(
 
 void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- MINION - HUNTER
     // [DMF_083] Dancing Cobra - COST: 2 [ATK: 1/HP: 5]
     // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Common
@@ -244,6 +246,9 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - POISONOUS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_083", CardDef(power));
 
     // ----------------------------------------- SPELL - HUNTER
     // [DMF_084] Jewel of N'Zoth - COST: 8
@@ -359,6 +364,8 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 void DarkmoonFaireCardsGen::AddHunterNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- MINION - HUNTER
     // [DMF_083t] Dancing Cobra - COST: 2 [ATK: 1/HP: 5]
     // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Common
@@ -369,6 +376,9 @@ void DarkmoonFaireCardsGen::AddHunterNonCollect(
     // GameTag:
     // - POISONOUS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_083t", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
     // [DMF_086e] Darkmoon Strider - COST: 3 [ATK: 3/HP: 3]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1193,6 +1193,15 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CORRUPT = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 4, true));
+    cards.emplace("DMF_701",
+                  CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } },
+                          "DMF_701t"));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [DMF_702] Stormstrike - COST:3
@@ -1297,6 +1306,17 @@ void DarkmoonFaireCardsGen::AddShamanNonCollect(
     // Text: <b>Corrupted</b>
     //       Deal 4 damage, then deal 2 damage to all enemy minions.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 4, true));
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 2, true));
+    cards.emplace(
+        "DMF_701t",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [DMF_702e] Stormstrike - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -248,7 +248,7 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
-    cards.emplace("DMF_083", CardDef(power));
+    cards.emplace("DMF_083", CardDef(power, "DMF_083t"));
 
     // ----------------------------------------- SPELL - HUNTER
     // [DMF_084] Jewel of N'Zoth - COST: 8
@@ -596,7 +596,7 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
-    cards.emplace("DMF_064", CardDef(power));
+    cards.emplace("DMF_064", CardDef(power, "DMF_064t"));
 
     // --------------------------------------- MINION - PALADIN
     // [DMF_194] Redscale Dragontamer - COST: 2 [ATK:2/HP:3]
@@ -869,7 +869,7 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
-    cards.emplace("DMF_184", CardDef(power));
+    cards.emplace("DMF_184", CardDef(power, "DMF_184t"));
 
     // ----------------------------------------- SPELL - PRIEST
     // [DMF_186] Auspicious Spirits - COST: 4
@@ -1042,7 +1042,7 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
-    cards.emplace("DMF_517", CardDef(power));
+    cards.emplace("DMF_517", CardDef(power, "DMF_517a"));
 
     // ------------------------------------------ SPELL - ROGUE
     // [DMF_518] Malevolent Strike - COST: 5
@@ -1794,7 +1794,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
-    cards.emplace("DMF_247", CardDef(power));
+    cards.emplace("DMF_247", CardDef(power, "DMF_247t"));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [DMF_248] Felsteel Executioner - COST: 3 [ATK:4/HP:3]
@@ -2014,7 +2014,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
-    cards.emplace("DMF_073", CardDef(power));
+    cards.emplace("DMF_073", CardDef(power, "DMF_073t"));
 
     // --------------------------------------- MINION - NEUTRAL
     // [DMF_074] Silas Darkmoon - COST: 7 [ATK:4/HP:4]
@@ -2065,7 +2065,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
-    cards.emplace("DMF_080", CardDef(power));
+    cards.emplace("DMF_080", CardDef(power, "DMF_080t"));
 
     // --------------------------------------- MINION - NEUTRAL
     // [DMF_081] K'thir Ritualist - COST: 3 [ATK:4/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -2043,6 +2043,9 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - CORRUPT = 1
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_080", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [DMF_081] K'thir Ritualist - COST: 3 [ATK:4/HP:4]
@@ -2413,6 +2416,9 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_080t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [DMF_082e] Imposing Statue - COST: 0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1835,6 +1835,8 @@ void DarkmoonFaireCardsGen::AddDemonHunterNonCollect(
 
 void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - NEUTRAL
     // [DMF_002] N'Zoth, God of the Deep - COST: 10 [ATK: 5/HP: 7]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
@@ -1960,6 +1962,9 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_073", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [DMF_074] Silas Darkmoon - COST: 7 [ATK: 4/HP: 4]
@@ -2196,6 +2201,8 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- SPELL - NEUTRAL
     // [DMF_004t1] Mysterybox - COST: 0
     // - Set: DARKMOON_FAIRE
@@ -2328,6 +2335,9 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // - DIVINE_SHIELD = 1
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_073t", CardDef(power));
 
     // ---------------------------------------- SPELL - NEUTRAL
     // [DMF_074a] This Way - COST: 0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -8,6 +8,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/HealTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
 
 using namespace RosettaStone::PlayMode;
@@ -2255,6 +2256,15 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - CORRUPT = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<HealTask>(EntityType::TARGET, 4));
+    cards.emplace(
+        "DMF_174",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } },
+                "DMF_174t"));
 
     // --------------------------------------- MINION - NEUTRAL
     // [DMF_188] Y'Shaarj, the Defiler - COST:10 [ATK:10/HP:10]
@@ -2644,6 +2654,14 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::TARGET, 4));
+    cards.emplace(
+        "DMF_174t",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } }));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [DMF_187e] Palm Reading - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -939,6 +939,8 @@ void DarkmoonFaireCardsGen::AddPriestNonCollect(
 
 void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- MINION - ROGUE
     // [DMF_071] Tenwu of the Red Smoke - COST: 2 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
@@ -1038,6 +1040,9 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - STEALTH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_517", CardDef(power));
 
     // ------------------------------------------ SPELL - ROGUE
     // [DMF_518] Malevolent Strike - COST: 5
@@ -1062,6 +1067,8 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 void DarkmoonFaireCardsGen::AddRogueNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------ ENCHANTMENT - ROGUE
     // [DMF_511e] Enabling - COST: 0
     // - Set: DARKMOON_FAIRE
@@ -1113,6 +1120,9 @@ void DarkmoonFaireCardsGen::AddRogueNonCollect(
     // GameTag:
     // - STEALTH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_517a", CardDef(power));
 }
 
 void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1615,6 +1615,8 @@ void DarkmoonFaireCardsGen::AddWarriorNonCollect(
 void DarkmoonFaireCardsGen::AddDemonHunter(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------- MINION - DEMONHUNTER
     // [DMF_217] Line Hopper - COST: 3 [ATK: 3/HP: 4]
     // - Set: DARKMOON_FAIRE, Rarity: Common
@@ -1770,6 +1772,9 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // - LIFESTEAL = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_247", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [DMF_248] Felsteel Executioner - COST: 3 [ATK: 4/HP: 3]
@@ -1792,6 +1797,8 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
 void DarkmoonFaireCardsGen::AddDemonHunterNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [DMF_217e] Marked for Passing - COST: 0
     // - Set: DARKMOON_FAIRE
@@ -1837,6 +1844,9 @@ void DarkmoonFaireCardsGen::AddDemonHunterNonCollect(
     // - LIFESTEAL = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_247t", CardDef(power));
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [DMF_248e] Wicked Transformation - COST: 0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -578,6 +578,8 @@ void DarkmoonFaireCardsGen::AddMageNonCollect(
 
 void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - PALADIN
     // [DMF_064] Carousel Gryphon - COST: 5 [ATK:5/HP:5]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
@@ -592,6 +594,9 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // - DIVINE_SHIELD = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_064", CardDef(power));
 
     // --------------------------------------- MINION - PALADIN
     // [DMF_194] Redscale Dragontamer - COST: 2 [ATK:2/HP:3]
@@ -713,6 +718,8 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 void DarkmoonFaireCardsGen::AddPaladinNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - PALADIN
     // [DMF_064t] Carousel Gryphon - COST: 5 [ATK:8/HP:8]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
@@ -724,6 +731,9 @@ void DarkmoonFaireCardsGen::AddPaladinNonCollect(
     // - DIVINE_SHIELD = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_064t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - PALADIN
     // [DMF_235e] Floaty - COST: 0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -26,7 +26,7 @@ void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ------------------------------------------ SPELL - DRUID
-    // [DMF_057] Lunar Eclipse - COST: 2
+    // [DMF_057] Lunar Eclipse - COST:2
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: Deal 3 damage to a minion.
@@ -34,14 +34,14 @@ void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [DMF_058] Solar Eclipse - COST: 2
+    // [DMF_058] Solar Eclipse - COST:2
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: Your next spell this turn casts twice.
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [DMF_059] Fizzy Elemental - COST: 9 [ATK:10/HP:10]
+    // [DMF_059] Fizzy Elemental - COST:9 [ATK:10/HP:10]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -53,7 +53,7 @@ void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [DMF_060] Umbral Owl - COST: 7 [ATK:4/HP:4]
+    // [DMF_060] Umbral Owl - COST:7 [ATK:4/HP:4]
     // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -65,7 +65,7 @@ void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [DMF_061] Faire Arborist - COST: 3 [ATK:2/HP:2]
+    // [DMF_061] Faire Arborist - COST:3 [ATK:2/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Choose One - </b>Draw a card;
@@ -78,7 +78,7 @@ void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [DMF_075] Guess the Weight - COST: 2
+    // [DMF_075] Guess the Weight - COST:2
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: Draw a card.
@@ -86,7 +86,7 @@ void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [DMF_730] Moontouched Amulet - COST: 3
+    // [DMF_730] Moontouched Amulet - COST:3
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Give your hero +4 Attack this turn.
@@ -101,14 +101,14 @@ void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     cards.emplace("DMF_730", CardDef(power, "DMF_730t"));
 
     // ------------------------------------------ SPELL - DRUID
-    // [DMF_732] Cenarion Ward - COST: 8
+    // [DMF_732] Cenarion Ward - COST:8
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: Gain 8 Armor. Summon a random 8-Cost minion.
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [DMF_733] Kiri, Chosen of Elune - COST: 4 [ATK:2/HP:2]
+    // [DMF_733] Kiri, Chosen of Elune - COST:4 [ATK:2/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Add a Solar Eclipse and
@@ -120,7 +120,7 @@ void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [DMF_734] Greybough - COST: 5 [ATK:4/HP:6]
+    // [DMF_734] Greybough - COST:5 [ATK:4/HP:6]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Taunt</b> <b>Deathrattle:</b> Give a random
@@ -139,14 +139,14 @@ void DarkmoonFaireCardsGen::AddDruidNonCollect(
     Power power;
 
     // ------------------------------------ ENCHANTMENT - DRUID
-    // [DMF_057e] Lunar Empowerment - COST: 0
+    // [DMF_057e] Lunar Empowerment - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: The next spell you cast costs (2) less.
     // --------------------------------------------------------
 
     // ------------------------------------ ENCHANTMENT - DRUID
-    // [DMF_057o] Lunar Empowerment - COST: 0
+    // [DMF_057o] Lunar Empowerment - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: The next spell you cast this turn costs (2) less.
@@ -156,7 +156,7 @@ void DarkmoonFaireCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
 
     // ------------------------------------ ENCHANTMENT - DRUID
-    // [DMF_058e] Solar Empowerment - COST: 0
+    // [DMF_058e] Solar Empowerment - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Your next spell this turn casts twice.
@@ -166,7 +166,7 @@ void DarkmoonFaireCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
 
     // ------------------------------------ ENCHANTMENT - DRUID
-    // [DMF_058o] Solar Empowerment - COST: 0
+    // [DMF_058o] Solar Empowerment - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Your next spell this turn casts twice.
@@ -176,21 +176,21 @@ void DarkmoonFaireCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [DMF_061a] Prune the Fruit - COST: 3
+    // [DMF_061a] Prune the Fruit - COST:3
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Draw a card.
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [DMF_061b] Dig It Up - COST: 3
+    // [DMF_061b] Dig It Up - COST:3
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Summon a 2/2 Treant.
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [DMF_061t] Faire Arborist - COST: 3 [ATK:2/HP:2]
+    // [DMF_061t] Faire Arborist - COST:3 [ATK:2/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -201,12 +201,12 @@ void DarkmoonFaireCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [DMF_061t2] Treant - COST: 2 [ATK:2/HP:2]
+    // [DMF_061t2] Treant - COST:2 [ATK:2/HP:2]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [DMF_075a] More! - COST: 0
+    // [DMF_075a] More! - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Guess that the next card costs more.
@@ -216,7 +216,7 @@ void DarkmoonFaireCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [DMF_075a2] Less! - COST: 0
+    // [DMF_075a2] Less! - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Guess that the next card costs less.
@@ -226,7 +226,7 @@ void DarkmoonFaireCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
 
     // ------------------------------------ ENCHANTMENT - DRUID
-    // [DMF_730e] Moontouched Amulet - COST: 0
+    // [DMF_730e] Moontouched Amulet - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +4 Attack this turn.
@@ -239,7 +239,7 @@ void DarkmoonFaireCardsGen::AddDruidNonCollect(
     cards.emplace("DMF_730e", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
-    // [DMF_730t] Moontouched Amulet - COST: 3
+    // [DMF_730t] Moontouched Amulet - COST:3
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -257,7 +257,7 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ---------------------------------------- MINION - HUNTER
-    // [DMF_083] Dancing Cobra - COST: 2 [ATK:1/HP:5]
+    // [DMF_083] Dancing Cobra - COST:2 [ATK:1/HP:5]
     // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupt:</b> Gain <b>Poisonous</b>.
@@ -273,7 +273,7 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     cards.emplace("DMF_083", CardDef(power, "DMF_083t"));
 
     // ----------------------------------------- SPELL - HUNTER
-    // [DMF_084] Jewel of N'Zoth - COST: 8
+    // [DMF_084] Jewel of N'Zoth - COST:8
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: Summon three friendly <b>Deathrattle</b> minions
@@ -284,7 +284,7 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [DMF_085] Darkmoon Tonk - COST: 7 [ATK:8/HP:5]
+    // [DMF_085] Darkmoon Tonk - COST:7 [ATK:8/HP:5]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Fire four missiles
@@ -295,7 +295,7 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - HUNTER
-    // [DMF_086] Petting Zoo - COST: 3
+    // [DMF_086] Petting Zoo - COST:3
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Summon a 3/3 Strider.
@@ -306,7 +306,7 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [DMF_087] Trampling Rhino - COST: 5 [ATK:5/HP:5]
+    // [DMF_087] Trampling Rhino - COST:5 [ATK:5/HP:5]
     // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Rush</b>. After this attacks and kills a minion,
@@ -318,7 +318,7 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- WEAPON - HUNTER
-    // [DMF_088] Rinling's Rifle - COST: 4
+    // [DMF_088] Rinling's Rifle - COST:4
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: After your hero attacks,
@@ -334,7 +334,7 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [DMF_089] Maxima Blastenheimer - COST: 6 [ATK:4/HP:4]
+    // [DMF_089] Maxima Blastenheimer - COST:6 [ATK:4/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Summon a minion from your deck.
@@ -346,7 +346,7 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - HUNTER
-    // [DMF_090] Don't Feed the Animals - COST: 2
+    // [DMF_090] Don't Feed the Animals - COST:2
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: Give all Beasts in your hand +1/+1.
@@ -357,7 +357,7 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [DMF_122] Mystery Winner - COST: 1 [ATK:1/HP:1]
+    // [DMF_122] Mystery Winner - COST:1 [ATK:1/HP:1]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> <b>Discover</b> a <b>Secret.</b>
@@ -371,7 +371,7 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - HUNTER
-    // [DMF_123] Open the Cages - COST: 2
+    // [DMF_123] Open the Cages - COST:2
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Secret:</b> When your turn starts,
@@ -389,7 +389,7 @@ void DarkmoonFaireCardsGen::AddHunterNonCollect(
     Power power;
 
     // ---------------------------------------- MINION - HUNTER
-    // [DMF_083t] Dancing Cobra - COST: 2 [ATK:1/HP:5]
+    // [DMF_083t] Dancing Cobra - COST:2 [ATK:1/HP:5]
     // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -403,26 +403,26 @@ void DarkmoonFaireCardsGen::AddHunterNonCollect(
     cards.emplace("DMF_083t", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
-    // [DMF_086e] Darkmoon Strider - COST: 3 [ATK:3/HP:3]
+    // [DMF_086e] Darkmoon Strider - COST:3 [ATK:3/HP:3]
     // - Race: Beast, Set: DARKMOON_FAIRE
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - HUNTER
-    // [DMF_090e] Well Fed - COST: 0
+    // [DMF_090e] Well Fed - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - HUNTER
-    // [DMF_090e2] Well Fed - COST: 0
+    // [DMF_090e2] Well Fed - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - HUNTER
-    // [DMF_090t] Don't Feed the Animals - COST: 2
+    // [DMF_090t] Don't Feed the Animals - COST:2
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -430,7 +430,7 @@ void DarkmoonFaireCardsGen::AddHunterNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - HUNTER
-    // [DMF_734e] Greybud - COST: 0
+    // [DMF_734e] Greybud - COST:0
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Summon Greybough.
@@ -440,7 +440,7 @@ void DarkmoonFaireCardsGen::AddHunterNonCollect(
 void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
     // ------------------------------------------ MINION - MAGE
-    // [DMF_100] Confection Cyclone - COST: 2 [ATK:3/HP:2]
+    // [DMF_100] Confection Cyclone - COST:2 [ATK:3/HP:2]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Add two 1/2 Sugar Elementals
@@ -451,7 +451,7 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [DMF_101] Firework Elemental - COST: 5 [ATK:3/HP:5]
+    // [DMF_101] Firework Elemental - COST:5 [ATK:3/HP:5]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Deal 3 damage to a minion.
@@ -463,7 +463,7 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [DMF_102] Game Master - COST: 2 [ATK:2/HP:3]
+    // [DMF_102] Game Master - COST:2 [ATK:2/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: The first <b>Secret</b> you play each turn costs (1).
@@ -476,7 +476,7 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------- SPELL - MAGE
-    // [DMF_103] Mask of C'Thun - COST: 7
+    // [DMF_103] Mask of C'Thun - COST:7
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Deal 10 damage randomly split among all enemies.
@@ -486,7 +486,7 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------- SPELL - MAGE
-    // [DMF_104] Grand Finale - COST: 8
+    // [DMF_104] Grand Finale - COST:8
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Summon an 8/8 Elemental.
@@ -494,7 +494,7 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------- SPELL - MAGE
-    // [DMF_105] Ring Toss - COST: 4
+    // [DMF_105] Ring Toss - COST:4
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Discover</b> a <b>Secret</b> and cast it.
@@ -509,7 +509,7 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [DMF_106] Occult Conjurer - COST: 4 [ATK:4/HP:4]
+    // [DMF_106] Occult Conjurer - COST:4 [ATK:4/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> If you control a <b>Secret</b>,
@@ -523,7 +523,7 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------- SPELL - MAGE
-    // [DMF_107] Rigged Faire Game - COST: 3
+    // [DMF_107] Rigged Faire Game - COST:3
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Secret:</b> If you didn't take any damage
@@ -534,7 +534,7 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------- SPELL - MAGE
-    // [DMF_108] Deck of Lunacy - COST: 2
+    // [DMF_108] Deck of Lunacy - COST:2
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: Transform spells in your deck into ones that cost (3) more.
@@ -545,7 +545,7 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [DMF_109] Sayge, Seer of Darkmoon - COST: 6 [ATK:5/HP:5]
+    // [DMF_109] Sayge, Seer of Darkmoon - COST:6 [ATK:5/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Draw 1 card.
@@ -565,12 +565,12 @@ void DarkmoonFaireCardsGen::AddMageNonCollect(
     std::map<std::string, CardDef>& cards)
 {
     // ------------------------------------------ MINION - MAGE
-    // [DMF_100t] Sugar Elemental - COST: 1 [ATK:1/HP:2]
+    // [DMF_100t] Sugar Elemental - COST:1 [ATK:1/HP:2]
     // - Race: Elemental, Set: DARKMOON_FAIRE
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [DMF_101t] Firework Elemental - COST: 5 [ATK:3/HP:5]
+    // [DMF_101t] Firework Elemental - COST:5 [ATK:3/HP:5]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -581,12 +581,12 @@ void DarkmoonFaireCardsGen::AddMageNonCollect(
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [DMF_104t] Exploding Sparkler - COST: 8 [ATK:8/HP:8]
+    // [DMF_104t] Exploding Sparkler - COST:8 [ATK:8/HP:8]
     // - Race: Elemental, Set: DARKMOON_FAIRE
     // --------------------------------------------------------
 
     // ------------------------------------------- SPELL - MAGE
-    // [DMF_105t] Ring Toss - COST: 4
+    // [DMF_105t] Ring Toss - COST:4
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -603,7 +603,7 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     Power power;
 
     // --------------------------------------- MINION - PALADIN
-    // [DMF_064] Carousel Gryphon - COST: 5 [ATK:5/HP:5]
+    // [DMF_064] Carousel Gryphon - COST:5 [ATK:5/HP:5]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Divine Shield</b>
@@ -621,7 +621,7 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     cards.emplace("DMF_064", CardDef(power, "DMF_064t"));
 
     // --------------------------------------- MINION - PALADIN
-    // [DMF_194] Redscale Dragontamer - COST: 2 [ATK:2/HP:3]
+    // [DMF_194] Redscale Dragontamer - COST:2 [ATK:2/HP:3]
     // - Race: Murloc, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Draw a Dragon.
@@ -631,7 +631,7 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [DMF_195] Snack Run - COST: 2
+    // [DMF_195] Snack Run - COST:2
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Discover</b> a spell.
@@ -642,7 +642,7 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [DMF_235] Balloon Merchant - COST: 4 [ATK:3/HP:5]
+    // [DMF_235] Balloon Merchant - COST:4 [ATK:3/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give your Silver Hand Recruits
@@ -656,7 +656,7 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [DMF_236] Oh My Yogg! - COST: 1
+    // [DMF_236] Oh My Yogg! - COST:1
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Secret:</b> When your opponent casts a spell,
@@ -667,7 +667,7 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [DMF_237] Carnival Barker - COST: 3 [ATK:3/HP:2]
+    // [DMF_237] Carnival Barker - COST:3 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Whenever you summon a 1-Health minion, give it +1/+2.
@@ -677,7 +677,7 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- WEAPON - PALADIN
-    // [DMF_238] Hammer of the Naaru - COST: 6
+    // [DMF_238] Hammer of the Naaru - COST:6
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Summon a 6/6 Holy Elemental
@@ -691,7 +691,7 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [DMF_240] Lothraxion the Redeemed - COST: 5 [ATK:5/HP:5]
+    // [DMF_240] Lothraxion the Redeemed - COST:5 [ATK:5/HP:5]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> For the rest of the game,
@@ -707,7 +707,7 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [DMF_241] High Exarch Yrel - COST: 8 [ATK:7/HP:5]
+    // [DMF_241] High Exarch Yrel - COST:8 [ATK:7/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> If your deck has no Neutral cards,
@@ -726,7 +726,7 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [DMF_244] Day at the Faire - COST: 3
+    // [DMF_244] Day at the Faire - COST:3
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: Summon 3 Silver Hand Recruits.
@@ -743,7 +743,7 @@ void DarkmoonFaireCardsGen::AddPaladinNonCollect(
     Power power;
 
     // --------------------------------------- MINION - PALADIN
-    // [DMF_064t] Carousel Gryphon - COST: 5 [ATK:8/HP:8]
+    // [DMF_064t] Carousel Gryphon - COST:5 [ATK:8/HP:8]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -758,26 +758,26 @@ void DarkmoonFaireCardsGen::AddPaladinNonCollect(
     cards.emplace("DMF_064t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - PALADIN
-    // [DMF_235e] Floaty - COST: 0
+    // [DMF_235e] Floaty - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +1 Attack.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - PALADIN
-    // [DMF_236t] Oh My Yogg! - COST: 0
+    // [DMF_236t] Oh My Yogg! - COST:0
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - PALADIN
-    // [DMF_237e] At the Faire - COST: 0
+    // [DMF_237e] At the Faire - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +1/+2.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [DMF_238t] Holy Elemental - COST: 6 [ATK:6/HP:6]
+    // [DMF_238t] Holy Elemental - COST:6 [ATK:6/HP:6]
     // - Race: Elemental, Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -787,7 +787,7 @@ void DarkmoonFaireCardsGen::AddPaladinNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [DMF_244t] Day at the Faire - COST: 3
+    // [DMF_244t] Day at the Faire - COST:3
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -800,7 +800,7 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ---------------------------------------- MINION - PRIEST
-    // [DMF_053] Blood of G'huun - COST: 9 [ATK:8/HP:8]
+    // [DMF_053] Blood of G'huun - COST:9 [ATK:8/HP:8]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Taunt</b> At the end of your turn,
@@ -812,7 +812,7 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - PRIEST
-    // [DMF_054] Insight - COST: 2
+    // [DMF_054] Insight - COST:2
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: Draw a minion. <b>Corrupt:</b> Reduce its Cost by (2).
@@ -822,14 +822,14 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - PRIEST
-    // [DMF_055] Idol of Y'Shaarj - COST: 8
+    // [DMF_055] Idol of Y'Shaarj - COST:8
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: Summon a 10/10 copy of a minion in your deck.
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [DMF_056] G'huun the Blood God - COST: 8 [ATK:8/HP:8]
+    // [DMF_056] G'huun the Blood God - COST:8 [ATK:8/HP:8]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Draw 2 cards.
@@ -841,7 +841,7 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [DMF_116] The Nameless One - COST: 4 [ATK:4/HP:4]
+    // [DMF_116] The Nameless One - COST:4 [ATK:4/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Choose a minion.
@@ -856,7 +856,7 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [DMF_120] Nazmani Bloodweaver - COST: 3 [ATK:2/HP:5]
+    // [DMF_120] Nazmani Bloodweaver - COST:3 [ATK:2/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: After you cast a spell,
@@ -867,7 +867,7 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [DMF_121] Fortune Teller - COST: 5 [ATK:3/HP:3]
+    // [DMF_121] Fortune Teller - COST:5 [ATK:3/HP:3]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -879,7 +879,7 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [DMF_184] Fairground Fool - COST: 3 [ATK:4/HP:3]
+    // [DMF_184] Fairground Fool - COST:3 [ATK:4/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -894,7 +894,7 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     cards.emplace("DMF_184", CardDef(power, "DMF_184t"));
 
     // ----------------------------------------- SPELL - PRIEST
-    // [DMF_186] Auspicious Spirits - COST: 4
+    // [DMF_186] Auspicious Spirits - COST:4
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Summon a random 4-Cost minion.
@@ -905,7 +905,7 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - PRIEST
-    // [DMF_187] Palm Reading - COST: 3
+    // [DMF_187] Palm Reading - COST:3
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Discover</b> a spell.
@@ -922,7 +922,7 @@ void DarkmoonFaireCardsGen::AddPriestNonCollect(
     Power power;
 
     // ----------------------------------------- SPELL - PRIEST
-    // [DMF_054t] Insight - COST: 2
+    // [DMF_054t] Insight - COST:2
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -930,14 +930,14 @@ void DarkmoonFaireCardsGen::AddPriestNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - PRIEST
-    // [DMF_121e2] Spelltacular! - COST: 0
+    // [DMF_121e2] Spelltacular! - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [DMF_184t] Fairground Fool - COST: 3 [ATK:4/HP:7]
+    // [DMF_184t] Fairground Fool - COST:3 [ATK:4/HP:7]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -951,7 +951,7 @@ void DarkmoonFaireCardsGen::AddPriestNonCollect(
     cards.emplace("DMF_184t", CardDef(power));
 
     // ----------------------------------------- SPELL - PRIEST
-    // [DMF_186a] Auspicious Spirits - COST: 4
+    // [DMF_186a] Auspicious Spirits - COST:4
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -964,7 +964,7 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ----------------------------------------- MINION - ROGUE
-    // [DMF_071] Tenwu of the Red Smoke - COST: 2 [ATK:3/HP:2]
+    // [DMF_071] Tenwu of the Red Smoke - COST:2 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Return a friendly minion to your hand.
@@ -976,7 +976,7 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [DMF_511] Foxy Fraud - COST: 2 [ATK:3/HP:2]
+    // [DMF_511] Foxy Fraud - COST:2 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Your next <b>Combo</b> card
@@ -990,7 +990,7 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - ROGUE
-    // [DMF_512] Cloak of Shadows - COST: 3
+    // [DMF_512] Cloak of Shadows - COST:3
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: Give your hero <b>Stealth</b> for 1 turn.
@@ -1000,7 +1000,7 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - ROGUE
-    // [DMF_513] Shadow Clone - COST: 2
+    // [DMF_513] Shadow Clone - COST:2
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Secret:</b> After a minion attacks your hero,
@@ -1014,7 +1014,7 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [DMF_514] Ticket Master - COST: 3 [ATK:4/HP:3]
+    // [DMF_514] Ticket Master - COST:3 [ATK:4/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Shuffle 3 Tickets into your deck.
@@ -1025,7 +1025,7 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - ROGUE
-    // [DMF_515] Swindle - COST: 2
+    // [DMF_515] Swindle - COST:2
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: Draw a spell.
@@ -1036,7 +1036,7 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [DMF_516] Grand Empress Shek'zara - COST: 6 [ATK:5/HP:7]
+    // [DMF_516] Grand Empress Shek'zara - COST:6 [ATK:5/HP:7]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> <b>Discover</b> a card in your deck
@@ -1051,7 +1051,7 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [DMF_517] Sweet Tooth - COST: 2 [ATK:3/HP:2]
+    // [DMF_517] Sweet Tooth - COST:2 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupt:</b> Gain +2 Attack and <b>Stealth</b>.
@@ -1067,7 +1067,7 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     cards.emplace("DMF_517", CardDef(power, "DMF_517a"));
 
     // ------------------------------------------ SPELL - ROGUE
-    // [DMF_518] Malevolent Strike - COST: 5
+    // [DMF_518] Malevolent Strike - COST:5
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: Destroy a minion. Costs (1) less for each card
@@ -1075,7 +1075,7 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [DMF_519] Prize Plunderer - COST: 1 [ATK:2/HP:1]
+    // [DMF_519] Prize Plunderer - COST:1 [ATK:2/HP:1]
     // - Race: Pirate, Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Combo:</b> Deal 1 damage to a minion
@@ -1092,7 +1092,7 @@ void DarkmoonFaireCardsGen::AddRogueNonCollect(
     Power power;
 
     // ------------------------------------ ENCHANTMENT - ROGUE
-    // [DMF_511e] Enabling - COST: 0
+    // [DMF_511e] Enabling - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Your next <b>Combo</b> card costs (2) less.
@@ -1103,21 +1103,21 @@ void DarkmoonFaireCardsGen::AddRogueNonCollect(
     // --------------------------------------------------------
 
     // ------------------------------------ ENCHANTMENT - ROGUE
-    // [DMF_511e2] Cheaper Combos - COST: 0
+    // [DMF_511e2] Cheaper Combos - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Costs (2) less.
     // --------------------------------------------------------
 
     // ------------------------------------ ENCHANTMENT - ROGUE
-    // [DMF_512e] Sneaky - COST: 0
+    // [DMF_512e] Sneaky - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: <b>Stealth</b> for 1 turn.
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - ROGUE
-    // [DMF_514t] Tickets - COST: 3
+    // [DMF_514t] Tickets - COST:3
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: <b>Casts When Drawn</b>
@@ -1128,12 +1128,12 @@ void DarkmoonFaireCardsGen::AddRogueNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [DMF_514t2] Plush Bear - COST: 3 [ATK:3/HP:3]
+    // [DMF_514t2] Plush Bear - COST:3 [ATK:3/HP:3]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [DMF_517a] Sweet Tooth - COST: 2 [ATK:5/HP:2]
+    // [DMF_517a] Sweet Tooth - COST:2 [ATK:5/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -1150,14 +1150,14 @@ void DarkmoonFaireCardsGen::AddRogueNonCollect(
 void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 {
     // ----------------------------------------- SPELL - SHAMAN
-    // [DMF_700] Revolve - COST: 1
+    // [DMF_700] Revolve - COST:1
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: Transform all minions into random ones with the same Cost.
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - SHAMAN
-    // [DMF_701] Dunk Tank - COST: 4
+    // [DMF_701] Dunk Tank - COST:4
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Deal 4 damage.
@@ -1168,7 +1168,7 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - SHAMAN
-    // [DMF_702] Stormstrike - COST: 3
+    // [DMF_702] Stormstrike - COST:3
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: Deal 3 damage to a minion.
@@ -1176,7 +1176,7 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [DMF_703] Pit Master - COST: 3 [ATK:1/HP:2]
+    // [DMF_703] Pit Master - COST:3 [ATK:1/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Summon a 3/2 Duelist.
@@ -1188,7 +1188,7 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [DMF_704] Cagematch Custodian - COST: 2 [ATK:2/HP:2]
+    // [DMF_704] Cagematch Custodian - COST:2 [ATK:2/HP:2]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Draw a weapon.
@@ -1198,7 +1198,7 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- WEAPON - SHAMAN
-    // [DMF_705] Whack-A-Gnoll Hammer - COST: 3
+    // [DMF_705] Whack-A-Gnoll Hammer - COST:3
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: After your hero attacks,
@@ -1209,7 +1209,7 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - SHAMAN
-    // [DMF_706] Deathmatch Pavilion - COST: 2
+    // [DMF_706] Deathmatch Pavilion - COST:2
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: Summon a 3/2 Duelist.
@@ -1217,7 +1217,7 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [DMF_707] Magicfin - COST: 3 [ATK:3/HP:4]
+    // [DMF_707] Magicfin - COST:3 [ATK:3/HP:4]
     // - Race: Murloc, Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: After a friendly Murloc dies,
@@ -1228,7 +1228,7 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [DMF_708] Inara Stormcrash - COST: 5 [ATK:4/HP:5]
+    // [DMF_708] Inara Stormcrash - COST:5 [ATK:4/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: On your turn, your hero has +2 Attack and <b>Windfury</b>.
@@ -1242,7 +1242,7 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [DMF_709] Grand Totem Eys'or - COST: 3 [ATK:0/HP:4]
+    // [DMF_709] Grand Totem Eys'or - COST:3 [ATK:0/HP:4]
     // - Race: Totem, Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: At the end of your turn, give +1/+1 to all other Totems
@@ -1258,7 +1258,7 @@ void DarkmoonFaireCardsGen::AddShamanNonCollect(
     std::map<std::string, CardDef>& cards)
 {
     // ----------------------------------------- SPELL - SHAMAN
-    // [DMF_701t] Dunk Tank - COST: 4
+    // [DMF_701t] Dunk Tank - COST:4
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -1266,7 +1266,7 @@ void DarkmoonFaireCardsGen::AddShamanNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
-    // [DMF_702e] Stormstrike - COST: 0
+    // [DMF_702e] Stormstrike - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +3 Attack this turn.
@@ -1276,7 +1276,7 @@ void DarkmoonFaireCardsGen::AddShamanNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [DMF_703t] Pit Master - COST: 3 [ATK:1/HP:2]
+    // [DMF_703t] Pit Master - COST:3 [ATK:1/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -1287,31 +1287,31 @@ void DarkmoonFaireCardsGen::AddShamanNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [DMF_703t2] Duelist - COST: 2 [ATK:3/HP:2]
+    // [DMF_703t2] Duelist - COST:2 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
-    // [DMF_705e] Winner! - COST: 0
+    // [DMF_705e] Winner! - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [DMF_706t] Pavilion Duelist - COST: 2 [ATK:3/HP:2]
+    // [DMF_706t] Pavilion Duelist - COST:2 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
-    // [DMF_708e] Storm Crashing - COST: 0
+    // [DMF_708e] Storm Crashing - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +2 Attack and <b>Windfury</b>.
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
-    // [DMF_709e] Strength of Eys'or - COST: 0
+    // [DMF_709e] Strength of Eys'or - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +1/+1.
@@ -1321,7 +1321,7 @@ void DarkmoonFaireCardsGen::AddShamanNonCollect(
 void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
     // --------------------------------------- MINION - WARLOCK
-    // [DMF_110] Fire Breather - COST: 4 [ATK:4/HP:3]
+    // [DMF_110] Fire Breather - COST:4 [ATK:4/HP:3]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Deal 2 damage to all minions except Demons.
@@ -1331,7 +1331,7 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [DMF_111] Man'ari Mosher - COST: 3 [ATK:3/HP:4]
+    // [DMF_111] Man'ari Mosher - COST:3 [ATK:3/HP:4]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give a friendly Demon +3 Attack
@@ -1345,7 +1345,7 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARLOCK
-    // [DMF_113] Free Admission - COST: 3
+    // [DMF_113] Free Admission - COST:3
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Draw 2 minions.
@@ -1353,7 +1353,7 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [DMF_114] Midway Maniac - COST: 2 [ATK:1/HP:5]
+    // [DMF_114] Midway Maniac - COST:2 [ATK:1/HP:5]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -1363,7 +1363,7 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [DMF_115] Revenant Rascal - COST: 3 [ATK:3/HP:3]
+    // [DMF_115] Revenant Rascal - COST:3 [ATK:3/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Destroy a Mana Crystal for both players.
@@ -1373,7 +1373,7 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARLOCK
-    // [DMF_117] Cascading Disaster - COST: 4
+    // [DMF_117] Cascading Disaster - COST:4
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: Destroy a random enemy minion.
@@ -1385,7 +1385,7 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [DMF_118] Tickatus - COST: 6 [ATK:8/HP:8]
+    // [DMF_118] Tickatus - COST:6 [ATK:8/HP:8]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Remove the top 5 cards from your deck.
@@ -1398,14 +1398,14 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARLOCK
-    // [DMF_119] Wicked Whispers - COST: 1
+    // [DMF_119] Wicked Whispers - COST:1
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Discard your lowest Cost card. Give your minions +1/+1.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [DMF_533] Ring Matron - COST: 6 [ATK:6/HP:4]
+    // [DMF_533] Ring Matron - COST:6 [ATK:6/HP:4]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -1417,7 +1417,7 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARLOCK
-    // [DMF_534] Deck of Chaos - COST: 6
+    // [DMF_534] Deck of Chaos - COST:6
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: Swap the Cost and Attack of all minions in your deck.
@@ -1431,7 +1431,7 @@ void DarkmoonFaireCardsGen::AddWarlockNonCollect(
     std::map<std::string, CardDef>& cards)
 {
     // ---------------------------------- ENCHANTMENT - WARLOCK
-    // [DMF_111e] Dark Power - COST: 0
+    // [DMF_111e] Dark Power - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +3 Attack and <b>Lifesteal</b> until end of turn.
@@ -1442,7 +1442,7 @@ void DarkmoonFaireCardsGen::AddWarlockNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARLOCK
-    // [DMF_117t] Cascading Disaster - COST: 4
+    // [DMF_117t] Cascading Disaster - COST:4
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -1454,7 +1454,7 @@ void DarkmoonFaireCardsGen::AddWarlockNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARLOCK
-    // [DMF_117t2] Cascading Disaster - COST: 4
+    // [DMF_117t2] Cascading Disaster - COST:4
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -1462,7 +1462,7 @@ void DarkmoonFaireCardsGen::AddWarlockNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [DMF_118t] Tickatus - COST: 6 [ATK:8/HP:8]
+    // [DMF_118t] Tickatus - COST:6 [ATK:8/HP:8]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -1475,14 +1475,14 @@ void DarkmoonFaireCardsGen::AddWarlockNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - WARLOCK
-    // [DMF_119e] Nightfall - COST: 0
+    // [DMF_119e] Nightfall - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [DMF_533t] Fiery Imp - COST: 2 [ATK:3/HP:2]
+    // [DMF_533t] Fiery Imp - COST:2 [ATK:3/HP:2]
     // - Race: Demon, Set: DARKMOON_FAIRE
     // --------------------------------------------------------
 }
@@ -1490,7 +1490,7 @@ void DarkmoonFaireCardsGen::AddWarlockNonCollect(
 void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 {
     // --------------------------------------- MINION - WARRIOR
-    // [DMF_521] Sword Eater - COST: 4 [ATK:2/HP:5]
+    // [DMF_521] Sword Eater - COST:4 [ATK:2/HP:5]
     // - Race: Pirate, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -1502,7 +1502,7 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARRIOR
-    // [DMF_522] Minefield - COST: 2
+    // [DMF_522] Minefield - COST:2
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: Deal 5 damage randomly split among all minions.
@@ -1512,7 +1512,7 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [DMF_523] Bumper Car - COST: 2 [ATK:1/HP:3]
+    // [DMF_523] Bumper Car - COST:2 [ATK:1/HP:3]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Rush</b> <b>Deathrattle:</b> Add two 1/1 Riders
@@ -1524,7 +1524,7 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- WEAPON - WARRIOR
-    // [DMF_524] Ringmaster's Baton - COST: 2
+    // [DMF_524] Ringmaster's Baton - COST:2
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: After your hero attacks, give a Mech, Dragon,
@@ -1535,7 +1535,7 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [DMF_525] Ringmaster Whatley - COST: 5 [ATK:3/HP:5]
+    // [DMF_525] Ringmaster Whatley - COST:5 [ATK:3/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Draw a Mech, Dragon, and Pirate.
@@ -1546,7 +1546,7 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARRIOR
-    // [DMF_526] Stage Dive - COST: 1
+    // [DMF_526] Stage Dive - COST:1
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Draw a <b>Rush</b> minion.
@@ -1560,7 +1560,7 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [DMF_528] Tent Trasher - COST: 5 [ATK:5/HP:5]
+    // [DMF_528] Tent Trasher - COST:5 [ATK:5/HP:5]
     // - Race: Dragon, Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b><b>Rush</b>.</b> Costs (1) less for each friendly minion with a
@@ -1571,7 +1571,7 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [DMF_529] E.T.C., God of Metal - COST: 2 [ATK:1/HP:4]
+    // [DMF_529] E.T.C., God of Metal - COST:2 [ATK:1/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: After a friendly <b>Rush</b> minion attacks,
@@ -1586,7 +1586,7 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARRIOR
-    // [DMF_530] Feat of Strength - COST: 3
+    // [DMF_530] Feat of Strength - COST:3
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Give a random <b>Taunt</b> minion in your hand +5/+5.
@@ -1596,7 +1596,7 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [DMF_531] Stage Hand - COST: 2 [ATK:3/HP:2]
+    // [DMF_531] Stage Hand - COST:2 [ATK:3/HP:2]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give a random minion in your hand +1/+1.
@@ -1610,19 +1610,19 @@ void DarkmoonFaireCardsGen::AddWarriorNonCollect(
     std::map<std::string, CardDef>& cards)
 {
     // --------------------------------------- WEAPON - WARRIOR
-    // [DMF_521t] Jawbreaker - COST: 3
+    // [DMF_521t] Jawbreaker - COST:3
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
-    // [DMF_524e] Big-Top Special - COST: 0
+    // [DMF_524e] Big-Top Special - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARRIOR
-    // [DMF_526a] Stage Dive - COST: 1
+    // [DMF_526a] Stage Dive - COST:1
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -1633,21 +1633,21 @@ void DarkmoonFaireCardsGen::AddWarriorNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
-    // [DMF_526e] Bweeeoooow! - COST: 0
+    // [DMF_526e] Bweeeoooow! - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +2/+1.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
-    // [DMF_530e] So Strong! - COST: 0
+    // [DMF_530e] So Strong! - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +5/+5.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
-    // [DMF_531e] Ready to Perform - COST: 0
+    // [DMF_531e] Ready to Perform - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +1/+1.
@@ -1660,7 +1660,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     Power power;
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_217] Line Hopper - COST: 3 [ATK:3/HP:4]
+    // [DMF_217] Line Hopper - COST:3 [ATK:3/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: Your <b>Outcast</b> cards cost (1) less.
@@ -1673,7 +1673,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ------------------------------------ SPELL - DEMONHUNTER
-    // [DMF_219] Relentless Pursuit - COST: 3
+    // [DMF_219] Relentless Pursuit - COST:3
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: Give your hero +4 Attack and <b>Immune</b> this turn.
@@ -1683,7 +1683,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ------------------------------------ SPELL - DEMONHUNTER
-    // [DMF_221] Felscream Blast - COST: 1
+    // [DMF_221] Felscream Blast - COST:1
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Lifesteal</b>.
@@ -1694,7 +1694,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_222] Redeemed Pariah - COST: 2 [ATK:2/HP:3]
+    // [DMF_222] Redeemed Pariah - COST:2 [ATK:2/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: After you play an <b>Outcast</b> card, gain +1/+1.
@@ -1707,7 +1707,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_223] Renowned Performer - COST: 4 [ATK:3/HP:3]
+    // [DMF_223] Renowned Performer - COST:4 [ATK:3/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -1723,7 +1723,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ------------------------------------ SPELL - DEMONHUNTER
-    // [DMF_224] Expendable Performers - COST: 7
+    // [DMF_224] Expendable Performers - COST:7
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: Summon seven 1/1 Illidari with <b>Rush</b>.
@@ -1734,7 +1734,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ------------------------------------ SPELL - DEMONHUNTER
-    // [DMF_225] Throw Glaive - COST: 1
+    // [DMF_225] Throw Glaive - COST:1
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Deal 2 damage to a minion.
@@ -1742,7 +1742,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_226] Bladed Lady - COST: 6 [ATK:6/HP:6]
+    // [DMF_226] Bladed Lady - COST:6 [ATK:6/HP:6]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -1753,7 +1753,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ----------------------------------- WEAPON - DEMONHUNTER
-    // [DMF_227] Dreadlord's Bite - COST: 3
+    // [DMF_227] Dreadlord's Bite - COST:3
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Outcast:</b> Deal 1 damage to all enemies.
@@ -1763,7 +1763,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_229] Stiltstepper - COST: 3 [ATK:4/HP:1]
+    // [DMF_229] Stiltstepper - COST:3 [ATK:4/HP:1]
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Draw a card.
@@ -1775,7 +1775,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_230] Il'gynoth - COST: 4 [ATK:2/HP:6]
+    // [DMF_230] Il'gynoth - COST:4 [ATK:2/HP:6]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Lifesteal</b>
@@ -1789,7 +1789,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_231] Zai, the Incredible - COST: 5 [ATK:5/HP:3]
+    // [DMF_231] Zai, the Incredible - COST:5 [ATK:5/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Copy the left- and right-most cards
@@ -1801,7 +1801,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_247] Insatiable Felhound - COST: 3 [ATK:2/HP:5]
+    // [DMF_247] Insatiable Felhound - COST:3 [ATK:2/HP:5]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -1819,7 +1819,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     cards.emplace("DMF_247", CardDef(power, "DMF_247t"));
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_248] Felsteel Executioner - COST: 3 [ATK:4/HP:3]
+    // [DMF_248] Felsteel Executioner - COST:3 [ATK:4/HP:3]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Corrupt:</b> Become a weapon.
@@ -1829,7 +1829,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ------------------------------------ SPELL - DEMONHUNTER
-    // [DMF_249] Acrobatics - COST: 3
+    // [DMF_249] Acrobatics - COST:3
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: Draw 2 cards. If you play both this turn, draw 2 more.
@@ -1842,14 +1842,14 @@ void DarkmoonFaireCardsGen::AddDemonHunterNonCollect(
     Power power;
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
-    // [DMF_217e] Marked for Passing - COST: 0
+    // [DMF_217e] Marked for Passing - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Your <b>Outcast</b> cards cost (1) less.
     // --------------------------------------------------------
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
-    // [DMF_219e] Out for Blood - COST: 0
+    // [DMF_219e] Out for Blood - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +4 Attack and <b>Immune</b> this turn.
@@ -1859,14 +1859,14 @@ void DarkmoonFaireCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
-    // [DMF_222e] Pariah's Resolve - COST: 0
+    // [DMF_222e] Pariah's Resolve - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_223t] Performer's Assistant - COST: 1 [ATK:1/HP:1]
+    // [DMF_223t] Performer's Assistant - COST:1 [ATK:1/HP:1]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -1876,7 +1876,7 @@ void DarkmoonFaireCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_247t] Insatiable Felhound - COST: 3 [ATK:3/HP:6]
+    // [DMF_247t] Insatiable Felhound - COST:3 [ATK:3/HP:6]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -1891,14 +1891,14 @@ void DarkmoonFaireCardsGen::AddDemonHunterNonCollect(
     cards.emplace("DMF_247t", CardDef(power));
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
-    // [DMF_248e] Wicked Transformation - COST: 0
+    // [DMF_248e] Wicked Transformation - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Health became Durability.
     // --------------------------------------------------------
 
     // ----------------------------------- WEAPON - DEMONHUNTER
-    // [DMF_248t] Felsteel Executioner - COST: 3
+    // [DMF_248t] Felsteel Executioner - COST:3
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -1910,7 +1910,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     Power power;
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_002] N'Zoth, God of the Deep - COST: 10 [ATK:5/HP:7]
+    // [DMF_002] N'Zoth, God of the Deep - COST:10 [ATK:5/HP:7]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Resurrect a friendly minion
@@ -1922,7 +1922,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_004] Yogg-Saron, Master of Fate - COST: 10 [ATK:7/HP:5]
+    // [DMF_004] Yogg-Saron, Master of Fate - COST:10 [ATK:7/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> If you've cast 10 spells this game,
@@ -1935,7 +1935,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_044] Rock Rager - COST: 2 [ATK:5/HP:1]
+    // [DMF_044] Rock Rager - COST:2 [ATK:5/HP:1]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -1945,7 +1945,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_062] Gyreworm - COST: 3 [ATK:3/HP:2]
+    // [DMF_062] Gyreworm - COST:3 [ATK:3/HP:2]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> If you played an Elemental last turn,
@@ -1956,7 +1956,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_065] Banana Vendor - COST: 3 [ATK:2/HP:4]
+    // [DMF_065] Banana Vendor - COST:3 [ATK:2/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Add 2 Bananas to each player's hand.
@@ -1966,7 +1966,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_066] Knife Vendor - COST: 4 [ATK:3/HP:4]
+    // [DMF_066] Knife Vendor - COST:4 [ATK:3/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Deal 4 damage to each hero.
@@ -1976,7 +1976,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_067] Prize Vendor - COST: 2 [ATK:2/HP:3]
+    // [DMF_067] Prize Vendor - COST:2 [ATK:2/HP:3]
     // - Race: Murloc, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Both players draw a card.
@@ -1986,7 +1986,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_068] Optimistic Ogre - COST: 5 [ATK:6/HP:7]
+    // [DMF_068] Optimistic Ogre - COST:5 [ATK:6/HP:7]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: 50% chance to attack the correct enemy.
@@ -1997,7 +1997,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_069] Claw Machine - COST: 6 [ATK:6/HP:3]
+    // [DMF_069] Claw Machine - COST:6 [ATK:6/HP:3]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Rush</b>.
@@ -2009,7 +2009,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_070] Darkmoon Rabbit - COST: 10 [ATK:1/HP:1]
+    // [DMF_070] Darkmoon Rabbit - COST:10 [ATK:1/HP:1]
     // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Rush</b>, <b>Poisonous</b>
@@ -2021,7 +2021,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_073] Darkmoon Dirigible - COST: 3 [ATK:3/HP:2]
+    // [DMF_073] Darkmoon Dirigible - COST:3 [ATK:3/HP:2]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Divine Shield</b>
@@ -2039,7 +2039,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("DMF_073", CardDef(power, "DMF_073t"));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_074] Silas Darkmoon - COST: 7 [ATK:4/HP:4]
+    // [DMF_074] Silas Darkmoon - COST:7 [ATK:4/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Choose a direction to rotate all minions.
@@ -2050,7 +2050,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_078] Strongman - COST: 7 [ATK:6/HP:6]
+    // [DMF_078] Strongman - COST:7 [ATK:6/HP:6]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -2062,7 +2062,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_079] Inconspicuous Rider - COST: 3 [ATK:2/HP:2]
+    // [DMF_079] Inconspicuous Rider - COST:3 [ATK:2/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Cast a <b>Secret</b> from your deck.
@@ -2075,7 +2075,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_080] Fleethoof Pearltusk - COST: 5 [ATK:4/HP:4]
+    // [DMF_080] Fleethoof Pearltusk - COST:5 [ATK:4/HP:4]
     // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -2090,7 +2090,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("DMF_080", CardDef(power, "DMF_080t"));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_081] K'thir Ritualist - COST: 3 [ATK:4/HP:4]
+    // [DMF_081] K'thir Ritualist - COST:3 [ATK:4/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -2103,7 +2103,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_082] Darkmoon Statue - COST: 3 [ATK:0/HP:5]
+    // [DMF_082] Darkmoon Statue - COST:3 [ATK:0/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: Your other minions have +1 Attack.
@@ -2115,7 +2115,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_091] Wriggling Horror - COST: 2 [ATK:2/HP:1]
+    // [DMF_091] Wriggling Horror - COST:2 [ATK:2/HP:1]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give adjacent minions +1/+1.
@@ -2125,7 +2125,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_124] Horrendous Growth - COST: 2 [ATK:2/HP:2]
+    // [DMF_124] Horrendous Growth - COST:2 [ATK:2/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Corrupt:</b> Gain +1/+1.
@@ -2136,7 +2136,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_125] Safety Inspector - COST: 1 [ATK:1/HP:3]
+    // [DMF_125] Safety Inspector - COST:1 [ATK:1/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Shuffle the lowest-Cost card
@@ -2147,7 +2147,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_163] Carnival Clown - COST: 9 [ATK:4/HP:4]
+    // [DMF_163] Carnival Clown - COST:9 [ATK:4/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -2161,7 +2161,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_174] Circus Medic - COST: 4 [ATK:3/HP:4]
+    // [DMF_174] Circus Medic - COST:4 [ATK:3/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Restore 4 Health.
@@ -2173,7 +2173,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_188] Y'Shaarj, the Defiler - COST: 10 [ATK:10/HP:10]
+    // [DMF_188] Y'Shaarj, the Defiler - COST:10 [ATK:10/HP:10]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Add a copy of each <b>Corrupted</b>
@@ -2186,7 +2186,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_189] Costumed Entertainer - COST: 2 [ATK:1/HP:2]
+    // [DMF_189] Costumed Entertainer - COST:2 [ATK:1/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give a random minion in your hand +2/+2.
@@ -2196,7 +2196,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_190] Fantastic Firebird - COST: 4 [ATK:3/HP:5]
+    // [DMF_190] Fantastic Firebird - COST:4 [ATK:3/HP:5]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Windfury</b>
@@ -2206,7 +2206,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_191] Showstopper - COST: 2 [ATK:3/HP:2]
+    // [DMF_191] Showstopper - COST:2 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> <b>Silence</b> all minions.
@@ -2219,7 +2219,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_202] Derailed Coaster - COST: 5 [ATK:3/HP:2]
+    // [DMF_202] Derailed Coaster - COST:5 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Summon a 1/1 Rider with <b>Rush</b>
@@ -2233,7 +2233,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_254] C'Thun, the Shattered - COST: 10 [ATK:6/HP:6]
+    // [DMF_254] C'Thun, the Shattered - COST:10 [ATK:6/HP:6]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Start of Game:</b> Break into pieces.
@@ -2249,7 +2249,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_520] Parade Leader - COST: 2 [ATK:2/HP:3]
+    // [DMF_520] Parade Leader - COST:2 [ATK:2/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: After you summon a <b>Rush</b> minion, give it +2 Attack.
@@ -2262,7 +2262,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_532] Circus Amalgam - COST: 4 [ATK:4/HP:5]
+    // [DMF_532] Circus Amalgam - COST:4 [ATK:4/HP:5]
     // - Race: All, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -2279,7 +2279,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     Power power;
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [DMF_004t1] Mysterybox - COST: 0
+    // [DMF_004t1] Mysterybox - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Cast a random spell for every spell you've cast this game
@@ -2287,7 +2287,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_004t1e] Prizes! - COST: 0
+    // [DMF_004t1e] Prizes! - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Costs (0) this turn.
@@ -2297,7 +2297,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [DMF_004t2] Hand of Fate - COST: 0
+    // [DMF_004t2] Hand of Fate - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Fill your hand with random spells.
@@ -2305,7 +2305,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [DMF_004t3] Curse of Flesh - COST: 0
+    // [DMF_004t3] Curse of Flesh - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Fill the board with random minions,
@@ -2316,91 +2316,91 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [DMF_004t4] Mindflayer Goggles - COST: 0
+    // [DMF_004t4] Mindflayer Goggles - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Take control of three random enemy minions.
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [DMF_004t5] Devouring Hunger - COST: 0
+    // [DMF_004t5] Devouring Hunger - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Destroy all other minions. Gain their Attack and Health.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_004t5e] Consume - COST: 0
+    // [DMF_004t5e] Consume - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Increased stats.
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [DMF_004t6] Rod of Roasting - COST: 0
+    // [DMF_004t6] Rod of Roasting - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Cast 'Pyroblast' randomly until a player dies.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_053e] Blood of G'huun - COST: 0
+    // [DMF_053e] Blood of G'huun - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Attack and Health set to 5.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_054e] Insightful - COST: 0
+    // [DMF_054e] Insightful - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Costs (2) less.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_055e] Idolized - COST: 0
+    // [DMF_055e] Idolized - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Attack and Health set to 10.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_056e] Blood of Gods - COST: 0
+    // [DMF_056e] Blood of Gods - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Costs Health instead of Mana.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_065e] Bananas - COST: 0
+    // [DMF_065e] Bananas - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Has +1/+1.
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [DMF_065t] Bananas - COST: 1
+    // [DMF_065t] Bananas - COST:1
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Give a minion +1/+1.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_069e] AHHHHH! - COST: 0
+    // [DMF_069e] AHHHHH! - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +3/+3.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_071e] Fired Up - COST: 0
+    // [DMF_071e] Fired Up - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Costs (1) this turn.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_073t] Darkmoon Dirigible - COST: 3 [ATK:3/HP:2]
+    // [DMF_073t] Darkmoon Dirigible - COST:3 [ATK:3/HP:2]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -2415,7 +2415,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     cards.emplace("DMF_073t", CardDef(power));
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [DMF_074a] This Way - COST: 0
+    // [DMF_074a] This Way - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Minions will rotate
@@ -2423,7 +2423,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [DMF_074b] That Way - COST: 0
+    // [DMF_074b] That Way - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Minions will rotate
@@ -2431,14 +2431,14 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_078e] Corruption - COST: 0
+    // [DMF_078e] Corruption - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Costs (0).
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_078t] Strongman - COST: 0 [ATK:6/HP:6]
+    // [DMF_078t] Strongman - COST:0 [ATK:6/HP:6]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -2449,7 +2449,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_080t] Fleethoof Pearltusk - COST: 5 [ATK:8/HP:8]
+    // [DMF_080t] Fleethoof Pearltusk - COST:5 [ATK:8/HP:8]
     // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -2463,14 +2463,14 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     cards.emplace("DMF_080t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_082e] Imposing Statue - COST: 0
+    // [DMF_082e] Imposing Statue - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +1 Attack from Darkmoon Statue.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_082t] Darkmoon Statue - COST: 3 [ATK:4/HP:5]
+    // [DMF_082t] Darkmoon Statue - COST:3 [ATK:4/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -2481,49 +2481,49 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_091e2] Wriggling Around - COST: 0
+    // [DMF_091e2] Wriggling Around - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_102e] Special Discount - COST: 0
+    // [DMF_102e] Special Discount - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Costs (1).
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_108e] Sanity Renounced - COST: 0
+    // [DMF_108e] Sanity Renounced - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Cost adjusted.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_113e] Skipped Line - COST: 0
+    // [DMF_113e] Skipped Line - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Costs (2) less.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_116e] Nameless - COST: 0
+    // [DMF_116e] Nameless - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: 4/4.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_120e2] Bloodweaving - COST: 0
+    // [DMF_120e2] Bloodweaving - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Costs (1) less.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_124t] Horrendous Growth - COST: 2 [ATK:3/HP:3]
+    // [DMF_124t] Horrendous Growth - COST:2 [ATK:3/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -2535,7 +2535,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_163t] Carnival Clown - COST: 9 [ATK:4/HP:4]
+    // [DMF_163t] Carnival Clown - COST:9 [ATK:4/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -2548,7 +2548,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_174t] Circus Medic - COST: 4 [ATK:3/HP:4]
+    // [DMF_174t] Circus Medic - COST:4 [ATK:3/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -2559,7 +2559,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_187e] Palm Reading - COST: 0
+    // [DMF_187e] Palm Reading - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Costs (1) less.
@@ -2569,7 +2569,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_188e] True Corruption - COST: 0
+    // [DMF_188e] True Corruption - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Your next <b>Corrupt</b> card costs (0).
@@ -2579,7 +2579,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_188e2] Corruption of Y'Shaarj - COST: 0
+    // [DMF_188e2] Corruption of Y'Shaarj - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Costs (0) this turn.
@@ -2589,21 +2589,21 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [DMF_188t] Corruption - COST: 1
+    // [DMF_188t] Corruption - COST:1
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: <b>Corrupt</b> all your cards.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_189e] Definitely Entertained - COST: 0
+    // [DMF_189e] Definitely Entertained - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_224e] Expendable - COST: 0
+    // [DMF_224e] Expendable - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: When no more Illidari are present, summon seven more.
@@ -2613,7 +2613,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_229e] Stilts - COST: 0
+    // [DMF_229e] Stilts - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +4 Attack this turn.
@@ -2623,7 +2623,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_229e2] Stepping - COST: 0
+    // [DMF_229e2] Stepping - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Play the card to give your Hero +4 Attack this turn..
@@ -2633,7 +2633,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_230e] Corruption - COST: 0
+    // [DMF_230e] Corruption - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Your <b>Lifesteal</b> damages the opposing hero
@@ -2641,14 +2641,14 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_240e] Lothraxion's Power - COST: 0
+    // [DMF_240e] Lothraxion's Power - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Gives your Silver Hand Recruits <b>Divine Shield</b>.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_247e] Corruption - COST: 0
+    // [DMF_247e] Corruption - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Corrupted.
@@ -2658,7 +2658,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_249e] Acrobatics - COST: 0
+    // [DMF_249e] Acrobatics - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Play the 2 cards to draw 2 more.
@@ -2668,7 +2668,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [DMF_254t3] Eye of C'Thun - COST: 5
+    // [DMF_254t3] Eye of C'Thun - COST:5
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: <b>Piece of C'Thun ({0}/4)</b>
@@ -2679,7 +2679,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [DMF_254t4] Heart of C'Thun - COST: 5
+    // [DMF_254t4] Heart of C'Thun - COST:5
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: <b>Piece of C'Thun ({0}/4)</b>
@@ -2687,7 +2687,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [DMF_254t5] Body of C'Thun - COST: 5
+    // [DMF_254t5] Body of C'Thun - COST:5
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: <b>Piece of C'Thun ({0}/4)</b>
@@ -2698,7 +2698,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_254t5t] C'Thun's Body - COST: 6 [ATK:6/HP:6]
+    // [DMF_254t5t] C'Thun's Body - COST:6 [ATK:6/HP:6]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -2708,7 +2708,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [DMF_254t7] Maw of C'Thun - COST: 5
+    // [DMF_254t7] Maw of C'Thun - COST:5
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: <b>Piece of C'Thun ({0}/4)</b>
@@ -2716,14 +2716,14 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_520e] Leading Strong - COST: 0
+    // [DMF_520e] Leading Strong - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: +2 Attack.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_523t] Darkmoon Rider - COST: 1 [ATK:1/HP:1]
+    // [DMF_523t] Darkmoon Rider - COST:1 [ATK:1/HP:1]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -2733,28 +2733,28 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_534e] Deck of Chaos - COST: 0
+    // [DMF_534e] Deck of Chaos - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Adjusted Attack.
     // --------------------------------------------------------
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
-    // [DMF_534e2] Cost of Chaos - COST: 0
+    // [DMF_534e2] Cost of Chaos - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Adjusted Cost.
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [DMF_COIN1] The Coin - COST: 0
+    // [DMF_COIN1] The Coin - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Gain 1 Mana Crystal this turn only.
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [DMF_COIN2] The Coin - COST: 0
+    // [DMF_COIN2] The Coin - COST:0
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: Gain 1 Mana Crystal this turn only.

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -2025,6 +2025,9 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_044", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [DMF_062] Gyreworm - COST:3 [ATK:3/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -4,6 +4,12 @@
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 #include <Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.hpp>
+#include <Rosetta/PlayMode/Enchants/Enchants.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
+
+using namespace RosettaStone::PlayMode;
+using namespace SimpleTasks;
 
 namespace RosettaStone::PlayMode
 {
@@ -17,6 +23,8 @@ void DarkmoonFaireCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
 void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------ SPELL - DRUID
     // [DMF_057] Lunar Eclipse - COST: 2
     // - Set: DARKMOON_FAIRE, Rarity: Common
@@ -87,6 +95,10 @@ void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CORRUPT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DMF_730e", EntityType::HERO));
+    cards.emplace("DMF_730", CardDef(power, "DMF_730t"));
 
     // ------------------------------------------ SPELL - DRUID
     // [DMF_732] Cenarion Ward - COST: 8
@@ -124,6 +136,8 @@ void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 void DarkmoonFaireCardsGen::AddDruidNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------ ENCHANTMENT - DRUID
     // [DMF_057e] Lunar Empowerment - COST: 0
     // - Set: DARKMOON_FAIRE
@@ -220,6 +234,9 @@ void DarkmoonFaireCardsGen::AddDruidNonCollect(
     // GameTag:
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DMF_730e"));
+    cards.emplace("DMF_730e", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [DMF_730t] Moontouched Amulet - COST: 3
@@ -228,6 +245,11 @@ void DarkmoonFaireCardsGen::AddDruidNonCollect(
     // Text: <b>Corrupted</b>
     //       Give your hero +4 Attack this turn. Gain 6 Armor.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DMF_730e", EntityType::HERO));
+    power.AddPowerTask(std::make_shared<ArmorTask>(6));
+    cards.emplace("DMF_730t", CardDef(power));
 }
 
 void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -760,6 +760,16 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CORRUPT = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("CS2_101t", 3, SummonSide::SPELL));
+    cards.emplace(
+        "DMF_244",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } },
+                "DMF_244t"));
 }
 
 void DarkmoonFaireCardsGen::AddPaladinNonCollect(
@@ -818,6 +828,15 @@ void DarkmoonFaireCardsGen::AddPaladinNonCollect(
     // Text: <b>Corrupted</b>
     //       Summon 5 Silver Hand Recruits.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("CS2_101t", 5, SummonSide::SPELL));
+    cards.emplace(
+        "DMF_244t",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 }
 
 void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -8,6 +8,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
 
 using namespace RosettaStone::PlayMode;
 using namespace SimpleTasks;
@@ -1173,6 +1174,8 @@ void DarkmoonFaireCardsGen::AddRogueNonCollect(
 
 void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- SPELL - SHAMAN
     // [DMF_700] Revolve - COST:1
     // - Set: DARKMOON_FAIRE, Rarity: Common
@@ -1210,6 +1213,10 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - CORRUPT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("DMF_703t2", SummonSide::RIGHT));
+    cards.emplace("DMF_703", CardDef(power, "DMF_703t"));
 
     // ---------------------------------------- MINION - SHAMAN
     // [DMF_704] Cagematch Custodian - COST:2 [ATK:2/HP:2]
@@ -1281,6 +1288,8 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 void DarkmoonFaireCardsGen::AddShamanNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- SPELL - SHAMAN
     // [DMF_701t] Dunk Tank - COST:4
     // - Set: DARKMOON_FAIRE, Rarity: Rare
@@ -1309,11 +1318,20 @@ void DarkmoonFaireCardsGen::AddShamanNonCollect(
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("DMF_703t2", SummonSide::LEFT));
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("DMF_703t2", SummonSide::RIGHT));
+    cards.emplace("DMF_703t", CardDef(power));
 
     // ---------------------------------------- MINION - SHAMAN
     // [DMF_703t2] Duelist - COST:2 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_703t2", CardDef(power));
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [DMF_705e] Winner! - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -2301,6 +2301,9 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - WINDFURY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_190", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [DMF_191] Showstopper - COST:2 [ATK:3/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1405,6 +1405,8 @@ void DarkmoonFaireCardsGen::AddShamanNonCollect(
 
 void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - WARLOCK
     // [DMF_110] Fire Breather - COST:4 [ATK:4/HP:3]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Rare
@@ -1446,6 +1448,9 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_114", CardDef(power));
 
     // --------------------------------------- MINION - WARLOCK
     // [DMF_115] Revenant Rascal - COST:3 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -7,12 +7,15 @@
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
 
 using namespace RosettaStone::PlayMode;
 using namespace SimpleTasks;
 
 namespace RosettaStone::PlayMode
 {
+using PlayReqs = std::map<PlayReq, int>;
+
 void DarkmoonFaireCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
 }
@@ -439,6 +442,8 @@ void DarkmoonFaireCardsGen::AddHunterNonCollect(
 
 void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------ MINION - MAGE
     // [DMF_100] Confection Cyclone - COST:2 [ATK:3/HP:2]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
@@ -461,6 +466,17 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - CORRUPT = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::TARGET, 3));
+    cards.emplace("DMF_101",
+                  CardDef(power,
+                          PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },
+                                    { PlayReq::REQ_MINION_TARGET, 0 } },
+                          "DMF_101t"));
 
     // ------------------------------------------ MINION - MAGE
     // [DMF_102] Game Master - COST:2 [ATK:2/HP:3]
@@ -564,6 +580,8 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 void DarkmoonFaireCardsGen::AddMageNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------ MINION - MAGE
     // [DMF_100t] Sugar Elemental - COST:1 [ATK:1/HP:2]
     // - Race: Elemental, Set: DARKMOON_FAIRE
@@ -579,6 +597,12 @@ void DarkmoonFaireCardsGen::AddMageNonCollect(
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::TARGET, 12));
+    cards.emplace(
+        "DMF_101t",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ------------------------------------------ MINION - MAGE
     // [DMF_104t] Exploding Sparkler - COST:8 [ATK:8/HP:8]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -2060,6 +2060,9 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - CORRUPT = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_078", CardDef(power, "DMF_078t"));
 
     // --------------------------------------- MINION - NEUTRAL
     // [DMF_079] Inconspicuous Rider - COST:3 [ATK:2/HP:2]
@@ -2447,6 +2450,9 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_078t", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [DMF_080t] Fleethoof Pearltusk - COST:5 [ATK:8/HP:8]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -755,6 +755,8 @@ void DarkmoonFaireCardsGen::AddPaladinNonCollect(
 
 void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- MINION - PRIEST
     // [DMF_053] Blood of G'huun - COST: 9 [ATK: 8/HP: 8]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Epic
@@ -845,6 +847,9 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // - CORRUPT = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_184", CardDef(power));
 
     // ----------------------------------------- SPELL - PRIEST
     // [DMF_186] Auspicious Spirits - COST: 4
@@ -872,6 +877,8 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 void DarkmoonFaireCardsGen::AddPriestNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- SPELL - PRIEST
     // [DMF_054t] Insight - COST: 2
     // - Set: DARKMOON_FAIRE, Rarity: Common
@@ -897,6 +904,9 @@ void DarkmoonFaireCardsGen::AddPriestNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_184t", CardDef(power));
 
     // ----------------------------------------- SPELL - PRIEST
     // [DMF_186a] Auspicious Spirits - COST: 4

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -33,7 +33,7 @@ void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [DMF_059] Fizzy Elemental - COST: 9 [ATK: 10/HP: 10]
+    // [DMF_059] Fizzy Elemental - COST: 9 [ATK:10/HP:10]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -45,7 +45,7 @@ void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [DMF_060] Umbral Owl - COST: 7 [ATK: 4/HP: 4]
+    // [DMF_060] Umbral Owl - COST: 7 [ATK:4/HP:4]
     // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -57,7 +57,7 @@ void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [DMF_061] Faire Arborist - COST: 3 [ATK: 2/HP: 2]
+    // [DMF_061] Faire Arborist - COST: 3 [ATK:2/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Choose One - </b>Draw a card;
@@ -96,7 +96,7 @@ void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [DMF_733] Kiri, Chosen of Elune - COST: 4 [ATK: 2/HP: 2]
+    // [DMF_733] Kiri, Chosen of Elune - COST: 4 [ATK:2/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Add a Solar Eclipse and
@@ -108,7 +108,7 @@ void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [DMF_734] Greybough - COST: 5 [ATK: 4/HP: 6]
+    // [DMF_734] Greybough - COST: 5 [ATK:4/HP:6]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Taunt</b> <b>Deathrattle:</b> Give a random
@@ -176,7 +176,7 @@ void DarkmoonFaireCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [DMF_061t] Faire Arborist - COST: 3 [ATK: 2/HP: 2]
+    // [DMF_061t] Faire Arborist - COST: 3 [ATK:2/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -187,7 +187,7 @@ void DarkmoonFaireCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - DRUID
-    // [DMF_061t2] Treant - COST: 2 [ATK: 2/HP: 2]
+    // [DMF_061t2] Treant - COST: 2 [ATK:2/HP:2]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
 
@@ -235,7 +235,7 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ---------------------------------------- MINION - HUNTER
-    // [DMF_083] Dancing Cobra - COST: 2 [ATK: 1/HP: 5]
+    // [DMF_083] Dancing Cobra - COST: 2 [ATK:1/HP:5]
     // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupt:</b> Gain <b>Poisonous</b>.
@@ -262,7 +262,7 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [DMF_085] Darkmoon Tonk - COST: 7 [ATK: 8/HP: 5]
+    // [DMF_085] Darkmoon Tonk - COST: 7 [ATK:8/HP:5]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Fire four missiles
@@ -284,7 +284,7 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [DMF_087] Trampling Rhino - COST: 5 [ATK: 5/HP: 5]
+    // [DMF_087] Trampling Rhino - COST: 5 [ATK:5/HP:5]
     // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Rush</b>. After this attacks and kills a minion,
@@ -312,7 +312,7 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [DMF_089] Maxima Blastenheimer - COST: 6 [ATK: 4/HP: 4]
+    // [DMF_089] Maxima Blastenheimer - COST: 6 [ATK:4/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Summon a minion from your deck.
@@ -335,7 +335,7 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [DMF_122] Mystery Winner - COST: 1 [ATK: 1/HP: 1]
+    // [DMF_122] Mystery Winner - COST: 1 [ATK:1/HP:1]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> <b>Discover</b> a <b>Secret.</b>
@@ -367,7 +367,7 @@ void DarkmoonFaireCardsGen::AddHunterNonCollect(
     Power power;
 
     // ---------------------------------------- MINION - HUNTER
-    // [DMF_083t] Dancing Cobra - COST: 2 [ATK: 1/HP: 5]
+    // [DMF_083t] Dancing Cobra - COST: 2 [ATK:1/HP:5]
     // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -381,7 +381,7 @@ void DarkmoonFaireCardsGen::AddHunterNonCollect(
     cards.emplace("DMF_083t", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
-    // [DMF_086e] Darkmoon Strider - COST: 3 [ATK: 3/HP: 3]
+    // [DMF_086e] Darkmoon Strider - COST: 3 [ATK:3/HP:3]
     // - Race: Beast, Set: DARKMOON_FAIRE
     // --------------------------------------------------------
 
@@ -418,7 +418,7 @@ void DarkmoonFaireCardsGen::AddHunterNonCollect(
 void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
     // ------------------------------------------ MINION - MAGE
-    // [DMF_100] Confection Cyclone - COST: 2 [ATK: 3/HP: 2]
+    // [DMF_100] Confection Cyclone - COST: 2 [ATK:3/HP:2]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Add two 1/2 Sugar Elementals
@@ -429,7 +429,7 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [DMF_101] Firework Elemental - COST: 5 [ATK: 3/HP: 5]
+    // [DMF_101] Firework Elemental - COST: 5 [ATK:3/HP:5]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Deal 3 damage to a minion.
@@ -441,7 +441,7 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [DMF_102] Game Master - COST: 2 [ATK: 2/HP: 3]
+    // [DMF_102] Game Master - COST: 2 [ATK:2/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: The first <b>Secret</b> you play each turn costs (1).
@@ -487,7 +487,7 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [DMF_106] Occult Conjurer - COST: 4 [ATK: 4/HP: 4]
+    // [DMF_106] Occult Conjurer - COST: 4 [ATK:4/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> If you control a <b>Secret</b>,
@@ -523,7 +523,7 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [DMF_109] Sayge, Seer of Darkmoon - COST: 6 [ATK: 5/HP: 5]
+    // [DMF_109] Sayge, Seer of Darkmoon - COST: 6 [ATK:5/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Draw 1 card.
@@ -543,12 +543,12 @@ void DarkmoonFaireCardsGen::AddMageNonCollect(
     std::map<std::string, CardDef>& cards)
 {
     // ------------------------------------------ MINION - MAGE
-    // [DMF_100t] Sugar Elemental - COST: 1 [ATK: 1/HP: 2]
+    // [DMF_100t] Sugar Elemental - COST: 1 [ATK:1/HP:2]
     // - Race: Elemental, Set: DARKMOON_FAIRE
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [DMF_101t] Firework Elemental - COST: 5 [ATK: 3/HP: 5]
+    // [DMF_101t] Firework Elemental - COST: 5 [ATK:3/HP:5]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -559,7 +559,7 @@ void DarkmoonFaireCardsGen::AddMageNonCollect(
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [DMF_104t] Exploding Sparkler - COST: 8 [ATK: 8/HP: 8]
+    // [DMF_104t] Exploding Sparkler - COST: 8 [ATK:8/HP:8]
     // - Race: Elemental, Set: DARKMOON_FAIRE
     // --------------------------------------------------------
 
@@ -579,7 +579,7 @@ void DarkmoonFaireCardsGen::AddMageNonCollect(
 void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 {
     // --------------------------------------- MINION - PALADIN
-    // [DMF_064] Carousel Gryphon - COST: 5 [ATK: 5/HP: 5]
+    // [DMF_064] Carousel Gryphon - COST: 5 [ATK:5/HP:5]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Divine Shield</b>
@@ -594,7 +594,7 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [DMF_194] Redscale Dragontamer - COST: 2 [ATK: 2/HP: 3]
+    // [DMF_194] Redscale Dragontamer - COST: 2 [ATK:2/HP:3]
     // - Race: Murloc, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Draw a Dragon.
@@ -615,7 +615,7 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [DMF_235] Balloon Merchant - COST: 4 [ATK: 3/HP: 5]
+    // [DMF_235] Balloon Merchant - COST: 4 [ATK:3/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give your Silver Hand Recruits
@@ -640,7 +640,7 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [DMF_237] Carnival Barker - COST: 3 [ATK: 3/HP: 2]
+    // [DMF_237] Carnival Barker - COST: 3 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Whenever you summon a 1-Health minion, give it +1/+2.
@@ -664,7 +664,7 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [DMF_240] Lothraxion the Redeemed - COST: 5 [ATK: 5/HP: 5]
+    // [DMF_240] Lothraxion the Redeemed - COST: 5 [ATK:5/HP:5]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> For the rest of the game,
@@ -680,7 +680,7 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [DMF_241] High Exarch Yrel - COST: 8 [ATK: 7/HP: 5]
+    // [DMF_241] High Exarch Yrel - COST: 8 [ATK:7/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> If your deck has no Neutral cards,
@@ -714,7 +714,7 @@ void DarkmoonFaireCardsGen::AddPaladinNonCollect(
     std::map<std::string, CardDef>& cards)
 {
     // --------------------------------------- MINION - PALADIN
-    // [DMF_064t] Carousel Gryphon - COST: 5 [ATK: 8/HP: 8]
+    // [DMF_064t] Carousel Gryphon - COST: 5 [ATK:8/HP:8]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -745,7 +745,7 @@ void DarkmoonFaireCardsGen::AddPaladinNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [DMF_238t] Holy Elemental - COST: 6 [ATK: 6/HP: 6]
+    // [DMF_238t] Holy Elemental - COST: 6 [ATK:6/HP:6]
     // - Race: Elemental, Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -768,7 +768,7 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ---------------------------------------- MINION - PRIEST
-    // [DMF_053] Blood of G'huun - COST: 9 [ATK: 8/HP: 8]
+    // [DMF_053] Blood of G'huun - COST: 9 [ATK:8/HP:8]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Taunt</b> At the end of your turn,
@@ -797,7 +797,7 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [DMF_056] G'huun the Blood God - COST: 8 [ATK: 8/HP: 8]
+    // [DMF_056] G'huun the Blood God - COST: 8 [ATK:8/HP:8]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Draw 2 cards.
@@ -809,7 +809,7 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [DMF_116] The Nameless One - COST: 4 [ATK: 4/HP: 4]
+    // [DMF_116] The Nameless One - COST: 4 [ATK:4/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Choose a minion.
@@ -824,7 +824,7 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [DMF_120] Nazmani Bloodweaver - COST: 3 [ATK: 2/HP: 5]
+    // [DMF_120] Nazmani Bloodweaver - COST: 3 [ATK:2/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: After you cast a spell,
@@ -835,7 +835,7 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [DMF_121] Fortune Teller - COST: 5 [ATK: 3/HP: 3]
+    // [DMF_121] Fortune Teller - COST: 5 [ATK:3/HP:3]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -847,7 +847,7 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [DMF_184] Fairground Fool - COST: 3 [ATK: 4/HP: 3]
+    // [DMF_184] Fairground Fool - COST: 3 [ATK:4/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -905,7 +905,7 @@ void DarkmoonFaireCardsGen::AddPriestNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - PRIEST
-    // [DMF_184t] Fairground Fool - COST: 3 [ATK: 4/HP: 7]
+    // [DMF_184t] Fairground Fool - COST: 3 [ATK:4/HP:7]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -930,7 +930,7 @@ void DarkmoonFaireCardsGen::AddPriestNonCollect(
 void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 {
     // ----------------------------------------- MINION - ROGUE
-    // [DMF_071] Tenwu of the Red Smoke - COST: 2 [ATK: 3/HP: 2]
+    // [DMF_071] Tenwu of the Red Smoke - COST: 2 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Return a friendly minion to your hand.
@@ -942,7 +942,7 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [DMF_511] Foxy Fraud - COST: 2 [ATK: 3/HP: 2]
+    // [DMF_511] Foxy Fraud - COST: 2 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Your next <b>Combo</b> card
@@ -980,7 +980,7 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [DMF_514] Ticket Master - COST: 3 [ATK: 4/HP: 3]
+    // [DMF_514] Ticket Master - COST: 3 [ATK:4/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Shuffle 3 Tickets into your deck.
@@ -1002,7 +1002,7 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [DMF_516] Grand Empress Shek'zara - COST: 6 [ATK: 5/HP: 7]
+    // [DMF_516] Grand Empress Shek'zara - COST: 6 [ATK:5/HP:7]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> <b>Discover</b> a card in your deck
@@ -1017,7 +1017,7 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [DMF_517] Sweet Tooth - COST: 2 [ATK: 3/HP: 2]
+    // [DMF_517] Sweet Tooth - COST: 2 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupt:</b> Gain +2 Attack and <b>Stealth</b>.
@@ -1038,7 +1038,7 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [DMF_519] Prize Plunderer - COST: 1 [ATK: 2/HP: 1]
+    // [DMF_519] Prize Plunderer - COST: 1 [ATK:2/HP:1]
     // - Race: Pirate, Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Combo:</b> Deal 1 damage to a minion
@@ -1089,12 +1089,12 @@ void DarkmoonFaireCardsGen::AddRogueNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [DMF_514t2] Plush Bear - COST: 3 [ATK: 3/HP: 3]
+    // [DMF_514t2] Plush Bear - COST: 3 [ATK:3/HP:3]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [DMF_517a] Sweet Tooth - COST: 2 [ATK: 5/HP: 2]
+    // [DMF_517a] Sweet Tooth - COST: 2 [ATK:5/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -1134,7 +1134,7 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [DMF_703] Pit Master - COST: 3 [ATK: 1/HP: 2]
+    // [DMF_703] Pit Master - COST: 3 [ATK:1/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Summon a 3/2 Duelist.
@@ -1146,7 +1146,7 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [DMF_704] Cagematch Custodian - COST: 2 [ATK: 2/HP: 2]
+    // [DMF_704] Cagematch Custodian - COST: 2 [ATK:2/HP:2]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Draw a weapon.
@@ -1175,7 +1175,7 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [DMF_707] Magicfin - COST: 3 [ATK: 3/HP: 4]
+    // [DMF_707] Magicfin - COST: 3 [ATK:3/HP:4]
     // - Race: Murloc, Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: After a friendly Murloc dies,
@@ -1186,7 +1186,7 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [DMF_708] Inara Stormcrash - COST: 5 [ATK: 4/HP: 5]
+    // [DMF_708] Inara Stormcrash - COST: 5 [ATK:4/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: On your turn, your hero has +2 Attack and <b>Windfury</b>.
@@ -1200,7 +1200,7 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [DMF_709] Grand Totem Eys'or - COST: 3 [ATK: 0/HP: 4]
+    // [DMF_709] Grand Totem Eys'or - COST: 3 [ATK:0/HP:4]
     // - Race: Totem, Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: At the end of your turn, give +1/+1 to all other Totems
@@ -1234,7 +1234,7 @@ void DarkmoonFaireCardsGen::AddShamanNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [DMF_703t] Pit Master - COST: 3 [ATK: 1/HP: 2]
+    // [DMF_703t] Pit Master - COST: 3 [ATK:1/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -1245,7 +1245,7 @@ void DarkmoonFaireCardsGen::AddShamanNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [DMF_703t2] Duelist - COST: 2 [ATK: 3/HP: 2]
+    // [DMF_703t2] Duelist - COST: 2 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
 
@@ -1257,7 +1257,7 @@ void DarkmoonFaireCardsGen::AddShamanNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [DMF_706t] Pavilion Duelist - COST: 2 [ATK: 3/HP: 2]
+    // [DMF_706t] Pavilion Duelist - COST: 2 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
 
@@ -1279,7 +1279,7 @@ void DarkmoonFaireCardsGen::AddShamanNonCollect(
 void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
     // --------------------------------------- MINION - WARLOCK
-    // [DMF_110] Fire Breather - COST: 4 [ATK: 4/HP: 3]
+    // [DMF_110] Fire Breather - COST: 4 [ATK:4/HP:3]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Deal 2 damage to all minions except Demons.
@@ -1289,7 +1289,7 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [DMF_111] Man'ari Mosher - COST: 3 [ATK: 3/HP: 4]
+    // [DMF_111] Man'ari Mosher - COST: 3 [ATK:3/HP:4]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give a friendly Demon +3 Attack
@@ -1311,7 +1311,7 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [DMF_114] Midway Maniac - COST: 2 [ATK: 1/HP: 5]
+    // [DMF_114] Midway Maniac - COST: 2 [ATK:1/HP:5]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -1321,7 +1321,7 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [DMF_115] Revenant Rascal - COST: 3 [ATK: 3/HP: 3]
+    // [DMF_115] Revenant Rascal - COST: 3 [ATK:3/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Destroy a Mana Crystal for both players.
@@ -1343,7 +1343,7 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [DMF_118] Tickatus - COST: 6 [ATK: 8/HP: 8]
+    // [DMF_118] Tickatus - COST: 6 [ATK:8/HP:8]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Remove the top 5 cards from your deck.
@@ -1363,7 +1363,7 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [DMF_533] Ring Matron - COST: 6 [ATK: 6/HP: 4]
+    // [DMF_533] Ring Matron - COST: 6 [ATK:6/HP:4]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -1420,7 +1420,7 @@ void DarkmoonFaireCardsGen::AddWarlockNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [DMF_118t] Tickatus - COST: 6 [ATK: 8/HP: 8]
+    // [DMF_118t] Tickatus - COST: 6 [ATK:8/HP:8]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -1440,7 +1440,7 @@ void DarkmoonFaireCardsGen::AddWarlockNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [DMF_533t] Fiery Imp - COST: 2 [ATK: 3/HP: 2]
+    // [DMF_533t] Fiery Imp - COST: 2 [ATK:3/HP:2]
     // - Race: Demon, Set: DARKMOON_FAIRE
     // --------------------------------------------------------
 }
@@ -1448,7 +1448,7 @@ void DarkmoonFaireCardsGen::AddWarlockNonCollect(
 void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 {
     // --------------------------------------- MINION - WARRIOR
-    // [DMF_521] Sword Eater - COST: 4 [ATK: 2/HP: 5]
+    // [DMF_521] Sword Eater - COST: 4 [ATK:2/HP:5]
     // - Race: Pirate, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -1470,7 +1470,7 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [DMF_523] Bumper Car - COST: 2 [ATK: 1/HP: 3]
+    // [DMF_523] Bumper Car - COST: 2 [ATK:1/HP:3]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Rush</b> <b>Deathrattle:</b> Add two 1/1 Riders
@@ -1493,7 +1493,7 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [DMF_525] Ringmaster Whatley - COST: 5 [ATK: 3/HP: 5]
+    // [DMF_525] Ringmaster Whatley - COST: 5 [ATK:3/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Draw a Mech, Dragon, and Pirate.
@@ -1518,7 +1518,7 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [DMF_528] Tent Trasher - COST: 5 [ATK: 5/HP: 5]
+    // [DMF_528] Tent Trasher - COST: 5 [ATK:5/HP:5]
     // - Race: Dragon, Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b><b>Rush</b>.</b> Costs (1) less for each friendly minion with a
@@ -1529,7 +1529,7 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [DMF_529] E.T.C., God of Metal - COST: 2 [ATK: 1/HP: 4]
+    // [DMF_529] E.T.C., God of Metal - COST: 2 [ATK:1/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: After a friendly <b>Rush</b> minion attacks,
@@ -1554,7 +1554,7 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [DMF_531] Stage Hand - COST: 2 [ATK: 3/HP: 2]
+    // [DMF_531] Stage Hand - COST: 2 [ATK:3/HP:2]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give a random minion in your hand +1/+1.
@@ -1618,7 +1618,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     Power power;
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_217] Line Hopper - COST: 3 [ATK: 3/HP: 4]
+    // [DMF_217] Line Hopper - COST: 3 [ATK:3/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: Your <b>Outcast</b> cards cost (1) less.
@@ -1652,7 +1652,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_222] Redeemed Pariah - COST: 2 [ATK: 2/HP: 3]
+    // [DMF_222] Redeemed Pariah - COST: 2 [ATK:2/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: After you play an <b>Outcast</b> card, gain +1/+1.
@@ -1665,7 +1665,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_223] Renowned Performer - COST: 4 [ATK: 3/HP: 3]
+    // [DMF_223] Renowned Performer - COST: 4 [ATK:3/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -1700,7 +1700,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_226] Bladed Lady - COST: 6 [ATK: 6/HP: 6]
+    // [DMF_226] Bladed Lady - COST: 6 [ATK:6/HP:6]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -1721,7 +1721,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_229] Stiltstepper - COST: 3 [ATK: 4/HP: 1]
+    // [DMF_229] Stiltstepper - COST: 3 [ATK:4/HP:1]
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Draw a card.
@@ -1733,7 +1733,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_230] Il'gynoth - COST: 4 [ATK: 2/HP: 6]
+    // [DMF_230] Il'gynoth - COST: 4 [ATK:2/HP:6]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Lifesteal</b>
@@ -1747,7 +1747,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_231] Zai, the Incredible - COST: 5 [ATK: 5/HP: 3]
+    // [DMF_231] Zai, the Incredible - COST: 5 [ATK:5/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Copy the left- and right-most cards
@@ -1759,7 +1759,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_247] Insatiable Felhound - COST: 3 [ATK: 2/HP: 5]
+    // [DMF_247] Insatiable Felhound - COST: 3 [ATK:2/HP:5]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -1777,7 +1777,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     cards.emplace("DMF_247", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_248] Felsteel Executioner - COST: 3 [ATK: 4/HP: 3]
+    // [DMF_248] Felsteel Executioner - COST: 3 [ATK:4/HP:3]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Corrupt:</b> Become a weapon.
@@ -1824,7 +1824,7 @@ void DarkmoonFaireCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_223t] Performer's Assistant - COST: 1 [ATK: 1/HP: 1]
+    // [DMF_223t] Performer's Assistant - COST: 1 [ATK:1/HP:1]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -1834,7 +1834,7 @@ void DarkmoonFaireCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_247t] Insatiable Felhound - COST: 3 [ATK: 3/HP: 6]
+    // [DMF_247t] Insatiable Felhound - COST: 3 [ATK:3/HP:6]
     // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -1868,7 +1868,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     Power power;
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_002] N'Zoth, God of the Deep - COST: 10 [ATK: 5/HP: 7]
+    // [DMF_002] N'Zoth, God of the Deep - COST: 10 [ATK:5/HP:7]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Resurrect a friendly minion
@@ -1880,7 +1880,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_004] Yogg-Saron, Master of Fate - COST: 10 [ATK: 7/HP: 5]
+    // [DMF_004] Yogg-Saron, Master of Fate - COST: 10 [ATK:7/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> If you've cast 10 spells this game,
@@ -1893,7 +1893,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_044] Rock Rager - COST: 2 [ATK: 5/HP: 1]
+    // [DMF_044] Rock Rager - COST: 2 [ATK:5/HP:1]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -1903,7 +1903,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_062] Gyreworm - COST: 3 [ATK: 3/HP: 2]
+    // [DMF_062] Gyreworm - COST: 3 [ATK:3/HP:2]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> If you played an Elemental last turn,
@@ -1914,7 +1914,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_065] Banana Vendor - COST: 3 [ATK: 2/HP: 4]
+    // [DMF_065] Banana Vendor - COST: 3 [ATK:2/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Add 2 Bananas to each player's hand.
@@ -1924,7 +1924,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_066] Knife Vendor - COST: 4 [ATK: 3/HP: 4]
+    // [DMF_066] Knife Vendor - COST: 4 [ATK:3/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Deal 4 damage to each hero.
@@ -1934,7 +1934,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_067] Prize Vendor - COST: 2 [ATK: 2/HP: 3]
+    // [DMF_067] Prize Vendor - COST: 2 [ATK:2/HP:3]
     // - Race: Murloc, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Both players draw a card.
@@ -1944,7 +1944,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_068] Optimistic Ogre - COST: 5 [ATK: 6/HP: 7]
+    // [DMF_068] Optimistic Ogre - COST: 5 [ATK:6/HP:7]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: 50% chance to attack the correct enemy.
@@ -1955,7 +1955,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_069] Claw Machine - COST: 6 [ATK: 6/HP: 3]
+    // [DMF_069] Claw Machine - COST: 6 [ATK:6/HP:3]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Rush</b>.
@@ -1967,7 +1967,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_070] Darkmoon Rabbit - COST: 10 [ATK: 1/HP: 1]
+    // [DMF_070] Darkmoon Rabbit - COST: 10 [ATK:1/HP:1]
     // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Rush</b>, <b>Poisonous</b>
@@ -1979,7 +1979,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_073] Darkmoon Dirigible - COST: 3 [ATK: 3/HP: 2]
+    // [DMF_073] Darkmoon Dirigible - COST: 3 [ATK:3/HP:2]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Divine Shield</b>
@@ -1997,7 +1997,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("DMF_073", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_074] Silas Darkmoon - COST: 7 [ATK: 4/HP: 4]
+    // [DMF_074] Silas Darkmoon - COST: 7 [ATK:4/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Choose a direction to rotate all minions.
@@ -2008,7 +2008,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_078] Strongman - COST: 7 [ATK: 6/HP: 6]
+    // [DMF_078] Strongman - COST: 7 [ATK:6/HP:6]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -2020,7 +2020,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_079] Inconspicuous Rider - COST: 3 [ATK: 2/HP: 2]
+    // [DMF_079] Inconspicuous Rider - COST: 3 [ATK:2/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Cast a <b>Secret</b> from your deck.
@@ -2033,7 +2033,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_080] Fleethoof Pearltusk - COST: 5 [ATK: 4/HP: 4]
+    // [DMF_080] Fleethoof Pearltusk - COST: 5 [ATK:4/HP:4]
     // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -2045,7 +2045,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_081] K'thir Ritualist - COST: 3 [ATK: 4/HP: 4]
+    // [DMF_081] K'thir Ritualist - COST: 3 [ATK:4/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -2058,7 +2058,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_082] Darkmoon Statue - COST: 3 [ATK: 0/HP: 5]
+    // [DMF_082] Darkmoon Statue - COST: 3 [ATK:0/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: Your other minions have +1 Attack.
@@ -2070,7 +2070,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_091] Wriggling Horror - COST: 2 [ATK: 2/HP: 1]
+    // [DMF_091] Wriggling Horror - COST: 2 [ATK:2/HP:1]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give adjacent minions +1/+1.
@@ -2080,7 +2080,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_124] Horrendous Growth - COST: 2 [ATK: 2/HP: 2]
+    // [DMF_124] Horrendous Growth - COST: 2 [ATK:2/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Corrupt:</b> Gain +1/+1.
@@ -2091,7 +2091,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_125] Safety Inspector - COST: 1 [ATK: 1/HP: 3]
+    // [DMF_125] Safety Inspector - COST: 1 [ATK:1/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Shuffle the lowest-Cost card
@@ -2102,7 +2102,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_163] Carnival Clown - COST: 9 [ATK: 4/HP: 4]
+    // [DMF_163] Carnival Clown - COST: 9 [ATK:4/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -2116,7 +2116,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_174] Circus Medic - COST: 4 [ATK: 3/HP: 4]
+    // [DMF_174] Circus Medic - COST: 4 [ATK:3/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Restore 4 Health.
@@ -2128,7 +2128,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_188] Y'Shaarj, the Defiler - COST: 10 [ATK: 10/HP: 10]
+    // [DMF_188] Y'Shaarj, the Defiler - COST: 10 [ATK:10/HP:10]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Add a copy of each <b>Corrupted</b>
@@ -2141,7 +2141,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_189] Costumed Entertainer - COST: 2 [ATK: 1/HP: 2]
+    // [DMF_189] Costumed Entertainer - COST: 2 [ATK:1/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give a random minion in your hand +2/+2.
@@ -2151,7 +2151,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_190] Fantastic Firebird - COST: 4 [ATK: 3/HP: 5]
+    // [DMF_190] Fantastic Firebird - COST: 4 [ATK:3/HP:5]
     // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Windfury</b>
@@ -2161,7 +2161,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_191] Showstopper - COST: 2 [ATK: 3/HP: 2]
+    // [DMF_191] Showstopper - COST: 2 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> <b>Silence</b> all minions.
@@ -2174,7 +2174,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_202] Derailed Coaster - COST: 5 [ATK: 3/HP: 2]
+    // [DMF_202] Derailed Coaster - COST: 5 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Summon a 1/1 Rider with <b>Rush</b>
@@ -2188,7 +2188,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_254] C'Thun, the Shattered - COST: 10 [ATK: 6/HP: 6]
+    // [DMF_254] C'Thun, the Shattered - COST: 10 [ATK:6/HP:6]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Start of Game:</b> Break into pieces.
@@ -2204,7 +2204,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_520] Parade Leader - COST: 2 [ATK: 2/HP: 3]
+    // [DMF_520] Parade Leader - COST: 2 [ATK:2/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: After you summon a <b>Rush</b> minion, give it +2 Attack.
@@ -2217,7 +2217,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_532] Circus Amalgam - COST: 4 [ATK: 4/HP: 5]
+    // [DMF_532] Circus Amalgam - COST: 4 [ATK:4/HP:5]
     // - Race: All, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -2355,7 +2355,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_073t] Darkmoon Dirigible - COST: 3 [ATK: 3/HP: 2]
+    // [DMF_073t] Darkmoon Dirigible - COST: 3 [ATK:3/HP:2]
     // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -2393,7 +2393,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_078t] Strongman - COST: 0 [ATK: 6/HP: 6]
+    // [DMF_078t] Strongman - COST: 0 [ATK:6/HP:6]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -2404,7 +2404,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_080t] Fleethoof Pearltusk - COST: 5 [ATK: 8/HP: 8]
+    // [DMF_080t] Fleethoof Pearltusk - COST: 5 [ATK:8/HP:8]
     // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -2422,7 +2422,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_082t] Darkmoon Statue - COST: 3 [ATK: 4/HP: 5]
+    // [DMF_082t] Darkmoon Statue - COST: 3 [ATK:4/HP:5]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -2475,7 +2475,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_124t] Horrendous Growth - COST: 2 [ATK: 3/HP: 3]
+    // [DMF_124t] Horrendous Growth - COST: 2 [ATK:3/HP:3]
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -2487,7 +2487,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_163t] Carnival Clown - COST: 9 [ATK: 4/HP: 4]
+    // [DMF_163t] Carnival Clown - COST: 9 [ATK:4/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -2500,7 +2500,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_174t] Circus Medic - COST: 4 [ATK: 3/HP: 4]
+    // [DMF_174t] Circus Medic - COST: 4 [ATK:3/HP:4]
     // - Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Corrupted</b>
@@ -2650,7 +2650,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_254t5t] C'Thun's Body - COST: 6 [ATK: 6/HP: 6]
+    // [DMF_254t5t] C'Thun's Body - COST: 6 [ATK:6/HP:6]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -2675,7 +2675,7 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_523t] Darkmoon Rider - COST: 1 [ATK: 1/HP: 1]
+    // [DMF_523t] Darkmoon Rider - COST: 1 [ATK:1/HP:1]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
     // Text: <b>Rush</b>

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -56,6 +56,9 @@ void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - RUSH = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_059", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [DMF_060] Umbral Owl - COST:7 [ATK:4/HP:4]

--- a/Sources/Rosetta/PlayMode/Cards/CardDef.cpp
+++ b/Sources/Rosetta/PlayMode/Cards/CardDef.cpp
@@ -50,6 +50,15 @@ CardDef::CardDef(Power _power, std::map<PlayReq, int> _playReqs,
 }
 
 CardDef::CardDef(Power _power, std::map<PlayReq, int> _playReqs,
+                 std::string _corruptCardID)
+    : power(std::move(_power)),
+      playReqs(std::move(_playReqs)),
+      corruptCardID(std::move(_corruptCardID))
+{
+    // Do nothing
+}
+
+CardDef::CardDef(Power _power, std::map<PlayReq, int> _playReqs,
                  std::vector<std::string> _chooseCardIDs,
                  std::vector<std::string> _entourages)
     : power(std::move(_power)),

--- a/Sources/Rosetta/PlayMode/Cards/CardDef.cpp
+++ b/Sources/Rosetta/PlayMode/Cards/CardDef.cpp
@@ -26,6 +26,12 @@ CardDef::CardDef(Power _power, std::vector<std::string> _chooseCardIDs)
     // Do nothing
 }
 
+CardDef::CardDef(Power _power, std::string _corruptCardID)
+    : power(std::move(_power)), corruptCardID(std::move(_corruptCardID))
+{
+    // Do nothing
+}
+
 CardDef::CardDef(Power _power, int _questProgressTotal, int _heroPowerDbfID)
     : power(std::move(_power)),
       questProgressTotal(_questProgressTotal),

--- a/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
@@ -107,9 +107,21 @@ void CardLoader::Load(std::vector<Card*>& cards)
         }
 
         // NOTE: Skyvateer (YOD_016) doesn't have GameTag::DEATHRATTLE
+        // NOTE: Insatiable Felhound (DMF_247) doesn't have GameTag::TAUNT
+        // NOTE: Insatiable Felhound (DMF_247t) doesn't have GameTag::TAUNT
+        //       and GameTag::LIFESTEAL
         if (dbfID == 56091)
         {
             gameTags.emplace(GameTag::DEATHRATTLE, 1);
+        }
+        else if (dbfID == 61269)
+        {
+            gameTags.emplace(GameTag::TAUNT, 1);
+        }
+        else if (dbfID == 61270)
+        {
+            gameTags.emplace(GameTag::TAUNT, 1);
+            gameTags.emplace(GameTag::LIFESTEAL, 1);
         }
 
         Card* card = new Card();

--- a/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
@@ -26,6 +26,9 @@ void CardLoader::Load(std::vector<Card*>& cards)
 
     cards.reserve(j.size());
 
+    std::regex spellburstRegex("([<b>]*<b>Spellburst[</b>]*:</b>)");
+    std::smatch values;
+
     for (auto& cardData : j)
     {
         const std::string id = cardData["id"].get<std::string>();
@@ -139,9 +142,6 @@ void CardLoader::Load(std::vector<Card*>& cards)
         {
             card->gameTags[GameTag::OVERLOAD] = overload;
         }
-
-        static std::regex spellburstRegex("([<b>]*<b>Spellburst[</b>]*:</b>)");
-        std::smatch values;
 
         if (std::regex_search(text, values, spellburstRegex))
         {

--- a/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
@@ -110,6 +110,7 @@ void CardLoader::Load(std::vector<Card*>& cards)
         // NOTE: Insatiable Felhound (DMF_247) doesn't have GameTag::TAUNT
         // NOTE: Insatiable Felhound (DMF_247t) doesn't have GameTag::TAUNT
         //       and GameTag::LIFESTEAL
+        // NOTE: Carousel Gryphon (DMF_064) doesn't have GameTag::DIVINE_SHIELD
         if (dbfID == 56091)
         {
             gameTags.emplace(GameTag::DEATHRATTLE, 1);
@@ -122,6 +123,10 @@ void CardLoader::Load(std::vector<Card*>& cards)
         {
             gameTags.emplace(GameTag::TAUNT, 1);
             gameTags.emplace(GameTag::LIFESTEAL, 1);
+        }
+        else if (dbfID == 61581)
+        {
+            gameTags.emplace(GameTag::DIVINE_SHIELD, 1);
         }
 
         Card* card = new Card();

--- a/Sources/Rosetta/PlayMode/Loaders/InternalCardLoader.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/InternalCardLoader.cpp
@@ -5,6 +5,7 @@
 // property of any third parties.
 
 #include <Rosetta/PlayMode/Cards/CardDefs.hpp>
+#include <Rosetta/PlayMode/Cards/Cards.hpp>
 #include <Rosetta/PlayMode/Loaders/InternalCardLoader.hpp>
 
 namespace RosettaStone::PlayMode
@@ -22,6 +23,8 @@ void InternalCardLoader::Load(std::vector<Card*>& cards)
         card->gameTags[GameTag::QUEST_PROGRESS_TOTAL] =
             cardDef.questProgressTotal;
         card->gameTags[GameTag::HERO_POWER] = cardDef.heroPowerDbfID;
+        card->gameTags[GameTag::CORRUPTEDCARD] =
+            Cards::FindCardByID(cardDef.corruptCardID)->dbfID;
 
         // NOTE: Load some game tag data
         // Scheme series

--- a/Sources/Rosetta/PlayMode/Models/Playable.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Playable.cpp
@@ -139,6 +139,11 @@ bool Playable::IsEcho() const
     return GetGameTag(GameTag::ECHO) == 1;
 }
 
+bool Playable::HasCorrupt() const
+{
+    return GetGameTag(GameTag::CORRUPT) == 1;
+}
+
 void Playable::ResetCost()
 {
     costManager = nullptr;

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -760,7 +760,7 @@ TEST_CASE("[Priest : Minion] - BT_258 : Imprisoned Homunculus")
 }
 
 // ---------------------------------------- SPELL - PALADIN
-// [BT_292] Hand of A'dal - COST: 2
+// [BT_292] Hand of A'dal - COST:2
 // - Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------
 // Text: Give a minion +2/+2. Draw a card.

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -211,6 +211,8 @@ TEST_CASE("[Mage : Minion] - DMF_101 : Firework Elemental")
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);
 
+    opPlayer->GetHero()->SetDamage(0);
+
     game.Process(curPlayer, PlayCardTask::Spell(card4));
     CHECK_EQ(curHand[0]->card->id, "DMF_101");
 

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -16,6 +16,70 @@ using namespace PlayMode;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ---------------------------------------- MINION - HUNTER
+// [DMF_083] Dancing Cobra - COST: 2 [ATK: 1/HP: 5]
+// - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Corrupt:</b> Gain <b>Poisonous</b>.
+// --------------------------------------------------------
+// GameTag:
+// - CORRUPT = 1
+// --------------------------------------------------------
+// RefTag:
+// - POISONOUS = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - DMF_083 : Dancing Cobra")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Dancing Cobra"));
+    [[maybe_unused]] auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Dancing Cobra"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Arcane Missiles"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasPoisonous(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card4));
+    CHECK_EQ(curHand[0]->card->id, "DMF_083");
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
+    CHECK_EQ(curHand[0]->card->id, "DMF_083t");
+
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[0]));
+    CHECK_EQ(curField[1]->HasPoisonous(), true);
+}
+
 // ---------------------------------------- MINION - PRIEST
 // [DMF_184] Fairground Fool - COST: 3 [ATK: 4/HP: 3]
 // - Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -498,6 +498,58 @@ TEST_CASE("[Neutral : Minion] - DMF_073 : Darkmoon Dirigible")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [DMF_078] Strongman - COST:7 [ATK:6/HP:6]
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Corrupt:</b> This costs (0).
+// --------------------------------------------------------
+// GameTag:
+// - CORRUPT = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - DMF_078 : Strongman")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Strongman"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Deep Freeze"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Frostbolt"));
+
+    CHECK_EQ(card1->GetCost(), 7);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
+    CHECK_EQ(curHand[0]->card->id, "DMF_078");
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(curHand[0]->card->id, "DMF_078t");
+    CHECK_EQ(curHand[0]->GetCost(), 0);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [DMF_080] Fleethoof Pearltusk - COST:5 [ATK:4/HP:4]
 // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -17,7 +17,7 @@ using namespace PlayerTasks;
 using namespace SimpleTasks;
 
 // ------------------------------------------ SPELL - DRUID
-// [DMF_730] Moontouched Amulet - COST: 3
+// [DMF_730] Moontouched Amulet - COST:3
 // - Set: DARKMOON_FAIRE, Rarity: Rare
 // --------------------------------------------------------
 // Text: Give your hero +4 Attack this turn.
@@ -81,7 +81,7 @@ TEST_CASE("[Druid : Spell] - DMF_730 : Moontouched Amulet")
 }
 
 // ---------------------------------------- MINION - HUNTER
-// [DMF_083] Dancing Cobra - COST: 2 [ATK:1/HP:5]
+// [DMF_083] Dancing Cobra - COST:2 [ATK:1/HP:5]
 // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Corrupt:</b> Gain <b>Poisonous</b>.
@@ -145,7 +145,7 @@ TEST_CASE("[Hunter : Minion] - DMF_083 : Dancing Cobra")
 }
 
 // --------------------------------------- MINION - PALADIN
-// [DMF_064] Carousel Gryphon - COST: 5 [ATK:5/HP:5]
+// [DMF_064] Carousel Gryphon - COST:5 [ATK:5/HP:5]
 // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Divine Shield</b>
@@ -222,7 +222,7 @@ TEST_CASE("[Paladin : Minion] - DMF_064 : Carousel Gryphon")
 }
 
 // ---------------------------------------- MINION - PRIEST
-// [DMF_184] Fairground Fool - COST: 3 [ATK:4/HP:3]
+// [DMF_184] Fairground Fool - COST:3 [ATK:4/HP:3]
 // - Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Taunt</b>
@@ -290,7 +290,7 @@ TEST_CASE("[Priest : Minion] - DMF_184 : Fairground Fool")
 }
 
 // ----------------------------------------- MINION - ROGUE
-// [DMF_517] Sweet Tooth - COST: 2 [ATK:3/HP:2]
+// [DMF_517] Sweet Tooth - COST:2 [ATK:3/HP:2]
 // - Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Corrupt:</b> Gain +2 Attack and <b>Stealth</b>.
@@ -357,7 +357,7 @@ TEST_CASE("[Rogue : Minion] - DMF_517 : Sweet Tooth")
 }
 
 // ----------------------------------- MINION - DEMONHUNTER
-// [DMF_247] Insatiable Felhound - COST: 3 [ATK:2/HP:5]
+// [DMF_247] Insatiable Felhound - COST:3 [ATK:2/HP:5]
 // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Taunt</b>
@@ -429,7 +429,7 @@ TEST_CASE("[Demon Hunter : Minion] - DMF_247 : Insatiable Felhound")
 }
 
 // --------------------------------------- MINION - NEUTRAL
-// [DMF_073] Darkmoon Dirigible - COST: 3 [ATK:3/HP:2]
+// [DMF_073] Darkmoon Dirigible - COST:3 [ATK:3/HP:2]
 // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Divine Shield</b>
@@ -498,7 +498,7 @@ TEST_CASE("[Neutral : Minion] - DMF_073 : Darkmoon Dirigible")
 }
 
 // --------------------------------------- MINION - NEUTRAL
-// [DMF_080] Fleethoof Pearltusk - COST: 5 [ATK:4/HP:4]
+// [DMF_080] Fleethoof Pearltusk - COST:5 [ATK:4/HP:4]
 // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Rush</b>

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1034,3 +1034,17 @@ TEST_CASE("[Neutral : Minion] - DMF_174 : Circus Medic")
     game.Process(curPlayer, PlayCardTask::MinionTarget(curHand[0], opHero));
     CHECK_EQ(opHero->GetHealth(), 26);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [DMF_190] Fantastic Firebird - COST:4 [ATK:3/HP:5]
+// - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Windfury</b>
+// --------------------------------------------------------
+// GameTag:
+// - WINDFURY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - DMF_190 : Fantastic Firebird")
+{
+    // Do nothing
+}

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+﻿// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 // We are making my contributions/submissions to this project solely in our
 // personal capacity and are not conveying any rights to any intellectual
@@ -146,6 +146,78 @@ TEST_CASE("[Priest : Minion] - DMF_184 : Fairground Fool")
     CHECK_EQ(curField[1]->HasTaunt(), true);
     CHECK_EQ(curField[1]->GetAttack(), 4);
     CHECK_EQ(curField[1]->GetHealth(), 7);
+}
+
+// ----------------------------------- MINION - DEMONHUNTER
+// [DMF_247] Insatiable Felhound - COST: 3 [ATK: 2/HP: 5]
+// - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Corrupt:</b> Gain +1/+1 and <b>Lifesteal</b>.
+// --------------------------------------------------------
+// GameTag:
+// - CORRUPT = 1
+// --------------------------------------------------------
+// RefTag:
+// - LIFESTEAL = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - DMF_247 : Insatiable Felhound")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Insatiable Felhound"));
+    [[maybe_unused]] auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Insatiable Felhound"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Arcane Missiles"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+    CHECK_EQ(curField[0]->HasLifesteal(), false);
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card4));
+    CHECK_EQ(curHand[0]->card->id, "DMF_247");
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
+    CHECK_EQ(curHand[0]->card->id, "DMF_247t");
+
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[0]));
+    CHECK_EQ(curField[1]->HasTaunt(), true);
+    CHECK_EQ(curField[1]->HasLifesteal(), true);
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->GetHealth(), 6);
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -6,7 +6,81 @@
 
 #include <Utils/CardSetUtils.hpp>
 
-TEST_CASE("[DarkmoonFaireCardsGen] - Temp")
+#include <Rosetta/PlayMode/Actions/Draw.hpp>
+#include <Rosetta/PlayMode/Cards/Cards.hpp>
+#include <Rosetta/PlayMode/Zones/FieldZone.hpp>
+#include <Rosetta/PlayMode/Zones/HandZone.hpp>
+
+using namespace RosettaStone;
+using namespace PlayMode;
+using namespace PlayerTasks;
+using namespace SimpleTasks;
+
+// --------------------------------------- MINION - NEUTRAL
+// [DMF_073] Darkmoon Dirigible - COST: 3 [ATK: 3/HP: 2]
+// - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Divine Shield</b>
+//       <b>Corrupt:</b> Gain <b>Rush</b>.
+// --------------------------------------------------------
+// GameTag:
+// - CORRUPT = 1
+// - DIVINE_SHIELD = 1
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - DMF_073 : Darkmoon Dirigible")
 {
-    CHECK(true);
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Darkmoon Dirigible"));
+    [[maybe_unused]] auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Darkmoon Dirigible"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasDivineShield(), true);
+    CHECK_EQ(curField[0]->HasRush(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card4, opPlayer->GetHero()));
+    CHECK_EQ(curHand[0]->card->id, "DMF_073");
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
+    CHECK_EQ(curHand[0]->card->id, "DMF_073t");
+
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[0]));
+    CHECK_EQ(curField[1]->HasDivineShield(), true);
+    CHECK_EQ(curField[1]->HasRush(), true);
 }

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -695,6 +695,20 @@ TEST_CASE("[Shaman : Minion] - DMF_703 : Pit Master")
     CHECK_EQ(curField[4]->card->name, "Duelist");
 }
 
+// --------------------------------------- MINION - WARLOCK
+// [DMF_114] Midway Maniac - COST:2 [ATK:1/HP:5]
+// - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - DMF_114 : Midway Maniac")
+{
+    // Do nothing
+}
+
 // ----------------------------------- MINION - DEMONHUNTER
 // [DMF_247] Insatiable Felhound - COST:3 [ATK:2/HP:5]
 // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -225,6 +225,73 @@ TEST_CASE("[Priest : Minion] - DMF_184 : Fairground Fool")
     CHECK_EQ(curField[1]->GetHealth(), 7);
 }
 
+// ----------------------------------------- MINION - ROGUE
+// [DMF_517] Sweet Tooth - COST: 2 [ATK:3/HP:2]
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Corrupt:</b> Gain +2 Attack and <b>Stealth</b>.
+// --------------------------------------------------------
+// GameTag:
+// - CORRUPT = 1
+// --------------------------------------------------------
+// RefTag:
+// - STEALTH = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - DMF_517 : Sweet Tooth")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Sweet Tooth"));
+    [[maybe_unused]] auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Sweet Tooth"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasStealth(), false);
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card4, opPlayer->GetHero()));
+    CHECK_EQ(curHand[0]->card->id, "DMF_517");
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
+    CHECK_EQ(curHand[0]->card->id, "DMF_517a");
+
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[0]));
+    CHECK_EQ(curField[1]->HasStealth(), true);
+    CHECK_EQ(curField[1]->GetAttack(), 5);
+}
+
 // ----------------------------------- MINION - DEMONHUNTER
 // [DMF_247] Insatiable Felhound - COST: 3 [ATK:2/HP:5]
 // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -752,6 +752,20 @@ TEST_CASE("[Demon Hunter : Minion] - DMF_247 : Insatiable Felhound")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [DMF_044] Rock Rager - COST:2 [ATK:5/HP:1]
+// - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - DMF_044 : Rock Rager")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [DMF_073] Darkmoon Dirigible - COST:3 [ATK:3/HP:2]
 // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -17,7 +17,7 @@ using namespace PlayerTasks;
 using namespace SimpleTasks;
 
 // ---------------------------------------- MINION - HUNTER
-// [DMF_083] Dancing Cobra - COST: 2 [ATK: 1/HP: 5]
+// [DMF_083] Dancing Cobra - COST: 2 [ATK:1/HP:5]
 // - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Corrupt:</b> Gain <b>Poisonous</b>.
@@ -81,7 +81,7 @@ TEST_CASE("[Hunter : Minion] - DMF_083 : Dancing Cobra")
 }
 
 // ---------------------------------------- MINION - PRIEST
-// [DMF_184] Fairground Fool - COST: 3 [ATK: 4/HP: 3]
+// [DMF_184] Fairground Fool - COST: 3 [ATK:4/HP:3]
 // - Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Taunt</b>
@@ -149,7 +149,7 @@ TEST_CASE("[Priest : Minion] - DMF_184 : Fairground Fool")
 }
 
 // ----------------------------------- MINION - DEMONHUNTER
-// [DMF_247] Insatiable Felhound - COST: 3 [ATK: 2/HP: 5]
+// [DMF_247] Insatiable Felhound - COST: 3 [ATK:2/HP:5]
 // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Taunt</b>
@@ -221,7 +221,7 @@ TEST_CASE("[Demon Hunter : Minion] - DMF_247 : Insatiable Felhound")
 }
 
 // --------------------------------------- MINION - NEUTRAL
-// [DMF_073] Darkmoon Dirigible - COST: 3 [ATK: 3/HP: 2]
+// [DMF_073] Darkmoon Dirigible - COST: 3 [ATK:3/HP:2]
 // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Divine Shield</b>

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -16,6 +16,22 @@ using namespace PlayMode;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ----------------------------------------- MINION - DRUID
+// [DMF_059] Fizzy Elemental - COST:9 [ATK:10/HP:10]
+// - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Rush</b>
+//       <b>Taunt</b>
+// --------------------------------------------------------
+// GameTag:
+// - RUSH = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - DMF_059 : Fizzy Elemental")
+{
+    // Do nothing
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [DMF_730] Moontouched Amulet - COST:3
 // - Set: DARKMOON_FAIRE, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -16,6 +16,74 @@ using namespace PlayMode;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ---------------------------------------- MINION - PRIEST
+// [DMF_184] Fairground Fool - COST: 3 [ATK: 4/HP: 3]
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Corrupt:</b> Gain +4 Health.
+// --------------------------------------------------------
+// GameTag:
+// - CORRUPT = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - DMF_184 : Fairground Fool")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fairground Fool"));
+    [[maybe_unused]] auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fairground Fool"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card4, opPlayer->GetHero()));
+    CHECK_EQ(curHand[0]->card->id, "DMF_184");
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
+    CHECK_EQ(curHand[0]->card->id, "DMF_184t");
+
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[0]));
+    CHECK_EQ(curField[1]->HasTaunt(), true);
+    CHECK_EQ(curField[1]->GetAttack(), 4);
+    CHECK_EQ(curField[1]->GetHealth(), 7);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [DMF_073] Darkmoon Dirigible - COST: 3 [ATK: 3/HP: 2]
 // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -288,3 +288,76 @@ TEST_CASE("[Neutral : Minion] - DMF_073 : Darkmoon Dirigible")
     CHECK_EQ(curField[1]->HasDivineShield(), true);
     CHECK_EQ(curField[1]->HasRush(), true);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [DMF_080] Fleethoof Pearltusk - COST: 5 [ATK:4/HP:4]
+// - Race: Beast, Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Rush</b>
+//       <b>Corrupt:</b> Gain +4/+4.
+// --------------------------------------------------------
+// GameTag:
+// - CORRUPT = 1
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - DMF_080 : Fleethoof Pearltusk")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Fleethoof Pearltusk"));
+    [[maybe_unused]] auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Fleethoof Pearltusk"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Blizzard"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasRush(), true);
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card4, opPlayer->GetHero()));
+    CHECK_EQ(curHand[0]->card->id, "DMF_080");
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(curHand[0]->card->id, "DMF_080t");
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[0]));
+    CHECK_EQ(curField[1]->HasRush(), true);
+    CHECK_EQ(curField[1]->GetAttack(), 8);
+    CHECK_EQ(curField[1]->GetAttack(), 8);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -306,6 +306,84 @@ TEST_CASE("[Paladin : Minion] - DMF_064 : Carousel Gryphon")
     CHECK_EQ(curField[1]->GetHealth(), 8);
 }
 
+// ---------------------------------------- SPELL - PALADIN
+// [DMF_244] Day at the Faire - COST:3
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: Summon 3 Silver Hand Recruits.
+//       <b>Corrupt:</b> Summon 5.
+// --------------------------------------------------------
+// GameTag:
+// - CORRUPT = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Spell] - DMF_244 : Day at the Faire")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Day at the Faire"));
+    [[maybe_unused]] auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Day at the Faire"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Arcane Missiles"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Arcane Explosion"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[0]->card->name, "Silver Hand Recruit");
+    CHECK_EQ(curField[1]->card->name, "Silver Hand Recruit");
+    CHECK_EQ(curField[2]->card->name, "Silver Hand Recruit");
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Spell(card5));
+    CHECK_EQ(curField.GetCount(), 0);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card4));
+    CHECK_EQ(curHand[0]->card->id, "DMF_244");
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
+    CHECK_EQ(curHand[0]->card->id, "DMF_244t");
+
+    game.Process(curPlayer, PlayCardTask::Spell(curHand[0]));
+    CHECK_EQ(curField.GetCount(), 5);
+    CHECK_EQ(curField[0]->card->name, "Silver Hand Recruit");
+    CHECK_EQ(curField[1]->card->name, "Silver Hand Recruit");
+    CHECK_EQ(curField[2]->card->name, "Silver Hand Recruit");
+    CHECK_EQ(curField[3]->card->name, "Silver Hand Recruit");
+    CHECK_EQ(curField[4]->card->name, "Silver Hand Recruit");
+}
+
 // ---------------------------------------- MINION - PRIEST
 // [DMF_184] Fairground Fool - COST:3 [ATK:4/HP:3]
 // - Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -80,6 +80,83 @@ TEST_CASE("[Hunter : Minion] - DMF_083 : Dancing Cobra")
     CHECK_EQ(curField[1]->HasPoisonous(), true);
 }
 
+// --------------------------------------- MINION - PALADIN
+// [DMF_064] Carousel Gryphon - COST: 5 [ATK:5/HP:5]
+// - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Divine Shield</b>
+//       <b>Corrupt:</b> Gain +3/+3 and <b>Taunt</b>.
+// --------------------------------------------------------
+// GameTag:
+// - CORRUPT = 1
+// --------------------------------------------------------
+// RefTag:
+// - DIVINE_SHIELD = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Minion] - DMF_064 : Carousel Gryphon")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Carousel Gryphon"));
+    [[maybe_unused]] auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Carousel Gryphon"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Blizzard"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Arcane Missiles"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasDivineShield(), true);
+    CHECK_EQ(curField[0]->HasTaunt(), false);
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card4));
+    CHECK_EQ(curHand[0]->card->id, "DMF_064");
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(curHand[0]->card->id, "DMF_064t");
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[0]));
+    CHECK_EQ(curField[1]->HasDivineShield(), true);
+    CHECK_EQ(curField[1]->HasTaunt(), true);
+    CHECK_EQ(curField[1]->GetAttack(), 8);
+    CHECK_EQ(curField[1]->GetHealth(), 8);
+}
+
 // ---------------------------------------- MINION - PRIEST
 // [DMF_184] Fairground Fool - COST: 3 [ATK:4/HP:3]
 // - Set: DARKMOON_FAIRE, Rarity: Common


### PR DESCRIPTION
This revision includes:
- Implement 18 DARKMOON_FAIRE cards
  - Rock Rager (DMF_044)
  - Fizzy Elemental (DMF_059)
  - Carousel Gryphon (DMF_064)
  - Darkmoon Dirigible (DMF_073)
  - Strongman (DMF_078)
  - Fleethoof Pearltusk (DMF_080)
  - Dancing Cobra (DMF_083)
  - Firework Elemental (DMF_101)
  - Midway Maniac (DMF_114)
  - Circus Medic (DMF_174)
  - Fairground Fool (DMF_184)
  - Fantastic Firebird (DMF_190)
  - Day at the Faire (DMF_244)
  - Insatiable Felhound (DMF_247)
  - Sweet Tooth (DMF_517)
  - Dunk Tank (DMF_701)
  - Pit Master (DMF_703)
  - Moontouched Amulet (DMF_730)
- Implement keyword 'Corrupt'
  - Corrupt is an ability introduced in Madness at the Darkmoon Faire which activates when the user plays a card with a higher mana cost than the Corrupt card's cost while in hand, causing it to transform into a Corrupted card and gain additional effects.
  - Add method 'HasCorrupt()': Returns the flag that indicates whether it has corrupt
- Add code to set the value of new card's game tags in method 'ChangeEntity()'
- Add code to assign missing game tags of some cards
  - Carousel Gryphon (DMF_064)
  - Insatiable Felhound (DMF_247)
- Improve performance
  - Delete keyword 'static' of local variable 'spellburstRegex'