### PR TITLE
Implement 2 SCHOLOMANCE cards

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -12,10 +12,10 @@ jobs:
       matrix:
         include:
           # Ubuntu 16.04 + gcc-7
-          - name: "Ubuntu 16.04 + gcc-7"
-            os: ubuntu-16.04
-            compiler: gcc
-            version: "7"
+          #- name: "Ubuntu 16.04 + gcc-7"
+          #  os: ubuntu-16.04
+          #  compiler: gcc
+          #  version: "7"
           # Ubuntu 18.04 + gcc-8
           - name: "Ubuntu 18.04 + gcc-8"
             os: ubuntu-18.04
@@ -27,10 +27,10 @@ jobs:
             compiler: gcc
             version: "9"
           # Ubuntu 16.04 + clang-8
-          - name: "Ubuntu 16.04 + clang-8"
-            os: ubuntu-16.04
-            compiler: clang
-            version: "8"
+          #- name: "Ubuntu 16.04 + clang-8"
+          #  os: ubuntu-16.04
+          #  compiler: clang
+          #  version: "8"
           # Ubuntu 18.04 + clang-9
           - name: "Ubuntu 18.04 + clang-9"
             os: ubuntu-18.04

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -1143,7 +1143,7 @@ SCHOLOMANCE | SCH_248 | Pen Flinger |
 SCHOLOMANCE | SCH_250 | Wave of Apathy |  
 SCHOLOMANCE | SCH_252 | Marrowslicer |  
 SCHOLOMANCE | SCH_253 | Cycle of Hatred |  
-SCHOLOMANCE | SCH_259 | Sphere of Sapience |  
+SCHOLOMANCE | SCH_259 | Sphere of Sapience | O
 SCHOLOMANCE | SCH_270 | Primordial Studies | O
 SCHOLOMANCE | SCH_271 | Molten Blast |  
 SCHOLOMANCE | SCH_273 | Ras Frostwhisper |  

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -1232,7 +1232,7 @@ SCHOLOMANCE | SCH_711 | Plagued Protodrake | O
 SCHOLOMANCE | SCH_712 | Judicious Junior | O
 SCHOLOMANCE | SCH_713 | Cult Neophyte | O
 SCHOLOMANCE | SCH_714 | Educated Elekk |  
-SCHOLOMANCE | SCH_717 | Keymaster Alabaster |  
+SCHOLOMANCE | SCH_717 | Keymaster Alabaster | O
 
 - Progress: 24% (33 of 135 Cards)
 

--- a/Documents/PullRequests.md
+++ b/Documents/PullRequests.md
@@ -47,10 +47,10 @@ Once you've built the project locally, you're ready to start making changes!
 ### Step 3: Branch
 
 To keep your development environment organized, create local branches to
-hold your work. These should be branched directly off of the `master` branch.
+hold your work. These should be branched directly off of the `main` branch.
 
 ```
-$ git checkout -b my-branch -t upstream/master
+$ git checkout -b my-branch -t upstream/main
 ```
 
 ## Making Changes
@@ -137,11 +137,11 @@ Once you have committed your changes, it is a good idea to use `git rebase`
 
 ```
 $ git fetch upstream
-$ git rebase upstream/master
+$ git rebase upstream/main
 ```
 
 This ensures that your working branch has the latest changes from `utilForever/RosettaStone`
-master.
+main.
 
 ### Step 7: Test
 
@@ -182,7 +182,7 @@ the requirements below.
 
 Bug fixes and new features should include tests and possibly benchmarks.
 
