### PR TITLE
Implement 15 DARKMOON_FAIRE cards

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -1251,7 +1251,7 @@ DARKMOON_FAIRE | DMF_057 | Lunar Eclipse |
 DARKMOON_FAIRE | DMF_058 | Solar Eclipse |  
 DARKMOON_FAIRE | DMF_059 | Fizzy Elemental | O
 DARKMOON_FAIRE | DMF_060 | Umbral Owl |  
-DARKMOON_FAIRE | DMF_061 | Faire Arborist |  
+DARKMOON_FAIRE | DMF_061 | Faire Arborist | O
 DARKMOON_FAIRE | DMF_062 | Gyreworm |  
 DARKMOON_FAIRE | DMF_064 | Carousel Gryphon | O
 DARKMOON_FAIRE | DMF_065 | Banana Vendor | O
@@ -1288,8 +1288,8 @@ DARKMOON_FAIRE | DMF_106 | Occult Conjurer |
 DARKMOON_FAIRE | DMF_107 | Rigged Faire Game |  
 DARKMOON_FAIRE | DMF_108 | Deck of Lunacy |  
 DARKMOON_FAIRE | DMF_109 | Sayge, Seer of Darkmoon |  
-DARKMOON_FAIRE | DMF_110 | Fire Breather |  
-DARKMOON_FAIRE | DMF_111 | Man'ari Mosher |  
+DARKMOON_FAIRE | DMF_110 | Fire Breather | O
+DARKMOON_FAIRE | DMF_111 | Man'ari Mosher | O
 DARKMOON_FAIRE | DMF_113 | Free Admission |  
 DARKMOON_FAIRE | DMF_114 | Midway Maniac | O
 DARKMOON_FAIRE | DMF_115 | Revenant Rascal |  
@@ -1332,7 +1332,7 @@ DARKMOON_FAIRE | DMF_236 | Oh My Yogg! |
 DARKMOON_FAIRE | DMF_237 | Carnival Barker |  
 DARKMOON_FAIRE | DMF_238 | Hammer of the Naaru | O
 DARKMOON_FAIRE | DMF_240 | Lothraxion the Redeemed |  
-DARKMOON_FAIRE | DMF_241 | High Exarch Yrel |  
+DARKMOON_FAIRE | DMF_241 | High Exarch Yrel | O
 DARKMOON_FAIRE | DMF_244 | Day at the Faire | O
 DARKMOON_FAIRE | DMF_247 | Insatiable Felhound | O
 DARKMOON_FAIRE | DMF_248 | Felsteel Executioner |  
@@ -1341,7 +1341,7 @@ DARKMOON_FAIRE | DMF_254 | C'Thun, the Shattered |
 DARKMOON_FAIRE | DMF_511 | Foxy Fraud |  
 DARKMOON_FAIRE | DMF_512 | Cloak of Shadows |  
 DARKMOON_FAIRE | DMF_513 | Shadow Clone |  
-DARKMOON_FAIRE | DMF_514 | Ticket Master |  
+DARKMOON_FAIRE | DMF_514 | Ticket Master | O
 DARKMOON_FAIRE | DMF_515 | Swindle | O
 DARKMOON_FAIRE | DMF_516 | Grand Empress Shek'zara |  
 DARKMOON_FAIRE | DMF_517 | Sweet Tooth | O
@@ -1350,24 +1350,24 @@ DARKMOON_FAIRE | DMF_519 | Prize Plunderer |
 DARKMOON_FAIRE | DMF_520 | Parade Leader |  
 DARKMOON_FAIRE | DMF_521 | Sword Eater | O
 DARKMOON_FAIRE | DMF_522 | Minefield | O
-DARKMOON_FAIRE | DMF_523 | Bumper Car |  
+DARKMOON_FAIRE | DMF_523 | Bumper Car | O
 DARKMOON_FAIRE | DMF_524 | Ringmaster's Baton |  
 DARKMOON_FAIRE | DMF_525 | Ringmaster Whatley |  
-DARKMOON_FAIRE | DMF_526 | Stage Dive |  
+DARKMOON_FAIRE | DMF_526 | Stage Dive | O
 DARKMOON_FAIRE | DMF_528 | Tent Trasher |  
 DARKMOON_FAIRE | DMF_529 | E.T.C., God of Metal |  
 DARKMOON_FAIRE | DMF_530 | Feat of Strength |  
 DARKMOON_FAIRE | DMF_531 | Stage Hand | O
 DARKMOON_FAIRE | DMF_532 | Circus Amalgam | O
