### PR TITLE
Implement 10 DARKMOON_FAIRE cards

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -1306,7 +1306,7 @@ DARKMOON_FAIRE | DMF_125 | Safety Inspector |
 DARKMOON_FAIRE | DMF_163 | Carnival Clown |  
 DARKMOON_FAIRE | DMF_174 | Circus Medic | O
 DARKMOON_FAIRE | DMF_184 | Fairground Fool | O
-DARKMOON_FAIRE | DMF_186 | Auspicious Spirits |  
+DARKMOON_FAIRE | DMF_186 | Auspicious Spirits | O
 DARKMOON_FAIRE | DMF_187 | Palm Reading |  
 DARKMOON_FAIRE | DMF_188 | Y'Shaarj, the Defiler |  
 DARKMOON_FAIRE | DMF_189 | Costumed Entertainer | O
@@ -1327,9 +1327,9 @@ DARKMOON_FAIRE | DMF_227 | Dreadlord's Bite | O
 DARKMOON_FAIRE | DMF_229 | Stiltstepper |  
 DARKMOON_FAIRE | DMF_230 | Il'gynoth |  
 DARKMOON_FAIRE | DMF_231 | Zai, the Incredible |  
-DARKMOON_FAIRE | DMF_235 | Balloon Merchant |  
+DARKMOON_FAIRE | DMF_235 | Balloon Merchant | O
 DARKMOON_FAIRE | DMF_236 | Oh My Yogg! |  
-DARKMOON_FAIRE | DMF_237 | Carnival Barker |  
+DARKMOON_FAIRE | DMF_237 | Carnival Barker | O
 DARKMOON_FAIRE | DMF_238 | Hammer of the Naaru | O
 DARKMOON_FAIRE | DMF_240 | Lothraxion the Redeemed |  
 DARKMOON_FAIRE | DMF_241 | High Exarch Yrel | O
@@ -1361,7 +1361,7 @@ DARKMOON_FAIRE | DMF_531 | Stage Hand | O
 DARKMOON_FAIRE | DMF_532 | Circus Amalgam | O
 DARKMOON_FAIRE | DMF_533 | Ring Matron | O
 DARKMOON_FAIRE | DMF_534 | Deck of Chaos |  
-DARKMOON_FAIRE | DMF_700 | Revolve |  
+DARKMOON_FAIRE | DMF_700 | Revolve | O
 DARKMOON_FAIRE | DMF_701 | Dunk Tank | O
 DARKMOON_FAIRE | DMF_702 | Stormstrike | O
 DARKMOON_FAIRE | DMF_703 | Pit Master | O
@@ -1384,12 +1384,12 @@ DARKMOON_FAIRE | YOP_006 | Hysteria |
 DARKMOON_FAIRE | YOP_007 | Dark Inquisitor Xanesh |  
 DARKMOON_FAIRE | YOP_008 | Lightsteed |  
 DARKMOON_FAIRE | YOP_009 | Rally! |  
-DARKMOON_FAIRE | YOP_010 | Imprisoned Celestial |  
-DARKMOON_FAIRE | YOP_011 | Libram of Judgment |  
+DARKMOON_FAIRE | YOP_010 | Imprisoned Celestial | O
+DARKMOON_FAIRE | YOP_011 | Libram of Judgment | O
 DARKMOON_FAIRE | YOP_012 | Deathwarden |  
 DARKMOON_FAIRE | YOP_013 | Spiked Wheel |  
 DARKMOON_FAIRE | YOP_014 | Ironclad | O
-DARKMOON_FAIRE | YOP_015 | Nitroboost Poison |  
+DARKMOON_FAIRE | YOP_015 | Nitroboost Poison | O
 DARKMOON_FAIRE | YOP_016 | Sparkjoy Cheat | O
 DARKMOON_FAIRE | YOP_017 | Shenanigans |  
 DARKMOON_FAIRE | YOP_018 | Keywarden Ivory |  
@@ -1405,10 +1405,10 @@ DARKMOON_FAIRE | YOP_027 | Bola Shot |
 DARKMOON_FAIRE | YOP_028 | Saddlemaster |  
 DARKMOON_FAIRE | YOP_029 | Resizing Pouch |  
 DARKMOON_FAIRE | YOP_030 | Felfire Deadeye |  
