### PR TITLE
Implement 15 BLACK_TEMPLE cards

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -958,14 +958,14 @@ Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
 BLACK_TEMPLE | BT_002 | Incanter's Flow | O
 BLACK_TEMPLE | BT_003 | Netherwind Portal | O
-BLACK_TEMPLE | BT_004 | Imprisoned Observer |  
+BLACK_TEMPLE | BT_004 | Imprisoned Observer | O
 BLACK_TEMPLE | BT_006 | Evocation |  
 BLACK_TEMPLE | BT_008 | Rustsworn Initiate | O
-BLACK_TEMPLE | BT_009 | Imprisoned Sungill |  
+BLACK_TEMPLE | BT_009 | Imprisoned Sungill | O
 BLACK_TEMPLE | BT_010 | Felfin Navigator | O
 BLACK_TEMPLE | BT_011 | Libram of Justice | O
 BLACK_TEMPLE | BT_014 | Starscryer | O
-BLACK_TEMPLE | BT_018 | Underlight Angling Rod |  
+BLACK_TEMPLE | BT_018 | Underlight Angling Rod | O
 BLACK_TEMPLE | BT_019 | Murgur Murgurgle |  
 BLACK_TEMPLE | BT_020 | Aldor Attendant |  
 BLACK_TEMPLE | BT_021 | Font of Power |  
@@ -987,21 +987,21 @@ BLACK_TEMPLE | BT_114 | Shattered Rumbler | O
 BLACK_TEMPLE | BT_115 | Marshspawn | O
 BLACK_TEMPLE | BT_117 | Bladestorm | O
 BLACK_TEMPLE | BT_120 | Warmaul Challenger | O
-BLACK_TEMPLE | BT_121 | Imprisoned Gan'arg |  
+BLACK_TEMPLE | BT_121 | Imprisoned Gan'arg | O
 BLACK_TEMPLE | BT_123 | Kargath Bladefist | O
 BLACK_TEMPLE | BT_124 | Corsair Cache | O
 BLACK_TEMPLE | BT_126 | Teron Gorefiend |  
-BLACK_TEMPLE | BT_127 | Imprisoned Satyr |  
+BLACK_TEMPLE | BT_127 | Imprisoned Satyr | O
 BLACK_TEMPLE | BT_128 | Fungal Fortunes |  
 BLACK_TEMPLE | BT_129 | Germination |  
 BLACK_TEMPLE | BT_130 | Overgrowth | O
 BLACK_TEMPLE | BT_131 | Ysiel Windsinger | O
-BLACK_TEMPLE | BT_132 | Ironbark |  
-BLACK_TEMPLE | BT_133 | Marsh Hydra |  
-BLACK_TEMPLE | BT_134 | Bogbeam |  
+BLACK_TEMPLE | BT_132 | Ironbark | O
+BLACK_TEMPLE | BT_133 | Marsh Hydra | O
+BLACK_TEMPLE | BT_134 | Bogbeam | O
 BLACK_TEMPLE | BT_135 | Glowfly Swarm |  
 BLACK_TEMPLE | BT_136 | Archspore Msshi'fn | O
-BLACK_TEMPLE | BT_138 | Bloodboil Brute |  
+BLACK_TEMPLE | BT_138 | Bloodboil Brute | O
 BLACK_TEMPLE | BT_140 | Bonechewer Raider |  
 BLACK_TEMPLE | BT_155 | Scrapyard Colossus | O
 BLACK_TEMPLE | BT_156 | Imprisoned Vilefiend | O
@@ -1031,17 +1031,17 @@ BLACK_TEMPLE | BT_252 | Renew | O
 BLACK_TEMPLE | BT_253 | Psyche Split | O
 BLACK_TEMPLE | BT_254 | Sethekk Veilweaver |  
 BLACK_TEMPLE | BT_255 | Kael'thas Sunstrider |  
-BLACK_TEMPLE | BT_256 | Dragonmaw Overseer |  
+BLACK_TEMPLE | BT_256 | Dragonmaw Overseer | O
 BLACK_TEMPLE | BT_257 | Apotheosis | O
 BLACK_TEMPLE | BT_258 | Imprisoned Homunculus | O
 BLACK_TEMPLE | BT_262 | Dragonmaw Sentinel | O
 BLACK_TEMPLE | BT_291 | Apexis Blast | O
 BLACK_TEMPLE | BT_292 | Hand of A'dal | O
 BLACK_TEMPLE | BT_300 | Hand of Gul'dan |  
