### PR TITLE
Implement 2 SCHOLOMANCE cards

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -1178,7 +1178,7 @@ SCHOLOMANCE | SCH_422 | Double Jump |
 SCHOLOMANCE | SCH_425 | Doctor Krastinov | O
 SCHOLOMANCE | SCH_426 | Infiltrator Lilian | O
 SCHOLOMANCE | SCH_427 | Lightning Bloom | O
-SCHOLOMANCE | SCH_428 | Lorekeeper Polkelt |  
+SCHOLOMANCE | SCH_428 | Lorekeeper Polkelt | O
 SCHOLOMANCE | SCH_507 | Instructor Fireheart |  
 SCHOLOMANCE | SCH_509 | Brain Freeze | O
 SCHOLOMANCE | SCH_512 | Initiation |  

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -1234,7 +1234,7 @@ SCHOLOMANCE | SCH_713 | Cult Neophyte | O
 SCHOLOMANCE | SCH_714 | Educated Elekk |  
 SCHOLOMANCE | SCH_717 | Keymaster Alabaster | O
 
-- Progress: 46% (63 of 135 Cards)
+- Progress: 48% (65 of 135 Cards)
 
 ## Madness at the Darkmoon Faire
 

--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -1118,7 +1118,7 @@ SCHOLOMANCE | SCH_157 | Enchanted Cauldron |
 SCHOLOMANCE | SCH_158 | Demonic Studies | O
 SCHOLOMANCE | SCH_159 | Mindrender Illucia |  
 SCHOLOMANCE | SCH_160 | Wandmaker |  
-SCHOLOMANCE | SCH_162 | Vectus |  
+SCHOLOMANCE | SCH_162 | Vectus | O
 SCHOLOMANCE | SCH_181 | Archwitch Willow |  
 SCHOLOMANCE | SCH_182 | Speaker Gidra |  
 SCHOLOMANCE | SCH_199 | Transfer Student |  

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 ### Expansions
 
   * 28% Madness at the Darkmoon Faire (38 of 135 cards)
-  * 46% Scholomance Academy (63 of 135 cards)
+  * 48% Scholomance Academy (65 of 135 cards)
   * 48% Ashes of Outland (65 of 135 cards)
   * **100% Descent of Dragons (140 of 140 cards)**
   * 83% Saviors of Uldum (113 of 135 cards)

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -11,6 +11,7 @@
 #include <Rosetta/PlayMode/Conditions/RelaCondition.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/ActivateCapturedDeathrattleTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddCardTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddStackToTask.hpp>
@@ -2103,6 +2104,26 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::GRAVEYARD));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsMinion()),
+        std::make_shared<SelfCondition>(SelfCondition::IsDead()),
+        std::make_shared<SelfCondition>(SelfCondition::HasDeathrattle()) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 2));
+    power.AddPowerTask(std::make_shared<GetGameTagTask>(EntityType::STACK,
+                                                        GameTag::ENTITY_ID));
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("SCH_162t", SummonSide::LEFT));
+    power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
+        "SCH_162e", EntityType::STACK, false, true));
+    power.AddPowerTask(std::make_shared<GetGameTagTask>(EntityType::STACK,
+                                                        GameTag::ENTITY_ID));
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("SCH_162t", SummonSide::RIGHT));
+    power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
+        "SCH_162e", EntityType::STACK, false, true));
+    cards.emplace("SCH_162", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SCH_182] Speaker Gidra - COST:3 [ATK:1/HP:4]
@@ -2805,6 +2826,10 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: Copied <b>Deathrattle</b> from {0}.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<ActivateCapturedDeathrattleTask>());
+    cards.emplace("SCH_162e", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SCH_162t] Plagued Hatchling - COST:1 [ATK:1/HP:1]
@@ -2813,6 +2838,9 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // RefTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("SCH_162t", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SCH_199t] Transfer Student - COST:2 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -3,6 +3,7 @@
 // Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
