### PR TITLE
Implement 6 DARKMOON_FAIRE cards

### DIFF
--- a/Documents/CardList.md
+++ b/Documents/CardList.md
@@ -1271,17 +1271,17 @@ DARKMOON_FAIRE | DMF_080 | Fleethoof Pearltusk | O
 DARKMOON_FAIRE | DMF_081 | K'thir Ritualist |  
 DARKMOON_FAIRE | DMF_082 | Darkmoon Statue |  
 DARKMOON_FAIRE | DMF_083 | Dancing Cobra | O
-DARKMOON_FAIRE | DMF_084 | Jewel of N'Zoth |  
+DARKMOON_FAIRE | DMF_084 | Jewel of N'Zoth | O
 DARKMOON_FAIRE | DMF_085 | Darkmoon Tonk | O
 DARKMOON_FAIRE | DMF_086 | Petting Zoo |  
 DARKMOON_FAIRE | DMF_087 | Trampling Rhino |  
-DARKMOON_FAIRE | DMF_088 | Rinling's Rifle |  
+DARKMOON_FAIRE | DMF_088 | Rinling's Rifle | O
 DARKMOON_FAIRE | DMF_089 | Maxima Blastenheimer |  
 DARKMOON_FAIRE | DMF_090 | Don't Feed the Animals |  
 DARKMOON_FAIRE | DMF_091 | Wriggling Horror | O
 DARKMOON_FAIRE | DMF_100 | Confection Cyclone | O
 DARKMOON_FAIRE | DMF_101 | Firework Elemental | O
-DARKMOON_FAIRE | DMF_102 | Game Master |  
+DARKMOON_FAIRE | DMF_102 | Game Master | O
 DARKMOON_FAIRE | DMF_103 | Mask of C'Thun | O
 DARKMOON_FAIRE | DMF_104 | Grand Finale |  
 DARKMOON_FAIRE | DMF_105 | Ring Toss |  
@@ -1293,14 +1293,14 @@ DARKMOON_FAIRE | DMF_110 | Fire Breather | O
 DARKMOON_FAIRE | DMF_111 | Man'ari Mosher | O
 DARKMOON_FAIRE | DMF_113 | Free Admission |  
 DARKMOON_FAIRE | DMF_114 | Midway Maniac | O
-DARKMOON_FAIRE | DMF_115 | Revenant Rascal |  
+DARKMOON_FAIRE | DMF_115 | Revenant Rascal | O
 DARKMOON_FAIRE | DMF_116 | The Nameless One |  
 DARKMOON_FAIRE | DMF_117 | Cascading Disaster |  
 DARKMOON_FAIRE | DMF_118 | Tickatus |  
 DARKMOON_FAIRE | DMF_119 | Wicked Whispers |  
 DARKMOON_FAIRE | DMF_120 | Nazmani Bloodweaver |  
 DARKMOON_FAIRE | DMF_121 | Fortune Teller |  
-DARKMOON_FAIRE | DMF_122 | Mystery Winner |  
+DARKMOON_FAIRE | DMF_122 | Mystery Winner | O
 DARKMOON_FAIRE | DMF_123 | Open the Cages |  
 DARKMOON_FAIRE | DMF_124 | Horrendous Growth |  
 DARKMOON_FAIRE | DMF_125 | Safety Inspector |  
@@ -1408,11 +1408,11 @@ DARKMOON_FAIRE | YOP_029 | Resizing Pouch |
 DARKMOON_FAIRE | YOP_030 | Felfire Deadeye |  
 DARKMOON_FAIRE | YOP_031 | Crabrider | O
 DARKMOON_FAIRE | YOP_032 | Armor Vendor | O
-DARKMOON_FAIRE | YOP_033 | Backfire |  
+DARKMOON_FAIRE | YOP_033 | Backfire | O
 DARKMOON_FAIRE | YOP_034 | Runaway Blackwing | O
 DARKMOON_FAIRE | YOP_035 | Moonfang |  
 
-- Progress: 42% (73 of 170 Cards)
+- Progress: 46% (79 of 170 Cards)
 
 ## Forged in the Barrens
 