-DARKMOON_FAIRE | DMF_533 | Ring Matron |  
+DARKMOON_FAIRE | DMF_533 | Ring Matron | O
 DARKMOON_FAIRE | DMF_534 | Deck of Chaos |  
 DARKMOON_FAIRE | DMF_700 | Revolve |  
 DARKMOON_FAIRE | DMF_701 | Dunk Tank | O
 DARKMOON_FAIRE | DMF_702 | Stormstrike | O
 DARKMOON_FAIRE | DMF_703 | Pit Master | O
 DARKMOON_FAIRE | DMF_704 | Cagematch Custodian | O
-DARKMOON_FAIRE | DMF_705 | Whack-A-Gnoll Hammer |  
-DARKMOON_FAIRE | DMF_706 | Deathmatch Pavilion |  
+DARKMOON_FAIRE | DMF_705 | Whack-A-Gnoll Hammer | O
+DARKMOON_FAIRE | DMF_706 | Deathmatch Pavilion | O
 DARKMOON_FAIRE | DMF_707 | Magicfin |  
 DARKMOON_FAIRE | DMF_708 | Inara Stormcrash |  
 DARKMOON_FAIRE | DMF_709 | Grand Totem Eys'or |  
@@ -1375,5 +1375,40 @@ DARKMOON_FAIRE | DMF_730 | Moontouched Amulet | O
 DARKMOON_FAIRE | DMF_732 | Cenarion Ward |  
 DARKMOON_FAIRE | DMF_733 | Kiri, Chosen of Elune |  
 DARKMOON_FAIRE | DMF_734 | Greybough |  
+DARKMOON_FAIRE | YOP_001 | Illidari Studies |  
+DARKMOON_FAIRE | YOP_002 | Felsaber |  
+DARKMOON_FAIRE | YOP_003 | Luckysoul Hoarder |  
+DARKMOON_FAIRE | YOP_004 | Envoy Rustwix |  
+DARKMOON_FAIRE | YOP_005 | Barricade |  
+DARKMOON_FAIRE | YOP_006 | Hysteria |  
+DARKMOON_FAIRE | YOP_007 | Dark Inquisitor Xanesh |  
+DARKMOON_FAIRE | YOP_008 | Lightsteed |  
+DARKMOON_FAIRE | YOP_009 | Rally! |  
+DARKMOON_FAIRE | YOP_010 | Imprisoned Celestial |  
+DARKMOON_FAIRE | YOP_011 | Libram of Judgment |  
+DARKMOON_FAIRE | YOP_012 | Deathwarden |  
+DARKMOON_FAIRE | YOP_013 | Spiked Wheel |  
+DARKMOON_FAIRE | YOP_014 | Ironclad | O
+DARKMOON_FAIRE | YOP_015 | Nitroboost Poison |  
+DARKMOON_FAIRE | YOP_016 | Sparkjoy Cheat | O
+DARKMOON_FAIRE | YOP_017 | Shenanigans |  
+DARKMOON_FAIRE | YOP_018 | Keywarden Ivory |  
+DARKMOON_FAIRE | YOP_019 | Conjure Mana Biscuit |  
+DARKMOON_FAIRE | YOP_020 | Glacier Racer |  
+DARKMOON_FAIRE | YOP_021 | Imprisoned Phoenix | O
+DARKMOON_FAIRE | YOP_022 | Mistrunner | O
+DARKMOON_FAIRE | YOP_023 | Landslide | O
+DARKMOON_FAIRE | YOP_024 | Guidance |  
+DARKMOON_FAIRE | YOP_025 | Dreaming Drake |  
+DARKMOON_FAIRE | YOP_026 | Arbor Up |  
+DARKMOON_FAIRE | YOP_027 | Bola Shot |  
+DARKMOON_FAIRE | YOP_028 | Saddlemaster |  
+DARKMOON_FAIRE | YOP_029 | Resizing Pouch |  
+DARKMOON_FAIRE | YOP_030 | Felfire Deadeye |  
+DARKMOON_FAIRE | YOP_031 | Crabrider |  
+DARKMOON_FAIRE | YOP_032 | Armor Vendor |  
+DARKMOON_FAIRE | YOP_033 | Backfire |  
+DARKMOON_FAIRE | YOP_034 | Runaway Blackwing |  
+DARKMOON_FAIRE | YOP_035 | Moonfang |  
 
-- Progress: 28% (38 of 135 Cards)
+- Progress: 31% (53 of 170 Cards)

--- a/Includes/Rosetta/PlayMode/Cards/CardDef.hpp
+++ b/Includes/Rosetta/PlayMode/Cards/CardDef.hpp
@@ -67,6 +67,14 @@ class CardDef
     explicit CardDef(Power _power, std::map<PlayReq, int> _playReqs,
                      std::string _corruptCardID);
 
