### PR TITLE
Implement 20 DARKMOON_FAIRE cards and fix several bugs

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -1254,9 +1254,9 @@ DARKMOON_FAIRE | DMF_060 | Umbral Owl |
 DARKMOON_FAIRE | DMF_061 | Faire Arborist |  
 DARKMOON_FAIRE | DMF_062 | Gyreworm |  
 DARKMOON_FAIRE | DMF_064 | Carousel Gryphon | O
-DARKMOON_FAIRE | DMF_065 | Banana Vendor |  
-DARKMOON_FAIRE | DMF_066 | Knife Vendor |  
-DARKMOON_FAIRE | DMF_067 | Prize Vendor |  
+DARKMOON_FAIRE | DMF_065 | Banana Vendor | O
+DARKMOON_FAIRE | DMF_066 | Knife Vendor | O
+DARKMOON_FAIRE | DMF_067 | Prize Vendor | O
 DARKMOON_FAIRE | DMF_068 | Optimistic Ogre |  
 DARKMOON_FAIRE | DMF_069 | Claw Machine |  
 DARKMOON_FAIRE | DMF_070 | Darkmoon Rabbit |  
@@ -1271,17 +1271,17 @@ DARKMOON_FAIRE | DMF_081 | K'thir Ritualist |
 DARKMOON_FAIRE | DMF_082 | Darkmoon Statue |  
 DARKMOON_FAIRE | DMF_083 | Dancing Cobra | O
 DARKMOON_FAIRE | DMF_084 | Jewel of N'Zoth |  
-DARKMOON_FAIRE | DMF_085 | Darkmoon Tonk |  
+DARKMOON_FAIRE | DMF_085 | Darkmoon Tonk | O
 DARKMOON_FAIRE | DMF_086 | Petting Zoo |  
 DARKMOON_FAIRE | DMF_087 | Trampling Rhino |  
 DARKMOON_FAIRE | DMF_088 | Rinling's Rifle |  
 DARKMOON_FAIRE | DMF_089 | Maxima Blastenheimer |  
 DARKMOON_FAIRE | DMF_090 | Don't Feed the Animals |  
-DARKMOON_FAIRE | DMF_091 | Wriggling Horror |  
+DARKMOON_FAIRE | DMF_091 | Wriggling Horror | O
 DARKMOON_FAIRE | DMF_100 | Confection Cyclone |  
 DARKMOON_FAIRE | DMF_101 | Firework Elemental | O
 DARKMOON_FAIRE | DMF_102 | Game Master |  
-DARKMOON_FAIRE | DMF_103 | Mask of C'Thun |  
+DARKMOON_FAIRE | DMF_103 | Mask of C'Thun | O
 DARKMOON_FAIRE | DMF_104 | Grand Finale |  
 DARKMOON_FAIRE | DMF_105 | Ring Toss |  
 DARKMOON_FAIRE | DMF_106 | Occult Conjurer |  
@@ -1309,28 +1309,28 @@ DARKMOON_FAIRE | DMF_184 | Fairground Fool | O
 DARKMOON_FAIRE | DMF_186 | Auspicious Spirits |  
 DARKMOON_FAIRE | DMF_187 | Palm Reading |  
 DARKMOON_FAIRE | DMF_188 | Y'Shaarj, the Defiler |  
-DARKMOON_FAIRE | DMF_189 | Costumed Entertainer |  
+DARKMOON_FAIRE | DMF_189 | Costumed Entertainer | O
 DARKMOON_FAIRE | DMF_190 | Fantastic Firebird | O
-DARKMOON_FAIRE | DMF_191 | Showstopper |  
-DARKMOON_FAIRE | DMF_194 | Redscale Dragontamer |  
+DARKMOON_FAIRE | DMF_191 | Showstopper | O
+DARKMOON_FAIRE | DMF_194 | Redscale Dragontamer | O
 DARKMOON_FAIRE | DMF_195 | Snack Run |  
 DARKMOON_FAIRE | DMF_202 | Derailed Coaster |  
 DARKMOON_FAIRE | DMF_217 | Line Hopper |  
-DARKMOON_FAIRE | DMF_219 | Relentless Pursuit |  
+DARKMOON_FAIRE | DMF_219 | Relentless Pursuit | O
 DARKMOON_FAIRE | DMF_221 | Felscream Blast |  
 DARKMOON_FAIRE | DMF_222 | Redeemed Pariah |  
-DARKMOON_FAIRE | DMF_223 | Renowned Performer |  
+DARKMOON_FAIRE | DMF_223 | Renowned Performer | O
 DARKMOON_FAIRE | DMF_224 | Expendable Performers |  
 DARKMOON_FAIRE | DMF_225 | Throw Glaive |  
 DARKMOON_FAIRE | DMF_226 | Bladed Lady |  
-DARKMOON_FAIRE | DMF_227 | Dreadlord's Bite |  
+DARKMOON_FAIRE | DMF_227 | Dreadlord's Bite | O
 DARKMOON_FAIRE | DMF_229 | Stiltstepper |  
 DARKMOON_FAIRE | DMF_230 | Il'gynoth |  
 DARKMOON_FAIRE | DMF_231 | Zai, the Incredible |  
 DARKMOON_FAIRE | DMF_235 | Balloon Merchant |  
 DARKMOON_FAIRE | DMF_236 | Oh My Yogg! |  
 DARKMOON_FAIRE | DMF_237 | Carnival Barker |  
-DARKMOON_FAIRE | DMF_238 | Hammer of the Naaru |  
+DARKMOON_FAIRE | DMF_238 | Hammer of the Naaru | O
 DARKMOON_FAIRE | DMF_240 | Lothraxion the Redeemed |  
 DARKMOON_FAIRE | DMF_241 | High Exarch Yrel |  
 DARKMOON_FAIRE | DMF_244 | Day at the Faire | O
@@ -1342,14 +1342,14 @@ DARKMOON_FAIRE | DMF_511 | Foxy Fraud |
 DARKMOON_FAIRE | DMF_512 | Cloak of Shadows |  
 DARKMOON_FAIRE | DMF_513 | Shadow Clone |  
 DARKMOON_FAIRE | DMF_514 | Ticket Master |  
-DARKMOON_FAIRE | DMF_515 | Swindle |  
+DARKMOON_FAIRE | DMF_515 | Swindle | O
 DARKMOON_FAIRE | DMF_516 | Grand Empress Shek'zara |  
 DARKMOON_FAIRE | DMF_517 | Sweet Tooth | O
 DARKMOON_FAIRE | DMF_518 | Malevolent Strike |  
 DARKMOON_FAIRE | DMF_519 | Prize Plunderer |  
 DARKMOON_FAIRE | DMF_520 | Parade Leader |  
-DARKMOON_FAIRE | DMF_521 | Sword Eater |  
-DARKMOON_FAIRE | DMF_522 | Minefield |  
+DARKMOON_FAIRE | DMF_521 | Sword Eater | O
+DARKMOON_FAIRE | DMF_522 | Minefield | O
 DARKMOON_FAIRE | DMF_523 | Bumper Car |  
 DARKMOON_FAIRE | DMF_524 | Ringmaster's Baton |  
 DARKMOON_FAIRE | DMF_525 | Ringmaster Whatley |  
@@ -1357,15 +1357,15 @@ DARKMOON_FAIRE | DMF_526 | Stage Dive |
 DARKMOON_FAIRE | DMF_528 | Tent Trasher |  
 DARKMOON_FAIRE | DMF_529 | E.T.C., God of Metal |  
 DARKMOON_FAIRE | DMF_530 | Feat of Strength |  