-BLACK_TEMPLE | BT_301 | Nightshade Matron |  
-BLACK_TEMPLE | BT_302 | The Dark Portal |  
+BLACK_TEMPLE | BT_301 | Nightshade Matron | O
+BLACK_TEMPLE | BT_302 | The Dark Portal | O
 BLACK_TEMPLE | BT_304 | Enhanced Dreadlord | O
-BLACK_TEMPLE | BT_305 | Imprisoned Scrap Imp |  
+BLACK_TEMPLE | BT_305 | Imprisoned Scrap Imp | O
 BLACK_TEMPLE | BT_306 | Shadow Council |  
 BLACK_TEMPLE | BT_307 | Darkglare |  
 BLACK_TEMPLE | BT_309 | Kanrethad Ebonlocke |  
@@ -1057,7 +1057,7 @@ BLACK_TEMPLE | BT_491 | Spectral Sight | O
 BLACK_TEMPLE | BT_493 | Priestess of Fury | O
 BLACK_TEMPLE | BT_496 | Furious Felfin | O
 BLACK_TEMPLE | BT_509 | Fel Summoner | O
-BLACK_TEMPLE | BT_514 | Immolation Aura |  
+BLACK_TEMPLE | BT_514 | Immolation Aura | O
 BLACK_TEMPLE | BT_601 | Skull of Gul'dan | O
 BLACK_TEMPLE | BT_701 | Spymistress | O
 BLACK_TEMPLE | BT_702 | Ashtongue Slayer |  
@@ -1090,9 +1090,9 @@ BLACK_TEMPLE | BT_737 | Maiev Shadowsong |
 BLACK_TEMPLE | BT_761 | Coilfang Warlord | O
 BLACK_TEMPLE | BT_781 | Bulwark of Azzinoth |  
 BLACK_TEMPLE | BT_850 | Magtheridon |  
-BLACK_TEMPLE | BT_934 | Imprisoned Antaen |  
+BLACK_TEMPLE | BT_934 | Imprisoned Antaen | O
 
-- Progress: 48% (65 of 135 Cards)
+- Progress: 59% (80 of 135 Cards)
 
 ## Scholomance Academy
 

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -400,6 +400,12 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition HasNoNeutralCardsInDeck();
 
+    //! SelfCondition wrapper for checking the player has at least
+    //! \p num card(s) in hand.
+    //! \param num The number of card(s) to check.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition HasAtLeastCardInHand(int num);
+
     //! SelfCondition wrapper for checking it is left- or right-most card
     //! in your hand.
     //! \return Generated SelfCondition for intended purpose.

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -369,6 +369,12 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsOverloaded();
 
+    //! SelfCondition wrapper for checking the player has at least
+    //! \p num mana crystal.
+    //! \param num The number of mana crystal to check.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition HasAtLeastManaCrystal(int num);
+
     //! SelfCondition wrapper for checking the player's total mana is full.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsManaCrystalFull();

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
   * 28% Madness at the Darkmoon Faire (38 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
-  * 48% Ashes of Outland (65 of 135 cards)
+  * 59% Ashes of Outland (80 of 135 cards)
   * **100% Descent of Dragons (140 of 140 cards)**
   * **99% Saviors of Uldum (134 of 135 cards)**
     * Except 'Zephrys the Great' (ULD_003)

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -19,6 +19,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DiscardTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawRaceMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawTask.hpp>
@@ -1722,6 +1723,15 @@ void BlackTempleCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // Text: Draw a minion. If you have at least 8 cards in hand,
     //       it costs (5) less.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawMinionTask>(1, true));
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::HERO, SelfCondList{ std::make_shared<SelfCondition>(
+                              SelfCondition::HasAtLeastCardInHand(8)) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<AddEnchantmentTask>(
+                  "BT_302e", EntityType::STACK) }));
+    cards.emplace("BT_302", CardDef(power));
 
     // --------------------------------------- MINION - WARLOCK
     // [BT_304] Enhanced Dreadlord - COST:8 [ATK:5/HP:7]