+    //! Constructs card def with given \p _power, \p _chooseCardIDs and
+    //! \p _corruptCardID.
+    //! \param _power The power data.
+    //! \param _chooseCardIDs The choose card IDs data.
+    //! \param _corruptCardID The card ID to change when 'Corrupt' is activated.
+    explicit CardDef(Power _power, std::vector<std::string> _chooseCardIDs,
+                     std::string _corruptCardID);
+
     //! Constructs card def with given \p _power, \p _playReqs,
     //! \p _chooseCardIDs and \p _entourages.
     //! \param _power The power data.

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -153,6 +153,11 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsControllingLackey();
 
+    //! SelfCondition wrapper for checking the player has secret card
+    //! in hand zone.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsHoldingSecret();
+
     //! SelfCondition wrapper for checking the player has entity
     //! with \p race in hand zone.
     //! \param race The race for checking.

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -121,6 +121,11 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsRace(Race race);
 
+    //! SelfCondition wrapper for checking race of entity is not \p race.
+    //! \param race The race for checking.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsNotRace(Race race);
+
     //! SelfCondition wrapper for checking there is the entity
     //! with \p race in field zone.
     //! \param race The race for checking.

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -206,6 +206,10 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsFrozen();
 
+    //! SelfCondition wrapper for checking the hero has armor.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition HasHeroArmor();
+
     //! SelfCondition wrapper for checking the entity has spellpower.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition HasSpellPower();

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.hpp
@@ -18,9 +18,10 @@ namespace RosettaStone::PlayMode::SimpleTasks
 class DrawStackTask : public ITask
 {
  public:
-    //! Constructs task with given \p amount.
+    //! Constructs task with given \p amount and \p addToStack.
     //! \param amount The amount to draw card.
-    explicit DrawStackTask(std::size_t amount);
+    //! \param addToStack A flag to store card to stack.
+    explicit DrawStackTask(std::size_t amount, bool addToStack = false);
 
  private:
     //! Processes task logic internally and returns meta data.
@@ -33,6 +34,7 @@ class DrawStackTask : public ITask
     std::unique_ptr<ITask> CloneImpl() override;
 
     std::size_t m_amount = 0;
+    bool m_addToStack = false;
 };
 }  // namespace RosettaStone::PlayMode::SimpleTasks
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Expansions
 
-  * 28% Madness at the Darkmoon Faire (38 of 135 cards)
+  * 31% Madness at the Darkmoon Faire (53 of 170 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 59% Ashes of Outland (80 of 135 cards)
   * **100% Descent of Dragons (140 of 140 cards)**

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1553,6 +1553,14 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // Text: Summon a 3/2 Duelist.
     //       If your hero attacked this turn, summon another.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("DMF_706t"));
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::HERO, SelfCondList{ std::make_shared<SelfCondition>(
+                              SelfCondition::IsAttackThisTurn()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<SummonTask>("DMF_706t") }));
+    cards.emplace("DMF_706", CardDef(power));
 
     // ---------------------------------------- MINION - SHAMAN
     // [DMF_707] Magicfin - COST:3 [ATK:3/HP:4]
@@ -1688,6 +1696,9 @@ void DarkmoonFaireCardsGen::AddShamanNonCollect(
     // [DMF_706t] Pavilion Duelist - COST:2 [ATK:3/HP:2]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_706t", CardDef(power));
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [DMF_708e] Storm Crashing - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1672,6 +1672,16 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - OVERLOAD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 1, true));
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsOverloaded()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS,
+                                                     1, true) }));
+    cards.emplace("YOP_023", CardDef(power));
 }
 
 void DarkmoonFaireCardsGen::AddShamanNonCollect(

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -14,6 +14,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawOpTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawRaceMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawWeaponTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueTask.hpp>
@@ -2051,6 +2052,13 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::DECK));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::HasRush()) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddPowerTask(std::make_shared<DrawStackTask>(1));
+    cards.emplace("DMF_526", CardDef(power, "DMF_526a"));
 
     // --------------------------------------- MINION - WARRIOR
     // [DMF_528] Tent Trasher - COST:5 [ATK:5/HP:5]