-DARKMOON_FAIRE | DMF_531 | Stage Hand |  
-DARKMOON_FAIRE | DMF_532 | Circus Amalgam |  
+DARKMOON_FAIRE | DMF_531 | Stage Hand | O
+DARKMOON_FAIRE | DMF_532 | Circus Amalgam | O
 DARKMOON_FAIRE | DMF_533 | Ring Matron |  
 DARKMOON_FAIRE | DMF_534 | Deck of Chaos |  
 DARKMOON_FAIRE | DMF_700 | Revolve |  
 DARKMOON_FAIRE | DMF_701 | Dunk Tank | O
-DARKMOON_FAIRE | DMF_702 | Stormstrike |  
+DARKMOON_FAIRE | DMF_702 | Stormstrike | O
 DARKMOON_FAIRE | DMF_703 | Pit Master | O
-DARKMOON_FAIRE | DMF_704 | Cagematch Custodian |  
+DARKMOON_FAIRE | DMF_704 | Cagematch Custodian | O
 DARKMOON_FAIRE | DMF_705 | Whack-A-Gnoll Hammer |  
 DARKMOON_FAIRE | DMF_706 | Deathmatch Pavilion |  
 DARKMOON_FAIRE | DMF_707 | Magicfin |  
@@ -1376,4 +1376,4 @@ DARKMOON_FAIRE | DMF_732 | Cenarion Ward |
 DARKMOON_FAIRE | DMF_733 | Kiri, Chosen of Elune |  
 DARKMOON_FAIRE | DMF_734 | Greybough |  
 
-- Progress: 13% (18 of 135 Cards)
+- Progress: 28% (38 of 135 Cards)

--- a/Documents/TaskList.md
+++ b/Documents/TaskList.md
@@ -45,8 +45,11 @@
 * DrawMinionTask
 * DrawNumberTask
 * DrawOpTask
+* DrawRaceMinionTask
+* DrawSpellTask
 * DrawStackTask
 * DrawTask
+* DrawWeaponTask
 * EnqueueNumberTask
 * EnqueueTask
 * FilterStackTask

--- a/Includes/Rosetta/PlayMode/Models/Playable.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Playable.hpp
@@ -181,6 +181,7 @@ class Playable : public Entity
 
     int orderOfPlay = 0;
     bool isDestroyed = false;
+    bool isTransformed = false;
 };
 }  // namespace RosettaStone::PlayMode
 

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.hpp
@@ -18,6 +18,11 @@ namespace RosettaStone::PlayMode::SimpleTasks
 class DrawMinionTask : public ITask
 {
  public:
+    //! Constructs task with given \p amount and \p addToStack.
+    //! \param amount The amount to draw minion card(s).
+    //! \param addToStack A flag to store card to stack.
+    explicit DrawMinionTask(int amount, bool addToStack);
+
     //! Constructs task with given \p lowestCost, \p amount and \p addToStack.
     //! \param lowestCost A flag to draw lowest cost card(s).
     //! \param amount The amount to draw minion card(s).

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawRaceMinionTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawRaceMinionTask.hpp
@@ -1,0 +1,44 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_PLAYMODE_DRAW_RACE_MINION_TASK_HPP
+#define ROSETTASTONE_PLAYMODE_DRAW_RACE_MINION_TASK_HPP
+
+#include <Rosetta/PlayMode/Tasks/ITask.hpp>
+
+namespace RosettaStone::PlayMode::SimpleTasks
+{
+//!
+//! \brief DrawRaceMinionTask class.
+//!
+//! This class represents the task for drawing minion card(s)
+//! that matches the race from the deck.
+//!
+class DrawRaceMinionTask : public ITask
+{
+ public:
+    //! Constructs task with given \p race, \p amount and \p addToStack.
+    //! \param race The race to draw minion card(s).
+    //! \param amount The amount to draw minion card(s).
+    //! \param addToStack A flag to store card to stack.
+    explicit DrawRaceMinionTask(Race race, int amount, bool addToStack);
+
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player* player) override;
+
+    //! Internal method of Clone().
+    //! \return The cloned task.
+    std::unique_ptr<ITask> CloneImpl() override;
+
+    Race m_race = Race::INVALID;
+    int m_amount = 0;
+    bool m_addToStack = false;
+};
+}  // namespace RosettaStone::PlayMode::SimpleTasks
+
+#endif  // ROSETTASTONE_PLAYMODE_DRAW_RACE_MINION_TASK_HPP

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp
@@ -1,0 +1,41 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_PLAYMODE_DRAW_SPELL_TASK_HPP
+#define ROSETTASTONE_PLAYMODE_DRAW_SPELL_TASK_HPP
+
+#include <Rosetta/PlayMode/Tasks/ITask.hpp>
+
+namespace RosettaStone::PlayMode::SimpleTasks
+{
+//!
+//! \brief DrawSpellTask class.
+//!
+//! This class represents the task for drawing spell card(s) from the deck.
+//!
+class DrawSpellTask : public ITask
+{
+ public:
+    //! Constructs task with given \p amount and \p addToStack.
+    //! \param amount The amount to draw minion card(s).
+    //! \param addToStack A flag to store card to stack.
+    explicit DrawSpellTask(int amount, bool addToStack = false);
+
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player* player) override;
+
+    //! Internal method of Clone().
+    //! \return The cloned task.
+    std::unique_ptr<ITask> CloneImpl() override;
+
+    int m_amount = 0;
+    bool m_addToStack = false;
+};
+}  // namespace RosettaStone::PlayMode::SimpleTasks
+
+#endif  // ROSETTASTONE_PLAYMODE_DRAW_SPELL_TASK_HPP

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawWeaponTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawWeaponTask.hpp
@@ -1,0 +1,41 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_PLAYMODE_DRAW_WEAPON_TASK_HPP
+#define ROSETTASTONE_PLAYMODE_DRAW_WEAPON_TASK_HPP
+
+#include <Rosetta/PlayMode/Tasks/ITask.hpp>
+
+namespace RosettaStone::PlayMode::SimpleTasks
+{
+//!
+//! \brief DrawWeaponTask class.
+//!
+//! This class represents the task for drawing weapon card(s) from the deck.
+//!
+class DrawWeaponTask : public ITask
+{
+ public:
+    //! Constructs task with given \p amount and \p addToStack.
+    //! \param amount The amount to draw minion card(s).
+    //! \param addToStack A flag to store card to stack.
+    explicit DrawWeaponTask(int amount, bool addToStack = false);
+
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player* player) override;
+
+    //! Internal method of Clone().
+    //! \return The cloned task.
+    std::unique_ptr<ITask> CloneImpl() override;
+
+    int m_amount = 0;
+    bool m_addToStack = false;
+};
+}  // namespace RosettaStone::PlayMode::SimpleTasks
+
+#endif  // ROSETTASTONE_PLAYMODE_DRAW_WEAPON_TASK_HPP

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -196,6 +196,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawWeaponTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueNumberTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -193,6 +193,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawNumberTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawOpTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawRaceMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawTask.hpp>

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -193,6 +193,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawNumberTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawOpTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueNumberTask.hpp>

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Expansions
 
-  * 13% Madness at the Darkmoon Faire (18 of 135 cards)
+  * 28% Madness at the Darkmoon Faire (38 of 135 cards)
   * 24% Scholomance Academy (33 of 135 cards)
   * 25% Ashes of Outland (35 of 135 cards)
   * **100% Descent of Dragons (140 of 140 cards)**