-DARKMOON_FAIRE | YOP_031 | Crabrider |  
-DARKMOON_FAIRE | YOP_032 | Armor Vendor |  
+DARKMOON_FAIRE | YOP_031 | Crabrider | O
+DARKMOON_FAIRE | YOP_032 | Armor Vendor | O
 DARKMOON_FAIRE | YOP_033 | Backfire |  
-DARKMOON_FAIRE | YOP_034 | Runaway Blackwing |  
+DARKMOON_FAIRE | YOP_034 | Runaway Blackwing | O
 DARKMOON_FAIRE | YOP_035 | Moonfang |  
 
-- Progress: 37% (63 of 170 Cards)
+- Progress: 42% (73 of 170 Cards)

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -116,6 +116,10 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsLackey();
 
+    //! SelfCondition wrapper for checking it is Silver Hand Recruit.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsSilverHandRecruit();
+
     //! SelfCondition wrapper for checking race of entity is \p race.
     //! \param race The race for checking.
     //! \return Generated SelfCondition for intended purpose.

--- a/Includes/Rosetta/PlayMode/Models/Minion.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Minion.hpp
@@ -90,10 +90,6 @@ class Minion : public Character
     //! \return The flag that indicates whether it has reborn.
     bool HasReborn() const;
 
-    //! Returns the flag that indicates whether it has spellburst.
-    //! \return The flag that indicates whether it has spellburst.
-    bool HasSpellburst() const;
-
     //! Returns the flag that indicates whether it is attackable by rush.
     //! \return The flag that indicates whether it is attackable by rush.
     bool IsAttackableByRush() const;

--- a/Includes/Rosetta/PlayMode/Models/Playable.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Playable.hpp
@@ -119,6 +119,10 @@ class Playable : public Entity
     //! \return The flag that indicates whether it has corrupt.
     bool HasCorrupt() const;
 
+    //! Returns the flag that indicates it can activate 'Spellbrust'.
+    //! \return The flag that indicates it can activate 'Spellbrust'.
+    bool CanActivateSpellburst() const;
+
     //! Resets the value of the cost.
     void ResetCost();
 

--- a/Includes/Rosetta/PlayMode/Models/Playable.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Playable.hpp
@@ -111,6 +111,10 @@ class Playable : public Entity
     //! \return The flag that indicates whether it has dormant.
     bool HasDormant() const;
 
+    //! Returns the flag that indicates whether it has spellburst.
+    //! \return The flag that indicates whether it has spellburst.
+    bool HasSpellburst() const;
+
     //! Returns the flag that indicates whether it has corrupt.
     //! \return The flag that indicates whether it has corrupt.
     bool HasCorrupt() const;

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp
@@ -18,11 +18,13 @@ namespace RosettaStone::PlayMode::SimpleTasks
 class ArmorTask : public ITask
 {
  public:
-    //! Constructs task with given \p amount and \p useNumber.
+    //! Constructs task with given \p amount, \p isOpponent and \p useNumber.
     //! \param amount The amount to gain armor.
+    //! \param isOpponent A flag to owner indicating opponent player.
     //! \param useNumber The flag that indicates it adds the value
     //! contained in task stack as armor.
-    explicit ArmorTask(int amount, bool useNumber = false);
+    explicit ArmorTask(int amount, bool isOpponent = false,
+                       bool useNumber = false);
 
  private:
     //! Processes task logic internally and returns meta data.
@@ -35,6 +37,7 @@ class ArmorTask : public ITask
     std::unique_ptr<ITask> CloneImpl() override;
 
     int m_amount;
+    bool m_isOpponent = false;
     bool m_useNumber = false;
 };
 }  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Expansions
 