--- a/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
@@ -25,6 +25,7 @@ enum class DiscoverType
     DEATHRATTLE_MINION_DIED,
     SPELL,
     SPELL_THREE_COST_OR_LESS,
+    SECRET,
     DEMON,
     DRAGON,
     LACKEY,

--- a/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
@@ -38,6 +38,7 @@ enum class DiscoverType
     SIR_FINLEY_OF_THE_SANDS,
     VULPERA_SCOUNDREL,
     BODY_WRAPPER,
+    RINLINGS_RIFLE,
 };
 
 //! The action type of choice.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 ### Expansions
 
   * 0% Forged in the Barrens (0 of 1 cards)
-  * 42% Madness at the Darkmoon Faire (73 of 170 cards)
+  * 46% Madness at the Darkmoon Faire (79 of 170 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 59% Ashes of Outland (80 of 135 cards)
   * **100% Descent of Dragons (140 of 140 cards)**

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -3,6 +3,7 @@
 // Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
+#include <Rosetta/PlayMode/Auras/SwitchingAura.hpp>
 #include <Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
@@ -704,6 +705,16 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<SwitchingAura>(
+        AuraType::HAND, SelfCondition::SpellsCastThisTurn(0),
+        TriggerType::CAST_SPELL, EffectList{ Effects::SetCost(1) }));
+    {
+        const auto aura = dynamic_cast<SwitchingAura*>(power.GetAura());
+        aura->condition =
+            std::make_shared<SelfCondition>(SelfCondition::IsSecret());
+    }
+    cards.emplace("DMF_102", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [DMF_103] Mask of C'Thun - COST:7

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -23,6 +23,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/HealTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeAdjacentTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/ManaCrystalTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/PlayTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
@@ -2035,6 +2036,10 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ManaCrystalTask>(-1, false, true));
+    power.AddPowerTask(std::make_shared<ManaCrystalTask>(-1, false, false));
+    cards.emplace("DMF_115", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [DMF_117] Cascading Disaster - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -2117,6 +2117,10 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Draw 3 cards. Deal 3 damage to your hero.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawTask>(3));
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::HERO, 3, true));
+    cards.emplace("YOP_033", CardDef(power));
 }
 
 void DarkmoonFaireCardsGen::AddWarlockNonCollect(

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -9,6 +9,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddCardTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/CopyTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.hpp>
@@ -439,6 +440,25 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // - REQ_FRIENDLY_DEATHRATTLE_MINION_DIED_THIS_GAME = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::GRAVEYARD));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsDead()),
+        std::make_shared<SelfCondition>(SelfCondition::HasDeathrattle()) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 3));
+    power.AddPowerTask(
+        std::make_shared<CopyTask>(EntityType::STACK, ZoneType::PLAY));
+    cards.emplace(
+        "DMF_084",
+        CardDef(
+            power,
+            PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 },
+                      { PlayReq::REQ_FRIENDLY_DEATHRATTLE_MINION_DIED_THIS_GAME,
+                        0 } }));
 
     // ---------------------------------------- MINION - HUNTER
     // [DMF_085] Darkmoon Tonk - COST:7 [ATK:8/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -519,6 +519,12 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // - DISCOVER = 1
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->tasks = { std::make_shared<DiscoverTask>(
+        DiscoverType::RINLINGS_RIFLE) };
+    cards.emplace("DMF_088", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
     // [DMF_089] Maxima Blastenheimer - COST:6 [ATK:4/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -10,6 +10,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawOpTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawRaceMinionTask.hpp>
@@ -534,6 +535,9 @@ void DarkmoonFaireCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DiscoverTask>(DiscoverType::SECRET));
+    cards.emplace("DMF_122", CardDef(power));
 
     // ----------------------------------------- SPELL - HUNTER
     // [DMF_123] Open the Cages - COST:2

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
@@ -322,7 +322,7 @@ std::vector<Card*> DiscoverTask::Discover(Game* game, Player* player,
             }
             break;
         case DiscoverType::SECRET:
-            choiceAction = ChoiceAction::CAST_SPELL;
+            choiceAction = ChoiceAction::HAND;
             for (auto& card : allCards)
             {
                 if (card->IsSecret())

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
@@ -466,6 +466,16 @@ std::vector<Card*> DiscoverTask::Discover(Game* game, Player* player,
                 }
             }
             break;
+        case DiscoverType::RINLINGS_RIFLE:
+            choiceAction = ChoiceAction::CAST_SPELL;
+            for (auto& card : allCards)
+            {
+                if (card->IsSecret())
+                {
+                    cards.emplace_back(card);
+                }
+            }
+            break;
     }
 
     return cards;

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
@@ -321,6 +321,16 @@ std::vector<Card*> DiscoverTask::Discover(Game* game, Player* player,
                 }
             }
             break;
+        case DiscoverType::SECRET:
+            choiceAction = ChoiceAction::CAST_SPELL;
+            for (auto& card : allCards)
+            {
+                if (card->IsSecret())
+                {
+                    cards.emplace_back(card);
+                }
+            }
+            break;
         case DiscoverType::DEMON:
             choiceAction = ChoiceAction::HAND;
             for (auto& card : allCards)

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -967,6 +967,64 @@ TEST_CASE("[Mage : Minion] - DMF_101 : Firework Elemental")
     CHECK_EQ(opField.GetCount(), 0);
 }
 
+// ------------------------------------------ MINION - MAGE
+// [DMF_102] Game Master - COST:2 [ATK:2/HP:3]
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: The first <b>Secret</b> you play each turn costs (1).
+// --------------------------------------------------------
+// GameTag:
+// - AURA = 1
+// --------------------------------------------------------
+// RefTag:
+// - SECRET = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - DMF_102 : Game Master")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Game Master"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Counterspell"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ice Barrier"));
+
+    CHECK_EQ(card2->GetCost(), 3);
+    CHECK_EQ(card3->GetCost(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(card2->GetCost(), 1);
+    CHECK_EQ(card3->GetCost(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(card3->GetCost(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card3->GetCost(), 1);
+}
+
 // ------------------------------------------- SPELL - MAGE
 // [DMF_103] Mask of C'Thun - COST:7
 // - Set: DARKMOON_FAIRE, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -730,6 +730,64 @@ TEST_CASE("[Hunter : Minion] - DMF_085 : Darkmoon Tonk")
     CHECK_EQ(opHero.GetHealth(), 22);
 }
 
+// ---------------------------------------- WEAPON - HUNTER
+// [DMF_088] Rinling's Rifle - COST:4
+// - Set: DARKMOON_FAIRE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: After your hero attacks,
+//       <b>Discover</b> a <b>Secret</b> and cast it.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+// RefTag:
+// - DISCOVER = 1
+// - SECRET = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Weapon] - DMF_088 : Rinling's Rifle")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Rinling's Rifle"));
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    CHECK_EQ(curPlayer->GetHero()->HasWeapon(), true);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetAttack(), 2);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 2);
+
+    game.Process(curPlayer,
+                 AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
+    CHECK(curPlayer->choice != nullptr);
+    CHECK_EQ(curPlayer->choice->choices.size(), 3);
+
+    auto cards = TestUtils::GetChoiceCards(game);
+    for (auto& card : cards)
+    {
+        CHECK_EQ(card->IsSecret(), true);
+    }
+
+    TestUtils::ChooseNthChoice(game, 1);
+    CHECK_EQ(curPlayer->GetSecretZone()->GetCount(), 1);
+}
+
 // ---------------------------------------- MINION - HUNTER
 // [DMF_122] Mystery Winner - COST:1 [ATK:1/HP:1]
 // - Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -821,6 +821,8 @@ TEST_CASE("[Hunter : Minion] - DMF_122 : Mystery Winner")
     opPlayer->SetTotalMana(10);
     opPlayer->SetUsedMana(0);
 
+    auto& curHand = *(curPlayer->GetHandZone());
+
     const auto card1 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Mystery Winner"));
 
@@ -835,7 +837,8 @@ TEST_CASE("[Hunter : Minion] - DMF_122 : Mystery Winner")
     }
 
     TestUtils::ChooseNthChoice(game, 1);