--- a/Sources/Rosetta/PlayMode/Actions/Generic.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Generic.cpp
@@ -221,6 +221,9 @@ void ChangeEntity(Player* player, Playable* playable, Card* newCard,
         playable = entity;
     }
 
+    // Set it is transformed playable
+    playable->isTransformed = true;
+
     // Replay auras
     if (hand != nullptr)
     {

--- a/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
@@ -336,6 +336,9 @@ void PlaySpell(Player* player, Spell* spell, Character* target, int chooseOne)
     player->game->taskQueue.EndEvent();
     player->game->ProcessDestroyAndUpdateAura();
 
+    // Store minions in field to process spellburst task
+    auto minions = player->GetFieldZone()->GetAll();
+
     // Check spell is countered
     if (spell->IsCountered())
     {
@@ -376,7 +379,7 @@ void PlaySpell(Player* player, Spell* spell, Character* target, int chooseOne)
     // Process spellburst tasks
     player->game->taskQueue.StartEvent();
 
-    for (auto& minion : player->GetFieldZone()->GetAll())
+    for (auto& minion : minions)
     {
         if (!minion->isDestroyed && minion->HasSpellburst())
         {

--- a/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
@@ -158,6 +158,12 @@ void PlayCard(Player* player, Playable* source, Character* target, int fieldPos,
         }
     }
 
+    // Reset transformed minions
+    for (auto& minion : player->GetFieldZone()->GetAll())
+    {
+        minion->isTransformed = false;
+    }
+
     // Set combo active to true
     if (!player->IsComboActive())
     {
@@ -381,7 +387,8 @@ void PlaySpell(Player* player, Spell* spell, Character* target, int chooseOne)
 
     for (auto& minion : minions)
     {
-        if (!minion->isDestroyed && minion->HasSpellburst())
+        if (!minion->isDestroyed && !minion->isTransformed &&
+            minion->HasSpellburst())
         {
             minion->ActivateTask(PowerType::SPELLBURST);
             minion->SetGameTag(GameTag::SPELLBURST, 0);

--- a/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
@@ -455,6 +455,15 @@ void PlayWeapon(Player* player, Weapon* weapon, Character* target)
         weapon->ActivateTask(PowerType::POWER, target);
     }
 
+    const int handPos = weapon->GetZonePosition();
+
+    // Process outcast tasks
+    if (weapon->HasOutcast() &&
+        (handPos == 0 || handPos == player->GetHandZone()->GetCount()))
+    {
+        weapon->ActivateTask(PowerType::OUTCAST, target);
+    }
+
     // Check card has overload
     if (weapon->HasOverload())
     {

--- a/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
@@ -56,6 +56,20 @@ void PlayCard(Player* player, Playable* source, Character* target, int fieldPos,
 
     const bool isEcho = source->IsEcho();
 
+    // Process keyword 'Corrupt'
+    for (auto& playable : player->GetHandZone()->GetAll())
+    {
+        if (playable->HasCorrupt() && source->GetCost() > playable->GetCost())
+        {
+            Card* newCard = Cards::FindCardByDbfID(
+                playable->GetGameTag(GameTag::CORRUPTEDCARD));
+            if (newCard != nullptr)
+            {
+                ChangeEntity(player, playable, newCard, true);
+            }
+        }
+    }
+
     // Erase from player's hand
     player->GetHandZone()->Remove(source);
 
@@ -74,20 +88,6 @@ void PlayCard(Player* player, Playable* source, Character* target, int fieldPos,
             player->opponent->GetDeckZone()->GetCount() + 7)
     {
         player->IncreaseNumCardsPlayedThisGameNotStartInDeck();
-    }
-
-    // Process keyword 'Corrupt'
-    for (auto& playable : player->GetHandZone()->GetAll())
-    {
-        if (playable->HasCorrupt() && source->GetCost() > playable->GetCost())
-        {
-            Card* newCard = Cards::FindCardByDbfID(
-                playable->GetGameTag(GameTag::CORRUPTEDCARD));
-            if (newCard != nullptr)
-            {
-                ChangeEntity(player, playable, newCard, true);
-            }
-        }
     }
 
     // Set card's owner

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -15,8 +15,8 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp>
-#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawWeaponTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FlagTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/HealTask.hpp>
@@ -1720,13 +1720,9 @@ void BlackTempleCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // Text: Draw a weapon. Give it +1 Durability.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::DECK));
-    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
-        std::make_shared<SelfCondition>(SelfCondition::IsWeapon()) }));
-    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddPowerTask(std::make_shared<DrawWeaponTask>(1, true));
     power.AddPowerTask(
         std::make_shared<AddEnchantmentTask>("BT_124e", EntityType::STACK));
-    power.AddPowerTask(std::make_shared<DrawStackTask>(1));
     cards.emplace("BT_124", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -14,6 +14,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/CustomTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
@@ -514,12 +515,7 @@ void BlackTempleCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddDeathrattleTask(std::make_shared<IncludeTask>(EntityType::DECK));
-    power.AddDeathrattleTask(std::make_shared<FilterStackTask>(SelfCondList{
-        std::make_shared<SelfCondition>(SelfCondition::IsSpell()) }));
-    power.AddDeathrattleTask(
-        std::make_shared<RandomTask>(EntityType::STACK, 1));
-    power.AddDeathrattleTask(std::make_shared<DrawStackTask>(1));
+    power.AddDeathrattleTask(std::make_shared<DrawSpellTask>(1));
     cards.emplace("BT_014", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE

--- a/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
@@ -34,6 +34,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawNumberTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawRaceMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueNumberTask.hpp>
@@ -637,13 +638,8 @@ void DalaranCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddDeathrattleTask(std::make_shared<IncludeTask>(EntityType::DECK));
-    power.AddDeathrattleTask(std::make_shared<FilterStackTask>(
-        SelfCondList{ std::make_shared<SelfCondition>(
-            SelfCondition::IsRace(Race::MECHANICAL)) }));
     power.AddDeathrattleTask(
-        std::make_shared<RandomTask>(EntityType::STACK, 1));
-    power.AddDeathrattleTask(std::make_shared<DrawStackTask>(1));
+        std::make_shared<DrawRaceMinionTask>(Race::MECHANICAL, 1, false));
     cards.emplace("DAL_604", CardDef(power));
 }
 

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -23,6 +23,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SilenceTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/WeaponTask.hpp>
 
 using namespace RosettaStone::PlayMode;
 using namespace SimpleTasks;
@@ -1650,6 +1651,9 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<WeaponTask>("DMF_521t"));
+    cards.emplace("DMF_521", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [DMF_522] Minefield - COST:2
@@ -1782,6 +1786,9 @@ void DarkmoonFaireCardsGen::AddWarriorNonCollect(
     // [DMF_521t] Jawbreaker - COST:3
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_521t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [DMF_524e] Big-Top Special - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -2393,6 +2393,9 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_532", CardDef(power));
 }
 
 void DarkmoonFaireCardsGen::AddNeutralNonCollect(

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1660,6 +1660,15 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - ImmuneToSpellpower = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<EnqueueTask>(
+        TaskList{
+            std::make_shared<FilterStackTask>(SelfCondList{
+                std::make_shared<SelfCondition>(SelfCondition::IsNotDead()) }),
+            std::make_shared<RandomTask>(EntityType::ALL_MINIONS, 1),
+            std::make_shared<DamageTask>(EntityType::STACK, 1) },
+        5, true));
+    cards.emplace("DMF_522", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [DMF_523] Bumper Car - COST:2 [ATK:1/HP:3]
@@ -1713,8 +1722,8 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // [DMF_528] Tent Trasher - COST:5 [ATK:5/HP:5]
     // - Race: Dragon, Set: DARKMOON_FAIRE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b><b>Rush</b>.</b> Costs (1) less for each friendly minion with a
-    // unique minion type.
+    // Text: <b>Rush</b>. Costs (1) less for each friendly minion
+    //       with a unique minion type.
     // --------------------------------------------------------
     // GameTag:
     // - RUSH = 1

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -11,11 +11,11 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/HealTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeAdjacentTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SilenceTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
-
-#include "Rosetta/PlayMode/Tasks/SimpleTasks/IncludeTask.hpp"
 
 using namespace RosettaStone::PlayMode;
 using namespace SimpleTasks;
@@ -2251,6 +2251,12 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<IncludeAdjacentTask>(EntityType::SOURCE));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DMF_091e2", EntityType::STACK));
+    cards.emplace("DMF_091", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [DMF_124] Horrendous Growth - COST:2 [ATK:2/HP:2]
@@ -2643,6 +2649,9 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DMF_091e2"));
+    cards.emplace("DMF_091e2", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [DMF_102e] Special Discount - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1925,6 +1925,9 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // GameTag:
     // - OUTCAST = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddOutcastTask(std::make_shared<DamageTask>(EntityType::ENEMIES, 1));
+    cards.emplace("DMF_227", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [DMF_229] Stiltstepper - COST:3 [ATK:4/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -741,6 +741,9 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("DMF_238t"));
+    cards.emplace("DMF_238", CardDef(power));
 
     // --------------------------------------- MINION - PALADIN
     // [DMF_240] Lothraxion the Redeemed - COST:5 [ATK:5/HP:5]
@@ -847,6 +850,9 @@ void DarkmoonFaireCardsGen::AddPaladinNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_238t", CardDef(power));
 
     // ---------------------------------------- SPELL - PALADIN
     // [DMF_244t] Day at the Faire - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -23,6 +23,8 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SilenceTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
 
+#include "Rosetta/PlayMode/Tasks/SimpleTasks/AddCardTask.hpp"
+
 using namespace RosettaStone::PlayMode;
 using namespace SimpleTasks;
 
@@ -2129,6 +2131,12 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::HAND, "EX1_014t", 2));
+    power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::ENEMY_HAND, "EX1_014t", 2));
+    cards.emplace("DMF_065", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [DMF_066] Knife Vendor - COST:4 [ATK:3/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -8,7 +8,10 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/HealTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
 
 using namespace RosettaStone::PlayMode;
@@ -17,6 +20,8 @@ using namespace SimpleTasks;
 namespace RosettaStone::PlayMode
 {
 using PlayReqs = std::map<PlayReq, int>;
+using TaskList = std::vector<std::shared_ptr<ITask>>;
+using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
 
 void DarkmoonFaireCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
@@ -301,6 +306,15 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(std::make_shared<EnqueueTask>(
+        TaskList{
+            std::make_shared<FilterStackTask>(SelfCondList{
+                std::make_shared<SelfCondition>(SelfCondition::IsNotDead()) }),
+            std::make_shared<RandomTask>(EntityType::ENEMIES, 1),
+            std::make_shared<DamageTask>(EntityType::STACK, 2) },
+        4, false));
+    cards.emplace("DMF_085", CardDef(power));
 
     // ----------------------------------------- SPELL - HUNTER
     // [DMF_086] Petting Zoo - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -8,6 +8,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawWeaponTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/HealTask.hpp>
@@ -1276,6 +1277,9 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawWeaponTask>(1));
+    cards.emplace("DMF_704", CardDef(power));
 
     // ---------------------------------------- WEAPON - SHAMAN
     // [DMF_705] Whack-A-Gnoll Hammer - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -530,6 +530,15 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - ImmuneToSpellpower = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<EnqueueTask>(
+        TaskList{
+            std::make_shared<FilterStackTask>(SelfCondList{
+                std::make_shared<SelfCondition>(SelfCondition::IsNotDead()) }),
+            std::make_shared<RandomTask>(EntityType::ENEMIES, 1),
+            std::make_shared<DamageTask>(EntityType::STACK, 1) },
+        10, true));
+    cards.emplace("DMF_103", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [DMF_104] Grand Finale - COST:8

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -5,6 +5,7 @@
 
 #include <Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/AddCardTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
@@ -22,8 +23,6 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SilenceTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
-
-#include "Rosetta/PlayMode/Tasks/SimpleTasks/AddCardTask.hpp"
 
 using namespace RosettaStone::PlayMode;
 using namespace SimpleTasks;
@@ -1885,6 +1884,10 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // - RUSH = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("DMF_223t", 2, SummonSide::DEATHRATTLE));
+    cards.emplace("DMF_223", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [DMF_224] Expendable Performers - COST:7
@@ -2041,6 +2044,9 @@ void DarkmoonFaireCardsGen::AddDemonHunterNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_223t", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [DMF_247t] Insatiable Felhound - COST:3 [ATK:3/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -8,7 +8,9 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawRaceMinionTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawWeaponTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
@@ -1111,6 +1113,11 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - COMBO = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawSpellTask>(1));
+    power.AddComboTask(std::make_shared<DrawSpellTask>(1));
+    power.AddComboTask(std::make_shared<DrawMinionTask>(1, false));
+    cards.emplace("DMF_515", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
     // [DMF_516] Grand Empress Shek'zara - COST:6 [ATK:5/HP:7]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -12,6 +12,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/HealTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/SilenceTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
 
 using namespace RosettaStone::PlayMode;
@@ -2339,6 +2340,9 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SILENCE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SilenceTask>(EntityType::ALL_MINIONS));
+    cards.emplace("DMF_191", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [DMF_202] Derailed Coaster - COST:5 [ATK:3/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1265,7 +1265,10 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
         std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
     power.AddPowerTask(
         std::make_shared<AddEnchantmentTask>("DMF_702e", EntityType::HERO));
-    cards.emplace("DMF_702", CardDef(power));
+    cards.emplace(
+        "DMF_702",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ---------------------------------------- MINION - SHAMAN
     // [DMF_703] Pit Master - COST:3 [ATK:1/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1251,6 +1251,16 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // Text: Deal 3 damage to a minion.
     //       Give your hero +3 Attack this turn.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DMF_702e", EntityType::HERO));
+    cards.emplace("DMF_702", CardDef(power));
 
     // ---------------------------------------- MINION - SHAMAN
     // [DMF_703] Pit Master - COST:3 [ATK:1/HP:2]
@@ -1371,6 +1381,9 @@ void DarkmoonFaireCardsGen::AddShamanNonCollect(
     // GameTag:
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DMF_702e"));
+    cards.emplace("DMF_702e", CardDef(power));
 
     // ---------------------------------------- MINION - SHAMAN
     // [DMF_703t] Pit Master - COST:3 [ATK:1/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -2139,6 +2139,10 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::HERO, 4));
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 4));
+    cards.emplace("DMF_066", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [DMF_067] Prize Vendor - COST:2 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1844,6 +1844,10 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // RefTag:
     // - IMMUNE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DMF_219e", EntityType::HERO));
+    cards.emplace("DMF_219", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [DMF_221] Felscream Blast - COST:1
@@ -2027,6 +2031,9 @@ void DarkmoonFaireCardsGen::AddDemonHunterNonCollect(
     // GameTag:
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DMF_219e"));
+    cards.emplace("DMF_219e", CardDef(power));
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [DMF_222e] Pariah's Resolve - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -9,8 +9,10 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawOpTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawRaceMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawWeaponTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
@@ -2147,6 +2149,10 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawTask>(1));
+    power.AddPowerTask(std::make_shared<DrawOpTask>(1));
+    cards.emplace("DMF_067", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [DMF_068] Optimistic Ogre - COST:5 [ATK:6/HP:7]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -2331,6 +2331,14 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::HAND));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsMinion()) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DMF_189e", EntityType::STACK));
+    cards.emplace("DMF_189", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [DMF_190] Fantastic Firebird - COST:4 [ATK:3/HP:5]
@@ -2758,6 +2766,9 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DMF_189e"));
+    cards.emplace("DMF_189e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [DMF_224e] Expendable - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -15,6 +15,8 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SilenceTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
 
+#include "Rosetta/PlayMode/Tasks/SimpleTasks/IncludeTask.hpp"
+
 using namespace RosettaStone::PlayMode;
 using namespace SimpleTasks;
 
@@ -1594,6 +1596,8 @@ void DarkmoonFaireCardsGen::AddWarlockNonCollect(
 
 void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - WARRIOR
     // [DMF_521] Sword Eater - COST:4 [ATK:2/HP:5]
     // - Race: Pirate, Set: DARKMOON_FAIRE, Rarity: Common
@@ -1709,11 +1713,21 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::HAND));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsMinion()) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DMF_531e", EntityType::STACK));
+    cards.emplace("DMF_531", CardDef(power));
 }
 
 void DarkmoonFaireCardsGen::AddWarriorNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- WEAPON - WARRIOR
     // [DMF_521t] Jawbreaker - COST:3
     // - Set: DARKMOON_FAIRE
@@ -1757,6 +1771,9 @@ void DarkmoonFaireCardsGen::AddWarriorNonCollect(
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DMF_531e"));
+    cards.emplace("DMF_531e", CardDef(power));
 }
 
 void DarkmoonFaireCardsGen::AddDemonHunter(

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -8,6 +8,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawRaceMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawWeaponTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
@@ -676,6 +677,10 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<DrawRaceMinionTask>(Race::DRAGON, 1, false));
+    cards.emplace("DMF_194", CardDef(power));
 
     // ---------------------------------------- SPELL - PALADIN
     // [DMF_195] Snack Run - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UldumCardsGen.cpp
@@ -2944,6 +2944,7 @@ void UldumCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
         std::make_shared<IncludeTask>(EntityType::HAND),
         std::make_shared<FilterStackTask>(SelfCondList{
             std::make_shared<SelfCondition>(SelfCondition::IsMinion()) }),
+        std::make_shared<RandomTask>(EntityType::STACK, 1),
         std::make_shared<AddEnchantmentTask>("ULD_290e", EntityType::STACK)
     };
     cards.emplace("ULD_290", CardDef(power));

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/AddCardTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/AddCardTask.cpp
@@ -32,6 +32,7 @@ TaskStatus AddCardTask::Impl(Player* player)
                 Generic::AddCardToHand(player,
                                        Entity::GetFromCard(player, card));
             }
+            break;
         }
         case EntityType::ENEMY_HAND:
         {

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.cpp
@@ -14,6 +14,12 @@ using Random = effolkronium::random_static;
 
 namespace RosettaStone::PlayMode::SimpleTasks
 {
+DrawMinionTask::DrawMinionTask(int amount, bool addToStack)
+    : m_amount(amount), m_addToStack(addToStack)
+{
+    // Do nothing
+}
+
 DrawMinionTask::DrawMinionTask(bool lowestCost, int amount, bool addToStack)
     : m_amount(amount), m_lowestCost(lowestCost), m_addToStack(addToStack)
 {

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawRaceMinionTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawRaceMinionTask.cpp
@@ -1,0 +1,89 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/PlayMode/Actions/Draw.hpp>
+#include <Rosetta/PlayMode/Games/Game.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawRaceMinionTask.hpp>
+#include <Rosetta/PlayMode/Zones/DeckZone.hpp>
+
+#include <effolkronium/random.hpp>
+
+using Random = effolkronium::random_static;
+
+namespace RosettaStone::PlayMode::SimpleTasks
+{
+DrawRaceMinionTask::DrawRaceMinionTask(Race race, int amount, bool addToStack)
+    : m_race(race), m_amount(amount), m_addToStack(addToStack)
+{
+    // Do nothing
+}
+
+TaskStatus DrawRaceMinionTask::Impl(Player* player)
+{
+    if (m_addToStack)
+    {
+        player->game->taskStack.playables.clear();
+    }
+
+    auto deck = player->GetDeckZone()->GetAll();
+    if (deck.empty())
+    {
+        return TaskStatus::STOP;
+    }
+
+    std::vector<Playable*> cards;
+    cards.reserve(m_amount);
+
+    for (auto& deckCard : deck)
+    {
+        if (deckCard->card->GetCardType() == CardType::MINION &&
+            (deckCard->card->GetRace() == m_race ||
+             deckCard->card->GetRace() == Race::ALL))
+        {
+            cards.emplace_back(deckCard);
+        }
+    }
+
+    if (cards.empty())
+    {
+        return TaskStatus::STOP;
+    }
+
+    if (static_cast<int>(cards.size()) <= m_amount)
+    {
+        for (int i = 0; i < m_amount; ++i)
+        {
+            if (m_addToStack)
+            {
+                player->game->taskStack.playables.emplace_back(cards[i]);
+            }
+
+            Generic::Draw(player, cards[i]);
+        }
+    }
+    else
+    {
+        for (int i = 0; i < m_amount; ++i)
+        {
+            const auto pick = Random::get<std::size_t>(0, cards.size() - 1);
+
+            if (m_addToStack)
+            {
+                player->game->taskStack.playables.emplace_back(cards[pick]);
+            }
+
+            Generic::Draw(player, cards[pick]);
+            cards.erase(std::begin(cards) + pick);
+        }
+    }
+
+    return TaskStatus::COMPLETE;
+}
+
+std::unique_ptr<ITask> DrawRaceMinionTask::CloneImpl()
+{
+    return std::make_unique<DrawRaceMinionTask>(m_race, m_amount, m_addToStack);
+}
+}  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.cpp
@@ -1,0 +1,87 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/PlayMode/Actions/Draw.hpp>
+#include <Rosetta/PlayMode/Games/Game.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp>
+#include <Rosetta/PlayMode/Zones/DeckZone.hpp>
+
+#include <effolkronium/random.hpp>
+
+using Random = effolkronium::random_static;
+
+namespace RosettaStone::PlayMode::SimpleTasks
+{
+DrawSpellTask::DrawSpellTask(int amount, bool addToStack)
+    : m_amount(amount), m_addToStack(addToStack)
+{
+    // Do nothing
+}
+
+TaskStatus DrawSpellTask::Impl(Player* player)
+{
+    if (m_addToStack)
+    {
+        player->game->taskStack.playables.clear();
+    }
+
+    auto deck = player->GetDeckZone()->GetAll();
+    if (deck.empty())
+    {
+        return TaskStatus::STOP;
+    }
+
+    std::vector<Playable*> cards;
+    cards.reserve(m_amount);
+
+    for (auto& deckCard : deck)
+    {
+        if (deckCard->card->GetCardType() == CardType::SPELL)
+        {
+            cards.emplace_back(deckCard);
+        }
+    }
+
+    if (cards.empty())
+    {
+        return TaskStatus::STOP;
+    }
+
+    if (static_cast<int>(cards.size()) <= m_amount)
+    {
+        for (int i = 0; i < m_amount; ++i)
+        {
+            if (m_addToStack)
+            {
+                player->game->taskStack.playables.emplace_back(cards[i]);
+            }
+
+            Generic::Draw(player, cards[i]);
+        }
+    }
+    else
+    {
+        for (int i = 0; i < m_amount; ++i)
+        {
+            const auto pick = Random::get<std::size_t>(0, cards.size() - 1);
+
+            if (m_addToStack)
+            {
+                player->game->taskStack.playables.emplace_back(cards[pick]);
+            }
+
+            Generic::Draw(player, cards[pick]);
+            cards.erase(std::begin(cards) + pick);
+        }
+    }
+
+    return TaskStatus::COMPLETE;
+}
+
+std::unique_ptr<ITask> DrawSpellTask::CloneImpl()
+{
+    return std::make_unique<DrawSpellTask>(m_amount, m_addToStack);
+}
+}  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawWeaponTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawWeaponTask.cpp
@@ -1,0 +1,87 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/PlayMode/Actions/Draw.hpp>
+#include <Rosetta/PlayMode/Games/Game.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawWeaponTask.hpp>
+#include <Rosetta/PlayMode/Zones/DeckZone.hpp>
+
+#include <effolkronium/random.hpp>
+
+using Random = effolkronium::random_static;
+
+namespace RosettaStone::PlayMode::SimpleTasks
+{
+DrawWeaponTask::DrawWeaponTask(int amount, bool addToStack)
+    : m_amount(amount), m_addToStack(addToStack)
+{
+    // Do nothing
+}
+
+TaskStatus DrawWeaponTask::Impl(Player* player)
+{
+    if (m_addToStack)
+    {
+        player->game->taskStack.playables.clear();
+    }
+
+    auto deck = player->GetDeckZone()->GetAll();
+    if (deck.empty())
+    {
+        return TaskStatus::STOP;
+    }
+
+    std::vector<Playable*> cards;
+    cards.reserve(m_amount);
+
+    for (auto& deckCard : deck)
+    {
+        if (deckCard->card->GetCardType() == CardType::WEAPON)
+        {
+            cards.emplace_back(deckCard);
+        }
+    }
+
+    if (cards.empty())
+    {
+        return TaskStatus::STOP;
+    }
+
+    if (static_cast<int>(cards.size()) <= m_amount)
+    {
+        for (int i = 0; i < m_amount; ++i)
+        {
+            if (m_addToStack)
+            {
+                player->game->taskStack.playables.emplace_back(cards[i]);
+            }
+
+            Generic::Draw(player, cards[i]);
+        }
+    }
+    else
+    {
+        for (int i = 0; i < m_amount; ++i)
+        {
+            const auto pick = Random::get<std::size_t>(0, cards.size() - 1);
+
+            if (m_addToStack)
+            {
+                player->game->taskStack.playables.emplace_back(cards[pick]);
+            }
+
+            Generic::Draw(player, cards[pick]);
+            cards.erase(std::begin(cards) + pick);
+        }
+    }
+
+    return TaskStatus::COMPLETE;
+}
+
+std::unique_ptr<ITask> DrawWeaponTask::CloneImpl()
+{
+    return std::make_unique<DrawWeaponTask>(m_amount, m_addToStack);
+}
+}  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -759,6 +759,56 @@ TEST_CASE("[Warlock : Minion] - DMF_114 : Midway Maniac")
     // Do nothing
 }
 
+// --------------------------------------- MINION - WARRIOR
+// [DMF_531] Stage Hand - COST:2 [ATK:3/HP:2]
+// - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give a random minion in your hand +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - DMF_531 : Stage Hand")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Stage Hand"));
+    [[maybe_unused]] const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    [[maybe_unused]] const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bloodfen Raptor"));
+
+    CHECK_EQ(dynamic_cast<Minion*>(card2)->GetAttack(), 3);
+    CHECK_EQ(dynamic_cast<Minion*>(card2)->GetHealth(), 1);
+    CHECK_EQ(dynamic_cast<Minion*>(card3)->GetAttack(), 3);
+    CHECK_EQ(dynamic_cast<Minion*>(card3)->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    const int totalAttack = dynamic_cast<Minion*>(card2)->GetAttack() +
+                            dynamic_cast<Minion*>(card3)->GetAttack();
+    const int totalHealth = dynamic_cast<Minion*>(card2)->GetHealth() +
+                            dynamic_cast<Minion*>(card3)->GetHealth();
+    CHECK_EQ(totalAttack, 7);
+    CHECK_EQ(totalHealth, 4);
+}
+
 // ----------------------------------- MINION - DEMONHUNTER
 // [DMF_247] Insatiable Felhound - COST:3 [ATK:2/HP:5]
 // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1166,6 +1166,56 @@ TEST_CASE("[Neutral : Minion] - DMF_174 : Circus Medic")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [DMF_189] Costumed Entertainer - COST:2 [ATK:1/HP:2]
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give a random minion in your hand +2/+2.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - DMF_189 : Costumed Entertainer")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Costumed Entertainer"));
+    [[maybe_unused]] const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    [[maybe_unused]] const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bloodfen Raptor"));
+
+    CHECK_EQ(dynamic_cast<Minion*>(card2)->GetAttack(), 3);
+    CHECK_EQ(dynamic_cast<Minion*>(card2)->GetHealth(), 1);
+    CHECK_EQ(dynamic_cast<Minion*>(card3)->GetAttack(), 3);
+    CHECK_EQ(dynamic_cast<Minion*>(card3)->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    const int totalAttack = dynamic_cast<Minion*>(card2)->GetAttack() +
+                            dynamic_cast<Minion*>(card3)->GetAttack();
+    const int totalHealth = dynamic_cast<Minion*>(card2)->GetHealth() +
+                            dynamic_cast<Minion*>(card3)->GetHealth();
+    CHECK_EQ(totalAttack, 8);
+    CHECK_EQ(totalHealth, 5);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [DMF_190] Fantastic Firebird - COST:4 [ATK:3/HP:5]
 // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -428,6 +428,54 @@ TEST_CASE("[Paladin : Minion] - DMF_194 : Redscale Dragontamer")
     CHECK_EQ(curHand[4]->card->name, "Faerie Dragon");
 }
 
+// --------------------------------------- WEAPON - PALADIN
+// [DMF_238] Hammer of the Naaru - COST:6
+// - Set: DARKMOON_FAIRE, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Summon a 6/6 Holy Elemental
+//       with <b>Taunt</b>.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Weapon] - DMF_238 : Hammer of the Naaru")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Hammer of the Naaru"));
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetAttack(), 3);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 3);
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Holy Elemental");
+    CHECK_EQ(curField[0]->GetAttack(), 6);
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+}
+
 // ---------------------------------------- SPELL - PALADIN
 // [DMF_244] Day at the Faire - COST:3
 // - Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1065,6 +1065,62 @@ TEST_CASE("[Warrior : Minion] - DMF_531 : Stage Hand")
     CHECK_EQ(totalHealth, 4);
 }
 