+#include <algorithm>
 #include <Rosetta/PlayMode/Actions/Generic.hpp>
 #include <Rosetta/PlayMode/Actions/Summon.hpp>
 #include <Rosetta/PlayMode/Auras/AdaptiveCostEffect.hpp>
@@ -2540,6 +2541,24 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<CustomTask>(
+        [](Player* player, [[maybe_unused]] Entity* source,
+           [[maybe_unused]] Playable* target) {
+            DeckZone* deckZone = player->GetDeckZone();
+            auto v = deckZone->GetAll();
+            sort(v.begin(), v.end(), [](Playable* p1, Playable* p2) {
+                return p1->GetCost() < p2->GetCost();
+            });
+
+            for (int idx = 0; idx < deckZone->GetCount(); ++idx)
+            {
+                deckZone->SetEntity(idx, v[idx]);
+            }
+
+            return TaskStatus::COMPLETE;
+        }));
+    cards.emplace("SCH_428", CardDef(power));
 
     // ---------------------------------------- SPELL - NEUTRAL
     // [SCH_509] Brain Freeze - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -3,7 +3,6 @@
 // Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
-#include <algorithm>
 #include <Rosetta/PlayMode/Actions/Generic.hpp>
 #include <Rosetta/PlayMode/Actions/Summon.hpp>
 #include <Rosetta/PlayMode/Auras/AdaptiveCostEffect.hpp>
@@ -46,6 +45,8 @@
 #include <Rosetta/PlayMode/Zones/DeckZone.hpp>
 #include <Rosetta/PlayMode/Zones/FieldZone.hpp>
 #include <Rosetta/PlayMode/Zones/HandZone.hpp>
+
+#include <algorithm>
 
 using namespace RosettaStone::PlayMode::SimpleTasks;
 
@@ -2546,14 +2547,15 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
         [](Player* player, [[maybe_unused]] Entity* source,
            [[maybe_unused]] Playable* target) {
             DeckZone* deckZone = player->GetDeckZone();
-            auto v = deckZone->GetAll();
-            sort(v.begin(), v.end(), [](Playable* p1, Playable* p2) {
-                return p1->GetCost() < p2->GetCost();
-            });
+            std::vector<Playable*> deckCards = deckZone->GetAll();
+            std::sort(deckCards.begin(), deckCards.end(),
+                      [](Playable* p1, Playable* p2) {
+                          return p1->GetCost() < p2->GetCost();
+                      });
 
             for (int idx = 0; idx < deckZone->GetCount(); ++idx)
             {
-                deckZone->SetEntity(idx, v[idx]);
+                deckZone->SetEntity(idx, deckCards[idx]);
             }
 
             return TaskStatus::COMPLETE;

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -11,6 +11,7 @@
 #include <Rosetta/PlayMode/Actions/Generic.hpp>
 #include <Rosetta/PlayMode/Cards/Cards.hpp>
 #include <Rosetta/PlayMode/Models/Enchantment.hpp>
+#include <Rosetta/PlayMode/Utils/DeckCode.hpp>
 #include <Rosetta/PlayMode/Zones/DeckZone.hpp>
 #include <Rosetta/PlayMode/Zones/FieldZone.hpp>
 #include <Rosetta/PlayMode/Zones/HandZone.hpp>
@@ -3080,8 +3081,17 @@ TEST_CASE("[Neutral : Minion] - SCH_428 : Lorekeeper Polkelt")
     config.player1Class = CardClass::ROGUE;
     config.player2Class = CardClass::MAGE;
     config.startPlayer = PlayerType::PLAYER1;
-    config.doFillDecks = true;
+    config.doFillDecks = false;
     config.autoRun = false;
+
+    const std::string INNKEEPER_EXPERT_WARLOCK =
+        "AAEBAfqUAwAPMJMB3ALVA9AE9wTOBtwGkgeeB/sHsQjCCMQI9ggA";
+    auto deck = DeckCode::Decode(INNKEEPER_EXPERT_WARLOCK).GetCardIDs();
+
+    for (size_t j = 0; j < deck.size(); ++j)
+    {
+        config.player1Deck[j] = Cards::FindCardByID(deck[j]);
+    }
 
     Game game(config);
     game.Start();
@@ -3097,18 +3107,11 @@ TEST_CASE("[Neutral : Minion] - SCH_428 : Lorekeeper Polkelt")
     auto& curDeck = *(curPlayer->GetDeckZone());
 
     const auto card1 = Generic::DrawCard(
-        curPlayer, Cards::FindCardByName("Arch-Villain Rafaam"));
-
-    game.Process(curPlayer, PlayCardTask::Minion(card1));
-
-    curPlayer->SetUsedMana(0);
-
-    const auto card2 = Generic::DrawCard(
         curPlayer, Cards::FindCardByName("Lorekeeper Polkelt"));
 
-    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curDeck.GetCount(), 26);
 
