### PR TITLE
Implement 13 SCHOLOMANCE cards

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -1112,12 +1112,12 @@ SCHOLOMANCE | SCH_142 | Voracious Reader |
 SCHOLOMANCE | SCH_143 | Divine Rager | O
 SCHOLOMANCE | SCH_145 | Desk Imp | O
 SCHOLOMANCE | SCH_146 | Robes of Protection |  
-SCHOLOMANCE | SCH_147 | Boneweb Egg |  
+SCHOLOMANCE | SCH_147 | Boneweb Egg | O
 SCHOLOMANCE | SCH_149 | Argent Braggart |  
 SCHOLOMANCE | SCH_157 | Enchanted Cauldron |  
 SCHOLOMANCE | SCH_158 | Demonic Studies | O
 SCHOLOMANCE | SCH_159 | Mindrender Illucia |  
-SCHOLOMANCE | SCH_160 | Wandmaker |  
+SCHOLOMANCE | SCH_160 | Wandmaker | O
 SCHOLOMANCE | SCH_162 | Vectus | O
 SCHOLOMANCE | SCH_181 | Archwitch Willow |  
 SCHOLOMANCE | SCH_182 | Speaker Gidra |  
@@ -1139,25 +1139,25 @@ SCHOLOMANCE | SCH_243 | Wyrm Weaver | O
 SCHOLOMANCE | SCH_244 | Teacher's Pet | O
 SCHOLOMANCE | SCH_245 | Steward of Scrolls | O
 SCHOLOMANCE | SCH_247 | First Day of School | O
-SCHOLOMANCE | SCH_248 | Pen Flinger |  
+SCHOLOMANCE | SCH_248 | Pen Flinger | O
 SCHOLOMANCE | SCH_250 | Wave of Apathy |  
 SCHOLOMANCE | SCH_252 | Marrowslicer | O
 SCHOLOMANCE | SCH_253 | Cycle of Hatred |  
 SCHOLOMANCE | SCH_259 | Sphere of Sapience | O
 SCHOLOMANCE | SCH_270 | Primordial Studies | O
 SCHOLOMANCE | SCH_271 | Molten Blast |  
-SCHOLOMANCE | SCH_273 | Ras Frostwhisper |  
+SCHOLOMANCE | SCH_273 | Ras Frostwhisper | O
 SCHOLOMANCE | SCH_276 | Magehunter |  
 SCHOLOMANCE | SCH_279 | Trueaim Crescent |  
-SCHOLOMANCE | SCH_283 | Manafeeder Panthara |  
+SCHOLOMANCE | SCH_283 | Manafeeder Panthara | O
 SCHOLOMANCE | SCH_300 | Carrion Studies | O
 SCHOLOMANCE | SCH_301 | Rune Dagger |  
 SCHOLOMANCE | SCH_302 | Gift of Luminance |  
 SCHOLOMANCE | SCH_305 | Secret Passage |  
 SCHOLOMANCE | SCH_307 | School Spirits | O
 SCHOLOMANCE | SCH_310 | Lab Partner | O
-SCHOLOMANCE | SCH_311 | Animated Broomstick |  
-SCHOLOMANCE | SCH_312 | Tour Guide |  
+SCHOLOMANCE | SCH_311 | Animated Broomstick | O
+SCHOLOMANCE | SCH_312 | Tour Guide | O
 SCHOLOMANCE | SCH_313 | Wretched Tutor | O
 SCHOLOMANCE | SCH_317 | Playmaker |  
 SCHOLOMANCE | SCH_333 | Nature Studies | O
@@ -1174,7 +1174,7 @@ SCHOLOMANCE | SCH_355 | Shardshatter Mystic | O
 SCHOLOMANCE | SCH_356 | Glide |  
 SCHOLOMANCE | SCH_357 | Fel Guardians |  
 SCHOLOMANCE | SCH_400 | Mozaki, Master Duelist |  
-SCHOLOMANCE | SCH_422 | Double Jump |  
+SCHOLOMANCE | SCH_422 | Double Jump | O
 SCHOLOMANCE | SCH_425 | Doctor Krastinov | O
 SCHOLOMANCE | SCH_426 | Infiltrator Lilian | O
 SCHOLOMANCE | SCH_427 | Lightning Bloom | O
@@ -1185,21 +1185,21 @@ SCHOLOMANCE | SCH_512 | Initiation |
 SCHOLOMANCE | SCH_513 | Brittlebone Destroyer |  
 SCHOLOMANCE | SCH_514 | Raise Dead |  
 SCHOLOMANCE | SCH_517 | Shadowlight Scholar | O
-SCHOLOMANCE | SCH_519 | Vulpera Toxinblade |  
+SCHOLOMANCE | SCH_519 | Vulpera Toxinblade | O
 SCHOLOMANCE | SCH_521 | Coerce | O
 SCHOLOMANCE | SCH_522 | Steeldancer | O
 SCHOLOMANCE | SCH_523 | Ceremonial Maul |  
 SCHOLOMANCE | SCH_524 | Shield of Honor | O
 SCHOLOMANCE | SCH_525 | In Formation! | O
-SCHOLOMANCE | SCH_526 | Lord Barov |  
-SCHOLOMANCE | SCH_530 | Sorcerous Substitute |  
-SCHOLOMANCE | SCH_532 | Goody Two-Shields |  
+SCHOLOMANCE | SCH_526 | Lord Barov | O
+SCHOLOMANCE | SCH_530 | Sorcerous Substitute | O
+SCHOLOMANCE | SCH_532 | Goody Two-Shields | O
 SCHOLOMANCE | SCH_533 | Commencement | O
 SCHOLOMANCE | SCH_535 | Tidal Wave |  
 SCHOLOMANCE | SCH_537 | Trick Totem |  
 SCHOLOMANCE | SCH_538 | Ace Hunter Kreen |  
 SCHOLOMANCE | SCH_539 | Professor Slate |  
-SCHOLOMANCE | SCH_600 | Demon Companion |  
+SCHOLOMANCE | SCH_600 | Demon Companion | O
 SCHOLOMANCE | SCH_603 | Star Student Stelina |  
 SCHOLOMANCE | SCH_604 | Overwhelm |  
 SCHOLOMANCE | SCH_605 | Lake Thresher |  
@@ -1234,7 +1234,7 @@ SCHOLOMANCE | SCH_713 | Cult Neophyte | O
 SCHOLOMANCE | SCH_714 | Educated Elekk |  
 SCHOLOMANCE | SCH_717 | Keymaster Alabaster | O
 
-- Progress: 48% (65 of 135 Cards)
+- Progress: 57% (78 of 135 Cards)
 
 ## Madness at the Darkmoon Faire
 

--- a/Includes/Rosetta/Common/Enums/AuraEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/AuraEnums.hpp
@@ -20,6 +20,8 @@ enum class AuraType
     FIELD_EXCEPT_SOURCE,  //!< This type of aura affects all friendly minions
                           //!< except the source of the aura.
     HERO,              //!< This type of aura affects the source's controller.
+    HERO_POWER,        //!< This type of aura effects the power of the source's
+                       //!< controller.
     ENEMY_HERO_POWER,  //!< This type of aura effects the power of the source's
                        //!< enemy controller.
     WEAPON,            //!< This type of aura affects the weapon of the source's