-  * 37% Madness at the Darkmoon Faire (63 of 170 cards)
+  * 42% Madness at the Darkmoon Faire (73 of 170 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 59% Ashes of Outland (80 of 135 cards)
   * **100% Descent of Dragons (140 of 140 cards)**

--- a/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
@@ -394,8 +394,7 @@ void PlaySpell(Player* player, Spell* spell, Character* target, int chooseOne)
 
     for (auto& minion : minions)
     {
-        if (!minion->isDestroyed && !minion->isTransformed &&
-            minion->HasSpellburst())
+        if (minion->CanActivateSpellburst())
         {
             minion->ActivateTask(PowerType::SPELLBURST);
             minion->SetGameTag(GameTag::SPELLBURST, 0);

--- a/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
@@ -2598,7 +2598,7 @@ void DalaranCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::DEAL_DAMAGE));
     power.GetTrigger()->triggerSource = TriggerSource::SELF;
     power.GetTrigger()->tasks = { std::make_shared<GetEventNumberTask>(),
-                                  std::make_shared<ArmorTask>(0, true) };
+                                  std::make_shared<ArmorTask>(0, false, true) };
     cards.emplace("DAL_759", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR

--- a/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
@@ -2456,7 +2456,7 @@ void DalaranCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddPowerTask(std::make_shared<GetGameTagTask>(
         EntityType::SOURCE, GameTag::TAG_SCRIPT_DATA_NUM_1));
-    power.AddPowerTask(std::make_shared<ArmorTask>(0, true));
+    power.AddPowerTask(std::make_shared<ArmorTask>(0, false, true));
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
     power.GetTrigger()->triggerActivation = TriggerActivation::HAND;
     power.GetTrigger()->tasks = {

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1038,6 +1038,12 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - DIVINE_SHIELD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
+    power.GetTrigger()->tasks = { ComplexTask::ProcessDormant(TaskList{}) };
+    power.AddSpellburstTask(std::make_shared<SetGameTagTask>(
+        EntityType::MINIONS, GameTag::DIVINE_SHIELD, 1));
+    cards.emplace("YOP_010", CardDef(power));
 
     // --------------------------------------- WEAPON - PALADIN
     // [YOP_011] Libram of Judgment - COST:7

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -27,6 +27,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RefreshManaTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SilenceTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/TransformMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/WeaponTask.hpp>
 
 using namespace RosettaStone::PlayMode;
@@ -1632,6 +1633,10 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Transform all minions into random ones with the same Cost.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<TransformMinionTask>(EntityType::ALL_MINIONS, 0));
+    cards.emplace("DMF_700", CardDef(power));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [DMF_701] Dunk Tank - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -3276,6 +3276,16 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->tasks = {
+        std::make_shared<IncludeTask>(EntityType::ENEMY_MINIONS),
+        std::make_shared<FilterStackTask>(SelfCondList{
+            std::make_shared<SelfCondition>(SelfCondition::IsNotDead()) }),
+        std::make_shared<RandomTask>(EntityType::STACK, 1),
+        std::make_shared<DamageTask>(EntityType::STACK, 9)
+    };
+    cards.emplace("YOP_034", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [YOP_035] Moonfang - COST:5 [ATK:6/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -3246,6 +3246,10 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ArmorTask>(4));
+    power.AddPowerTask(std::make_shared<ArmorTask>(4, true));
+    cards.emplace("YOP_032", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [YOP_034] Runaway Blackwing - COST:9 [ATK:9/HP:9]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1051,6 +1051,9 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - LIFESTEAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("YOP_011", CardDef(power, "YOP_011t"));
 }
 
 void DarkmoonFaireCardsGen::AddPaladinNonCollect(
@@ -1132,6 +1135,9 @@ void DarkmoonFaireCardsGen::AddPaladinNonCollect(
     // GameTag:
     // - LIFESTEAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("YOP_011t", CardDef(power));
 }
 
 void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -915,6 +915,16 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - DIVINE_SHIELD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::MINIONS));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsSilverHandRecruit()) }));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("DMF_235e", EntityType::STACK));
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(
+        EntityType::STACK, GameTag::DIVINE_SHIELD, 1));
+    cards.emplace("DMF_235", CardDef(power));
 
     // ---------------------------------------- SPELL - PALADIN
     // [DMF_236] Oh My Yogg! - COST:1
@@ -1096,6 +1106,9 @@ void DarkmoonFaireCardsGen::AddPaladinNonCollect(
     // --------------------------------------------------------
     // Text: +1 Attack.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DMF_235e"));
+    cards.emplace("DMF_235e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - PALADIN
     // [DMF_236t] Oh My Yogg! - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1278,6 +1278,11 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CORRUPT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<RandomMinionTask>(
+        TagValues{ { GameTag::COST, 4, RelaSign::EQ } }));
+    power.AddPowerTask(std::make_shared<SummonStackTask>());
+    cards.emplace("DMF_186", CardDef(power, "DMF_186a"));
 
     // ----------------------------------------- SPELL - PRIEST
     // [DMF_187] Palm Reading - COST:3