-    CHECK_EQ(curPlayer->GetSecretZone()->GetCount(), 1);
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->IsSecret(), true);
 }
 
 // ------------------------------------------ MINION - MAGE

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -7,6 +7,7 @@
 #include "doctest_proxy.hpp"
 
 #include <Utils/CardSetUtils.hpp>
+#include <Utils/TestUtils.hpp>
 
 #include <Rosetta/PlayMode/Actions/Draw.hpp>
 #include <Rosetta/PlayMode/Cards/Cards.hpp>
@@ -650,6 +651,56 @@ TEST_CASE("[Hunter : Minion] - DMF_085 : Darkmoon Tonk")
 
     game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
     CHECK_EQ(opHero.GetHealth(), 22);
+}
+
+// ---------------------------------------- MINION - HUNTER
+// [DMF_122] Mystery Winner - COST:1 [ATK:1/HP:1]
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> <b>Discover</b> a <b>Secret.</b>
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - DISCOVER = 1
+// --------------------------------------------------------
+// RefTag:
+// - SECRET = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - DMF_122 : Mystery Winner")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mystery Winner"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK(curPlayer->choice != nullptr);
+    CHECK_EQ(curPlayer->choice->choices.size(), 3);
+
+    auto cards = TestUtils::GetChoiceCards(game);
+    for (auto& card : cards)
+    {
+        CHECK_EQ(card->IsSecret(), true);
+    }
+
+    TestUtils::ChooseNthChoice(game, 1);
+    CHECK_EQ(curPlayer->GetSecretZone()->GetCount(), 1);
 }
 
 // ------------------------------------------ MINION - MAGE

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -2895,6 +2895,45 @@ TEST_CASE("[Warlock : Minion] - DMF_533 : Ring Matron")
     CHECK_EQ(curField[1]->card->name, "Fiery Imp");
 }
 
+// ---------------------------------------- SPELL - WARLOCK
+// [YOP_033] Backfire - COST:3
+// - Set: DARKMOON_FAIRE, Rarity: Common
+// --------------------------------------------------------
+// Text: Draw 3 cards. Deal 3 damage to your hero.
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Spell] - YOP_033 : Backfire")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Backfire"));
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 27);
+    CHECK_EQ(curHand.GetCount(), 7);
+}
+
 // --------------------------------------- MINION - WARRIOR
 // [DMF_521] Sword Eater - COST:4 [ATK:2/HP:5]
 // - Race: Pirate, Set: DARKMOON_FAIRE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -2785,6 +2785,67 @@ TEST_CASE("[Warlock : Minion] - DMF_114 : Midway Maniac")
 }
 
 // --------------------------------------- MINION - WARLOCK
+// [DMF_115] Revenant Rascal - COST:3 [ATK:3/HP:3]
+// - Set: DARKMOON_FAIRE, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Destroy a Mana Crystal for both players.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - DMF_115 : Revenant Rascal")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Revenant Rascal"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Revenant Rascal"));
+
+    CHECK_EQ(curPlayer->GetTotalMana(), 10);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 10);
+    CHECK_EQ(opPlayer->GetTotalMana(), 10);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetTotalMana(), 9);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 7);
+    CHECK_EQ(opPlayer->GetTotalMana(), 9);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetTotalMana(), 8);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 4);
+    CHECK_EQ(opPlayer->GetTotalMana(), 8);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(opPlayer->GetTotalMana(), 9);
+    CHECK_EQ(opPlayer->GetRemainingMana(), 9);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetTotalMana(), 9);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 9);
+}
+
+// --------------------------------------- MINION - WARLOCK
 // [DMF_533] Ring Matron - COST:6 [ATK:6/HP:4]
 // - Race: Demon, Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------


### PR DESCRIPTION
This revision includes:
- Implement 6 DARKMOON_FAIRE cards
  - Jewel of N'Zoth (DMF_084)
  - Rinling's Rifle (DMF_088)
  - Game Master (DMF_102)
  - Revenant Rascal (DMF_115)
  - Mystery Winner (DMF_122)
  - Backfire (YOP_033)
- Add some enums and code to process it
  - DiscoverType::SECRET
  - DiscoverType::RINLINGS_RIFLE