@@ -3017,6 +3027,9 @@ void BlackTempleCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: Costs (5) less.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(std::make_shared<Enchant>(Effects::ReduceCost(5)));
+    cards.emplace("BT_302e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [BT_309e] Black Harvest - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -41,6 +41,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/TransformMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/WeaponTask.hpp>
+#include <Rosetta/PlayMode/Zones/FieldZone.hpp>
 
 using namespace RosettaStone::PlayMode::SimpleTasks;
 
@@ -1983,6 +1984,31 @@ void BlackTempleCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<AdaptiveCostEffect>([](Playable* playable) {
+        FieldZone* curField = playable->player->GetFieldZone();
+        FieldZone* opField = playable->player->opponent->GetFieldZone();
+        int count = 0;
+
+        for (auto& minion : curField->GetAll())
+        {
+            if (minion->GetDamage() > 0)
+            {
+                ++count;
+            }
+        }
+
+        for (auto& minion : opField->GetAll())
+        {
+            if (minion->GetDamage() > 0)
+            {
+                ++count;
+            }
+        }
+
+        return count;
+    }));
+    cards.emplace("BT_138", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [BT_140] Bonechewer Raider - COST:3 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -91,6 +91,14 @@ void BlackTempleCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // Text: <b>Dormant</b> for 2 turns. When this awakens,
     //       reduce the Cost of a random minion in your hand by (5).
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
+    power.GetTrigger()->tasks = { ComplexTask::ProcessDormant(TaskList{
+        std::make_shared<IncludeTask>(EntityType::HAND),
+        std::make_shared<FilterStackTask>(SelfCondList{
+            std::make_shared<SelfCondition>(SelfCondition::IsMinion()) }),
+        std::make_shared<AddEnchantmentTask>("BT_127e", EntityType::STACK) }) };
+    cards.emplace("BT_127", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [BT_128] Fungal Fortunes - COST:3
@@ -242,6 +250,9 @@ void BlackTempleCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
     // Text: Costs (5) less.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(std::make_shared<Enchant>(Effects::ReduceCost(5)));
+    cards.emplace("BT_127e", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [BT_132e] Ironbark - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -1031,6 +1031,14 @@ void BlackTempleCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->tasks = {
+        std::make_shared<IncludeTask>(EntityType::MINIONS_NOSOURCE),
+        std::make_shared<RandomTask>(EntityType::STACK, 1),
+        std::make_shared<AddEnchantmentTask>("BT_256e", EntityType::STACK)
+    };
+    cards.emplace("BT_256", CardDef(power));
 
     // ----------------------------------------- SPELL - PRIEST
     // [BT_257] Apotheosis - COST:3
@@ -1145,6 +1153,9 @@ void BlackTempleCardsGen::AddPriestNonCollect(
     // --------------------------------------------------------
     // Text: Stats increased.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(std::make_unique<Enchant>(Effects::AttackHealthN(2)));
+    cards.emplace("BT_256e", CardDef(power));
 
     // ----------------------------------- ENCHANTMENT - PRIEST
     // [BT_257e] Apotheosis - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -144,6 +144,20 @@ void BlackTempleCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("BT_132e", EntityType::TARGET));
+    power.AddAura(std::make_shared<AdaptiveCostEffect>(
+        []([[maybe_unused]] Playable* playable) { return 0; },
+        EffectOperator::SET, SelfCondition::HasAtLeastManaCrystal(7)));
+    cards.emplace(
+        "BT_132",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ----------------------------------------- MINION - DRUID
     // [BT_133] Marsh Hydra - COST:7 [ATK:7/HP:7]
@@ -222,6 +236,9 @@ void BlackTempleCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
     // Text: +1/+3 and <b>Taunt</b>.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("BT_132e"));
+    cards.emplace("BT_132e", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [BT_135t] Glowfly - COST:2 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -29,6 +29,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeAdjacentTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ManaCrystalTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomCardTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ReturnHandTask.hpp>
@@ -754,6 +755,15 @@ void BlackTempleCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->tasks = {
+        std::make_shared<RandomCardTask>(CardType::MINION, CardClass::INVALID,
+                                         Race::MURLOC),
+        std::make_shared<AddStackToTask>(EntityType::HAND)
+    };
+    cards.emplace("BT_018", CardDef(power));
 
     // --------------------------------------- MINION - PALADIN
     // [BT_019] Murgur Murgurgle - COST:2 [ATK:2/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -2283,6 +2283,17 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // Text: <b>Dormant</b> for 2 turns. When this awakens,
     //       deal 10 damage randomly split among all enemies.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
+    power.GetTrigger()->tasks = { ComplexTask::ProcessDormant(
+        TaskList{ std::make_shared<EnqueueTask>(
+            TaskList{ std::make_shared<FilterStackTask>(
+                          SelfCondList{ std::make_shared<SelfCondition>(
+                              SelfCondition::IsNotDead()) }),
+                      std::make_shared<RandomTask>(EntityType::ENEMIES, 1),
+                      std::make_shared<DamageTask>(EntityType::STACK, 1) },
+            10, false) }) };
+    cards.emplace("BT_934", CardDef(power));
 }
 
 void BlackTempleCardsGen::AddDemonHunterNonCollect(

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -14,6 +14,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AttackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ConditionTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/ConsecutiveDamageTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/CustomTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.hpp>
@@ -2241,6 +2242,10 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 1 damage to all minions twice.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConsecutiveDamageTask>(
+        EntityType::ALL_MINIONS, std::vector<int>{ 1, 1 }, true));
+    cards.emplace("BT_514", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [BT_601] Skull of Gul'dan - COST:6

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -164,6 +164,20 @@ void BlackTempleCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // Text: Deal 3 damage to a minion.
     //       Costs (0) if you have at least 7 Mana Crystals.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
+    power.AddAura(std::make_shared<AdaptiveCostEffect>(
+        []([[maybe_unused]] Playable* playable) { return 0; },
+        EffectOperator::SET, SelfCondition::HasAtLeastManaCrystal(7)));
+    cards.emplace(
+        "BT_134",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ------------------------------------------ SPELL - DRUID
     // [BT_135] Glowfly Swarm - COST:5

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -17,6 +17,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ConsecutiveDamageTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/CustomTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DiscardTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawRaceMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp>
@@ -1708,6 +1709,10 @@ void BlackTempleCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DiscardTask>(1, DiscardType::HIGHEST_COST));
+    cards.emplace("BT_301", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [BT_302] The Dark Portal - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -172,6 +172,14 @@ void BlackTempleCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - RUSH = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    power.GetTrigger()->tasks = { std::make_shared<RandomMinionTask>(TagValues{
+                                      { GameTag::COST, 8, RelaSign::EQ } }),
+                                  std::make_shared<AddStackToTask>(
+                                      EntityType::HAND) };
+    cards.emplace("BT_133", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [BT_134] Bogbeam - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -723,6 +723,12 @@ void BlackTempleCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // Text: <b>Dormant</b> for 2 turns. When this awakens,
     //       summon two 1/1 Murlocs.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
+    power.GetTrigger()->tasks = { ComplexTask::ProcessDormant(TaskList{
+        std::make_shared<SummonTask>("BT_009t", 1, SummonSide::LEFT),
+        std::make_shared<SummonTask>("BT_009t", 1, SummonSide::RIGHT) }) };
+    cards.emplace("BT_009", CardDef(power));
 
     // ---------------------------------------- SPELL - PALADIN
     // [BT_011] Libram of Justice - COST:5
@@ -858,6 +864,9 @@ void BlackTempleCardsGen::AddPaladinNonCollect(
     // [BT_009t] Sungill Streamrunner - COST:1 [ATK:1/HP:1]
     // - Race: Murloc, Set: BLACK_TEMPLE
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("BT_009t", CardDef(power));
 
     // --------------------------------------- WEAPON - PALADIN
     // [BT_011t] Overdue Justice - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -1915,6 +1915,11 @@ void BlackTempleCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // Text: <b>Dormant</b> for 2 turns.
     //       When this awakens, equip a 3/2 Axe.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
+    power.GetTrigger()->tasks = { ComplexTask::ProcessDormant(
+        TaskList{ std::make_shared<WeaponTask>("CS2_106") }) };
+    cards.emplace("BT_121", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [BT_123] Kargath Bladefist - COST:4 [ATK:4/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -1724,6 +1724,13 @@ void BlackTempleCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // Text: <b>Dormant</b> for 2 turns. When this awakens,
     //       give all minions in your hand +2/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
+    power.GetTrigger()->tasks = { ComplexTask::ProcessDormant(
+        TaskList{ std::make_shared<AddEnchantmentTask>(
+            "BT_305e", EntityType::HAND, false, false,
+            SelfCondition::IsMinion()) }) };
+    cards.emplace("BT_305", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [BT_306] Shadow Council - COST:1
@@ -1780,6 +1787,9 @@ void BlackTempleCardsGen::AddWarlockNonCollect(
     // --------------------------------------------------------
     // Text: +2/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("BT_305e"));
+    cards.emplace("BT_305e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - WARLOCK
     // [BT_306e] Ritual Summons - COST:0

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -832,6 +832,13 @@ SelfCondition SelfCondition::HasNoNeutralCardsInDeck()
     });
 }
 
+SelfCondition SelfCondition::HasAtLeastCardInHand(int num)
+{
+    return SelfCondition([num](Playable* playable) {
+        return playable->player->GetHandZone()->GetCount() >= num;
+    });
+}
+
 SelfCondition SelfCondition::IsLeftOrRightMostCardInHand()
 {
     return SelfCondition([](Playable* playable) {

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -749,6 +749,13 @@ SelfCondition SelfCondition::IsOverloaded()
     });
 }
 
+SelfCondition SelfCondition::HasAtLeastManaCrystal(int num)
+{
+    return SelfCondition([num](Playable* playable) {
+        return playable->player->GetTotalMana() >= num;
+    });
+}
+
 SelfCondition SelfCondition::IsManaCrystalFull()
 {
     return SelfCondition([](Playable* playable) {

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -19,6 +19,68 @@ using namespace PlayMode;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ----------------------------------------- MINION - DRUID
+// [BT_127] Imprisoned Satyr - COST:3 [ATK:3/HP:3]
+// - Race: Demon, Set: BLACK_TEMPLE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Dormant</b> for 2 turns. When this awakens,
+//       reduce the Cost of a random minion in your hand by (5).
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - BT_127 : Imprisoned Satyr")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Imprisoned Satyr"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1), 2);
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 0);
+    CHECK_EQ(curField[0]->IsUntouchable(), true);
+    CHECK_EQ(curField[0]->CanAttack(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 1);
+    CHECK_EQ(curField[0]->IsUntouchable(), true);
+    CHECK_EQ(curField[0]->CanAttack(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 2);
+    CHECK_EQ(curField[0]->IsUntouchable(), false);
+    CHECK_EQ(curField[0]->CanAttack(), false);
+    CHECK_EQ(dynamic_cast<Minion*>(card2)->GetCost(), 4);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [BT_130] Overgrowth - COST:4
 // - Faction: Neutral, Set: Core, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -3090,6 +3090,51 @@ TEST_CASE("[Demon Hunter : Minion] - BT_509 : Fel Summoner")
 }
 
 // ------------------------------------ SPELL - DEMONHUNTER
+// [BT_514] Immolation Aura - COST:2
+// - Set: BLACK_TEMPLE, Rarity: Common
+// --------------------------------------------------------
+// Text: Deal 1 damage to all minions twice.
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Spell] - BT_514 : Immolation Aura")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Immolation Aura"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Hench-Clan Hogsteed"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Argent Commander"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[0]->HasDivineShield(), false);
+}
+
+// ------------------------------------ SPELL - DEMONHUNTER
 // [BT_601] Skull of Gul'dan - COST:6
 // - Set: BLACK_TEMPLE, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -2305,6 +2305,73 @@ TEST_CASE("[Warlock : Minion] - BT_304 : Enhanced Dreadlord")
     CHECK_EQ(curField[0]->HasLifesteal(), true);
 }
 
+// --------------------------------------- MINION - WARLOCK
+// [BT_305] Imprisoned Scrap Imp - COST:2 [ATK:3/HP:3]
+// - Race: Demon, Set: BLACK_TEMPLE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Dormant</b> for 2 turns. When this awakens,
+//       give all minions in your hand +2/+1.
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - BT_305 : Imprisoned Scrap Imp")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Imprisoned Scrap Imp"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1), 2);
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 0);
+    CHECK_EQ(curField[0]->IsUntouchable(), true);
+    CHECK_EQ(curField[0]->CanAttack(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 1);
+    CHECK_EQ(curField[0]->IsUntouchable(), true);
+    CHECK_EQ(curField[0]->CanAttack(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 2);
+    CHECK_EQ(curField[0]->IsUntouchable(), false);
+    CHECK_EQ(curField[0]->CanAttack(), false);
+    CHECK_EQ(dynamic_cast<Minion*>(card2)->GetAttack(), 5);
+    CHECK_EQ(dynamic_cast<Minion*>(card2)->GetHealth(), 2);
+    CHECK_EQ(dynamic_cast<Minion*>(card3)->GetAttack(), 6);
+    CHECK_EQ(dynamic_cast<Minion*>(card3)->GetHealth(), 13);
+}
+
 // ---------------------------------------- SPELL - WARRIOR
 // [BT_117] Bladestorm - COST:3
 // - Set: BLACK_TEMPLE, Rarity: Epic

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -1232,6 +1232,55 @@ TEST_CASE("[Preist : Spell] - BT_253 : Psyche Split")
     CHECK_EQ(curField[1]->GetHealth(), 3);
 }
 
+// ---------------------------------------- MINION - PRIEST
+// [BT_256] Dragonmaw Overseer - COST:3 [ATK:2/HP:2]
+// - Set: BLACK_TEMPLE, Rarity: Rare
+// --------------------------------------------------------
+// Text: At the end of your turn,
+//       give another friendly minion +2/+2.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Preist : Minion] - BT_256 : Dragonmaw Overseer")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Dragonmaw Overseer"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[1]->GetAttack(), 5);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+}
+
 // ----------------------------------------- SPELL - PRIEST
 // [BT_257] Apotheosis - COST:3
 // - Set: BLACK_TEMPLE, Rarity: Common
@@ -1265,12 +1314,12 @@ TEST_CASE("[Preist : Spell] - BT_257 : Apotheosis")
     opPlayer->SetTotalMana(10);
     opPlayer->SetUsedMana(0);
 
+    auto& curField = *(curPlayer->GetFieldZone());
+
     const auto card1 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Apotheosis"));
     const auto card2 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Loot Hoarder"));
-
-    auto& curField = *(curPlayer->GetFieldZone());
 
     game.Process(curPlayer, PlayCardTask::Minion(card2));
     CHECK_EQ(curField[0]->GetGameTag(GameTag::LIFESTEAL), 0);

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -2359,7 +2359,7 @@ TEST_CASE("[Warlock : Minion] - BT_301 : Nightshade Matron")
     config.player1Class = CardClass::WARLOCK;
     config.player2Class = CardClass::MAGE;
     config.startPlayer = PlayerType::PLAYER1;
-    config.doFillDecks = true;
+    config.doFillDecks = false;
     config.autoRun = false;
 
     Game game(config);
@@ -2378,9 +2378,9 @@ TEST_CASE("[Warlock : Minion] - BT_301 : Nightshade Matron")
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::FindCardByName("Nightshade Matron"));
     [[maybe_unused]] const auto card2 =
-        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
     [[maybe_unused]] const auto card3 =
-        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     CHECK_EQ(curHand.GetCount(), 1);

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -2387,6 +2387,63 @@ TEST_CASE("[Warlock : Minion] - BT_301 : Nightshade Matron")
     CHECK_EQ(curHand[0]->card->name, "Wolfrider");
 }
 
+// ---------------------------------------- SPELL - WARLOCK
+// [BT_302] The Dark Portal - COST:4
+// - Set: BLACK_TEMPLE, Rarity: Rare
+// --------------------------------------------------------
+// Text: Draw a minion. If you have at least 8 cards in hand,
+//       it costs (5) less.
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Spell] - BT_302 : The Dark Portal")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; ++i)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Malygos");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("The Dark Portal"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("The Dark Portal"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    [[maybe_unused]] const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    CHECK_EQ(curHand.GetCount(), 8);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curHand.GetCount(), 8);
+    CHECK_EQ(curHand[7]->GetCost(), 4);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curHand.GetCount(), 7);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curHand.GetCount(), 7);
+    CHECK_EQ(curHand[6]->GetCost(), 9);
+}
+
 // --------------------------------------- MINION - WARLOCK
 // [BT_304] Enhanced Dreadlord - COST:8 [ATK:5/HP:7]
 // - Race: Demon, Set: BLACK_TEMPLE, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -977,6 +977,53 @@ TEST_CASE("[Paladin : Spell] - BT_011 : Libram of Justice")
     CHECK_EQ(opField[0]->GetHealth(), 1);
 }
 
