### PR TITLE
Correct the logic of keyword 'Dormant'

### DIFF
--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -60,6 +60,10 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsDiscoverCard();
 
+    //! SelfCondition wrapper for checking the minion is awaken.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsAwaken();
+
     //! SelfCondition wrapper for checking the entity is destroyed.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsDead();

--- a/Includes/Rosetta/PlayMode/Models/Playable.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Playable.hpp
@@ -103,9 +103,9 @@ class Playable : public Entity
     //! \return The flag that indicates whether it has lifesteal.
     virtual bool HasLifesteal() const;
 
-    //! Returns the flag that indicates whether it is echo.
-    //! \return The flag that indicates whether it is echo.
-    bool IsEcho() const;
+    //! Returns the flag that indicates whether it has echo.
+    //! \return The flag that indicates whether it has echo.
+    bool HasEcho() const;
 
     //! Returns the flag that indicates whether it has corrupt.
     //! \return The flag that indicates whether it has corrupt.

--- a/Includes/Rosetta/PlayMode/Models/Playable.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Playable.hpp
@@ -107,6 +107,10 @@ class Playable : public Entity
     //! \return The flag that indicates whether it has echo.
     bool HasEcho() const;
 
+    //! Returns the flag that indicates whether it has dormant.
+    //! \return The flag that indicates whether it has dormant.
+    bool HasDormant() const;
+
     //! Returns the flag that indicates whether it has corrupt.
     //! \return The flag that indicates whether it has corrupt.
     bool HasCorrupt() const;

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
@@ -7,6 +7,7 @@
 #define ROSETTASTONE_PLAYMODE_COMPLEX_TASK_HPP
 
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/CustomTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DestroyTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeTask.hpp>
@@ -96,6 +97,29 @@ class ComplexTask
             EntityType::SOURCE));
 
         return ret;
+    }
+
+    //! Returns a list of task for increasing turn of the dormant.
+    static TaskList IncreaseDormantTurn()
+    {
+        return TaskList{ std::make_shared<SimpleTasks::CustomTask>(
+            []([[maybe_unused]] Player* player, Entity* source,
+               [[maybe_unused]] Playable* target) {
+                const int value =
+                    source->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2);
+                if (value <= source->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1))
+                {
+                    source->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2,
+                                       value + 1);
+                }
+
+                if (value + 1 ==
+                    source->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1))
+                {
+                    source->SetGameTag(GameTag::UNTOUCHABLE, 0);
+                    source->SetGameTag(GameTag::EXHAUSTED, 1);
+                }
+            }) };
     }
 };
 }  // namespace RosettaStone::PlayMode

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
@@ -7,9 +7,11 @@
 #define ROSETTASTONE_PLAYMODE_COMPLEX_TASK_HPP
 
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/ConditionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/CustomTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DestroyTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/FlagTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/MoveToGraveyardTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
@@ -99,10 +101,13 @@ class ComplexTask
         return ret;
     }
 
-    //! Returns a list of task for increasing turn of the dormant.
-    static TaskList IncreaseDormantTurn()
+    //! Returns a list of task for processing the keyword 'Dormant'.
+    //! \param awakenTasks A list of task to execute when the minion awakens.
+    static TaskList ProcessDormant(TaskList awakenTasks)
     {
-        return TaskList{ std::make_shared<SimpleTasks::CustomTask>(
+        TaskList ret;
+
+        ret.emplace_back(std::make_shared<SimpleTasks::CustomTask>(
             []([[maybe_unused]] Player* player, Entity* source,
                [[maybe_unused]] Playable* target) {
                 const int value =
@@ -119,7 +124,14 @@ class ComplexTask
                     source->SetGameTag(GameTag::UNTOUCHABLE, 0);
                     source->SetGameTag(GameTag::EXHAUSTED, 1);
                 }
-            }) };
+            }));
+        ret.emplace_back(std::make_shared<SimpleTasks::ConditionTask>(
+            EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                    SelfCondition::IsAwaken()) }));
+        ret.emplace_back(std::make_shared<SimpleTasks::FlagTask>(
+            true, std::move(awakenTasks)));
+
+        return ret;
     }
 };
 }  // namespace RosettaStone::PlayMode