-Contributors guide: https://github.com/utilForever/RosettaStone/blob/master/Documents/Contributing.md
+Contributors guide: https://github.com/utilForever/RosettaStone/blob/main/Documents/Contributing.md
 -->
 ```
 

--- a/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
@@ -30,7 +30,6 @@ enum class DiscoverType
     MADAME_LAZUL,
     SWAMPQUEEN_HAGATHA,
     TORTOLLAN_PILGRIM,
-    JANDICE_BAROV,
     FROM_STACK,
 };
 

--- a/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
@@ -31,6 +31,7 @@ enum class DiscoverType
     SWAMPQUEEN_HAGATHA,
     TORTOLLAN_PILGRIM,
     JANDICE_BAROV,
+    FROM_STACK,
 };
 
 //! The action type of choice.

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.hpp
@@ -63,8 +63,9 @@ class DiscoverTask : public ITask
     //! \param discoverType The type of discover.
     //! \param numberOfChoices The number of choices.
     //! \param repeat The number to repeat this task.
+    //! \param doShuffle The flag that indicates it does shuffle.
     explicit DiscoverTask(DiscoverType discoverType, int numberOfChoices = 3,
-                          int repeat = 1);
+                          int repeat = 1, bool doShuffle = true);
 
     //! Constructs task with given various parameters.
     //! \param cards A list of cards to discover.

--- a/Includes/Rosetta/PlayMode/Zones/DeckZone.hpp
+++ b/Includes/Rosetta/PlayMode/Zones/DeckZone.hpp
@@ -35,9 +35,9 @@ class DeckZone : public LimitedZone<Playable>
     //! \return The top card of deck.
     Playable* GetTopCard() const;
 
-    //! Returns the Nth top card from deck.
+    //! Returns the n-th top card from deck.
     //! \param rank The rank of entity from deck.
-    //! \return The Nth top card of deck.
+    //! \return The n-th top card of deck.
     Playable* GetNthTopCard(int rank) const;
 
     //! Adds the specified entity into this zone, at the given position.

--- a/Includes/Rosetta/PlayMode/Zones/DeckZone.hpp
+++ b/Includes/Rosetta/PlayMode/Zones/DeckZone.hpp
@@ -35,6 +35,11 @@ class DeckZone : public LimitedZone<Playable>
     //! \return The top card of deck.
     Playable* GetTopCard() const;
 
+    //! Returns the Nth top card from deck.
+    //! \param rank The rank of entity from deck.
+    //! \return The Nth top card of deck.
+    Playable* GetNthTopCard(int rank) const;
+
     //! Adds the specified entity into this zone, at the given position.
     //! \param entity The entity.
     //! \param zonePos The zone position.

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -2147,7 +2147,7 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
             return TaskStatus::COMPLETE;
         }));
     power.AddPowerTask(
-        std::make_shared<DiscoverTask>(DiscoverType::JANDICE_BAROV, 2));
+        std::make_shared<DiscoverTask>(DiscoverType::FROM_STACK, 2, 1, false));
     power.AddAfterChooseTask(std::make_shared<CustomTask>(
         [](Player* player, [[maybe_unused]] Entity* source,
            [[maybe_unused]] Playable* target) {

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -1996,11 +1996,11 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     power.GetTrigger()->tasks = { std::make_shared<CustomTask>(
         [](Player* player, [[maybe_unused]] Entity* source,
            [[maybe_unused]] Playable* target) {
-            const auto& deckZone = player->GetDeckZone();
+            DeckZone* deckZone = player->GetDeckZone();
 
             if (!deckZone->IsEmpty())
             {
-                auto& stack = player->game->taskStack;
+                TaskStack& stack = player->game->taskStack;
                 stack.AddPlayables(
                     { deckZone->GetTopCard(),
                       Entity::GetFromCard(player,
@@ -2012,28 +2012,30 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
                 discoverTask->SetSource(source);
                 discoverTask->Run();
             }
+
             return TaskStatus::COMPLETE;
         }) };
     power.AddAfterChooseTask(std::make_shared<CustomTask>(
         [](Player* player, [[maybe_unused]] Entity* source,
            [[maybe_unused]] Playable* target) {
-            const auto& deckZone = player->GetDeckZone();
-            auto& stack = player->game->taskStack;
+            DeckZone* deckZone = player->GetDeckZone();
+            TaskStack& stack = player->game->taskStack;
             const Playable* result = stack.playables[0];
 
             if (result != nullptr && result->card->id == "SCH_259t")
             {
-                Weapon* weapon = player->GetHero()->weapon;
-                if (weapon != nullptr)
+                if (Weapon* weapon = player->GetHero()->weapon; weapon)
                 {
                     Playable* topCard = deckZone->GetTopCard();
+
+                    // Add a card at the bottom of stack
                     deckZone->Remove(topCard);
-                    deckZone->Add(topCard,
-                                  0);  // add a card at the bottom of stack
+                    deckZone->Add(topCard, 0);
 
                     weapon->RemoveDurability(1);
                 }
             }
+
             return TaskStatus::COMPLETE;
         }));
     cards.emplace("SCH_259", CardDef(power));

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -2524,6 +2524,14 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::DRAW_CARD));
+    power.GetTrigger()->triggerSource = TriggerSource::ENEMY;
+    power.GetTrigger()->tasks = {
+        std::make_shared<CopyTask>(EntityType::TARGET, ZoneType::HAND, 1, true),
+        std::make_shared<AddEnchantmentTask>("DRG_089e", EntityType::STACK)
+    };
+    cards.emplace("SCH_717", CardDef(power));
 }
 
 void ScholomanceCardsGen::AddNeutralNonCollect(

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -34,6 +34,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonCopyTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
+#include <Rosetta/PlayMode/Zones/DeckZone.hpp>
 #include <Rosetta/PlayMode/Zones/FieldZone.hpp>
 #include <Rosetta/PlayMode/Zones/HandZone.hpp>
 
@@ -1990,6 +1991,52 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
+    power.GetTrigger()->tasks = { std::make_shared<CustomTask>(
+        [](Player* player, [[maybe_unused]] Entity* source,
+           [[maybe_unused]] Playable* target) {
+            const auto& deckZone = player->GetDeckZone();
+
+            if (!deckZone->IsEmpty())
+            {
+                auto& stack = player->game->taskStack;
+                stack.AddPlayables(
+                    { deckZone->GetTopCard(),
+                      Entity::GetFromCard(player,
+                                          Cards::FindCardByID("SCH_259t")) });
+
+                const auto& discoverTask = std::make_shared<DiscoverTask>(
+                    DiscoverType::FROM_STACK, 2, 1, false);
+                discoverTask->SetPlayer(player);
+                discoverTask->SetSource(source);
+                discoverTask->Run();
+            }
+            return TaskStatus::COMPLETE;
+        }) };
+    power.AddAfterChooseTask(std::make_shared<CustomTask>(
+        [](Player* player, [[maybe_unused]] Entity* source,
+           [[maybe_unused]] Playable* target) {
+            const auto& deckZone = player->GetDeckZone();
+            auto& stack = player->game->taskStack;
+            const Playable* result = stack.playables[0];
+
+            if (result != nullptr && result->card->id == "SCH_259t")
+            {
+                Weapon* weapon = player->GetHero()->weapon;
+                if (weapon != nullptr)
+                {
+                    Playable* topCard = deckZone->GetTopCard();
+                    deckZone->Remove(topCard);
+                    deckZone->Add(topCard,
+                                  0);  // add a card at the bottom of stack
+
+                    weapon->RemoveDurability(1);
+                }
+            }
+            return TaskStatus::COMPLETE;
+        }));
+    cards.emplace("SCH_259", CardDef(power));
 
     // ---------------------------------------- SPELL - NEUTRAL
     // [SCH_270] Primordial Studies - COST:1
@@ -2860,6 +2907,9 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: Draw a different card.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("SCH_259t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [SCH_270e] Runic Studies - COST:0

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
@@ -59,10 +59,11 @@ DiscoverTask::DiscoverTask(const std::vector<std::string>& cardIDs,
 }
 
 DiscoverTask::DiscoverTask(DiscoverType discoverType, int numberOfChoices,
-                           int repeat)
+                           int repeat, bool doShuffle)
     : m_discoverType(discoverType),
       m_numberOfChoices(numberOfChoices),
-      m_repeat(repeat)
+      m_repeat(repeat),
+      m_doShuffle(doShuffle)
 {
     // Do nothing
 }
@@ -122,18 +123,18 @@ TaskStatus DiscoverTask::Impl(Player* player)
 
     if (!m_cards.empty())
     {
-        result = GetChoices(m_cards, m_numberOfChoices);
+        result = GetChoices(m_cards, m_numberOfChoices, m_doShuffle);
     }
     else if (m_discoverType != DiscoverType::INVALID)
     {
         cardsToDiscover =
             Discover(player->game, player, m_discoverType, m_choiceAction);
-        result = GetChoices(cardsToDiscover, m_numberOfChoices);
+        result = GetChoices(cardsToDiscover, m_numberOfChoices, m_doShuffle);
     }
     else
     {
         cardsToDiscover = Discover(player->game, player, m_discoverCriteria);
-        result = GetChoices(cardsToDiscover, m_numberOfChoices);
+        result = GetChoices(cardsToDiscover, m_numberOfChoices, m_doShuffle);
     }
 
     if (result.empty())

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
@@ -424,6 +424,15 @@ std::vector<Card*> DiscoverTask::Discover(Game* game, Player* player,
             }
             break;
         }
+        case DiscoverType::FROM_STACK:
+        {
+            choiceAction = ChoiceAction::STACK;
+            for (auto& playable : game->taskStack.playables)
+            {
+                cards.emplace_back(playable->card);
+            }
+            break;
+        }
     }
 
     return cards;

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
@@ -415,15 +415,6 @@ std::vector<Card*> DiscoverTask::Discover(Game* game, Player* player,
 
             break;
         }
-        case DiscoverType::JANDICE_BAROV:
-        {
-            choiceAction = ChoiceAction::STACK;
-            for (auto& playable : game->taskStack.playables)
-            {
-                cards.emplace_back(playable->card);
-            }
-            break;
-        }
         case DiscoverType::FROM_STACK:
         {
             choiceAction = ChoiceAction::STACK;

--- a/Sources/Rosetta/PlayMode/Zones/DeckZone.cpp
+++ b/Sources/Rosetta/PlayMode/Zones/DeckZone.cpp
@@ -37,6 +37,11 @@ Playable* DeckZone::GetTopCard() const
     return m_entities[m_count - 1];
 }
 
+Playable* DeckZone::GetNthTopCard(int rank) const
+{
+    return m_entities[m_count - rank];
+}
+
 void DeckZone::Add(Playable* entity, int zonePos)
 {
     LimitedZone::Add(entity, zonePos);

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -2061,3 +2061,56 @@ TEST_CASE("[Neutral : Minion] - SCH_713 : Cult Neophyte")
     CHECK_EQ(card2->GetCost(), 4);
     CHECK_EQ(card3->GetCost(), 10);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [SCH_717] Keymaster Alabaster - COST:7 [ATK:6/HP:8]
+// - Set: SCHOLOMANCE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: Whenever your opponent draws a card,
+//       add a copy to your hand that costs (1).
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[NEUTRAL : Minion] - SCH_717 : Keymaster Alabaster")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+    config.fillCardIDs = { "CS2_124", "CS2_124", "CS2_124",
+                           "CS2_124", "CS2_124", "CS2_124",
+                           "CS2_124", "CS2_124", "CS2_124" };
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& opHand = *(opPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Keymaster Alabaster"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask());
+
+    CHECK_EQ(curHand[4]->card->id, opHand[5]->card->id);
+    CHECK_EQ(curHand[5]->card->id, opHand[6]->card->id);
+    CHECK_EQ(curHand[4]->GetCost(), 1);
+    CHECK_EQ(curHand[5]->GetCost(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -11,6 +11,7 @@
 #include <Rosetta/PlayMode/Actions/Generic.hpp>
 #include <Rosetta/PlayMode/Cards/Cards.hpp>
 #include <Rosetta/PlayMode/Models/Enchantment.hpp>
+#include <Rosetta/PlayMode/Zones/DeckZone.hpp>
 #include <Rosetta/PlayMode/Zones/FieldZone.hpp>
 #include <Rosetta/PlayMode/Zones/HandZone.hpp>
 
@@ -1028,6 +1029,87 @@ TEST_CASE("[Neutral : Minion] - SCH_231 : Intrepid Initiate")
                  PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
     CHECK_EQ(curField[0]->GetAttack(), 3);
     CHECK_EQ(curField[0]->HasSpellburst(), false);
+}
+
+// --------------------------------------- WEAPON - NEUTRAL
+// [SCH_259] Sphere of Sapience - COST:1
+// - Set: SCHOLOMANCE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: At the start of your turn, look at your top card.
+//       You can put it on the bottom and lose 1 Durability.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Weapon] - SCH_259 : Sphere of Sapience")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curDeck = *(curPlayer->GetDeckZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto curHero = curPlayer->GetHero();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Sphere of Sapience"));
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK(curPlayer->choice == nullptr);
+
+    auto topCardId = curDeck.GetTopCard()->card->id;
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_RESOURCE);
+
+    CHECK(curPlayer->choice != nullptr);
+    auto cards = TestUtils::GetChoiceCards(game);
+    CHECK_EQ(cards.size(), 2);
+    CHECK_EQ(cards[0]->id, topCardId);
+    CHECK_EQ(cards[1]->id, "SCH_259t");
+
+    TestUtils::ChooseNthChoice(game, 1);
+    game.ProcessUntil(Step::MAIN_ACTION);
+    CHECK_EQ(curHero->weapon->GetDurability(), 4);
+    CHECK_EQ(curHand.GetAll().back()->card->id, topCardId);
+
+    auto secondCardId = curDeck.GetNthTopCard(2)->card->id;
+    topCardId = curDeck.GetTopCard()->card->id;
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_RESOURCE);
+
+    CHECK(curPlayer->choice != nullptr);
+    cards = TestUtils::GetChoiceCards(game);
+    CHECK_EQ(cards.size(), 2);
+    CHECK_EQ(cards[0]->id, topCardId);
+    CHECK_EQ(cards[1]->id, "SCH_259t");
+
+    TestUtils::ChooseNthChoice(game, 2);
+    game.ProcessUntil(Step::MAIN_ACTION);
+    CHECK_EQ(curHero->weapon->GetDurability(), 3);
+    CHECK_EQ(curHand.GetAll().back()->card->id, secondCardId);
+    CHECK_EQ(curDeck.GetNthTopCard(curDeck.GetCount())->card->id, topCardId);
 }
 
 // ---------------------------------------- SPELL - NEUTRAL

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -132,7 +132,7 @@ TEST_CASE("[Druid : Spell] - SCH_333 : Nature Studies")
     game.Process(curPlayer, PlayCardTask::Spell(card2, 1));
     if (curHand[0]->GetCost() != 0)
     {
-        CHECK_EQ(curHand[0]->GetCost(), oldCost + 1);   
+        CHECK_EQ(curHand[0]->GetCost(), oldCost + 1);
     }
 }
 
@@ -1073,7 +1073,8 @@ TEST_CASE("[Neutral : Weapon] - SCH_259 : Sphere of Sapience")
     game.Process(curPlayer, HeroPowerTask());
     CHECK(curPlayer->choice == nullptr);
 
-    auto topCardId = curDeck.GetTopCard()->card->id;
+    std::string topCardID = curDeck.GetTopCard()->card->id;
+
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);
 
@@ -1081,18 +1082,21 @@ TEST_CASE("[Neutral : Weapon] - SCH_259 : Sphere of Sapience")
     game.ProcessUntil(Step::MAIN_RESOURCE);
 
     CHECK(curPlayer->choice != nullptr);
+
     auto cards = TestUtils::GetChoiceCards(game);
     CHECK_EQ(cards.size(), 2);
-    CHECK_EQ(cards[0]->id, topCardId);
+    CHECK_EQ(cards[0]->id, topCardID);
     CHECK_EQ(cards[1]->id, "SCH_259t");
 
     TestUtils::ChooseNthChoice(game, 1);
     game.ProcessUntil(Step::MAIN_ACTION);
-    CHECK_EQ(curHero->weapon->GetDurability(), 4);
-    CHECK_EQ(curHand.GetAll().back()->card->id, topCardId);
 
-    auto secondCardId = curDeck.GetNthTopCard(2)->card->id;
-    topCardId = curDeck.GetTopCard()->card->id;
+    CHECK_EQ(curHero->weapon->GetDurability(), 4);
+    CHECK_EQ(curHand.GetAll().back()->card->id, topCardID);
+
+    std::string secondCardID = curDeck.GetNthTopCard(2)->card->id;
+    topCardID = curDeck.GetTopCard()->card->id;
+
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);
 
@@ -1100,16 +1104,18 @@ TEST_CASE("[Neutral : Weapon] - SCH_259 : Sphere of Sapience")
     game.ProcessUntil(Step::MAIN_RESOURCE);
 
     CHECK(curPlayer->choice != nullptr);
+
     cards = TestUtils::GetChoiceCards(game);
     CHECK_EQ(cards.size(), 2);
-    CHECK_EQ(cards[0]->id, topCardId);
+    CHECK_EQ(cards[0]->id, topCardID);
     CHECK_EQ(cards[1]->id, "SCH_259t");
 
     TestUtils::ChooseNthChoice(game, 2);
     game.ProcessUntil(Step::MAIN_ACTION);
+
     CHECK_EQ(curHero->weapon->GetDurability(), 3);
-    CHECK_EQ(curHand.GetAll().back()->card->id, secondCardId);
-    CHECK_EQ(curDeck.GetNthTopCard(curDeck.GetCount())->card->id, topCardId);
+    CHECK_EQ(curHand.GetAll().back()->card->id, secondCardID);
+    CHECK_EQ(curDeck.GetNthTopCard(curDeck.GetCount())->card->id, topCardID);
 }
 
 // ---------------------------------------- SPELL - NEUTRAL
@@ -2108,7 +2114,6 @@ TEST_CASE("[NEUTRAL : Minion] - SCH_717 : Keymaster Alabaster")
     game.ProcessUntil(Step::MAIN_ACTION);
 
     game.Process(opPlayer, HeroPowerTask());
-
     CHECK_EQ(curHand[4]->card->id, opHand[5]->card->id);
     CHECK_EQ(curHand[5]->card->id, opHand[6]->card->id);
     CHECK_EQ(curHand[4]->GetCost(), 1);


### PR DESCRIPTION
This revision includes
- Replace 'master' with 'main' in 'PullRequests.md'
- Add new features
  - Add a DiscoverType 'FROM_STACK'
  - Remove a DiscoverType 'JANDICE_BAROV'
  - Add a method 'GetNthTopCard' in 'DeckZone'
- Implementation of 2 Scholomance cards
  - 'Sphere of Sapience' (SCH_259)
  - 'Keymaster Alabaster' (SCH_717)
- Disable 'Ubuntu 16.04' temporarily