--- a/Includes/Rosetta/Common/Enums/TriggerEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/TriggerEnums.hpp
@@ -46,9 +46,11 @@ enum class TriggerType
     PREDAMAGE,    //!< The effect will be triggered when a character gets
                 //!< predamage. This event happens just before the character is
                 //!< actually damaged.
-    TARGET,  //!< The effect will be triggered when a card is targeted by an
-             //!< attacking minion or a played card.
-    DEATH,   //!< The effect will be triggered when a minion dies.
+    TARGET,   //!< The effect will be triggered when a card is targeted by an
+              //!< attacking minion or a played card.
+    DISCARD,  //!< The effect will be triggered when a card is discarded from
+              //!< hand.
+    DEATH,    //!< The effect will be triggered when a minion dies.
     USE_HERO_POWER,  //!< The effect will be triggered when a hero uses power.
     SHUFFLE_INTO_DECK,  //!< The effect will be triggered when a card is
                         //!< shuffled into a deck.

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -369,6 +369,10 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsUnspentMana();
 
+    //! SelfCondition wrapper for checking the player used hero power this turn. 
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsUsedHeroPowerThisTurn();
+
     //! SelfCondition wrapper for checking it is no duplicate cards in deck.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsNoDuplicateInDeck();

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -189,6 +189,10 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsChooseOneCard();
 
+    //! SelfCondition wrapper for checking the entity is outcast card.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsOutcastCard();
+
     //! SelfCondition wrapper for checking the entity is frozen.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsFrozen();
@@ -369,7 +373,7 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsUnspentMana();
 
-    //! SelfCondition wrapper for checking the player used hero power this turn. 
+    //! SelfCondition wrapper for checking the player used hero power this turn.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsUsedHeroPowerThisTurn();
 

--- a/Includes/Rosetta/PlayMode/Enchants/AuraEffects.hpp
+++ b/Includes/Rosetta/PlayMode/Enchants/AuraEffects.hpp
@@ -149,18 +149,18 @@ class AuraEffects
     // Weapon
     // 0 : IMMUNE
     // Character
-    // 1 : CANT_BE_TARGETED_BY_SPELLS / CANT_BE_TARGETED_BY_HERO_POWERS
-    // 2 : ATK
+    // 0 : CANT_BE_TARGETED_BY_SPELLS / CANT_BE_TARGETED_BY_HERO_POWERS
+    // 1 : ATK
     // Hero
-    // 3 : CANNOT_ATTACK_HEROES
-    // 4 : IMMUNE
-    // 5 : HEROPOWER_DAMAGE
+    // 2 : CANNOT_ATTACK_HEROES
+    // 3 : IMMUNE
+    // 4 : HEROPOWER_DAMAGE
     // Minion
-    // 3 : HEALTH
-    // 4 : CHARGE
-    // 5 : TAUNT
-    // 6 : LIFESTEAL
-    // 7 : CANT_ATTACK
+    // 2 : HEALTH
+    // 3 : CHARGE
+    // 4 : TAUNT
+    // 5 : LIFESTEAL
+    // 6 : CANT_ATTACK
     int* m_data = nullptr;
 };
 }  // namespace RosettaStone::PlayMode

--- a/Includes/Rosetta/PlayMode/Enchants/AuraEffects.hpp
+++ b/Includes/Rosetta/PlayMode/Enchants/AuraEffects.hpp
@@ -13,7 +13,7 @@ namespace RosettaStone::PlayMode
 class Entity;
 
 constexpr int AURA_EFFECT_CARD_SIZE = 0;
-constexpr int AURA_EFFECT_WEAPON_SIZE = AURA_EFFECT_CARD_SIZE + 1;
+constexpr int AURA_EFFECT_WEAPON_SIZE = AURA_EFFECT_CARD_SIZE + 2;
 constexpr int AURA_EFFECT_CHARACTER_SIZE = AURA_EFFECT_CARD_SIZE + 2;
 constexpr int AURA_EFFECT_HERO_SIZE = AURA_EFFECT_CHARACTER_SIZE + 3;
 constexpr int AURA_EFFECT_MINION_SIZE = AURA_EFFECT_CHARACTER_SIZE + 5;
@@ -148,6 +148,7 @@ class AuraEffects
     // ...
     // Weapon
     // 0 : IMMUNE
+    // 1 : ATK
     // Character
     // 0 : CANT_BE_TARGETED_BY_SPELLS / CANT_BE_TARGETED_BY_HERO_POWERS
     // 1 : ATK

--- a/Includes/Rosetta/PlayMode/Managers/TriggerManager.hpp
+++ b/Includes/Rosetta/PlayMode/Managers/TriggerManager.hpp
@@ -101,6 +101,10 @@ class TriggerManager
     //! \param sender An entity that is the source of trigger.
     void OnTargetTrigger(Entity* sender);
 
+    //! Callback for trigger when a card is discarded from hand.
+    //! \param sender An entity that is the source of trigger.
+    void OnDiscardTrigger(Entity* sender);
+
     //! Callback for trigger when minion is dead.
     //! \param sender An entity that is the source of trigger.
     void OnDeathTrigger(Entity* sender);
@@ -133,6 +137,7 @@ class TriggerManager
     TriggerEvent dealDamageTrigger;
     TriggerEvent takeDamageTrigger;
     TriggerEvent targetTrigger;
+    TriggerEvent discardTrigger;
     TriggerEvent deathTrigger;
     TriggerEvent useHeroPowerTrigger;
     TriggerEvent shuffleIntoDeckTrigger;

--- a/Includes/Rosetta/PlayMode/Models/Entity.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Entity.hpp
@@ -58,6 +58,11 @@ class Entity
     //! Deleted move assignment operator.
     Entity& operator=(Entity&&) noexcept = delete;
 
+    //! Returns the value of native game tag.
+    //! \param tag The game tag of card.
+    //! \return The value of native game tag.
+    int GetNativeGameTag(GameTag tag) const;
+
     //! Returns a list of game tag.
     //! \return A list of game tag.
     std::map<GameTag, int> GetGameTags() const;

--- a/Includes/Rosetta/PlayMode/Models/Entity.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Entity.hpp
@@ -67,7 +67,7 @@ class Entity
     //! \return The value of game tag.
     virtual int GetGameTag(GameTag tag) const;
 
-    //! Sets game tag to the card.
+    //! Sets the value of game tag to the card.
     //! \param tag The game tag to indicate ability or condition.
     //! \param value The value to set for game tag.
     virtual void SetGameTag(GameTag tag, int value);

--- a/Includes/Rosetta/PlayMode/Models/Entity.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Entity.hpp
@@ -63,6 +63,11 @@ class Entity
     //! \return The value of native game tag.
     int GetNativeGameTag(GameTag tag) const;
 
+    //! Sets the value of game tag to the card.
+    //! \param tag The game tag to indicate ability or condition.
+    //! \param value The value to set for native game tag.
+    void SetNativeGameTag(GameTag tag, int value);
+
     //! Returns a list of game tag.
     //! \return A list of game tag.
     std::map<GameTag, int> GetGameTags() const;

--- a/Includes/Rosetta/PlayMode/Models/Hero.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Hero.hpp
@@ -78,6 +78,8 @@ class Hero : public Character
     HeroPower* heroPower = nullptr;
     Weapon* weapon = nullptr;
 
+    std::vector<Aura*> weaponAuras;
+
     int fatigue = 0;
     int damageTakenThisTurn = 0;
 };

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 ### Expansions
 
   * 28% Madness at the Darkmoon Faire (38 of 135 cards)