@@ -2149,6 +2157,15 @@ void DarkmoonFaireCardsGen::AddWarriorNonCollect(
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::DECK));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::HasRush()) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddPowerTask(std::make_shared<DrawStackTask>(1, true));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DMF_526e", EntityType::STACK));
+    cards.emplace("DMF_526a", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [DMF_526e] Bweeeoooow! - COST:0
@@ -2156,6 +2173,9 @@ void DarkmoonFaireCardsGen::AddWarriorNonCollect(
     // --------------------------------------------------------
     // Text: +2/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DMF_526e"));
+    cards.emplace("DMF_526e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [DMF_530e] So Strong! - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1836,6 +1836,10 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - DEATHRATTLE = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("DMF_533t", 2, SummonSide::DEATHRATTLE));
+    cards.emplace("DMF_533", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [DMF_534] Deck of Chaos - COST:6
@@ -1870,6 +1874,8 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 void DarkmoonFaireCardsGen::AddWarlockNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------- ENCHANTMENT - WARLOCK
     // [DMF_111e] Dark Power - COST:0
     // - Set: DARKMOON_FAIRE
@@ -1925,6 +1931,9 @@ void DarkmoonFaireCardsGen::AddWarlockNonCollect(
     // [DMF_533t] Fiery Imp - COST:2 [ATK:3/HP:2]
     // - Race: Demon, Set: DARKMOON_FAIRE
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_533t", CardDef(power));
 }
 
 void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1633,6 +1633,19 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - OVERLOAD = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("YOP_022e", EntityType::TARGET));
+    cards.emplace(
+        "YOP_022",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_FRIENDLY_TARGET, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } }));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [YOP_023] Landslide - COST:2
@@ -1746,6 +1759,9 @@ void DarkmoonFaireCardsGen::AddShamanNonCollect(
     // --------------------------------------------------------
     // Text: +3/+3.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("YOP_022e"));
+    cards.emplace("YOP_022e", CardDef(power));
 }
 
 void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -893,6 +893,20 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // - RUSH = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::HasNoNeutralCardsInDeck()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<SetGameTagTask>(EntityType::SOURCE,
+                                                         GameTag::RUSH, 1),
+                        std::make_shared<SetGameTagTask>(EntityType::SOURCE,
+                                                         GameTag::LIFESTEAL, 1),
+                        std::make_shared<SetGameTagTask>(EntityType::SOURCE,
+                                                         GameTag::TAUNT, 1),
+                        std::make_shared<SetGameTagTask>(
+                            EntityType::SOURCE, GameTag::DIVINE_SHIELD, 1) }));
+    cards.emplace("DMF_241", CardDef(power));
 
     // ---------------------------------------- SPELL - PALADIN
     // [DMF_244] Day at the Faire - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -20,6 +20,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/HealTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeAdjacentTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/PlayTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SilenceTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
@@ -1380,6 +1381,19 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsHoldingSecret()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<IncludeTask>(EntityType::HAND),
+                        std::make_shared<FilterStackTask>(
+                            SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsSecret()) }),
+                        std::make_shared<RandomTask>(EntityType::STACK, 1),
+                        std::make_shared<PlayTask>(PlayType::SPELL, false),
+                        std::make_shared<DrawTask>(1) }));
+    cards.emplace("YOP_016", CardDef(power));
 
     // ------------------------------------------ SPELL - ROGUE
     // [YOP_017] Shenanigans - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -2016,6 +2016,10 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // - DEATHRATTLE = 1
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("DMF_523t", 2, SummonSide::DEATHRATTLE));
+    cards.emplace("DMF_523", CardDef(power));
 
     // --------------------------------------- WEAPON - WARRIOR
     // [DMF_524] Ringmaster's Baton - COST:2