@@ -1358,6 +1363,11 @@ void DarkmoonFaireCardsGen::AddPriestNonCollect(
     // Text: <b>Corrupted</b>
     //       Summon a random 7-Cost minion.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<RandomMinionTask>(
+        TagValues{ { GameTag::COST, 7, RelaSign::EQ } }));
+    power.AddPowerTask(std::make_shared<SummonStackTask>());
+    cards.emplace("DMF_186a", CardDef(power));
 
     // ----------------------------------- ENCHANTMENT - PRIEST
     // [YOP_008e] Lightsteed - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -3236,6 +3236,9 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - RUSH = 1
     // - WINDFURY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("YOP_031", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [YOP_032] Armor Vendor - COST:1 [ATK:1/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -3160,6 +3160,18 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CORRUPT = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("YOP_015e", EntityType::TARGET));
+    cards.emplace("YOP_015",
+                  CardDef(power,
+                          PlayReqs{ { PlayReq::REQ_MINION_TARGET, 0 },
+                                    { PlayReq::REQ_TARGET_TO_PLAY, 0 } },
+                          "YOP_015t"));
 
     // --------------------------------------- MINION - NEUTRAL
     // [YOP_018] Keywarden Ivory - COST:5 [ATK:4/HP:5]
@@ -3856,6 +3868,9 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +2 Attack.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("YOP_015e"));
+    cards.emplace("YOP_015e", CardDef(power));
 
     // ---------------------------------------- SPELL - NEUTRAL
     // [YOP_015t] Nitroboost Poison - COST:1
@@ -3864,6 +3879,19 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // Text: <b>Corrupted</b>
     //       Give a minion and your weapon +2 Attack.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("YOP_015e", EntityType::TARGET));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("YOP_015e", EntityType::WEAPON));
+    cards.emplace(
+        "YOP_015t",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ---------------------------------------- SPELL - NEUTRAL
     // [YOP_024t] Spirit Path - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -936,6 +936,14 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::SUMMON));
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
+        SelfCondition::IsHealth(1, RelaSign::EQ));
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "DMF_237e", EntityType::TARGET) };
+    cards.emplace("DMF_237", CardDef(power));
 
     // --------------------------------------- WEAPON - PALADIN
     // [DMF_238] Hammer of the Naaru - COST:6
@@ -1100,6 +1108,9 @@ void DarkmoonFaireCardsGen::AddPaladinNonCollect(
     // --------------------------------------------------------
     // Text: +1/+2.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("DMF_237e"));
+    cards.emplace("DMF_237e", CardDef(power));
 
     // --------------------------------------- MINION - PALADIN
     // [DMF_238t] Holy Elemental - COST:6 [ATK:6/HP:6]

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -203,6 +203,12 @@ SelfCondition SelfCondition::IsLackey()
     });
 }
 