-  * 48% Scholomance Academy (65 of 135 cards)
+  * 57% Scholomance Academy (78 of 135 cards)
   * 48% Ashes of Outland (65 of 135 cards)
   * **100% Descent of Dragons (140 of 140 cards)**
   * **99% Saviors of Uldum (134 of 135 cards)**

--- a/Sources/Rosetta/PlayMode/Auras/Aura.cpp
+++ b/Sources/Rosetta/PlayMode/Auras/Aura.cpp
@@ -406,6 +406,11 @@ void Aura::UpdateInternal()
             }
             break;
         }
+        case AuraType::HERO_POWER:
+        {
+            Apply(m_owner->player->GetHero()->heroPower);
+            break;
+        }
         case AuraType::ENEMY_HERO_POWER:
         {
             Apply(m_owner->player->opponent->GetHero()->heroPower);

--- a/Sources/Rosetta/PlayMode/Auras/Aura.cpp
+++ b/Sources/Rosetta/PlayMode/Auras/Aura.cpp
@@ -131,6 +131,12 @@ void Aura::Remove()
                     [this](Aura* aura) { return aura == this; });
             break;
         }
+        case AuraType::WEAPON:
+        {
+            EraseIf(m_owner->player->GetHero()->weaponAuras,
+                    [this](Aura* aura) { return aura == this; });
+            break;
+        }
         case AuraType::HAND:
         {
             EraseIf(m_owner->player->GetHandZone()->auras,
@@ -340,6 +346,9 @@ void Aura::AddToGame(Playable& owner, Aura& aura)
         case AuraType::FIELD:
         case AuraType::FIELD_EXCEPT_SOURCE:
             owner.player->GetFieldZone()->auras.emplace_back(&aura);
+            break;
+        case AuraType::WEAPON:
+            owner.player->GetHero()->weaponAuras.emplace_back(&aura);
             break;
         case AuraType::HAND:
             owner.player->GetHandZone()->auras.emplace_back(&aura);

--- a/Sources/Rosetta/PlayMode/Auras/Aura.cpp
+++ b/Sources/Rosetta/PlayMode/Auras/Aura.cpp
@@ -416,6 +416,14 @@ void Aura::UpdateInternal()
             Apply(m_owner->player->opponent->GetHero()->heroPower);
             break;
         }
+        case AuraType::WEAPON:
+        {
+            if (m_owner->player->GetHero()->HasWeapon())
+            {
+                Apply(m_owner->player->GetHero()->weapon);
+            }
+            break;
+        }
         case AuraType::HAND:
         {
             for (auto& card : m_owner->player->GetHandZone()->GetAll())

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -2372,6 +2372,11 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SPELLPOWER = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->tasks = { std::make_shared<DamageTask>(
+        EntityType::ENEMIES, 1, true) };
+    cards.emplace("SCH_273", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SCH_283] Manafeeder Panthara - COST:2 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -33,6 +33,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeAdjacentTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomCardTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomEntourageTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomMinionNumberTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
@@ -492,6 +493,9 @@ void ScholomanceCardsGen::AddHunterNonCollect(
     // --------------------------------------------------------
     // Text: Kolek is granting this minion +1 Attack.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("SCH_600t3e"));
+    cards.emplace("SCH_600t3e", CardDef(power));
 
     // ----------------------------------------- SPELL - HUNTER
     // [SCH_607a] Transfiguration - COST:3
@@ -1818,6 +1822,19 @@ void ScholomanceCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Summon a random Demon Companion.
     // --------------------------------------------------------
+    // Entourage: SCH_600t1, SCH_600t2, SCH_600t3
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<RandomEntourageTask>());
+    power.AddPowerTask(std::make_shared<SummonTask>());
+    cards.emplace(
+        "SCH_600",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } },
+                ChooseCardIDs{},
+                Entourages{ "SCH_600t1", "SCH_600t2", "SCH_600t3" }));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [SCH_603] Star Student Stelina - COST:4 [ATK:4/HP:3]
@@ -1967,6 +1984,9 @@ void ScholomanceCardsGen::AddDemonHunterNonCollect(
     // GameTag:
     // - CHARGE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("SCH_600t1", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [SCH_600t2] Shima - COST:1 [ATK:2/HP:2]
@@ -1977,6 +1997,9 @@ void ScholomanceCardsGen::AddDemonHunterNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("SCH_600t2", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [SCH_600t3] Kolek - COST:1 [ATK:1/HP:2]
@@ -1987,6 +2010,10 @@ void ScholomanceCardsGen::AddDemonHunterNonCollect(
     // GameTag:
     // - AURA = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(
+        std::make_shared<Aura>(AuraType::FIELD_EXCEPT_SOURCE, "SCH_600t3e"));
+    cards.emplace("SCH_600t3", CardDef(power));
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [SCH_702e] Felosophically Inclined - COST:0
@@ -2171,6 +2198,7 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
+    // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
     // [SCH_230] Onyx Magescribe - COST:6 [ATK:4/HP:9]

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -12,6 +12,7 @@
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ActivateCapturedDeathrattleTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/ActivateDeathrattleTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddCardTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddStackToTask.hpp>
@@ -1348,6 +1349,13 @@ void ScholomanceCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - DEATHRATTLE = 1
     // - InvisibleDeathrattle = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("SCH_147t", 2, SummonSide::DEATHRATTLE));
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::DISCARD));
+    power.GetTrigger()->tasks = { std::make_shared<ActivateDeathrattleTask>(
+        EntityType::SOURCE) };
+    cards.emplace("SCH_147", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [SCH_158] Demonic Studies - COST:1
@@ -1507,6 +1515,9 @@ void ScholomanceCardsGen::AddWarlockNonCollect(
     // [SCH_147t] Boneweb Spider - COST:1 [ATK:2/HP:1]
     // - Race: Beast, Set: SCHOLOMANCE
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("SCH_147t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - WARLOCK
     // [SCH_158e] Demonic Studies - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -39,6 +39,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomSpellTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/ReturnHandTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SetGameTagTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SetPlayerGameTagTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonCopyTask.hpp>
@@ -2312,6 +2313,16 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::TARGET, 1));
+    power.AddSpellburstTask(
+        std::make_shared<ReturnHandTask>(EntityType::SOURCE));
+    cards.emplace(
+        "SCH_248",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // --------------------------------------- WEAPON - NEUTRAL
     // [SCH_259] Sphere of Sapience - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -1130,7 +1130,6 @@ void ScholomanceCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
         const auto aura = dynamic_cast<Aura*>(power.GetAura());
         aura->condition =
             std::make_shared<SelfCondition>(SelfCondition::IsWeaponEquipped());
-        aura->restless = true;
     }
     cards.emplace("SCH_519", CardDef(power));
 

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -2699,6 +2699,14 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SPELLPOWER = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::HasPlayerSpellPower()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<SummonCopyTask>(
+                  EntityType::SOURCE, false, false, SummonSide::SPELL) }));
+    cards.emplace("SCH_530", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SCH_537] Trick Totem - COST:2 [ATK:0/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -1124,6 +1124,15 @@ void ScholomanceCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - AURA = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<Aura>(AuraType::WEAPON, "SCH_519e"));
+    {
+        const auto aura = dynamic_cast<Aura*>(power.GetAura());
+        aura->condition =
+            std::make_shared<SelfCondition>(SelfCondition::IsWeaponEquipped());
+        aura->restless = true;
+    }
+    cards.emplace("SCH_519", CardDef(power));
 
     // ----------------------------------------- WEAPON - ROGUE
     // [SCH_622] Self-Sharpening Sword - COST:3