+// ----------------------------------- MINION - DEMONHUNTER
+// [DMF_223] Renowned Performer - COST:4 [ATK:3/HP:3]
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Rush</b>
+//       <b>Deathrattle:</b> Summon two 1/1 Assistants
+//       with <b>Taunt</b>.  
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - DMF_223 : Renowned Performer")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Renowned Performer"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Performer's Assistant");
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+    CHECK_EQ(curField[1]->card->name, "Performer's Assistant");
+    CHECK_EQ(curField[1]->HasTaunt(), true);
+}
+
 // ----------------------------------- WEAPON - DEMONHUNTER
 // [DMF_227] Dreadlord's Bite - COST:3
 // - Set: DARKMOON_FAIRE, Rarity: Common
@@ -1077,7 +1133,7 @@ TEST_CASE("[Warrior : Minion] - DMF_531 : Stage Hand")
 TEST_CASE("[Demon Hunter : Weapon] - DMF_227 : Dreadlord's Bite")
 {
     GameConfig config;
-    config.player1Class = CardClass::WARRIOR;
+    config.player1Class = CardClass::DEMONHUNTER;
     config.player2Class = CardClass::HUNTER;
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = false;

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1152,6 +1152,46 @@ TEST_CASE("[Neutral : Minion] - DMF_044 : Rock Rager")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [DMF_066] Knife Vendor - COST:4 [ATK:3/HP:4]
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Deal 4 damage to each hero.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - DMF_066 : Knife Vendor")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Knife Vendor"));
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 26);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 26);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [DMF_067] Prize Vendor - COST:2 [ATK:2/HP:3]
 // - Race: Murloc, Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -895,7 +895,7 @@ TEST_CASE("[Shaman : Minion] - DMF_704 : Cagematch Custodian")
     game.Process(curPlayer, PlayCardTask::Spell(card));
     CHECK_EQ(curPlayer->GetRemainingMana(), 8);
     CHECK_EQ(curHand.GetCount(), 5);