@@ -3546,6 +3550,9 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_523t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [DMF_534e] Deck of Chaos - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1545,6 +1545,15 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->tasks = {
+        std::make_shared<IncludeTask>(EntityType::MINIONS),
+        std::make_shared<RandomTask>(EntityType::STACK, 1),
+        std::make_shared<AddEnchantmentTask>("DMF_705e", EntityType::STACK)
+    };
+    cards.emplace("DMF_705", CardDef(power));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [DMF_706] Deathmatch Pavilion - COST:2
@@ -1691,6 +1700,9 @@ void DarkmoonFaireCardsGen::AddShamanNonCollect(
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DMF_705e"));
+    cards.emplace("DMF_705e", CardDef(power));
 
     // ---------------------------------------- MINION - SHAMAN
     // [DMF_706t] Pavilion Duelist - COST:2 [ATK:3/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -2997,6 +2997,10 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - SPELLPOWER = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
+    power.GetTrigger()->tasks = { ComplexTask::ProcessDormant(TaskList{}) };
+    cards.emplace("YOP_021", CardDef(power));
 
     // ---------------------------------------- SPELL - NEUTRAL
     // [YOP_024] Guidance - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -2125,6 +2125,14 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::HasHeroArmor()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<AddEnchantmentTask>(
+                  "YOP_014e", EntityType::SOURCE) }));
+    cards.emplace("YOP_014", CardDef(power));
 }
 
 void DarkmoonFaireCardsGen::AddWarriorNonCollect(
@@ -3629,6 +3637,9 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("YOP_014e"));
+    cards.emplace("YOP_014e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [YOP_015e] Nitroboost Poison - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1302,6 +1302,10 @@ void DarkmoonFaireCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::DECK, "DMF_514t", 3));
+    cards.emplace("DMF_514", CardDef(power));
 
     // ------------------------------------------ SPELL - ROGUE
     // [DMF_515] Swindle - COST:2
@@ -1448,11 +1452,21 @@ void DarkmoonFaireCardsGen::AddRogueNonCollect(
     // GameTag:
     // - TOPDECK = 1
     // --------------------------------------------------------
+    // RefTag:
+    // - CASTSWHENDRAWN = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTopdeckTask(std::make_shared<SummonTask>("DMF_514t2"));
+    power.AddPowerTask(std::make_shared<SummonTask>("DMF_514t2"));
+    cards.emplace("DMF_514t", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
     // [DMF_514t2] Plush Bear - COST:3 [ATK:3/HP:3]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_514t2", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
     // [DMF_517a] Sweet Tooth - COST:2 [ATK:5/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1820,9 +1820,22 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_TARGET_WITH_RACE = 15
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
     // RefTag:
     // - LIFESTEAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DMF_111e", EntityType::TARGET));
+    cards.emplace(
+        "DMF_111",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_TARGET_WITH_RACE, 15 },
+                                 { PlayReq::REQ_FRIENDLY_TARGET, 0 } }));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [DMF_113] Free Admission - COST:3
@@ -1948,6 +1961,9 @@ void DarkmoonFaireCardsGen::AddWarlockNonCollect(
     // - LIFESTEAL = 1
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DMF_111e"));
+    cards.emplace("DMF_111e", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [DMF_117t] Cascading Disaster - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -31,6 +31,7 @@ using namespace SimpleTasks;
 namespace RosettaStone::PlayMode
 {
 using PlayReqs = std::map<PlayReq, int>;
+using ChooseCardIDs = std::vector<std::string>;
 using TaskList = std::vector<std::shared_ptr<ITask>>;
 using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
 
@@ -100,6 +101,11 @@ void DarkmoonFaireCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - CHOOSE_ONE = 1
     // - CORRUPT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace(
+        "DMF_061",
+        CardDef(power, ChooseCardIDs{ "DMF_061a", "DMF_061b" }, "DMF_061t"));
 
     // ------------------------------------------ SPELL - DRUID
     // [DMF_075] Guess the Weight - COST:2
@@ -224,6 +230,9 @@ void DarkmoonFaireCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
     // Text: Draw a card.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cards.emplace("DMF_061a", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [DMF_061b] Dig It Up - COST:3
@@ -231,6 +240,9 @@ void DarkmoonFaireCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
     // Text: Summon a 2/2 Treant.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("DMF_061t2"));
+    cards.emplace("DMF_061b", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [DMF_061t] Faire Arborist - COST:3 [ATK:2/HP:2]
@@ -242,11 +254,18 @@ void DarkmoonFaireCardsGen::AddDruidNonCollect(
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("DMF_061t2"));
+    power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cards.emplace("DMF_061t", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [DMF_061t2] Treant - COST:2 [ATK:2/HP:2]
     // - Set: DARKMOON_FAIRE
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DMF_061t2", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [DMF_075a] More! - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1802,6 +1802,13 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::ALL_MINIONS));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsNotRace(Race::DEMON)) }));
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::STACK, 2));
+    cards.emplace("DMF_110", CardDef(power));
 
     // --------------------------------------- MINION - WARLOCK
     // [DMF_111] Man'ari Mosher - COST:3 [ATK:3/HP:4]

--- a/Sources/Rosetta/PlayMode/Cards/CardDef.cpp
+++ b/Sources/Rosetta/PlayMode/Cards/CardDef.cpp
@@ -58,6 +58,15 @@ CardDef::CardDef(Power _power, std::map<PlayReq, int> _playReqs,
     // Do nothing
 }
 
+CardDef::CardDef(Power _power, std::vector<std::string> _chooseCardIDs,
+                 std::string _corruptCardID)
+    : power(std::move(_power)),
+      chooseCardIDs(std::move(_chooseCardIDs)),
+      corruptCardID(std::move(_corruptCardID))
+{
+    // Do nothing
+}
+
 CardDef::CardDef(Power _power, std::map<PlayReq, int> _playReqs,
                  std::vector<std::string> _chooseCardIDs,
                  std::vector<std::string> _entourages)

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -405,6 +405,13 @@ SelfCondition SelfCondition::IsFrozen()
     });
 }
 
+SelfCondition SelfCondition::HasHeroArmor()
+{
+    return SelfCondition([](Playable* playable) {
+        return playable->player->GetHero()->GetArmor() > 0;
+    });
+}
+
 SelfCondition SelfCondition::HasSpellPower()
 {
     return SelfCondition([](Playable* playable) {

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -285,6 +285,21 @@ SelfCondition SelfCondition::IsControllingLackey()
     });
 }
 