+SelfCondition SelfCondition::IsSilverHandRecruit()
+{
+    return SelfCondition(
+        [](Playable* playable) { return playable->card->id == "CS2_101t"; });
+}
+
 SelfCondition SelfCondition::IsRace(Race race)
 {
     return SelfCondition([race](Playable* playable) {

--- a/Sources/Rosetta/PlayMode/Models/Minion.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Minion.cpp
@@ -122,11 +122,6 @@ bool Minion::HasReborn() const
     return static_cast<bool>(GetGameTag(GameTag::REBORN));
 }
 
-bool Minion::HasSpellburst() const
-{
-    return static_cast<bool>(GetGameTag(GameTag::SPELLBURST));
-}
-
 bool Minion::IsAttackableByRush() const
 {
     return static_cast<bool>(GetGameTag(GameTag::ATTACKABLE_BY_RUSH));

--- a/Sources/Rosetta/PlayMode/Models/Playable.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Playable.cpp
@@ -159,6 +159,25 @@ bool Playable::HasCorrupt() const
     return GetGameTag(GameTag::CORRUPT) == 1;
 }
 
+bool Playable::CanActivateSpellburst() const
+{
+    if (!HasSpellburst())
+    {
+        return false;
+    }
+
+    if (const auto minion = dynamic_cast<const Minion*>(this); minion)
+    {
+        if (minion->isDestroyed || minion->isTransformed ||
+            minion->IsUntouchable())
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 void Playable::ResetCost()
 {
     costManager = nullptr;

--- a/Sources/Rosetta/PlayMode/Models/Playable.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Playable.cpp
@@ -149,6 +149,11 @@ bool Playable::HasDormant() const
     return GetGameTag(GameTag::DORMANT) == 1;
 }
 
+bool Playable::HasSpellburst() const
+{
+    return GetGameTag(GameTag::SPELLBURST) == 1;
+}
+
 bool Playable::HasCorrupt() const
 {
     return GetGameTag(GameTag::CORRUPT) == 1;

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.cpp
@@ -8,8 +8,8 @@
 
 namespace RosettaStone::PlayMode::SimpleTasks
 {
-ArmorTask::ArmorTask(int amount, bool useNumber)
-    : m_amount(amount), m_useNumber(useNumber)
+ArmorTask::ArmorTask(int amount, bool isOpponent, bool useNumber)
+    : m_amount(amount), m_isOpponent(isOpponent), m_useNumber(useNumber)
 {
     // Do nothing
 }
@@ -17,13 +17,21 @@ ArmorTask::ArmorTask(int amount, bool useNumber)
 TaskStatus ArmorTask::Impl(Player* player)
 {
     const int amount = m_useNumber ? player->game->taskStack.num[0] : m_amount;
-    player->GetHero()->GainArmor(amount);
+
+    if (m_isOpponent)
+    {
+        player->opponent->GetHero()->GainArmor(amount);
+    }
+    else
+    {
+        player->GetHero()->GainArmor(amount);
+    }
 
     return TaskStatus::COMPLETE;
 }
 
 std::unique_ptr<ITask> ArmorTask::CloneImpl()
 {
-    return std::make_unique<ArmorTask>(m_amount, m_useNumber);
+    return std::make_unique<ArmorTask>(m_amount, m_isOpponent, m_useNumber);
 }
 }  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1626,6 +1626,66 @@ TEST_CASE("[Priest : Minion] - DMF_184 : Fairground Fool")
     CHECK_EQ(curField[1]->GetHealth(), 7);
 }
 
+// ----------------------------------------- SPELL - PRIEST
+// [DMF_186] Auspicious Spirits - COST:4
+// - Set: DARKMOON_FAIRE, Rarity: Rare
+// --------------------------------------------------------
+// Text: Summon a random 4-Cost minion.
+//       <b>Corrupt:</b> Summon a 7-Cost minion instead.
+// --------------------------------------------------------
+// GameTag:
+// - CORRUPT = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - DMF_186 : Auspicious Spirits")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Auspicious Spirits"));
+    [[maybe_unused]] auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Auspicious Spirits"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Blizzard"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField[0]->card->GetCost(), 4);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card4, opPlayer->GetHero()));
+    CHECK_EQ(curHand[0]->card->id, "DMF_186");
+
+    curPlayer->SetUsedMana(0);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(curHand[0]->card->id, "DMF_186a");
+
+    curPlayer->SetUsedMana(0);
+
+    game.Process(curPlayer, PlayCardTask::Spell(curHand[0]));
+    CHECK_EQ(curField[1]->card->GetCost(), 7);
+}
+
 // ----------------------------------------- MINION - ROGUE
 // [DMF_514] Ticket Master - COST:3 [ATK:4/HP:3]
 // - Set: DARKMOON_FAIRE, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1915,6 +1915,69 @@ TEST_CASE("[Rogue : Minion] - YOP_016 : Sparkjoy Cheat")
 }
 
 // ----------------------------------------- SPELL - SHAMAN