@@ -3449,6 +3458,9 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +2 Attack.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("SCH_519e"));
+    cards.emplace("SCH_519e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [SCH_524e] Shield of Honor - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -2377,6 +2377,10 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("SCH_312e", EntityType::PLAYER));
+    cards.emplace("SCH_312", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SCH_313] Wretched Tutor - COST:4 [ATK:2/HP:5]
@@ -3309,6 +3313,14 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: Your Hero Power costs (0).
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<Aura>(AuraType::HERO_POWER,
+                                         EffectList{ Effects::SetCost(0) }));
+    {
+        const auto aura = dynamic_cast<Aura*>(power.GetAura());
+        aura->removeTrigger = { TriggerType::USE_HERO_POWER, nullptr };
+    }
+    cards.emplace("SCH_312e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [SCH_351a] This is an Illusion. - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -2402,6 +2402,10 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(
+        EntityType::MINIONS_NOSOURCE, GameTag::RUSH, 1));
+    cards.emplace("SCH_311", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SCH_312] Tour Guide - COST:1 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -782,6 +782,10 @@ void ScholomanceCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DIVINE_SHIELD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddSpellburstTask(std::make_shared<SetGameTagTask>(
+        EntityType::SOURCE, GameTag::DIVINE_SHIELD, 1));
+    cards.emplace("SCH_532", CardDef(power));
 
     // ---------------------------------------- SPELL - PALADIN
     // [SCH_533] Commencement - COST:7

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -2355,6 +2355,13 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsUsedHeroPowerThisTurn()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<DrawTask>(1) }));
+    cards.emplace("SCH_283", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SCH_311] Animated Broomstick - COST:1 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -24,6 +24,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DestroySoulFragmentTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DestroyTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
@@ -1802,6 +1803,13 @@ void ScholomanceCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - OUTCAST = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::DECK));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsOutcastCard()) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddPowerTask(std::make_shared<DrawStackTask>(1));
+    cards.emplace("SCH_422", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [SCH_538] Ace Hunter Kreen - COST:3 [ATK:2/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -771,6 +771,12 @@ void ScholomanceCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
+        "SCH_526e", EntityType::ALL_MINIONS_NOSOURCE));
+    power.AddDeathrattleTask(
+        std::make_shared<DamageTask>(EntityType::ALL_MINIONS, 1));
+    cards.emplace("SCH_526", CardDef(power));
 
     // --------------------------------------- MINION - PALADIN
     // [SCH_532] Goody Two-Shields - COST:3 [ATK:4/HP:2]
@@ -1699,6 +1705,9 @@ void ScholomanceCardsGen::AddWarriorNonCollect(
     // --------------------------------------------------------
     // Text: Health changed to 1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(std::make_shared<Enchant>(Effects::SetBaseHealth(1)));
+    cards.emplace("SCH_526e", CardDef(power));
 }
 
 void ScholomanceCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -36,6 +36,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomEntourageTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomMinionNumberTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomMinionTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomSpellTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SetGameTagTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SetPlayerGameTagTask.hpp>
@@ -2118,6 +2119,11 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<RandomSpellTask>(
+        CardClass::PLAYER_CLASS, GameTag::COST, 1));
+    power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
+    cards.emplace("SCH_160", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SCH_162] Vectus - COST:5 [ATK:4/HP:4]

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -356,6 +356,12 @@ SelfCondition SelfCondition::IsChooseOneCard()
         [](Playable* playable) { return playable->HasChooseOne(); });
 }
 
+SelfCondition SelfCondition::IsOutcastCard()
+{
+    return SelfCondition(
+        [](Playable* playable) { return playable->HasOutcast(); });
+}
+
 SelfCondition SelfCondition::IsFrozen()
 {
     return SelfCondition([](Playable* playable) {

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -742,6 +742,13 @@ SelfCondition SelfCondition::IsUnspentMana()
     });
 }
 
+SelfCondition SelfCondition::IsUsedHeroPowerThisTurn()
+{
+    return SelfCondition([](Playable* playable) {
+        return playable->player->GetHero()->heroPower->IsExhausted();
+    });
+}
+
 SelfCondition SelfCondition::IsNoDuplicateInDeck()
 {
     return SelfCondition([](Playable* playable) {

--- a/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
@@ -122,7 +122,7 @@ int AuraEffects::GetImmune() const
 
     if (m_type == CardType::HERO)
     {
-        return m_data[4];
+        return m_data[3];
     }
 
     return 0;
@@ -136,7 +136,7 @@ void AuraEffects::SetImmune(int value)
     }
     else if (m_type == CardType::HERO)
     {
-        m_data[4] = value;
+        m_data[3] = value;
     }
     else
     {
@@ -147,91 +147,91 @@ void AuraEffects::SetImmune(int value)
 
 int AuraEffects::GetCantBeTargetedBySpells() const
 {
-    return m_data[1];
+    return m_data[0];
 }
 
 void AuraEffects::SetCantBeTargetedBySpells(int value)
 {
-    m_data[1] = value;
+    m_data[0] = value;
 }
 
 int AuraEffects::GetAttack() const
 {
-    return m_data[2];
+    return m_data[1];
 }
 
 void AuraEffects::SetAttack(int value)
 {
-    m_data[2] = value;
+    m_data[1] = value;
 }
 
 int AuraEffects::GetCannotAttackHeroes() const
 {
-    return m_data[3];
+    return m_data[2];
 }
 
 void AuraEffects::SetCannotAttackHeroes(int value)
 {
-    m_data[3] = value;
+    m_data[2] = value;
 }
 
 int AuraEffects::GetHeroPowerDamage() const
 {
-    return m_data[5];
+    return m_data[4];
 }
 
 void AuraEffects::SetHeroPowerDamage(int value)
 {
-    m_data[5] = value;
+    m_data[4] = value;
 }
 
 int AuraEffects::GetHealth() const
 {
-    return m_data[3];
+    return m_data[2];
 }
 
 void AuraEffects::SetHealth(int value)
 {
-    m_data[3] = value;
+    m_data[2] = value;
 }
 
 int AuraEffects::GetCharge() const
 {
-    return m_data[4];
+    return m_data[3];
 }
 
 void AuraEffects::SetCharge(int value)
 {
-    m_data[4] = value;
+    m_data[3] = value;
 }
 
 int AuraEffects::GetTaunt() const
 {
-    return m_data[5];
+    return m_data[4];
 }
 
 void AuraEffects::SetTaunt(int value)
 {
-    m_data[5] = value;
+    m_data[4] = value;
 }
 
 int AuraEffects::GetLifesteal() const
 {
-    return m_data[6];
+    return m_data[5];
 }
 
 void AuraEffects::SetLifesteal(int value)
 {
-    m_data[6] = value;
+    m_data[5] = value;
 }
 
 int AuraEffects::GetCantAttack() const
 {
-    return m_data[7];
+    return m_data[6];
 }
 
 void AuraEffects::SetCantAttack(int value)
 {
-    m_data[7] = value;
+    m_data[6] = value;
 }
 }  // namespace RosettaStone::PlayMode

--- a/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
@@ -46,14 +46,7 @@ int AuraEffects::GetGameTag(GameTag tag) const
         case GameTag::CANT_BE_TARGETED_BY_HERO_POWERS:
             return GetCantBeTargetedBySpells();
         case GameTag::ATK:
-        {
-            if (m_type != CardType::MINION)
-            {
-                return 0;
-            }
-
             return GetAttack();
-        }
         case GameTag::CANNOT_ATTACK_HEROES:
             return GetCannotAttackHeroes();
         case GameTag::HEROPOWER_DAMAGE:

--- a/Sources/Rosetta/PlayMode/Enchants/Effect.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/Effect.cpp
@@ -24,21 +24,21 @@ void Effect::ApplyTo(Entity* entity, bool isOneTurnEffect) const
             std::make_pair(entity, new Effect(*this)));
     }
 