+SelfCondition SelfCondition::IsHoldingSecret()
+{
+    return SelfCondition([](Playable* playable) {
+        for (auto& handCard : playable->player->GetHandZone()->GetAll())
+        {
+            if (handCard->card->IsSecret() == true)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    });
+}
+
 SelfCondition SelfCondition::IsHoldingRace(Race race)
 {
     return SelfCondition([race](Playable* playable) {

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -210,6 +210,13 @@ SelfCondition SelfCondition::IsRace(Race race)
     });
 }
 
+SelfCondition SelfCondition::IsNotRace(Race race)
+{
+    return SelfCondition([race](Playable* playable) {
+        return playable->card->GetRace() != race;
+    });
+}
+
 SelfCondition SelfCondition::IsControllingRace(Race race)
 {
     return SelfCondition([race](Playable* playable) {

--- a/Sources/Rosetta/PlayMode/Enchants/Enchants.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/Enchants.cpp
@@ -87,6 +87,7 @@ std::shared_ptr<Enchant> Enchants::GetEnchantFromText(const std::string& cardID)
     }
 
     if (text.find("this turn") != std::string::npos ||
+        text.find("until end of turn") != std::string::npos ||
         card->gameTags[GameTag::TAG_ONE_TURN_EFFECT] > 0)
     {
         isOneTurn = true;

--- a/Sources/Rosetta/PlayMode/Models/Player.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Player.cpp
@@ -123,6 +123,11 @@ int Player::GetCurrentSpellPower() const
 
     for (auto& minion : GetFieldZone()->GetAll())
     {
+        if (minion->IsUntouchable())
+        {
+            continue;
+        }
+
         value += minion->GetSpellPower();
     }
 

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.cpp
@@ -9,7 +9,8 @@
 
 namespace RosettaStone::PlayMode::SimpleTasks
 {
-DrawStackTask::DrawStackTask(std::size_t amount) : m_amount(amount)
+DrawStackTask::DrawStackTask(std::size_t amount, bool addToStack)
+    : m_amount(amount), m_addToStack(addToStack)
 {
     // Do nothing
 }
@@ -26,13 +27,16 @@ TaskStatus DrawStackTask::Impl(Player* player)
         Generic::Draw(player, card);
     }
 
-    stack.clear();
+    if (!m_addToStack)
+    {
+        stack.clear();
+    }
 
     return TaskStatus::COMPLETE;
 }
 
 std::unique_ptr<ITask> DrawStackTask::CloneImpl()
 {
-    return std::make_unique<DrawStackTask>(m_amount);
+    return std::make_unique<DrawStackTask>(m_amount, m_addToStack);
 }
 }  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1544,6 +1544,87 @@ TEST_CASE("[Shaman : Spell] - YOP_023 : Landslide")
 }
 
 // --------------------------------------- MINION - WARLOCK
+// [DMF_110] Fire Breather - COST:4 [ATK:4/HP:3]
+// - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Deal 2 damage to all minions except Demons.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - DMF_110 : Fire Breather")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fire Breather"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Arcane Servant"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Evasive Feywing"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Midway Maniac"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("River Crocolisk"));
+    const auto card6 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Southsea Captain"));
+    const auto card7 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Crabrider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+    CHECK_EQ(curField[1]->GetHealth(), 4);
+    CHECK_EQ(curField[2]->GetHealth(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    game.Process(opPlayer, PlayCardTask::Minion(card6));
+    game.Process(opPlayer, PlayCardTask::Minion(card7));
+    CHECK_EQ(opField.GetCount(), 3);
+    CHECK_EQ(opField[0]->GetHealth(), 3);
+    CHECK_EQ(opField[1]->GetHealth(), 3);
+    CHECK_EQ(opField[2]->GetHealth(), 4);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+    CHECK_EQ(curField[2]->GetHealth(), 5);
+    CHECK_EQ(curField[3]->GetHealth(), 3);
+    CHECK_EQ(opField.GetCount(), 3);
+    CHECK_EQ(opField[0]->GetHealth(), 1);
+    CHECK_EQ(opField[1]->GetHealth(), 1);
+    CHECK_EQ(opField[2]->GetHealth(), 2);
+}
+
+// --------------------------------------- MINION - WARLOCK
 // [DMF_114] Midway Maniac - COST:2 [ATK:1/HP:5]
 // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1701,6 +1701,52 @@ TEST_CASE("[Warrior : Minion] - DMF_531 : Stage Hand")
     CHECK_EQ(totalHealth, 4);
 }
 
+// --------------------------------------- MINION - WARRIOR
+// [YOP_014] Ironclad - COST:3 [ATK:2/HP:4]
+// - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If your hero has Armor, gain +2/+2.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - YOP_014 : Ironclad")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ironclad"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ironclad"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+
+    game.Process(curPlayer, HeroPowerTask());
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 4);
+    CHECK_EQ(curField[1]->GetHealth(), 6);
+}
+
 // ------------------------------------ SPELL - DEMONHUNTER
 // [DMF_219] Relentless Pursuit - COST:3
 // - Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1581,6 +1581,76 @@ TEST_CASE("[Warrior : Spell] - DMF_522 : Minefield")
     CHECK_EQ(totalHealth, 9);
 }
 