+// --------------------------------------- WEAPON - PALADIN
+// [BT_018] Underlight Angling Rod - COST:3
+// - Set: BLACK_TEMPLE, Rarity: Epic
+// --------------------------------------------------------
+// Text: After your Hero attacks,
+//       add a random Murloc to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Weapon] - BT_018 : Underlight Angling Rod")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Underlight Angling Rod"));
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    CHECK_EQ(curPlayer->GetHero()->HasWeapon(), true);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetAttack(), 3);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 2);
+
+    game.Process(curPlayer,
+                 AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->GetCardType(), CardType::MINION);
+    CHECK_EQ(curHand[0]->card->GetRace(), Race::MURLOC);
+}
+
 // ---------------------------------------- SPELL - PALADIN
 // [BT_024] Libram of Hope - COST:9
 // - Set: BLACK_TEMPLE, Rarity: Epic

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -2343,6 +2343,51 @@ TEST_CASE("[Warlock : Spell] - BT_199 : Unstable Felbolt")
 }
 
 // --------------------------------------- MINION - WARLOCK
+// [BT_301] Nightshade Matron - COST:4 [ATK:5/HP:5]
+// - Race: Demon, Set: BLACK_TEMPLE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Rush</b>
+//       <b>Battlecry:</b> Discard your highest Cost card.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - BT_301 : Nightshade Matron")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Nightshade Matron"));
+    [[maybe_unused]] const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+    [[maybe_unused]] const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->name, "Wolfrider");
+}
+
+// --------------------------------------- MINION - WARLOCK
 // [BT_304] Enhanced Dreadlord - COST:8 [ATK:5/HP:7]
 // - Race: Demon, Set: BLACK_TEMPLE, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -861,6 +861,68 @@ TEST_CASE("[Mage : Spell] - BT_291 : Apexis Blast")
     CHECK_EQ(curField[0]->card->GetCost(), 5);
 }
 
