### PR TITLE
Update Hearthstone Patch 19.2.1

### DIFF
--- a/Resources/cards.collectible.json
+++ b/Resources/cards.collectible.json
@@ -6142,7 +6142,7 @@
     },
     {
         "artist": "Grace Liu",
-        "attack": 4,
+        "attack": 3,
         "cardClass": "SHAMAN",
         "collectible": true,
         "cost": 5,
@@ -26036,7 +26036,7 @@
         "attack": 2,
         "cardClass": "ROGUE",
         "collectible": true,
-        "cost": 3,
+        "cost": 4,
         "dbfId": 306,
         "elite": true,
         "flavor": "He led the Stonemasons in the reconstruction of Stormwind, and when the nobles refused to pay, he founded the Defias Brotherhood to, well, <i>deconstruct</i> Stormwind.",

--- a/Resources/cards.json
+++ b/Resources/cards.json
@@ -5385,13 +5385,13 @@
         "type": "ENCHANTMENT"
     },
     {
-        "attack": 7,
+        "attack": 4,
         "battlegroundsPremiumDbfId": 66840,
         "cardClass": "NEUTRAL",
         "cost": 8,
         "dbfId": 66835,
         "elite": true,
-        "health": 7,
+        "health": 4,
         "id": "BGS_205",
         "mechanics": [
             "DIVINE_SHIELD",
@@ -15361,7 +15361,7 @@
     },
     {
         "artist": "Grace Liu",
-        "attack": 4,
+        "attack": 3,
         "cardClass": "SHAMAN",
         "collectible": true,
         "cost": 5,
@@ -55864,7 +55864,7 @@
         "attack": 2,
         "cardClass": "ROGUE",
         "collectible": true,
-        "cost": 3,
+        "cost": 4,
         "dbfId": 306,
         "elite": true,
         "flavor": "He led the Stonemasons in the reconstruction of Stormwind, and when the nobles refused to pay, he founded the Defias Brotherhood to, well, <i>deconstruct</i> Stormwind.",
@@ -113850,13 +113850,13 @@
         "type": "MINION"
     },
     {
-        "attack": 14,
+        "attack": 8,
         "battlegroundsNormalDbfId": 66835,
         "cardClass": "NEUTRAL",
         "cost": 8,
         "dbfId": 66840,
         "elite": true,
-        "health": 14,
+        "health": 8,
         "id": "TB_BaconUps_306",
         "mechanics": [
             "DIVINE_SHIELD",

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -2655,7 +2655,7 @@ void Expert1CardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     cards.emplace("EX1_522", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
-    // [EX1_613] Edwin VanCleef - COST:3 [ATK:2/HP:2]
+    // [EX1_613] Edwin VanCleef - COST:4 [ATK:2/HP:2]
     // - Faction: Neutral, Set: Expert1, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Combo:</b> Gain +2/+2 for each other card

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -5419,7 +5419,7 @@ TEST_CASE("[Rogue : Minion] - EX1_522 : Patient Assassin")
 }
 
 // ----------------------------------------- MINION - ROGUE
-// [EX1_613] Edwin VanCleef - COST:3 [ATK:2/HP:2]
+// [EX1_613] Edwin VanCleef - COST:4 [ATK:2/HP:2]
 // - Faction: Neutral, Set: Expert1, Rarity: Legendary
 // --------------------------------------------------------
 // Text: <b>Combo:</b> Gain +2/+2 for each other card
@@ -5465,6 +5465,8 @@ TEST_CASE("[Rogue : Minion] - EX1_613 : Edwin VanCleef")
     game.Process(curPlayer, PlayCardTask::Minion(card2));
     CHECK_EQ(curField[1]->GetAttack(), 4);
     CHECK_EQ(curField[1]->GetHealth(), 4);
+
+    curPlayer->SetUsedMana(0);
 
     game.Process(curPlayer, PlayCardTask::Minion(card3));
     CHECK_EQ(curField[2]->GetAttack(), 6);


### PR DESCRIPTION
This revision includes:
- Update Hearthstone Patch 19.2.1 (#552)
  - Standard Updates
    - Edwin VanCleef: Old: [Costs 3] → New: [Costs 4]
    - Boggspine Knuckles: Old: 4 Attack → New: 3 Attack
  - Battlegrounds Updates
    - Elistra the Immortal: Old: 7 Attack, 7 Health → New: 4 Attack, 4 Health 