+// ---------------------------------------- SPELL - WARRIOR
+// [DMF_526] Stage Dive - COST:1
+// - Set: DARKMOON_FAIRE, Rarity: Rare
+// --------------------------------------------------------
+// Text: Draw a <b>Rush</b> minion.
+//       <b>Corrupt:</b> Give it +2/+1.
+// --------------------------------------------------------
+// GameTag:
+// - CORRUPT = 1
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Spell] - DMF_526 : Stage Dive")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Faerie Dragon");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Shotbot");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Burly Shovelfist");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Stage Dive"));
+    [[maybe_unused]] auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Stage Dive"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Heroic Strike"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curHand.GetCount(), 8);
+    CHECK_EQ(curHand[7]->card->name, "Burly Shovelfist");
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[7])->GetAttack(), 9);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[7])->GetHealth(), 9);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(curHand[4]->card->id, "DMF_526");
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(curHand[4]->card->id, "DMF_526a");
+
+    game.Process(curPlayer, PlayCardTask::Spell(curHand[4]));
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(curHand[5]->card->name, "Burly Shovelfist");
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[5])->GetAttack(), 11);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[5])->GetHealth(), 10);
+}
+
 // --------------------------------------- MINION - WARRIOR
 // [DMF_531] Stage Hand - COST:2 [ATK:3/HP:2]
 // - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1314,6 +1314,56 @@ TEST_CASE("[Warlock : Minion] - DMF_114 : Midway Maniac")
     // Do nothing
 }
 
+// --------------------------------------- MINION - WARLOCK
+// [DMF_533] Ring Matron - COST:6 [ATK:6/HP:4]
+// - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Deathrattle:</b> Summon two 3/2 Imps.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - DMF_533 : Ring Matron")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ring Matron"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Fiery Imp");
+    CHECK_EQ(curField[1]->card->name, "Fiery Imp");
+}
+
 // --------------------------------------- MINION - WARRIOR
 // [DMF_521] Sword Eater - COST:4 [ATK:2/HP:5]
 // - Race: Pirate, Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1201,6 +1201,54 @@ TEST_CASE("[Shaman : Minion] - DMF_704 : Cagematch Custodian")
     CHECK_EQ(curHand[4]->card->name, "Stormforged Axe");
 }
 
+// ---------------------------------------- WEAPON - SHAMAN
+// [DMF_705] Whack-A-Gnoll Hammer - COST:3
+// - Set: DARKMOON_FAIRE, Rarity: Rare
+// --------------------------------------------------------
+// Text: After your hero attacks,
+//       give a random friendly minion +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Weapon] - DMF_705 : Whack-A-Gnoll Hammer")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Whack-A-Gnoll Hammer"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    game.Process(curPlayer,
+                 AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+}
+
 // ----------------------------------------- SPELL - SHAMAN
 // [DMF_706] Deathmatch Pavilion - COST:2
 // - Set: DARKMOON_FAIRE, Rarity: Epic

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1192,13 +1192,64 @@ TEST_CASE("[Shaman : Minion] - DMF_704 : Cagematch Custodian")
 
     auto& curHand = *(curPlayer->GetHandZone());
 
-    const auto card = Generic::DrawCard(
+    const auto card1 = Generic::DrawCard(
         curPlayer, Cards::FindCardByName("Cagematch Custodian"));
 
-    game.Process(curPlayer, PlayCardTask::Spell(card));
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
     CHECK_EQ(curPlayer->GetRemainingMana(), 8);
     CHECK_EQ(curHand.GetCount(), 5);
     CHECK_EQ(curHand[4]->card->name, "Stormforged Axe");
+}
+
+// ----------------------------------------- SPELL - SHAMAN
+// [DMF_706] Deathmatch Pavilion - COST:2
+// - Set: DARKMOON_FAIRE, Rarity: Epic
+// --------------------------------------------------------
+// Text: Summon a 3/2 Duelist.
+//       If your hero attacked this turn, summon another.
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - DMF_706 : Deathmatch Pavilion")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Deathmatch Pavilion"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Deathmatch Pavilion"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Stormforged Axe"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Pavilion Duelist");
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card3));
+    game.Process(curPlayer,
+                 AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[1]->card->name, "Pavilion Duelist");
+    CHECK_EQ(curField[2]->card->name, "Pavilion Duelist");
 }
 
 // --------------------------------------- MINION - WARLOCK

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1474,6 +1474,75 @@ TEST_CASE("[Shaman : Minion] - YOP_022 : Mistrunner")
     CHECK_EQ(curPlayer->GetOverloadOwed(), 0);
 }
 