-    const int prevValue = entity->GetGameTag(m_gameTag);
+    const int prevValue = entity->GetNativeGameTag(m_gameTag);
 
     switch (m_effectOperator)
     {
         case EffectOperator::ADD:
-            entity->SetGameTag(m_gameTag, prevValue + m_value);
+            entity->SetNativeGameTag(m_gameTag, prevValue + m_value);
             break;
         case EffectOperator::SUB:
-            entity->SetGameTag(m_gameTag, prevValue - m_value);
+            entity->SetNativeGameTag(m_gameTag, prevValue - m_value);
             break;
         case EffectOperator::MUL:
-            entity->SetGameTag(m_gameTag, prevValue * m_value);
+            entity->SetNativeGameTag(m_gameTag, prevValue * m_value);
             break;
         case EffectOperator::SET:
-            entity->SetGameTag(m_gameTag, m_value);
+            entity->SetNativeGameTag(m_gameTag, m_value);
             break;
         default:
             throw std::invalid_argument(
@@ -113,19 +113,18 @@ void Effect::ApplyAuraTo(Entity* entity) const
 
 void Effect::RemoveFrom(Entity* entity) const
 {
-    const int prevValue = entity->GetGameTag(m_gameTag);
+    const int prevValue = entity->GetNativeGameTag(m_gameTag);
 
     switch (m_effectOperator)
     {
         case EffectOperator::ADD:
-            entity->SetGameTag(m_gameTag, prevValue - m_value);
+            entity->SetNativeGameTag(m_gameTag, prevValue - m_value);
             break;
         case EffectOperator::SUB:
-            entity->SetGameTag(m_gameTag,
-                               entity->card->gameTags.at(m_gameTag) + m_value);
+            entity->SetNativeGameTag(m_gameTag, prevValue + m_value);
             break;
         case EffectOperator::SET:
-            entity->SetGameTag(m_gameTag, 0);
+            entity->SetNativeGameTag(m_gameTag, 0);
             break;
         default:
             throw std::invalid_argument(

--- a/Sources/Rosetta/PlayMode/Managers/TriggerManager.cpp
+++ b/Sources/Rosetta/PlayMode/Managers/TriggerManager.cpp
@@ -108,6 +108,11 @@ void TriggerManager::OnTargetTrigger(Entity* sender)
     targetTrigger(sender);
 }
 
+void TriggerManager::OnDiscardTrigger(Entity* sender)
+{
+    discardTrigger(sender);
+}
+
 void TriggerManager::OnDeathTrigger(Entity* sender)
 {
     deathTrigger(sender);

--- a/Sources/Rosetta/PlayMode/Models/Entity.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Entity.cpp
@@ -112,6 +112,7 @@ void Entity::Reset()
     m_gameTags.erase(GameTag::WINDFURY);
     m_gameTags.erase(GameTag::DIVINE_SHIELD);
     m_gameTags.erase(GameTag::STEALTH);
+    m_gameTags.erase(GameTag::SPELLBURST);
     m_gameTags.erase(GameTag::NUM_ATTACKS_THIS_TURN);
 }
 

--- a/Sources/Rosetta/PlayMode/Models/Entity.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Entity.cpp
@@ -40,6 +40,11 @@ int Entity::GetNativeGameTag(GameTag tag) const
     return m_gameTags.find(tag) == m_gameTags.end() ? 0 : m_gameTags.at(tag);
 }
 
+void Entity::SetNativeGameTag(GameTag tag, int value)
+{
+    m_gameTags.insert_or_assign(tag, value);
+}
+
 std::map<GameTag, int> Entity::GetGameTags() const
 {
     return m_gameTags;

--- a/Sources/Rosetta/PlayMode/Models/Entity.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Entity.cpp
@@ -35,6 +35,11 @@ Entity::~Entity()
     m_gameTags.clear();
 }
 
+int Entity::GetNativeGameTag(GameTag tag) const
+{
+    return m_gameTags.find(tag) == m_gameTags.end() ? 0 : m_gameTags.at(tag);
+}
+
 std::map<GameTag, int> Entity::GetGameTags() const
 {
     return m_gameTags;

--- a/Sources/Rosetta/PlayMode/Models/Hero.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Hero.cpp
@@ -54,6 +54,11 @@ void Hero::AddWeapon(Weapon& _weapon)
     {
         SetExhausted(false);
     }
+
+    for (int i = static_cast<int>(weaponAuras.size()) - 1; i >= 0; --i)
+    {
+        weaponAuras[i]->NotifyEntityAdded(weapon);
+    }
 }
 
 void Hero::RemoveWeapon()
@@ -70,6 +75,11 @@ void Hero::RemoveWeapon()
     game->ProcessTasks();
 
     game->triggerManager.OnDeathTrigger(weapon);
+
+    for (int i = static_cast<int>(weaponAuras.size()) - 1; i >= 0; --i)
+    {
+        weaponAuras[i]->NotifyEntityRemoved(weapon);
+    }
 
     player->GetGraveyardZone()->Add(weapon);
 

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscardTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscardTask.cpp
@@ -56,6 +56,8 @@ TaskStatus DiscardTask::Impl(Player* player)
 
         player->game->taskQueue.StartEvent();
 
+        player->game->triggerManager.OnDiscardTrigger(handCards[i]);
+
         player->GetHandZone()->Remove(handCards[i]);
         player->GetGraveyardZone()->Add(handCards[i]);
 

--- a/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
+++ b/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
@@ -224,6 +224,9 @@ std::shared_ptr<Trigger> Trigger::Activate(Playable* source,
         case TriggerType::TARGET:
             game->triggerManager.targetTrigger += instance->handler;
             break;
+        case TriggerType::DISCARD:
+            game->triggerManager.discardTrigger += instance->handler;
+            break;
         case TriggerType::DEATH:
             game->triggerManager.deathTrigger += instance->handler;
             break;
@@ -375,6 +378,9 @@ void Trigger::Remove() const
             }
         case TriggerType::TARGET:
             game->triggerManager.targetTrigger -= handler;
+            break;
+        case TriggerType::DISCARD:
+            game->triggerManager.discardTrigger -= handler;
             break;
         case TriggerType::DEATH:
             game->triggerManager.deathTrigger -= handler;

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -1543,18 +1543,38 @@ TEST_CASE("[Hunter : Spell] - NEW1_031 : Animal Companion")
     const auto card1 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Animal Companion"));
     const auto card2 =
-        Generic::DrawCard(curPlayer, Cards::FindCardByName("Animal Companion"));
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
 
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
     game.Process(curPlayer, PlayCardTask::Spell(card1));
-    game.Process(curPlayer, PlayCardTask::Spell(card2));
 
-    int isLeokk1 = (curField[0]->card->name == "Leokk") ? 1 : 0;
-    int isLeokk2 = (curField[1]->card->name == "Leokk") ? 1 : 0;
-
-    CHECK_EQ(curField[0]->card->gameTags[GameTag::ATK] + isLeokk2,
-             curField[0]->GetAttack());
-    CHECK_EQ(curField[1]->card->gameTags[GameTag::ATK] + isLeokk1,
-             curField[1]->GetAttack());
+    if (curField[1]->card->id == "NEW1_032")
+    {
+        SUBCASE("Misha - NEW1_032")
+        {
+            CHECK_EQ(curField[1]->GetAttack(), 4);
+            CHECK_EQ(curField[1]->GetHealth(), 4);
+            CHECK_EQ(curField[1]->HasTaunt(), true);
+        }
+    }
+    else if (curField[1]->card->id == "NEW1_033")
+    {
+        SUBCASE("Leokk - NEW1_033")
+        {
+            CHECK_EQ(curField[1]->GetAttack(), 2);
+            CHECK_EQ(curField[1]->GetHealth(), 4);
+            CHECK_EQ(curField[0]->GetAttack(), 4);
+        }
+    }
+    else
+    {
+        SUBCASE("Huffer - NEW1_034")
+        {
+            CHECK_EQ(curField[1]->GetAttack(), 4);
+            CHECK_EQ(curField[1]->GetHealth(), 2);
+            CHECK_EQ(curField[1]->HasCharge(), true);
+        }
+    }
 }
 
 // ------------------------------------------- SPELL - MAGE

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -1375,55 +1375,55 @@ TEST_CASE("[Rogue : Minion] - SCH_426 : Infiltrator Lilian")
 // GameTag:
 // - AURA = 1
 // --------------------------------------------------------
-//TEST_CASE("[Rogue : Minion] - SCH_519 : Vulpera Toxinblade")
-//{
-//    GameConfig config;
-//    config.player1Class = CardClass::ROGUE;
-//    config.player2Class = CardClass::MAGE;
-//    config.startPlayer = PlayerType::PLAYER1;
-//    config.doFillDecks = true;
-//    config.autoRun = false;
-//
-//    Game game(config);
-//    game.Start();
-//    game.ProcessUntil(Step::MAIN_ACTION);
-//
-//    Player* curPlayer = game.GetCurrentPlayer();
-//    Player* opPlayer = game.GetOpponentPlayer();
-//    curPlayer->SetTotalMana(10);
-//    curPlayer->SetUsedMana(0);
-//    opPlayer->SetTotalMana(10);
-//    opPlayer->SetUsedMana(0);
-//
-//    auto curHero = curPlayer->GetHero();
-//    auto opHero = opPlayer->GetHero();
-//
-//    const auto card1 = Generic::DrawCard(
-//        curPlayer, Cards::FindCardByName("Vulpera Toxinblade"));
-//    const auto card2 = Generic::DrawCard(
-//        curPlayer, Cards::FindCardByName("Self-Sharpening Sword"));
-//    const auto card3 =
-//        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
-//
-//    game.Process(curPlayer, PlayCardTask::Minion(card1));
-//    CHECK_EQ(curHero->GetAttack(), 0);
-//
-//    game.Process(curPlayer, PlayCardTask::Weapon(card2));
-//    CHECK_EQ(curHero->GetAttack(), 3);
-//
-//    game.Process(curPlayer, AttackTask(curHero, opHero));
-//    CHECK_EQ(curHero->GetAttack(), 4);
-//    CHECK_EQ(opHero->GetHealth(), 27);
-//
-//    game.Process(curPlayer, HeroPowerTask());
-//    CHECK_EQ(curHero->GetAttack(), 3);
-//
-//    game.Process(curPlayer, EndTurnTask());
-//    game.ProcessUntil(Step::MAIN_ACTION);
-//
-//    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
-//    CHECK_EQ(curHero->GetAttack(), 1);
-//}
+TEST_CASE("[Rogue : Minion] - SCH_519 : Vulpera Toxinblade")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto curHero = curPlayer->GetHero();
+    auto opHero = opPlayer->GetHero();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Vulpera Toxinblade"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Self-Sharpening Sword"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHero->GetAttack(), 0);
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card2));
+    CHECK_EQ(curHero->GetAttack(), 3);
+
+    game.Process(curPlayer, AttackTask(curHero, opHero));
+    CHECK_EQ(curHero->GetAttack(), 4);
+    CHECK_EQ(opHero->GetHealth(), 27);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curHero->GetAttack(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
+    CHECK_EQ(curHero->GetAttack(), 1);
+}
 
 // ----------------------------------------- WEAPON - ROGUE
 // [SCH_622] Self-Sharpening Sword - COST:3

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -2682,6 +2682,47 @@ TEST_CASE("[Neutral : Spell] - SCH_270 : Primordial Studies")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [SCH_312] Tour Guide - COST:1 [ATK:1/HP:1]
+// - Set: SCHOLOMANCE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Your next Hero Power costs (0).
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SCH_312 : Tour Guide")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Tour Guide"));
+
+    CHECK_EQ(curPlayer->GetHero()->heroPower->GetCost(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->heroPower->GetCost(), 0);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curPlayer->GetHero()->heroPower->GetCost(), 2);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [SCH_313] Wretched Tutor - COST:4 [ATK:2/HP:5]
 // - Set: SCHOLOMANCE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -1668,6 +1668,60 @@ TEST_CASE("[Rogue : Spell] - SCH_706 : Plagiarize")
     CHECK_EQ(curHand[1]->card->name, "Blizzard");
 }
 