+// [DMF_700] Revolve - COST:1
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: Transform all minions into random ones with the same Cost.
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - DMF_700 : Revolve")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Revolve"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Cagematch Custodian"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(curField[0]->card->GetCost(), 3);
+    CHECK_EQ(curField[1]->card->GetCost(), 0);
+    CHECK_EQ(curField[2]->card->GetCost(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(opField[0]->card->GetCost(), 9);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField[0]->card->GetCost(), 3);
+    CHECK_EQ(curField[1]->card->GetCost(), 0);
+    CHECK_EQ(curField[2]->card->GetCost(), 2);
+    CHECK_EQ(opField[0]->card->GetCost(), 9);
+}
+
+// ----------------------------------------- SPELL - SHAMAN
 // [DMF_701] Dunk Tank - COST:4
 // - Set: DARKMOON_FAIRE, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1405,7 +1405,7 @@ TEST_CASE("[Paladin : Minion] - YOP_010 : Imprisoned Celestial")
     CHECK_EQ(curField[0]->CanAttack(), false);
 
     game.Process(curPlayer,
-                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+                 PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
     CHECK_EQ(curField[0]->HasSpellburst(), true);
     CHECK_EQ(curField[0]->HasDivineShield(), false);
     CHECK_EQ(curField[1]->HasDivineShield(), false);
@@ -1422,7 +1422,7 @@ TEST_CASE("[Paladin : Minion] - YOP_010 : Imprisoned Celestial")
     CHECK_EQ(curField[0]->HasSpellburst(), true);
 
     game.Process(curPlayer,
-                 PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
+                 PlayCardTask::SpellTarget(card4, opPlayer->GetHero()));
     CHECK_EQ(curField[0]->HasSpellburst(), false);
     CHECK_EQ(curField[0]->HasDivineShield(), true);
     CHECK_EQ(curField[1]->HasDivineShield(), true);

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -3997,3 +3997,40 @@ TEST_CASE("[Neutral : Minion] - YOP_021 : Imprisoned Phoenix")
                  PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 16);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [YOP_032] Armor Vendor - COST:1 [ATK:1/HP:3]
+// - Set: DARKMOON_FAIRE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give 4 Armor to each hero.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - YOP_032 : Armor Vendor")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Armor Vendor"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 4);
+    CHECK_EQ(opPlayer->GetHero()->GetArmor(), 4);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -3999,6 +3999,22 @@ TEST_CASE("[Neutral : Minion] - YOP_021 : Imprisoned Phoenix")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [YOP_031] Crabrider - COST:2 [ATK:1/HP:4]
+// - Race: Murloc, Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Rush</b>
+//       <b>Windfury</b>
+// --------------------------------------------------------
+// GameTag:
+// - RUSH = 1
+// - WINDFURY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - YOP_031 : Crabrider")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [YOP_032] Armor Vendor - COST:1 [ATK:1/HP:3]
 // - Set: DARKMOON_FAIRE, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1094,6 +1094,54 @@ TEST_CASE("[Paladin : Minion] - DMF_194 : Redscale Dragontamer")
     CHECK_EQ(curHand[4]->card->name, "Faerie Dragon");
 }
 
+// --------------------------------------- MINION - PALADIN
+// [DMF_237] Carnival Barker - COST:3 [ATK:3/HP:2]
+// - Set: DARKMOON_FAIRE, Rarity: Rare
+// --------------------------------------------------------
+// Text: Whenever you summon a 1-Health minion, give it +1/+2.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Minion] - DMF_237 : Carnival Barker")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Carnival Barker"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Shotbot"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 4);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[2]->GetAttack(), 2);
+    CHECK_EQ(curField[2]->GetHealth(), 2);
+}
+
 // --------------------------------------- WEAPON - PALADIN
 // [DMF_238] Hammer of the Naaru - COST:6
 // - Set: DARKMOON_FAIRE, Rarity: Epic

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1095,6 +1095,61 @@ TEST_CASE("[Paladin : Minion] - DMF_194 : Redscale Dragontamer")
 }
 
 // --------------------------------------- MINION - PALADIN
+// [DMF_235] Balloon Merchant - COST:4 [ATK:3/HP:5]
+// - Set: DARKMOON_FAIRE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give your Silver Hand Recruits
+//       +1 Attack and <b>Divine Shield</b>.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - DIVINE_SHIELD = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Minion] - DMF_235 : Balloon Merchant")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Balloon Merchant"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, HeroPowerTask());
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->HasDivineShield(), false);
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->HasDivineShield(), false);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->HasDivineShield(), true);
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->HasDivineShield(), false);
+}
+
+// --------------------------------------- MINION - PALADIN
 // [DMF_237] Carnival Barker - COST:3 [ATK:3/HP:2]
 // - Set: DARKMOON_FAIRE, Rarity: Rare
 // --------------------------------------------------------