--- a/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
@@ -142,6 +142,7 @@ void PlayCard(Player* player, Playable* source, Character* target, int fieldPos,
     player->game->taskQueue.EndEvent();
     player->game->ProcessDestroyAndUpdateAura();
 
+    // Process echo card
     if (hasEcho)
     {
         if (const auto spell = dynamic_cast<Spell*>(source);
@@ -298,6 +299,12 @@ void PlayMinion(Player* player, Minion* minion, Character* target, int fieldPos,
         (handPos == 0 || handPos == player->GetHandZone()->GetCount()))
     {
         minion->ActivateTask(PowerType::OUTCAST, target);
+    }
+
+    // Check card has dormant
+    if (minion->HasDormant())
+    {
+        minion->SetGameTag(GameTag::UNTOUCHABLE, 1);
     }
 
     // Check card has overload

--- a/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
@@ -54,7 +54,7 @@ void PlayCard(Player* player, Playable* source, Character* target, int fieldPos,
                             tempUsed);
     }
 
-    const bool isEcho = source->IsEcho();
+    const bool hasEcho = source->HasEcho();
 
     // Process keyword 'Corrupt'
     for (auto& playable : player->GetHandZone()->GetAll())
@@ -142,7 +142,7 @@ void PlayCard(Player* player, Playable* source, Character* target, int fieldPos,
     player->game->taskQueue.EndEvent();
     player->game->ProcessDestroyAndUpdateAura();
 
-    if (isEcho)
+    if (hasEcho)
     {
         if (const auto spell = dynamic_cast<Spell*>(source);
             spell == nullptr || !spell->IsCountered())

--- a/Sources/Rosetta/PlayMode/Actions/Summon.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Summon.cpp
@@ -18,6 +18,12 @@ void Summon(Minion* minion, int fieldPos, Entity* summoner)
 
     minion->player->GetFieldZone()->Add(minion, fieldPos);
 
+    // Check card has dormant
+    if (minion->HasDormant())
+    {
+        minion->SetGameTag(GameTag::UNTOUCHABLE, 1);
+    }
+
     game->UpdateAura();
 
     game->summonedMinions.emplace_back(minion);

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -530,6 +530,11 @@ void BlackTempleCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // Text: <b>Dormant</b> for 2 turns.
     //       When this awakens, deal 2 damage to all enemy minions.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
+    power.GetTrigger()->tasks = { ComplexTask::ProcessDormant(TaskList{
+        std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 2) }) };
+    cards.emplace("BT_004", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [BT_006] Evocation - COST:2
@@ -540,6 +545,7 @@ void BlackTempleCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
+    // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
     // [BT_014] Starscryer - COST:2 [ATK:3/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -996,22 +996,7 @@ void BlackTempleCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
-    power.GetTrigger()->tasks = { std::make_shared<CustomTask>(
-        []([[maybe_unused]] Player* player, Entity* source,
-           [[maybe_unused]] Playable* target) {
-            const int value =
-                source->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2);
-            if (value <= source->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1))
-            {
-                source->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, value + 1);
-            }
-
-            if (value + 1 == source->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1))
-            {
-                source->SetGameTag(GameTag::UNTOUCHABLE, 0);
-                source->SetGameTag(GameTag::EXHAUSTED, 1);
-            }
-        }) };
+    power.GetTrigger()->tasks = { ComplexTask::IncreaseDormantTurn() };
     cards.emplace("BT_258", CardDef(power));
 
     // ---------------------------------------- MINION - PRIEST
@@ -2346,22 +2331,7 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
-    power.GetTrigger()->tasks = { std::make_shared<CustomTask>(
-        []([[maybe_unused]] Player* player, Entity* source,
-           [[maybe_unused]] Playable* target) {
-            const int value =
-                source->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2);
-            if (value <= source->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1))
-            {
-                source->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, value + 1);
-            }
-
-            if (value + 1 == source->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1))
-            {
-                source->SetGameTag(GameTag::UNTOUCHABLE, 0);
-                source->SetGameTag(GameTag::EXHAUSTED, 1);
-            }
-        }) };
+    power.GetTrigger()->tasks = { ComplexTask::IncreaseDormantTurn() };
     cards.emplace("BT_156", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -996,7 +996,7 @@ void BlackTempleCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
-    power.GetTrigger()->tasks = { ComplexTask::IncreaseDormantTurn() };
+    power.GetTrigger()->tasks = { ComplexTask::ProcessDormant(TaskList{}) };
     cards.emplace("BT_258", CardDef(power));
 
     // ---------------------------------------- MINION - PRIEST
@@ -2331,7 +2331,7 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
-    power.GetTrigger()->tasks = { ComplexTask::IncreaseDormantTurn() };
+    power.GetTrigger()->tasks = { ComplexTask::ProcessDormant(TaskList{}) };
     cards.emplace("BT_156", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -995,17 +995,13 @@ void BlackTempleCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // - TAUNT = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(
-        EntityType::SOURCE, GameTag::UNTOUCHABLE, 1));
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(
-        EntityType::SOURCE, GameTag::TAG_SCRIPT_DATA_NUM_1, 2));
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
     power.GetTrigger()->tasks = { std::make_shared<CustomTask>(
         []([[maybe_unused]] Player* player, Entity* source,
            [[maybe_unused]] Playable* target) {
             const int value =
                 source->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2);
-            if (value <= 2)
+            if (value <= source->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1))
             {
                 source->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, value + 1);
             }