+// --------------------------------------- MINION - WARLOCK
+// [SCH_147] Boneweb Egg - COST:2 [ATK:0/HP:2]
+// - Set: SCHOLOMANCE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Summon two 2/1 Spiders.
+//       If you discard this, trigger its <b>Deathrattle</b>.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// - InvisibleDeathrattle = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - SCH_147 : Boneweb Egg")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Boneweb Egg"));
+    [[maybe_unused]] const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Boneweb Egg"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Soulfire"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curHand.GetCount(), 2);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card1));
+    CHECK_EQ(curField.GetCount(), 4);
+    CHECK_EQ(curHand.GetCount(), 0);
+    CHECK_EQ(curField[0]->card->name, "Boneweb Spider");
+    CHECK_EQ(curField[1]->card->name, "Boneweb Spider");
+    CHECK_EQ(curField[2]->card->name, "Boneweb Spider");
+    CHECK_EQ(curField[3]->card->name, "Boneweb Spider");
+}
+
 // ---------------------------------------- SPELL - WARLOCK
 // [SCH_158] Demonic Studies - COST:1
 // - Set: SCHOLOMANCE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -2682,6 +2682,61 @@ TEST_CASE("[Neutral : Spell] - SCH_270 : Primordial Studies")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [SCH_283] Manafeeder Panthara - COST:2 [ATK:2/HP:3]