-    CHECK_EQ(curHand[4]->card->name, "Cagematch Custodian");
+    CHECK_EQ(curHand[4]->card->name, "Stormforged Axe");
 }
 
 // --------------------------------------- MINION - WARLOCK

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -372,6 +372,62 @@ TEST_CASE("[Paladin : Minion] - DMF_064 : Carousel Gryphon")
     CHECK_EQ(curField[1]->GetHealth(), 8);
 }
 
+// --------------------------------------- MINION - PALADIN
+// [DMF_194] Redscale Dragontamer - COST:2 [ATK:2/HP:3]
+// - Race: Murloc, Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Draw a Dragon.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Minion] - DMF_194 : Redscale Dragontamer")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Faerie Dragon");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Shotbot");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Murmy");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Redscale Dragontamer"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(card1->isDestroyed, true);
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->card->name, "Faerie Dragon");
+}
+
 // ---------------------------------------- SPELL - PALADIN
 // [DMF_244] Day at the Faire - COST:3
 // - Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -745,6 +745,52 @@ TEST_CASE("[Shaman : Minion] - DMF_703 : Pit Master")
     CHECK_EQ(curField[4]->card->name, "Duelist");
 }
 
+// ---------------------------------------- MINION - SHAMAN
+// [DMF_704] Cagematch Custodian - COST:2 [ATK:2/HP:2]
+// - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Draw a weapon.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Minion] - DMF_704 : Cagematch Custodian")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 30; ++i)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Stormforged Axe");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Cagematch Custodian"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 8);
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->card->name, "Cagematch Custodian");
+}
+
 // --------------------------------------- MINION - WARLOCK
 // [DMF_114] Midway Maniac - COST:2 [ATK:1/HP:5]
 // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1015,6 +1015,46 @@ TEST_CASE("[Warlock : Minion] - DMF_114 : Midway Maniac")
     // Do nothing
 }
 