+// ----------------------------------------- SPELL - SHAMAN
+// [YOP_023] Landslide - COST:2
+// - Set: DARKMOON_FAIRE, Rarity: Rare
+// --------------------------------------------------------
+// Text: Deal 1 damage to all enemy minions.
+//       If you're <b>Overloaded</b>, deal 1 damage again.
+// --------------------------------------------------------
+// RefTag:
+// - OVERLOAD = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - YOP_023 : Landslide")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Landslide"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Landslide"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Kobold Geomancer"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mistrunner"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Onyxia"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(opField.GetCount(), 7);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 7);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card4, card3));
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 3);
+}
+
 // --------------------------------------- MINION - WARLOCK
 // [DMF_114] Midway Maniac - COST:2 [ATK:1/HP:5]
 // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -606,6 +606,76 @@ TEST_CASE("[Paladin : Weapon] - DMF_238 : Hammer of the Naaru")
     CHECK_EQ(curField[0]->HasTaunt(), true);
 }
 
+// --------------------------------------- MINION - PALADIN
+// [DMF_241] High Exarch Yrel - COST:8 [ATK:7/HP:5]
+// - Set: DARKMOON_FAIRE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If your deck has no Neutral cards,
+//       gain <b>Rush</b>, <b>Lifesteal</b>, <b>Taunt</b>,
+//       and <b>Divine Shield</b>.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - DIVINE_SHIELD = 1
+// - LIFESTEAL = 1
+// - RUSH = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Minion] - DMF_241 : High Exarch Yrel")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (std::size_t i = 0; i < 5; ++i)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Leper Gnome");
+        config.player2Deck[i] = Cards::FindCardByName("Leper Gnome");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("High Exarch Yrel"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("High Exarch Yrel"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasRush(), false);
+    CHECK_EQ(curField[0]->HasLifesteal(), false);
+    CHECK_EQ(curField[0]->HasTaunt(), false);
+    CHECK_EQ(curField[0]->HasDivineShield(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->HasRush(), true);
+    CHECK_EQ(curField[1]->HasLifesteal(), true);
+    CHECK_EQ(curField[1]->HasTaunt(), true);
+    CHECK_EQ(curField[1]->HasDivineShield(), true);
+}
+
 // ---------------------------------------- SPELL - PALADIN
 // [DMF_244] Day at the Faire - COST:3
 // - Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1581,6 +1581,56 @@ TEST_CASE("[Warrior : Spell] - DMF_522 : Minefield")
     CHECK_EQ(totalHealth, 9);
 }
 
+// --------------------------------------- MINION - WARRIOR
+// [DMF_523] Bumper Car - COST:2 [ATK:1/HP:3]
+// - Race: Mechanical, Set: DARKMOON_FAIRE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Rush</b> <b>Deathrattle:</b> Add two 1/1 Riders
+//       with <b>Rush</b> to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - DMF_523 : Bumper Car")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bumper Car"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Darkmoon Rider");
+    CHECK_EQ(curField[1]->card->name, "Darkmoon Rider");
+}
+
 // ---------------------------------------- SPELL - WARRIOR
 // [DMF_526] Stage Dive - COST:1
 // - Set: DARKMOON_FAIRE, Rarity: Rare


### PR DESCRIPTION
This revision includes:
- Implement 15 DARKMOON_FAIRE cards
  - Faire Arborist (DMF_061)
  - Fire Breather (DMF_110)
  - Man'ari Mosher (DMF_111)
  - High Exarch Yrel (DMF_241)
  - Ticket Master (DMF_514)
  - Bumper Car (DMF_523)
  - Stage Dive (DMF_526)
  - Ring Matron (DMF_533)
  - Whack-A-Gnoll Hammer (DMF_705)
  - Deathmatch Pavilion (DMF_706)
  - Ironclad (YOP_014)
  - Sparkjoy Cheat (YOP_016)
  - Imprisoned Phoenix (YOP_021)
  - Mistrunner (YOP_022)
  - Landslide (YOP_023)
- Add some methods
  - Add constructor for class 'CardDef'
  - Add member variable 'addToStack' to class 'DrawStackTask'
  - IsHoldingSecret(): SelfCondition wrapper for checking the player has secret card in hand zone
  - HasHeroArmor(): SelfCondition wrapper for checking the hero has armor
  - IsNotRace(): SelfCondition wrapper for checking race of entity is not race
- Fix bugs
  - Add code to check a minion is untouchable in method 'GetCurrentSpellPower()'
  - Add code to check the string "until end of turn" in method 'GetEnchantFromText()'