+// --------------------------------------- MINION - PALADIN
+// [BT_009] Imprisoned Sungill - COST:1 [ATK:2/HP:1]
+// - Race: Murloc, Set: BLACK_TEMPLE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Dormant</b> for 2 turns. When this awakens,
+//       summon two 1/1 Murlocs.
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Minion] - BT_009 : Imprisoned Sungill")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Imprisoned Sungill"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1), 2);
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 0);
+    CHECK_EQ(curField[0]->IsUntouchable(), true);
+    CHECK_EQ(curField[0]->CanAttack(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 1);
+    CHECK_EQ(curField[0]->IsUntouchable(), true);
+    CHECK_EQ(curField[0]->CanAttack(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[0]->card->name, "Sungill Streamrunner");
+    CHECK_EQ(curField[1]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 2);
+    CHECK_EQ(curField[1]->IsUntouchable(), false);
+    CHECK_EQ(curField[1]->CanAttack(), false);
+    CHECK_EQ(curField[2]->card->name, "Sungill Streamrunner");
+}
+
 // ---------------------------------------- SPELL - PALADIN
 // [BT_011] Libram of Justice - COST:5
 // - Set: BLACK_TEMPLE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -2474,6 +2474,68 @@ TEST_CASE("[Warrior : Minion] - BT_120 : Warmaul Challenger")
 }
 
 // --------------------------------------- MINION - WARRIOR