+// --------------------------------------- MINION - WARRIOR
+// [DMF_521] Sword Eater - COST:4 [ATK:2/HP:5]
+// - Race: Pirate, Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Battlecry:</b> Equip a 3/2 Sword.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - DMF_521 : Sword Eater")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Sword Eater"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->HasWeapon(), true);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetAttack(), 3);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 2);
+}
+
 // ---------------------------------------- SPELL - WARRIOR
 // [DMF_522] Minefield - COST:2
 // - Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1152,6 +1152,49 @@ TEST_CASE("[Neutral : Minion] - DMF_044 : Rock Rager")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [DMF_067] Prize Vendor - COST:2 [ATK:2/HP:3]
+// - Race: Murloc, Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Both players draw a card.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - DMF_067 : Prize Vendor")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& opHand = *(opPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Prize Vendor"));
+
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(opHand.GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(opHand.GetCount(), 6);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [DMF_073] Darkmoon Dirigible - COST:3 [ATK:3/HP:2]
 // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1130,6 +1130,85 @@ TEST_CASE("[Neutral : Minion] - DMF_190 : Fantastic Firebird")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [DMF_191] Showstopper - COST:2 [ATK:3/HP:2]
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> <b>Silence</b> all minions.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+// RefTag:
+// - SILENCE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - DMF_191 : Showstopper")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Showstopper"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Dalaran Mage"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Power Infusion"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card6 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Dalaran Mage"));
+    const auto card7 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Power Infusion"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card4, card2));
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 7);
+    CHECK_EQ(curField[1]->GetSpellPower(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    game.Process(opPlayer, PlayCardTask::Minion(card6));
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card7, card5));
+    CHECK_EQ(opField[0]->GetAttack(), 5);
+    CHECK_EQ(opField[0]->GetHealth(), 7);
+    CHECK_EQ(opField[1]->GetSpellPower(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->GetSpellPower(), 0);
+    CHECK_EQ(opField[0]->GetAttack(), 3);
+    CHECK_EQ(opField[0]->GetHealth(), 1);
+    CHECK_EQ(opField[1]->GetSpellPower(), 0);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [DMF_532] Circus Amalgam - COST:4 [ATK:4/HP:5]
 // - Race: All, Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -763,12 +763,18 @@ TEST_CASE("[Shaman : Spell] - DMF_702 : Stormstrike")
     opPlayer->SetTotalMana(10);
     opPlayer->SetUsedMana(0);
 
+    auto& curField = *(curPlayer->GetFieldZone());
+
     const auto card1 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Stormstrike"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Earth Elemental"));
 