@@ -2349,17 +2345,13 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - RUSH = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(
-        EntityType::SOURCE, GameTag::UNTOUCHABLE, 1));
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(
-        EntityType::SOURCE, GameTag::TAG_SCRIPT_DATA_NUM_1, 2));
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
     power.GetTrigger()->tasks = { std::make_shared<CustomTask>(
         []([[maybe_unused]] Player* player, Entity* source,
            [[maybe_unused]] Playable* target) {
             const int value =
                 source->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2);
-            if (value <= 2)
+            if (value <= source->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1))
             {
                 source->SetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2, value + 1);
             }

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -77,6 +77,21 @@ SelfCondition SelfCondition::IsGalakrondHero()
         [](Playable* playable) { return playable->card->IsGalakrond(); });
 }
 
+SelfCondition SelfCondition::IsAwaken()
+{
+    return SelfCondition([](Playable* playable) {
+        const auto minion = dynamic_cast<Minion*>(playable);
+        if (minion)
+        {
+            return minion->HasDormant() &&
+                   minion->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1) ==
+                       minion->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2);
+        }
+
+        return false;
+    });
+}
+
 SelfCondition SelfCondition::IsDead()
 {
     return SelfCondition(

--- a/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
@@ -28,6 +28,8 @@ void CardLoader::Load(std::vector<Card*>& cards)
     cards.reserve(j.size());
 
     std::regex spellburstRegex("([<b>]*<b>Spellburst[</b>]*:</b>)");
+    std::regex dormantRegex("<b>Dormant</b>");
+    std::regex dormantTurnRegex("for ([[:digit:]]) turns");
     std::smatch values;
 
     for (auto& cardData : j)
@@ -171,6 +173,16 @@ void CardLoader::Load(std::vector<Card*>& cards)
         if (std::regex_search(text, values, spellburstRegex))
         {
             card->gameTags[GameTag::SPELLBURST] = 1;
+        }
+        if (std::regex_search(text, values, dormantRegex))
+        {
+            card->gameTags[GameTag::DORMANT] = 1;
+
+            if (std::regex_search(text, values, dormantTurnRegex))
+            {
+                card->gameTags[GameTag::TAG_SCRIPT_DATA_NUM_1] =
+                    std::stoi(values[1].str());
+            }
         }
 
         // NOTE: Runic Carvings (SCH_612) has GameTag::OVERLOAD

--- a/Sources/Rosetta/PlayMode/Models/Playable.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Playable.cpp
@@ -144,6 +144,11 @@ bool Playable::HasEcho() const
     return GetGameTag(GameTag::ECHO) == 1;
 }
 
+bool Playable::HasDormant() const
+{
+    return GetGameTag(GameTag::DORMANT) == 1;
+}
+
 bool Playable::HasCorrupt() const
 {
     return GetGameTag(GameTag::CORRUPT) == 1;

--- a/Sources/Rosetta/PlayMode/Models/Playable.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Playable.cpp
@@ -139,7 +139,7 @@ bool Playable::HasLifesteal() const
     return GetGameTag(GameTag::LIFESTEAL) == 1;
 }
 
-bool Playable::IsEcho() const
+bool Playable::HasEcho() const
 {
     return GetGameTag(GameTag::ECHO) == 1;
 }

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -479,6 +479,89 @@ TEST_CASE("[Mage : Spell] - BT_003 : Netherwind Portal")
 }
 
 // ------------------------------------------ MINION - MAGE
+// [BT_004] Imprisoned Observer - COST:3 [ATK:4/HP:5]
+// - Race: Demon, Set: BLACK_TEMPLE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Dormant</b> for 2 turns.
+//       When this awakens, deal 2 damage to all enemy minions.
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - BT_004 : Imprisoned Observer")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Imprisoned Observer"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1), 2);
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 0);
+    CHECK_EQ(curField[0]->IsUntouchable(), true);
+    CHECK_EQ(curField[0]->CanAttack(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(opField.GetCount(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 1);
+    CHECK_EQ(curField[0]->IsUntouchable(), true);
+    CHECK_EQ(curField[0]->CanAttack(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 2);
+    CHECK_EQ(curField[0]->IsUntouchable(), false);
+    CHECK_EQ(curField[0]->CanAttack(), false);
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 10);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->CanAttack(), true);
+
+    game.Process(curPlayer, AttackTask(card1, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 26);
+}
+
+// ------------------------------------------ MINION - MAGE
 // [BT_014] Starscryer - COST:2 [ATK:3/HP:1]
 // - Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------


### PR DESCRIPTION
This revision includes:
- Correct the logic of keyword 'Dormant' (#543)
  - Add methods
    - HasDormant(): Returns the flag that indicates whether it has dormant
    - IsAwaken(): SelfCondition wrapper for checking the minion is awaken
    - ProcessDormant(): Returns a list of task for processing the keyword 'Dormant'
  - Add code to check card has dormant
  - Add code to prase 'GameTag::DORMANT' and related turn value
  - Implement card 'Imprisoned Observer' (BT_004)
- Change the name of method 'IsEcho()' to 'HasEcho()'