+// [BT_121] Imprisoned Gan'arg - COST:1 [ATK:2/HP:2]
+// - Race: Demon, Set: BLACK_TEMPLE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Dormant</b> for 2 turns.
+//       When this awakens, equip a 3/2 Axe.
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - BT_121 : Imprisoned Gan'arg")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Imprisoned Gan'arg"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1), 2);
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 0);
+    CHECK_EQ(curField[0]->IsUntouchable(), true);
+    CHECK_EQ(curField[0]->CanAttack(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 1);
+    CHECK_EQ(curField[0]->IsUntouchable(), true);
+    CHECK_EQ(curField[0]->CanAttack(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 2);
+    CHECK_EQ(curField[0]->IsUntouchable(), false);
+    CHECK_EQ(curField[0]->CanAttack(), false);
+    CHECK_EQ(curPlayer->GetHero()->HasWeapon(), true);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetAttack(), 3);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 2);
+}
+
+// --------------------------------------- MINION - WARRIOR
 // [BT_123] Kargath Bladefist - COST:4 [ATK:4/HP:4]
 // - Set: BLACK_TEMPLE, Rarity: LEGENDARY
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -2816,6 +2816,60 @@ TEST_CASE("[Warrior : Spell] - BT_124 : Corsair Cache")
     CHECK_EQ(dynamic_cast<Weapon*>(curHand[4])->GetDurability(), 3);
 }
 