-    game.Process(curPlayer,
-                 PlayCardTask::SpellTarget(card1, opPlayer->GetHero()));
-    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetHealth(), 8);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curField[0]->GetHealth(), 5);
     CHECK_EQ(curPlayer->GetHero()->GetAttack(), 3);
 
     game.Process(curPlayer, EndTurnTask());

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -676,6 +676,51 @@ TEST_CASE("[Shaman : Spell] - DMF_701 : Dunk Tank")
     CHECK_EQ(opField[0]->GetHealth(), 6);
 }
 
+// ----------------------------------------- SPELL - SHAMAN
+// [DMF_702] Stormstrike - COST:3
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: Deal 3 damage to a minion.
+//       Give your hero +3 Attack this turn.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - DMF_702 : Stormstrike")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Stormstrike"));
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card1, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+}
+
 // ---------------------------------------- MINION - SHAMAN
 // [DMF_703] Pit Master - COST:3 [ATK:1/HP:2]
 // - Set: DARKMOON_FAIRE, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1065,6 +1065,70 @@ TEST_CASE("[Warrior : Minion] - DMF_531 : Stage Hand")
     CHECK_EQ(totalHealth, 4);
 }
 
+// ----------------------------------- WEAPON - DEMONHUNTER
+// [DMF_227] Dreadlord's Bite - COST:3
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Outcast:</b> Deal 1 damage to all enemies.
+// --------------------------------------------------------
+// GameTag:
+// - OUTCAST = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Weapon] - DMF_227 : Dreadlord's Bite")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Dreadlord's Bite"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Dreadlord's Bite"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Dreadlord's Bite"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Oasis Snapjaw"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opField[0]->GetHealth(), 7);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    opPlayer->GetHero()->SetDamage(0);
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card2));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
+    CHECK_EQ(opField[0]->GetHealth(), 7);
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 29);
+    CHECK_EQ(opField[0]->GetHealth(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card3));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+    CHECK_EQ(opField[0]->GetHealth(), 5);
+}
+
 // ----------------------------------- MINION - DEMONHUNTER
 // [DMF_247] Insatiable Felhound - COST:3 [ATK:2/HP:5]
 // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1152,6 +1152,53 @@ TEST_CASE("[Neutral : Minion] - DMF_044 : Rock Rager")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [DMF_065] Banana Vendor - COST:3 [ATK:2/HP:4]
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Add 2 Bananas to each player's hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - DMF_065 : Banana Vendor")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& opHand = *(opPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Banana Vendor"));
+
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(opHand.GetCount(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 2);
+    CHECK_EQ(curHand[0]->card->name, "Bananas");
+    CHECK_EQ(curHand[1]->card->name, "Bananas");
+    CHECK_EQ(opHand.GetCount(), 3);
+    CHECK_EQ(opHand[1]->card->name, "Bananas");
+    CHECK_EQ(opHand[2]->card->name, "Bananas");
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [DMF_066] Knife Vendor - COST:4 [ATK:3/HP:4]
 // - Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -160,6 +160,56 @@ TEST_CASE("[Hunter : Minion] - DMF_083 : Dancing Cobra")
     CHECK_EQ(curField[1]->HasPoisonous(), true);
 }
 