+// - Race: Beast, Set: SCHOLOMANCE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you've used your Hero Power
+//       this turn, draw a card.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SCH_283 : Manafeeder Panthara")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Manafeeder Panthara"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Manafeeder Panthara"));
+
+    CHECK_EQ(curHand.GetCount(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curHand.GetCount(), 6);
+
+    game.Process(curPlayer, HeroPowerTask());
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curHand.GetCount(), 6);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [SCH_312] Tour Guide - COST:1 [ATK:1/HP:1]
 // - Set: SCHOLOMANCE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -2116,6 +2116,76 @@ TEST_CASE("[Demon Hunter : Minion] - SCH_355 : Shardshatter Mystic")
     CHECK_EQ(opField[0]->GetHealth(), 9);
 }
 
+// ------------------------------------ SPELL - DEMONHUNTER
+// [SCH_600] Demon Companion - COST:1
+// - Set: SCHOLOMANCE, Rarity: Rare
+// --------------------------------------------------------
+// Text: Summon a random Demon Companion.
+// --------------------------------------------------------
+// Entourage: SCH_600t1, SCH_600t2, SCH_600t3
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Spell] - SCH_600 : Demon Companion")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Demon Companion"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+
+    if (curField[1]->card->id == "SCH_600t1")
+    {
+        SUBCASE("Reffuh - SCH_600t1")
+        {
+            CHECK_EQ(curField[1]->GetAttack(), 2);
+            CHECK_EQ(curField[1]->GetHealth(), 1);
+            CHECK_EQ(curField[1]->HasCharge(), true);
+        }
+    }
+    else if (curField[1]->card->id == "SCH_600t2")
+    {
+        SUBCASE("Shima - SCH_600t2")
+        {
+            CHECK_EQ(curField[1]->GetAttack(), 2);
+            CHECK_EQ(curField[1]->GetHealth(), 2);
+            CHECK_EQ(curField[1]->HasTaunt(), true);
+        }
+    }
+    else
+    {
+        SUBCASE("Kolek - SCH_600t3")
+        {
+            CHECK_EQ(curField[1]->GetAttack(), 1);
+            CHECK_EQ(curField[1]->GetHealth(), 2);
+            CHECK_EQ(curField[0]->GetAttack(), 4);
+        }
+    }
+}
+
 // ----------------------------------- MINION - DEMONHUNTER
 // [SCH_704] Soulshard Lapidary - COST:5 [ATK:5/HP:5]
 // - Set: SCHOLOMANCE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -1026,6 +1026,70 @@ TEST_CASE("[Paladin : Spell] - SCH_524 : Shield of Honor")
 }
 
 // --------------------------------------- MINION - PALADIN
+// [SCH_526] Lord Barov - COST:3 [ATK:3/HP:2]
+// - Set: SCHOLOMANCE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Set the Health of all other minions to 1.
+//       <b>Deathrattle:</b> Deal 1 damage to all minions.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Minion] - SCH_526 : Lord Barov")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Lord Barov"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(opField[0]->GetHealth(), 12);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(opField[0]->GetHealth(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    game.Process(opPlayer, AttackTask(card3, card1));
+    CHECK_EQ(curField.GetCount(), 0);
+    CHECK_EQ(opField.GetCount(), 0);
+}
+
+// --------------------------------------- MINION - PALADIN
 // [SCH_532] Goody Two-Shields - COST:3 [ATK:4/HP:2]
 // - Set: SCHOLOMANCE, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -2752,6 +2752,72 @@ TEST_CASE("[Neutral : Spell] - SCH_270 : Primordial Studies")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [SCH_273] Ras Frostwhisper - COST:5 [ATK:3/HP:6]
+// - Set: SCHOLOMANCE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: At the end of your turn, deal 1 damage
+//       to all enemies (improved by <b>Spell Damage</b>).
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+// RefTag:
+// - SPELLPOWER = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SCH_273 : Ras Frostwhisper")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ras Frostwhisper"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ogre Magi"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 29);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField[0]->GetHealth(), 7);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
+    CHECK_EQ(opField[0]->GetHealth(), 5);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [SCH_283] Manafeeder Panthara - COST:2 [ATK:2/HP:3]
 // - Race: Beast, Set: SCHOLOMANCE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -1366,6 +1366,65 @@ TEST_CASE("[Rogue : Minion] - SCH_426 : Infiltrator Lilian")
     }
 }
 
+// ----------------------------------------- MINION - ROGUE
+// [SCH_519] Vulpera Toxinblade - COST:3 [ATK:3/HP:3]
+// - Set: SCHOLOMANCE, Rarity: Common
+// --------------------------------------------------------
+// Text: Your weapon has +2 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - AURA = 1
+// --------------------------------------------------------
+//TEST_CASE("[Rogue : Minion] - SCH_519 : Vulpera Toxinblade")
+//{
+//    GameConfig config;
+//    config.player1Class = CardClass::ROGUE;
+//    config.player2Class = CardClass::MAGE;
+//    config.startPlayer = PlayerType::PLAYER1;
+//    config.doFillDecks = true;
+//    config.autoRun = false;
+//
+//    Game game(config);
+//    game.Start();
+//    game.ProcessUntil(Step::MAIN_ACTION);
+//
+//    Player* curPlayer = game.GetCurrentPlayer();
+//    Player* opPlayer = game.GetOpponentPlayer();
+//    curPlayer->SetTotalMana(10);
+//    curPlayer->SetUsedMana(0);
+//    opPlayer->SetTotalMana(10);
+//    opPlayer->SetUsedMana(0);
+//
+//    auto curHero = curPlayer->GetHero();
+//    auto opHero = opPlayer->GetHero();
+//
+//    const auto card1 = Generic::DrawCard(
+//        curPlayer, Cards::FindCardByName("Vulpera Toxinblade"));
+//    const auto card2 = Generic::DrawCard(
+//        curPlayer, Cards::FindCardByName("Self-Sharpening Sword"));
+//    const auto card3 =
+//        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+//
+//    game.Process(curPlayer, PlayCardTask::Minion(card1));
+//    CHECK_EQ(curHero->GetAttack(), 0);
+//
+//    game.Process(curPlayer, PlayCardTask::Weapon(card2));
+//    CHECK_EQ(curHero->GetAttack(), 3);
+//
+//    game.Process(curPlayer, AttackTask(curHero, opHero));
+//    CHECK_EQ(curHero->GetAttack(), 4);
+//    CHECK_EQ(opHero->GetHealth(), 27);
+//
+//    game.Process(curPlayer, HeroPowerTask());
+//    CHECK_EQ(curHero->GetAttack(), 3);
+//
+//    game.Process(curPlayer, EndTurnTask());
+//    game.ProcessUntil(Step::MAIN_ACTION);
+//
+//    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
+//    CHECK_EQ(curHero->GetAttack(), 1);
+//}
+
 // ----------------------------------------- WEAPON - ROGUE
 // [SCH_622] Self-Sharpening Sword - COST:3
 // - Set: SCHOLOMANCE, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -2807,6 +2807,52 @@ TEST_CASE("[Neutral : Minion] - SCH_283 : Manafeeder Panthara")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [SCH_311] Animated Broomstick - COST:1 [ATK:1/HP:1]
+// - Set: SCHOLOMANCE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Rush</b>
+//       <b>Battlecry:</b> Give your other minions <b>Rush</b>.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SCH_311 : Animated Broomstick")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Animated Broomstick"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->HasRush(), false);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasRush(), true);
+    CHECK_EQ(curField[1]->HasRush(), true);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [SCH_312] Tour Guide - COST:1 [ATK:1/HP:1]
 // - Set: SCHOLOMANCE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -3472,6 +3472,66 @@ TEST_CASE("[Neutral : Minion] - SCH_522 : Steeldancer")
     CHECK_EQ(curField[3]->GetCost(), 4);
 }
 