+// --------------------------------------- MINION - WARRIOR
+// [BT_138] Bloodboil Brute - COST:7 [ATK:5/HP:8]
+// - Set: BLACK_TEMPLE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Rush</b> Costs (1) less for each damaged minion.
+// --------------------------------------------------------
+// GameTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - BT_138 : Bloodboil Brute")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    [[maybe_unused]] const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bloodboil Brute"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Sorcerer's Apprentice"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(card1->GetCost(), 7);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(card1->GetCost(), 7);
+
+    game.Process(opPlayer, HeroPowerTask(card3));
+    CHECK_EQ(card1->GetCost(), 6);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card2));
+    CHECK_EQ(card1->GetCost(), 5);
+}
+
 // ---------------------------------------- SPELL - WARRIOR
 // [BT_233] Sword and Board - COST:1
 // - Set: BLACK_TEMPLE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -115,6 +115,70 @@ TEST_CASE("[Druid : Minion] - BT_131 : Ysiel Windsinger")
 }
 
 // ------------------------------------------ SPELL - DRUID
+// [BT_132] Ironbark - COST:2
+// - Set: BLACK_TEMPLE, Rarity: Rare
+// --------------------------------------------------------
+// Text: Give a minion +1/+3 and <b>Taunt</b>.
+//       Costs (0) if you have at least 7 Mana Crystals.
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - BT_132 : Ironbark")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(6);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ironbark"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    CHECK_EQ(card1->GetCost(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(opField[0]->GetAttack(), 4);
+    CHECK_EQ(opField[0]->GetHealth(), 12);
+    CHECK_EQ(opField[0]->HasTaunt(), false);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card1->GetCost(), 0);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curPlayer->GetUsedMana(), 0);
+    CHECK_EQ(opField[0]->GetAttack(), 5);
+    CHECK_EQ(opField[0]->GetHealth(), 15);
+    CHECK_EQ(opField[0]->HasTaunt(), true);
+}
+
+// ------------------------------------------ SPELL - DRUID
 // [BT_134] Bogbeam - COST:3
 // - Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -3207,6 +3207,75 @@ TEST_CASE("[Demon Hunter : Minion] - BT_761 : Coilfang Warlord")
     CHECK_EQ(curField[0]->HasTaunt(), true);
 }
 