+// ---------------------------------------- MINION - HUNTER
+// [DMF_085] Darkmoon Tonk - COST:7 [ATK:8/HP:5]
+// - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Fire four missiles
+//       at random enemies that deal 2 damage each.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - DMF_085 : Darkmoon Tonk")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opHero = *(opPlayer->GetHero());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Darkmoon Tonk"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Kobold Geomancer"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(opHero.GetHealth(), 30);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
+    CHECK_EQ(opHero.GetHealth(), 22);
+}
+
 // ------------------------------------------ MINION - MAGE
 // [DMF_101] Firework Elemental - COST:5 [ATK:3/HP:5]
 // - Race: Elemental, Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -622,6 +622,61 @@ TEST_CASE("[Priest : Minion] - DMF_184 : Fairground Fool")
     CHECK_EQ(curField[1]->GetHealth(), 7);
 }
 
+// ------------------------------------------ SPELL - ROGUE
+// [DMF_515] Swindle - COST:2
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: Draw a spell.
+//       <b>Combo:</b> And a minion.
+// --------------------------------------------------------
+// GameTag:
+// - COMBO = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Spell] - DMF_515 : Swindle")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Faerie Dragon");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Shiv");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Assassin's Blade");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Swindle"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Swindle"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(curHand[5]->card->GetCardType(), CardType::SPELL);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curHand.GetCount(), 7);
+    CHECK_EQ(curHand[5]->card->GetCardType(), CardType::SPELL);
+    CHECK_EQ(curHand[6]->card->GetCardType(), CardType::MINION);
+}
+
 // ----------------------------------------- MINION - ROGUE
 // [DMF_517] Sweet Tooth - COST:2 [ATK:3/HP:2]
 // - Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1015,6 +1015,62 @@ TEST_CASE("[Warlock : Minion] - DMF_114 : Midway Maniac")
     // Do nothing
 }
 
+// ---------------------------------------- SPELL - WARRIOR
+// [DMF_522] Minefield - COST:2
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: Deal 5 damage randomly split among all minions.
+// --------------------------------------------------------
+// GameTag:
+// - ImmuneToSpellpower = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Spell] - DMF_522 : Minefield")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Minefield"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Oasis Snapjaw"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Oasis Snapjaw"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetHealth(), 7);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField[0]->GetHealth(), 7);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    const int totalHealth = curField[0]->GetHealth() + opField[0]->GetHealth();
+    CHECK_EQ(totalHealth, 9);
+}
+
 // --------------------------------------- MINION - WARRIOR
 // [DMF_531] Stage Hand - COST:2 [ATK:3/HP:2]
 // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1128,3 +1128,49 @@ TEST_CASE("[Neutral : Minion] - DMF_190 : Fantastic Firebird")
 {
     // Do nothing
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [DMF_532] Circus Amalgam - COST:4 [ATK:4/HP:5]
+// - Race: All, Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <i>This has all minion types.</i>
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - DMF_532 : Circus Amalgam")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Circus Amalgam"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fresh Scent"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField[0]->GetAttack(), 6);
+    CHECK_EQ(curField[0]->GetHealth(), 7);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1090,6 +1090,58 @@ TEST_CASE("[Neutral : Minion] - DMF_080 : Fleethoof Pearltusk")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [DMF_091] Wriggling Horror - COST:2 [ATK:2/HP:1]
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give adjacent minions +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - DMF_091 : Wriggling Horror")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wriggling Horror"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bloodfen Raptor"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask(card1, nullptr, 1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[2]->GetAttack(), 4);
+    CHECK_EQ(curField[2]->GetHealth(), 3);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [DMF_174] Circus Medic - COST:4 [ATK:3/HP:4]
 // - Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------


### PR DESCRIPTION
This revision includes:
- Implement 20 DARKMOON_FAIRE cards
  - Banana Vendor (DMF_065)
  - Knife Vendor (DMF_066)
  - Prize Vendor (DMF_067)
  - Darkmoon Tonk (DMF_085)
  - Wriggling Horror (DMF_091)
  - Mask of C'Thun (DMF_103)
  - Costumed Entertainer (DMF_189)
  - Showstopper (DMF_191)
  - Redscale Dragontamer (DMF_194)
  - Relentless Pursuit (DMF_219)
  - Renowned Performer (DMF_223)
  - Dreadlord's Bite (DMF_227)
  - Hammer of the Naaru (DMF_238)
  - Swindle (DMF_515)
  - Sword Eater (DMF_521)
  - Minefield (DMF_522)
  - Stage Hand (DMF_531)
  - Circus Amalgam (DMF_532)
  - Stormstrike (DMF_702)
  - Cagematch Custodian (DMF_704)
- Create 3 tasks
  - DrawSpellTask: This class represents the task for drawing spell card(s) from the deck
  - DrawWeaponTask: This class represents the task for drawing weapon card(s) from the deck
  - DrawRaceMinionTask: This class represents the task for drawing minion card(s) that matches the race from the deck
- Fix several bugs
  - Correct the logic of the card 'History Buff' (ULD_290)
    - Add missing code to perform 'RandomTask' from task stack
  - Correct the logic of the card 'Stormstrike' (DMF_702)
    - Add code to set play requirements
  - Correct the logic to process spellburst task
    - Store minions in field before the spell is cast
    - Add code to set/reset transformed playables/minions
  - Add missing keyword 'break' in class 'AddCardTask'
  - Move the position of the code to process keyword 'Corrupt'
    - To correct the logic when the cost of the card is applied by the aura
- Refactor some codes
  - Change the logic of the card 'Starscryer' (BT_021)
    - Update code to use 'DrawSpellTask'
  - Change the logic of the card 'Corsair Cache' (BT_124)
    - Update code to use 'DrawWeaponTask'
  - Change the logic of the card 'Ursatron' (DAL_604)
    - Update code to use 'DrawRaceMinionTask'