+// --------------------------------------- MINION - NEUTRAL
+// [SCH_530] Sorcerous Substitute - COST:6 [ATK:6/HP:6]
+// - Set: SCHOLOMANCE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you have <b>Spell Damage</b>,
+//       summon a copy of this.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - SPELLPOWER = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SCH_530 : Sorcerous Substitute")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Sorcerous Substitute"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Sorcerous Substitute"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Kobold Geomancer"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    curPlayer->SetUsedMana(0);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 4);
+    CHECK_EQ(curField[2]->card->name, "Sorcerous Substitute");
+    CHECK_EQ(curField[3]->card->name, "Sorcerous Substitute");
+}
+
 // ---------------------------------------- SPELL - NEUTRAL
 // [SCH_623] Cutting Class - COST:5
 // - Set: SCHOLOMANCE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -1025,6 +1025,61 @@ TEST_CASE("[Paladin : Spell] - SCH_524 : Shield of Honor")
     CHECK_EQ(curField[0]->HasDivineShield(), true);
 }
 
+// --------------------------------------- MINION - PALADIN
+// [SCH_532] Goody Two-Shields - COST:3 [ATK:4/HP:2]
+// - Set: SCHOLOMANCE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Divine Shield</b>
+//       <b>Spellburst:</b> Gain <b>Divine Shield</b>.
+// --------------------------------------------------------
+// GameTag:
+// - DIVINE_SHIELD = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Minion] - SCH_532 : Goody Two-Shields")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Goody Two-Shields"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Redemption"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasSpellburst(), true);
+    CHECK_EQ(curField[0]->HasDivineShield(), true);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField[0]->HasDivineShield(), false);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curField[0]->HasSpellburst(), false);
+    CHECK_EQ(curField[0]->HasDivineShield(), true);
+}
+
 // ---------------------------------------- SPELL - PALADIN
 // [SCH_533] Commencement - COST:7
 // - Set: SCHOLOMANCE, Rarity: Rare
@@ -1039,7 +1094,7 @@ TEST_CASE("[Paladin : Spell] - SCH_524 : Shield of Honor")
 TEST_CASE("[Paladin : Spell] - SCH_533 : Commencement")
 {
     GameConfig config;
-    config.player1Class = CardClass::MAGE;
+    config.player1Class = CardClass::PALADIN;
     config.player2Class = CardClass::HUNTER;
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = false;

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -2316,6 +2316,56 @@ TEST_CASE("[Neutral : Minion] - SCH_145 : Desk Imp")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [SCH_160] Wandmaker - COST:2 [ATK:2/HP:2]
+// - Set: SCHOLOMANCE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Add a 1-Cost spell
+//       from your class to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SCH_160 : Wandmaker")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& opHand = *(opPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wandmaker"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wandmaker"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->IsCardClass(CardClass::WARRIOR), true);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(opHand.GetCount(), 2);
+    CHECK_EQ(opHand[1]->card->IsCardClass(CardClass::MAGE), true);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [SCH_162] Vectus - COST:5 [ATK:4/HP:4]
 // - Set: SCHOLOMANCE, Rarity: Legendary
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -2117,6 +2117,61 @@ TEST_CASE("[Demon Hunter : Minion] - SCH_355 : Shardshatter Mystic")
 }
 
 // ------------------------------------ SPELL - DEMONHUNTER
+// [SCH_422] Double Jump - COST:1
+// - Set: SCHOLOMANCE, Rarity: Common
+// --------------------------------------------------------
+// Text: Draw an <b>Outcast</b> card from your deck.
+// --------------------------------------------------------
+// RefTag:
+// - OUTCAST = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Spell] - SCH_422 : Double Jump")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::ROGUE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 30; ++i)
+    {
+        config.player1Deck[i] = (i < 5)
+                                    ? Cards::FindCardByName("Eye Beam")
+                                    : Cards::FindCardByName("Faerie Dragon");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curDeck = *(curPlayer->GetDeckZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Double Jump"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Double Jump"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curDeck.GetCount(), 25);
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(curHand[5]->card->name, "Eye Beam");
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curDeck.GetCount(), 25);
+    CHECK_EQ(curHand.GetCount(), 5);
+}
+
+// ------------------------------------ SPELL - DEMONHUNTER
 // [SCH_600] Demon Companion - COST:1
 // - Set: SCHOLOMANCE, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -2873,6 +2873,70 @@ TEST_CASE("[Neutral : Minion] - SCH_245 : Steward of Scrolls")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 23);
 }
 
+// --------------------------------------- MINION - NEUTRAL
+// [SCH_248] Pen Flinger - COST:1 [ATK:1/HP:1]
+// - Set: SCHOLOMANCE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Deal 1 damage.
+//       <b>Spellburst:</b> Return this to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SCH_248 : Pen Flinger")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto opHero = opPlayer->GetHero();
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Pen Flinger"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Redemption"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Equality"));
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card1, opHero));
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(opHero->GetHealth(), 29);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(curHand[5]->card->name, "Pen Flinger");
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(curHand[5], opHero));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(opHero->GetHealth(), 28);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->card->name, "Pen Flinger");
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(curHand[4], opHero));
+    CHECK_EQ(curHand.GetCount(), 4);
+    CHECK_EQ(opHero->GetHealth(), 27);
+}
+
 // --------------------------------------- WEAPON - NEUTRAL
 // [SCH_259] Sphere of Sapience - COST:1
 // - Set: SCHOLOMANCE, Rarity: Legendary


### PR DESCRIPTION
This This revision includes:
- Implement 13 SCHOLOMANCE cards
  - Boneweb Egg (SCH_147)
  - Wandmaker (SCH_160)
  - Pen Flinger (SCH_248)
  - Ras Frostwhisper (SCH_273)
  - Manafeeder Panthara (SCH_283)
  - Animated Broomstick (SCH_311)
  - Tour Guide (SCH_312)
  - Double Jump (SCH_422)
  - Vulpera Toxinblade (SCH_519)
  - Lord Barov (SCH_526)
  - Sorcerous Substitute (SCH_530)
  - Goody Two-Shields (SCH_532)
  - Demon Companion (SCH_600)
- Add methods
  - IsOutcastCard(): SelfCondition wrapper for checking the entity is outcast card
  - GetNativeGameTag(): Returns the value of native game tag
  - SetNativeGameTag(): Sets the value of game tag to the card
  - OnDiscardTrigger(): Callback for trigger when a card is discarded from hand
- Fix codes
  - Correct index of the value of aura effects
  - Add missing minor typos in comment
  - Replace code to call setter/getter of game tag in method 'Effect::ApplyTo()' and 'Effect::RemoveFrom()'
- Refactor codes
  - Refactor unit test code of the card 'Animal Companion' (NEW1_031)
  - Change code to allow 'GameTag::ATK' for weapon
  - Add code to process 'AuraType::WEAPON'
    - Add variable 'weaponAuras'
    - Add code to process auras when weapon is added/removed
    - Add code to process 'AuraType::WEAPON'
  - Add code to reset 'GameTag::SPELLBURST'
- Add enum values of various enum classes
  - AuraEnums::HERO_POWER
  - TriggerType::DISCARD