@@ -1106,7 +1161,7 @@ TEST_CASE("[Paladin : Minion] - DMF_194 : Redscale Dragontamer")
 TEST_CASE("[Paladin : Minion] - DMF_237 : Carnival Barker")
 {
     GameConfig config;
-    config.player1Class = CardClass::HUNTER;
+    config.player1Class = CardClass::PALADIN;
     config.player2Class = CardClass::WARRIOR;
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = true;
@@ -1158,7 +1213,7 @@ TEST_CASE("[Paladin : Minion] - DMF_237 : Carnival Barker")
 TEST_CASE("[Paladin : Weapon] - DMF_238 : Hammer of the Naaru")
 {
     GameConfig config;
-    config.player1Class = CardClass::HUNTER;
+    config.player1Class = CardClass::PALADIN;
     config.player2Class = CardClass::WARRIOR;
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = true;

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -1290,6 +1290,81 @@ TEST_CASE("[Paladin : Spell] - DMF_244 : Day at the Faire")
     CHECK_EQ(curField[4]->card->name, "Silver Hand Recruit");
 }
 
+// --------------------------------------- WEAPON - PALADIN
+// [YOP_011] Libram of Judgment - COST:7
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Corrupt:</b> Gain <b>Lifesteal</b>.
+// --------------------------------------------------------
+// GameTag:
+// - CORRUPT = 1
+// --------------------------------------------------------
+// RefTag:
+// - LIFESTEAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Weapon] - YOP_011 : Libram of Judgment")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHero = *(curPlayer->GetHero());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Libram of Judgment"));
+    [[maybe_unused]] auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Libram of Judgment"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Tirion Fordring"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Shotbot"));
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    CHECK_EQ(curHero.HasWeapon(), true);
+    CHECK_EQ(curHero.weapon->GetAttack(), 5);
+    CHECK_EQ(curHero.weapon->GetDurability(), 3);
+    CHECK_EQ(curHero.HasLifesteal(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(curHand[0]->card->id, "YOP_011");
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curHand[0]->card->id, "YOP_011t");
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Weapon(curHand[0]));
+    CHECK_EQ(curHero.HasWeapon(), true);
+    CHECK_EQ(curHero.weapon->GetAttack(), 5);
+    CHECK_EQ(curHero.weapon->GetDurability(), 3);
+    CHECK_EQ(curHero.HasLifesteal(), true);
+}
+
 // ---------------------------------------- MINION - PRIEST
 // [DMF_184] Fairground Fool - COST:3 [ATK:4/HP:3]
 // - Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/HoFCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/HoFCardsGenTests.cpp
@@ -1351,7 +1351,7 @@ TEST_CASE("[Neutral : Minion] - EX1_284 : Azure Drake")
 // Text: Can't attack. At the end of your turn, deal 8 damage
 //       to a random enemy.
 // --------------------------------------------------------
-TEST_CASE("[Neutral : Minion] EX1_298 : Ragnaros the Firelord")
+TEST_CASE("[Neutral : Minion] - EX1_298 : Ragnaros the Firelord")
 {
     GameConfig config;
     config.player1Class = CardClass::MAGE;
@@ -1371,10 +1371,7 @@ TEST_CASE("[Neutral : Minion] EX1_298 : Ragnaros the Firelord")
     opPlayer->SetTotalMana(10);
     opPlayer->SetUsedMana(0);
 
-    auto& curField = *(curPlayer->GetFieldZone());
     auto& opField = *(opPlayer->GetFieldZone());
-
-    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
 
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::FindCardByName("Ragnaros the Firelord"));
@@ -1382,7 +1379,6 @@ TEST_CASE("[Neutral : Minion] EX1_298 : Ragnaros the Firelord")
         opPlayer, Cards::FindCardByName("Grommash Hellscream"));
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
-    CHECK_EQ(curField.GetCount(), 1);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);
@@ -1390,6 +1386,7 @@ TEST_CASE("[Neutral : Minion] EX1_298 : Ragnaros the Firelord")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 22);
 
     game.Process(opPlayer, PlayCardTask::Minion(card2));
+
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);
 


### PR DESCRIPTION
This revision includes:
- Implement 10 DARKMOON_FAIRE cards
  - Auspicious Spirits (DMF_186)
  - Balloon Merchant (DMF_235)
  - Carnival Barker (DMF_237)
  - Revolve (DMF_700)
  - Imprisoned Celestial (YOP_010)
  - Libram of Judgment (YOP_011)
  - Nitroboost Poison (YOP_015)
  - Crabrider (YOP_031)
  - Armor Vendor (YOP_032)
  - Runaway Blackwing (YOP_034)
- Add some methods
  - CanActivateSpellbrust(): Returns the flag that indicates it can activate 'Spellbrust'
  - IsSilverHandRecruit(): SelfCondition wrapper for checking it is Silver Hand Recruit