-    CHECK_EQ(curDeck.GetCount(), 5);
     for (int count = 1; count < curDeck.GetCount(); ++count)
     {
         CHECK(curDeck.GetNthTopCard(count)->GetCost() >=

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -3055,6 +3055,59 @@ TEST_CASE("[Neutral : Minion] - SCH_425 : Doctor Krastinov")
     CHECK_EQ(curPlayer->GetWeapon().GetDurability(), 4);
 }
 
+// --------------------------------------- MINION - NEUTRAL
+// [SCH_428] Lorekeeper Polkelt - COST:5 [ATK:4/HP:5]
+// - Set: SCHOLOMANCE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Reorder your deck from the highest
+//       Cost card to the lowest Cost card.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SCH_428 : Lorekeeper Polkelt")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curDeck = *(curPlayer->GetDeckZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Arch-Villain Rafaam"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    curPlayer->SetUsedMana(0);
+
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Lorekeeper Polkelt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+
+    CHECK_EQ(curDeck.GetCount(), 5);
+    for (int count = 1; count < curDeck.GetCount(); ++count)
+    {
+        CHECK(curDeck.GetNthTopCard(count)->GetCost() >=
+              curDeck.GetNthTopCard(count + 1)->GetCost());
+    }
+}
+
 // ---------------------------------------- SPELL - NEUTRAL
 // [SCH_509] Brain Freeze - COST:1
 // - Set: SCHOLOMANCE, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -2245,6 +2245,64 @@ TEST_CASE("[Neutral : Minion] - SCH_145 : Desk Imp")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [SCH_162] Vectus - COST:5 [ATK:4/HP:4]
+// - Set: SCHOLOMANCE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Summon two 1/1 Whelps.
+//       Each gains a <b>Deathrattle</b> from your minions
+//       that died this game.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SCH_162 : Vectus")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Kobold Sandtrooper"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Leper Gnome"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Whirlwind"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Vectus"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Whirlwind"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(curField.GetCount(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card5));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 15);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [SCH_230] Onyx Magescribe - COST:6 [ATK:4/HP:9]
 // - Race: Dragon, Set: SCHOLOMANCE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -2294,12 +2294,20 @@ TEST_CASE("[Neutral : Minion] - SCH_162 : Vectus")
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 2);
+
     game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(curField.GetCount(), 0);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 15);
+
     game.Process(curPlayer, PlayCardTask::Minion(card4));
     CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[0]->HasDeathrattle(), true);
+    CHECK_EQ(curField[2]->HasDeathrattle(), true);
 
     game.Process(curPlayer, PlayCardTask::Spell(card5));
-    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 15);
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 10);
 }
 
 // --------------------------------------- MINION - NEUTRAL


### PR DESCRIPTION
This revision includes:
- Implement 2 SCHOLOMANCE cards
   - Vectus (SCH_162)
   - Lorekeeper Polkelt (SCH_428)