+// ----------------------------------- MINION - DEMONHUNTER
+// [BT_934] Imprisoned Antaen - COST:6 [ATK:10/HP:6]
+// - Race: Demon, Set: BLACK_TEMPLE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Dormant</b> for 2 turns. When this awakens,
+//       deal 10 damage randomly split among all enemies.
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - BT_934 : Imprisoned Antaen")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Imprisoned Antaen"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_1), 2);
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 0);
+    CHECK_EQ(curField[0]->IsUntouchable(), true);
+    CHECK_EQ(curField[0]->CanAttack(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    int totalHealth =
+        opPlayer->GetHero()->GetHealth() + opField[0]->GetHealth();
+    CHECK_EQ(totalHealth, 42);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 1);
+    CHECK_EQ(curField[0]->IsUntouchable(), true);
+    CHECK_EQ(curField[0]->CanAttack(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAG_SCRIPT_DATA_NUM_2), 2);
+    CHECK_EQ(curField[0]->IsUntouchable(), false);
+    CHECK_EQ(curField[0]->CanAttack(), false);
+    totalHealth = opPlayer->GetHero()->GetHealth() + opField[0]->GetHealth();
+    CHECK_EQ(totalHealth, 32);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [BT_008] Rustsworn Initiate - COST:2 [ATK:2/HP:2]
 // - Set: BLACK_TEMPLE, Rarity: Common


### PR DESCRIPTION
This This revision includes:
- Implement 15 BLACK_TEMPLE cards
  - Imprisoned Observer (BT_004)
  - Imprisoned Sungill (BT_009)
  - Underlight Angling Rod (BT_018)
  - Imprisoned Gan'arg (BT_121)
  - Imprisoned Satyr (BT_127)
  - Ironbark (BT_132)
  - Marsh Hydra (BT_133)
  - Bogbeam (BT_134)
  - Bloodboil Brute (BT_138)
  - Dragonmaw Overseer (BT_256)
  - Nightshade Matron (BT_301)
  - The Dark Portal (BT_302)
  - Imprisoned Scrap Imp (BT_305)
  - Immolation Aura (BT_514)
  - Imprisoned Antaen (BT_934)
- Add methods
  - HasAtLeastManaCrystal(): SelfCondition wrapper for checking the player has at least num mana crystal
  - HasAtLeastCardInHand(): SelfCondition wrapper for checking the player has at least num card(s) in hand