### PR TITLE
Fix unit test failure of card 'King Phaoris' (ULD_304)

### DIFF
--- a/Tests/UnitTests/PlayMode/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/UldumCardsGenTests.cpp
@@ -7307,16 +7307,10 @@ TEST_CASE("[Neutral : Minion] - ULD_304 : King Phaoris")
 
     game.Process(curPlayer, PlayCardTask::Minion(card2));
     CHECK_EQ(curField.GetCount(), 7);
-    if (curField[1]->card->name == "Kirin Tor Tricaster")
-    {
-        CHECK_EQ(curField[5]->card->GetCost(), 4);
-        CHECK_EQ(curField[6]->card->GetCost(), 7);
-    }
-    else
-    {
-        CHECK_EQ(curField[5]->card->GetCost(), 3);
-        CHECK_EQ(curField[6]->card->GetCost(), 6);
-    }
+    CHECK_EQ(curField[5]->card->GetCost(),
+             curField[1]->card->name == "Kirin Tor Tricaster" ? 4 : 3);
+    CHECK_EQ(curField[6]->card->GetCost(),
+             curField[1]->card->name == "Kirin Tor Tricaster" ? 7 : 6);
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/PlayMode/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/UldumCardsGenTests.cpp
@@ -7307,8 +7307,16 @@ TEST_CASE("[Neutral : Minion] - ULD_304 : King Phaoris")
 
     game.Process(curPlayer, PlayCardTask::Minion(card2));
     CHECK_EQ(curField.GetCount(), 7);
-    CHECK_EQ(curField[5]->card->GetCost(), 3);
-    CHECK_EQ(curField[6]->card->GetCost(), 6);
+    if (curField[1]->card->name == "Kirin Tor Tricaster")
+    {
+        CHECK_EQ(curField[5]->card->GetCost(), 4);
+        CHECK_EQ(curField[6]->card->GetCost(), 7);
+    }
+    else
+    {
+        CHECK_EQ(curField[5]->card->GetCost(), 3);
+        CHECK_EQ(curField[6]->card->GetCost(), 6);
+    }
 }
 
 // --------------------------------------- MINION - NEUTRAL


### PR DESCRIPTION
This revision includes:
- Fix unit test failure of card 'King Phaoris' (ULD_304) (#560)
  - Consider card 'Kirin Tor Tricaster' (DAL_576)
    - <b>Spell Damage +3</b> Your spells cost (1) more.