### PR TITLE
Implement 15 CORE cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -10,8 +10,8 @@
 
 Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
-CORE | CORE_AT_003 | Fallen Hero |  
-CORE | CORE_AT_008 | Coldarra Drake |  
+CORE | CORE_AT_003 | Fallen Hero | O
+CORE | CORE_AT_008 | Coldarra Drake | O
 CORE | CORE_AT_021 | Tiny Knight of Evil |  
 CORE | CORE_AT_047 | Draenei Totemcarver |  
 CORE | CORE_AT_055 | Flash Heal |  
@@ -20,7 +20,7 @@ CORE | CORE_AT_075 | Warhorse Trainer |
 CORE | CORE_AT_092 | Ice Rager |  
 CORE | CORE_BOT_083 | Toxicologist |  
 CORE | CORE_BOT_420 | Landscaping | O
-CORE | CORE_BOT_453 | Shooting Star |  
+CORE | CORE_BOT_453 | Shooting Star | O
 CORE | CORE_BOT_533 | Menacing Nimbus |  
 CORE | CORE_BRM_013 | Quick Shot | O
 CORE | CORE_BT_035 | Chaos Strike |  
@@ -40,10 +40,10 @@ CORE | CORE_CS1_112 | Holy Nova |
 CORE | CORE_CS1_130 | Holy Smite |  
 CORE | CORE_CS2_009 | Mark of the Wild | O
 CORE | CORE_CS2_013 | Wild Growth | O
-CORE | CORE_CS2_023 | Arcane Intellect |  
-CORE | CORE_CS2_029 | Fireball |  
-CORE | CORE_CS2_032 | Flamestrike |  
-CORE | CORE_CS2_033 | Water Elemental |  
+CORE | CORE_CS2_023 | Arcane Intellect | O
+CORE | CORE_CS2_029 | Fireball | O
+CORE | CORE_CS2_032 | Flamestrike | O
+CORE | CORE_CS2_033 | Water Elemental | O
 CORE | CORE_CS2_039 | Windfury |  
 CORE | CORE_CS2_042 | Fire Elemental |  
 CORE | CORE_CS2_045 | Rockbiter Weapon |  
@@ -125,10 +125,10 @@ CORE | CORE_EX1_249 | Baron Geddon |
 CORE | CORE_EX1_250 | Earth Elemental |  
 CORE | CORE_EX1_258 | Unbound Elemental |  
 CORE | CORE_EX1_259 | Lightning Storm |  
-CORE | CORE_EX1_275 | Cone of Cold |  
-CORE | CORE_EX1_287 | Counterspell |  
-CORE | CORE_EX1_289 | Ice Barrier |  
-CORE | CORE_EX1_294 | Mirror Entity |  
+CORE | CORE_EX1_275 | Cone of Cold | O
+CORE | CORE_EX1_287 | Counterspell | O
+CORE | CORE_EX1_289 | Ice Barrier | O
+CORE | CORE_EX1_294 | Mirror Entity | O
 CORE | CORE_EX1_302 | Mortal Coil |  
 CORE | CORE_EX1_304 | Void Terror |  
 CORE | CORE_EX1_309 | Siphon Soul |  
@@ -173,7 +173,7 @@ CORE | CORE_FP1_011 | Webspinner | O
 CORE | CORE_FP1_020 | Avenge |  
 CORE | CORE_FP1_031 | Baron Rivendare |  
 CORE | CORE_GIL_191 | Fiendish Circle |  
-CORE | CORE_GIL_801 | Snap Freeze |  
+CORE | CORE_GIL_801 | Snap Freeze | O
 CORE | CORE_GIL_828 | Dire Frenzy | O
 CORE | CORE_GVG_013 | Cogmaster |  
 CORE | CORE_GVG_044 | Spider Tank |  
@@ -187,12 +187,12 @@ CORE | CORE_ICC_038 | Righteous Protector |
 CORE | CORE_ICC_055 | Drain Soul |  
 CORE | CORE_ICC_419 | Bearshark | O
 CORE | CORE_ICC_809 | Plague Scientist |  
-CORE | CORE_KAR_009 | Babbling Book |  
+CORE | CORE_KAR_009 | Babbling Book | O
 CORE | CORE_KAR_036 | Arcane Anomaly |  
 CORE | CORE_KAR_065 | Menagerie Warden | O
 CORE | CORE_KAR_069 | Swashburglar |  
 CORE | CORE_KAR_300 | Enchanted Raven | O
-CORE | CORE_LOE_003 | Ethereal Conjurer |  
+CORE | CORE_LOE_003 | Ethereal Conjurer | O
 CORE | CORE_LOE_012 | Tomb Pillager |  
 CORE | CORE_LOEA10_3 | Murloc Tinyfin |  
 CORE | CORE_LOOT_124 | Lone Champion |  
@@ -209,7 +209,7 @@ CORE | CORE_OG_273 | Stand Against Darkness |
 CORE | CORE_TRL_111 | Headhunter's Hatchet | O
 CORE | CORE_TRL_243 | Pounce | O
 CORE | CORE_tt_004 | Flesheating Ghoul |  
-CORE | CORE_UNG_020 | Arcanologist |  
+CORE | CORE_UNG_020 | Arcanologist | O
 CORE | CORE_UNG_813 | Stormwatcher |  
 CORE | CORE_UNG_817 | Tidal Surge |  
 CORE | CORE_UNG_833 | Lakkari Felhound |  
@@ -246,7 +246,7 @@ CORE | CS3_036 | Deathwing the Destroyer |
 CORE | CS3_037 | Emerald Skytalon |  
 CORE | CS3_038 | Redgill Razorjaw |  
 
-- Progress: 13% (32 of 235 Cards)
+- Progress: 20% (47 of 235 Cards)
 
 ## Ashes of Outland
 

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -9,8 +9,10 @@
 * [Curse of Naxxramas](#curse-of-naxxramas)
 * [Blackrock Mountain](#blackrock-mountain)
 * [The Grand Tournament](#the-grand-tournament)
+* [The League of Explorers](#the-league-of-explorers)
 * [Whispers of the Old Gods](#whispers-of-the-old-gods)
 * [One Night in Karazhan](#one-night-in-karazhan)
+* [Journey to Un'Goro](#journey-to-ungoro)
 * [Knights of the Frozen Throne](#knights-of-the-frozen-throne)
 * [The Witchwood](#the-witchwood)
 * [The Boomsday Project](#the-boomsday-project)
@@ -567,12 +569,12 @@ Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
 TGT | AT_001 | Flame Lance |  
 TGT | AT_002 | Effigy |  
-TGT | AT_003 | Fallen Hero |  
+TGT | AT_003 | Fallen Hero | O
 TGT | AT_004 | Arcane Blast |  
 TGT | AT_005 | Polymorph: Boar |  
 TGT | AT_006 | Dalaran Aspirant |  
 TGT | AT_007 | Spellslinger |  
-TGT | AT_008 | Coldarra Drake |  
+TGT | AT_008 | Coldarra Drake | O
 TGT | AT_009 | Rhonin |  
 TGT | AT_010 | Ram Wrangler |  
 TGT | AT_011 | Holy Champion |  
@@ -698,7 +700,59 @@ TGT | AT_131 | Eydis Darkbane |
 TGT | AT_132 | Justicar Trueheart |  
 TGT | AT_133 | Gadgetzan Jouster |  
 
-- Progress: 0% (1 of 132 Cards)
+- Progress: 2% (3 of 132 Cards)
+
+## The League of Explorers
+
+Set | ID | Name | Implemented
+:---: | :---: | :---: | :---:
+LOE | LOE_002 | Forgotten Torch |  
+LOE | LOE_003 | Ethereal Conjurer | O
+LOE | LOE_006 | Museum Curator |  
+LOE | LOE_007 | Curse of Rafaam |  
+LOE | LOE_009 | Obsidian Destroyer |  
+LOE | LOE_010 | Pit Snake |  
+LOE | LOE_011 | Reno Jackson |  
+LOE | LOE_012 | Tomb Pillager |  
+LOE | LOE_016 | Rumbling Elemental |  
+LOE | LOE_017 | Keeper of Uldaman |  
+LOE | LOE_018 | Tunnel Trogg |  
+LOE | LOE_019 | Unearthed Raptor |  
+LOE | LOE_020 | Desert Camel |  
+LOE | LOE_021 | Dart Trap |  
+LOE | LOE_022 | Fierce Monkey |  
+LOE | LOE_023 | Dark Peddler |  
+LOE | LOE_026 | Anyfin Can Happen |  
+LOE | LOE_027 | Sacred Trial |  
+LOE | LOE_029 | Jeweled Scarab |  
+LOE | LOE_038 | Naga Sea Witch |  
+LOE | LOE_039 | Gorillabot A-3 |  
+LOE | LOE_046 | Huge Toad |  
+LOE | LOE_047 | Tomb Spider |  
+LOE | LOE_050 | Mounted Raptor |  
+LOE | LOE_051 | Jungle Moonkin |  
+LOE | LOE_053 | Djinni of Zephyrs |  
+LOE | LOE_061 | Anubisath Sentinel |  
+LOE | LOE_073 | Fossilized Devilsaur |  
+LOE | LOE_076 | Sir Finley Mrrgglton |  
+LOE | LOE_077 | Brann Bronzebeard |  
+LOE | LOE_079 | Elise Starseeker |  
+LOE | LOE_086 | Summoning Stone |  
+LOE | LOE_089 | Wobbling Runts |  
+LOE | LOE_092 | Arch-Thief Rafaam |  
+LOE | LOE_104 | Entomb |  
+LOE | LOE_105 | Explorer's Hat |  
+LOE | LOE_107 | Eerie Statue |  
+LOE | LOE_110 | Ancient Shade |  
+LOE | LOE_111 | Excavated Evil |  
+LOE | LOE_113 | Everyfin is Awesome |  
+LOE | LOE_115 | Raven Idol |  
+LOE | LOE_116 | Reliquary Seeker |  
+LOE | LOE_118 | Cursed Blade |  
+LOE | LOE_119 | Animated Armor |  
+LOE | LOEA10_3 | Murloc Tinyfin |  
+
+- Progress: 2% (1 of 45 Cards)
 
 ## Whispers of the Old Gods
 
@@ -848,7 +902,7 @@ Set | ID | Name | Implemented
 KARA | KAR_004 | Cat Trick |  
 KARA | KAR_005 | Kindly Grandmother |  
 KARA | KAR_006 | Cloaked Huntress |  
-KARA | KAR_009 | Babbling Book |  
+KARA | KAR_009 | Babbling Book | O
 KARA | KAR_010 | Nightbane Templar |  
 KARA | KAR_011 | Pompous Thespian |  
 KARA | KAR_013 | Purify |  
@@ -891,7 +945,149 @@ KARA | KAR_710 | Arcanosmith |
 KARA | KAR_711 | Arcane Giant |  
 KARA | KAR_712 | Violet Illusionist |  
 
-- Progress: 4% (2 of 45 Cards)
+- Progress: 6% (3 of 45 Cards)
+
+## Journey to Un'Goro
+
+Set | ID | Name | Implemented
+:---: | :---: | :---: | :---:
+UNGORO | UNG_001 | Pterrordax Hatchling |  
+UNGORO | UNG_002 | Volcanosaur |  
+UNGORO | UNG_004 | Dinosize |  
+UNGORO | UNG_009 | Ravasaur Runt |  
+UNGORO | UNG_010 | Sated Threshadon |  
+UNGORO | UNG_011 | Hydrologist |  
+UNGORO | UNG_015 | Sunkeeper Tarim |  
+UNGORO | UNG_018 | Flame Geyser |  
+UNGORO | UNG_019 | Air Elemental |  
+UNGORO | UNG_020 | Arcanologist | O
+UNGORO | UNG_021 | Steam Surger |  
+UNGORO | UNG_022 | Mirage Caller |  
+UNGORO | UNG_024 | Mana Bind |  
+UNGORO | UNG_025 | Volcano |  
+UNGORO | UNG_027 | Pyros |  
+UNGORO | UNG_028 | Open the Waygate |  
+UNGORO | UNG_029 | Shadow Visions |  
+UNGORO | UNG_030 | Binding Heal |  
+UNGORO | UNG_032 | Crystalline Oracle |  
+UNGORO | UNG_034 | Radiant Elemental |  
+UNGORO | UNG_035 | Curious Glimmerroot |  
+UNGORO | UNG_037 | Tortollan Shellraiser |  
+UNGORO | UNG_047 | Ravenous Pterrordax |  
+UNGORO | UNG_049 | Tar Lurker |  
+UNGORO | UNG_057 | Razorpetal Volley |  
+UNGORO | UNG_058 | Razorpetal Lasher |  
+UNGORO | UNG_060 | Mimic Pod |  
+UNGORO | UNG_061 | Obsidian Shard |  
+UNGORO | UNG_063 | Biteweed |  
+UNGORO | UNG_064 | Vilespine Slayer |  
+UNGORO | UNG_065 | Sherazin, Corpse Flower |  
+UNGORO | UNG_067 | The Caverns Below |  
+UNGORO | UNG_070 | Tol'vir Stoneshaper |  
+UNGORO | UNG_071 | Giant Mastodon |  
+UNGORO | UNG_072 | Stonehill Defender |  
+UNGORO | UNG_073 | Rockpool Hunter |  
+UNGORO | UNG_075 | Vicious Fledgling |  
+UNGORO | UNG_076 | Eggnapper |  
+UNGORO | UNG_078 | Tortollan Forager |  
+UNGORO | UNG_079 | Frozen Crusher |  
+UNGORO | UNG_082 | Thunder Lizard |  
+UNGORO | UNG_083 | Devilsaur Egg |  
+UNGORO | UNG_084 | Fire Plume Phoenix |  
+UNGORO | UNG_085 | Emerald Hive Queen |  
+UNGORO | UNG_086 | Giant Anaconda |  
+UNGORO | UNG_087 | Bittertide Hydra |  
+UNGORO | UNG_088 | Tortollan Primalist |  
+UNGORO | UNG_089 | Gentle Megasaur |  
+UNGORO | UNG_099 | Charged Devilsaur |  
+UNGORO | UNG_100 | Verdant Longneck |  
+UNGORO | UNG_101 | Shellshifter |  
+UNGORO | UNG_103 | Evolving Spores |  
+UNGORO | UNG_108 | Earthen Scales |  
+UNGORO | UNG_109 | Elder Longneck |  
+UNGORO | UNG_111 | Living Mana |  
+UNGORO | UNG_113 | Bright-Eyed Scout |  
+UNGORO | UNG_116 | Jungle Giants |  
+UNGORO | UNG_201 | Primalfin Totem |  
+UNGORO | UNG_202 | Fire Plume Harbinger |  
+UNGORO | UNG_205 | Glacial Shard |  
+UNGORO | UNG_208 | Stone Sentinel |  
+UNGORO | UNG_211 | Kalimos, Primal Lord |  
+UNGORO | UNG_800 | Terrorscale Stalker |  
+UNGORO | UNG_801 | Nesting Roc |  
+UNGORO | UNG_803 | Emerald Reaver |  
+UNGORO | UNG_806 | Ultrasaur |  
+UNGORO | UNG_807 | Golakka Crawler |  
+UNGORO | UNG_808 | Stubborn Gastropod |  
+UNGORO | UNG_809 | Fire Fly |  
+UNGORO | UNG_810 | Stegodon |  
+UNGORO | UNG_812 | Sabretooth Stalker |  
+UNGORO | UNG_813 | Stormwatcher |  
+UNGORO | UNG_814 | Giant Wasp |  
+UNGORO | UNG_816 | Servant of Kalimos |  
+UNGORO | UNG_817 | Tidal Surge |  
+UNGORO | UNG_818 | Volatile Elemental |  
+UNGORO | UNG_823 | Envenom Weapon |  
+UNGORO | UNG_829 | Lakkari Sacrifice |  
+UNGORO | UNG_830 | Cruel Dinomancer |  
+UNGORO | UNG_831 | Corrupting Mist |  
+UNGORO | UNG_832 | Bloodbloom |  
+UNGORO | UNG_833 | Lakkari Felhound |  
+UNGORO | UNG_834 | Feeding Time |  
+UNGORO | UNG_835 | Chittering Tunneler |  
+UNGORO | UNG_836 | Clutchmother Zavas |  
+UNGORO | UNG_838 | Tar Lord |  
+UNGORO | UNG_840 | Hemet, Jungle Hunter |  
+UNGORO | UNG_843 | The Voraxx |  
+UNGORO | UNG_844 | Humongous Razorleaf |  
+UNGORO | UNG_845 | Igneous Elemental |  
+UNGORO | UNG_846 | Shimmering Tempest |  
+UNGORO | UNG_847 | Blazecaller |  
+UNGORO | UNG_848 | Primordial Drake |  
+UNGORO | UNG_851 | Elise the Trailblazer |  
+UNGORO | UNG_852 | Tyrantus |  
+UNGORO | UNG_854 | Free From Amber |  
+UNGORO | UNG_856 | Hallucination |  
+UNGORO | UNG_900 | Spiritsinger Umbra |  
+UNGORO | UNG_907 | Ozruk |  
+UNGORO | UNG_910 | Grievous Bite |  
+UNGORO | UNG_912 | Jeweled Macaw |  
+UNGORO | UNG_913 | Tol'vir Warden |  
+UNGORO | UNG_914 | Raptor Hatchling |  
+UNGORO | UNG_915 | Crackling Razormaw |  
+UNGORO | UNG_916 | Stampede |  
+UNGORO | UNG_917 | Dinomancy |  
+UNGORO | UNG_919 | Swamp King Dred |  
+UNGORO | UNG_920 | The Marsh Queen |  
+UNGORO | UNG_922 | Explore Un'Goro |  
+UNGORO | UNG_923 | Iron Hide |  
+UNGORO | UNG_925 | Ornery Direhorn |  
+UNGORO | UNG_926 | Cornered Sentry |  
+UNGORO | UNG_927 | Sudden Genesis |  
+UNGORO | UNG_928 | Tar Creeper |  
+UNGORO | UNG_929 | Molten Blade |  
+UNGORO | UNG_933 | King Mosh |  
+UNGORO | UNG_934 | Fire Plume's Heart |  
+UNGORO | UNG_937 | Primalfin Lookout |  
+UNGORO | UNG_938 | Hot Spring Guardian |  
+UNGORO | UNG_940 | Awaken the Makers |  
+UNGORO | UNG_941 | Primordial Glyph |  
+UNGORO | UNG_942 | Unite the Murlocs |  
+UNGORO | UNG_946 | Gluttonous Ooze |  
+UNGORO | UNG_948 | Molten Reflection |  
+UNGORO | UNG_950 | Vinecleaver |  
+UNGORO | UNG_952 | Spikeridged Steed |  
+UNGORO | UNG_953 | Primalfin Champion |  
+UNGORO | UNG_954 | The Last Kaleidosaur |  
+UNGORO | UNG_955 | Meteor |  
+UNGORO | UNG_956 | Spirit Echo |  
+UNGORO | UNG_957 | Direhorn Hatchling |  
+UNGORO | UNG_960 | Lost in the Jungle |  
+UNGORO | UNG_961 | Adaptation |  
+UNGORO | UNG_962 | Lightfused Stegodon |  
+UNGORO | UNG_963 | Lyra the Sunshard |  
+
+- Progress: 0% (1 of 135 Cards)
 
 ## Knights of the Frozen Throne
 
@@ -1147,7 +1343,7 @@ GILNEAS | GIL_693 | Blood Witch |
 GILNEAS | GIL_694 | Prince Liam |  
 GILNEAS | GIL_696 | Pick Pocket |  
 GILNEAS | GIL_800 | Duskfallen Aviana |  
-GILNEAS | GIL_801 | Snap Freeze |  
+GILNEAS | GIL_801 | Snap Freeze | O
 GILNEAS | GIL_803 | Militia Commander |  
 GILNEAS | GIL_805 | Coffin Crasher |  
 GILNEAS | GIL_807 | Bogshaper |  
@@ -1169,7 +1365,7 @@ GILNEAS | GIL_902 | Cutthroat Buccaneer |
 GILNEAS | GIL_903 | Hidden Wisdom |  
 GILNEAS | GIL_905 | Carrion Drake |  
 
-- Progress: 0% (1 of 129 Cards)
+- Progress: 1% (2 of 129 Cards)
 
 ## The Boomsday Project
 
@@ -1261,7 +1457,7 @@ BOOMSDAY | BOT_445 | Mecharoo |
 BOOMSDAY | BOT_447 | Crystallizer |  
 BOOMSDAY | BOT_448 | Damaged Stegotron |  
 BOOMSDAY | BOT_451 | Voltaic Burst |  
-BOOMSDAY | BOT_453 | Shooting Star |  
+BOOMSDAY | BOT_453 | Shooting Star | O
 BOOMSDAY | BOT_507 | Gloop Sprayer |  
 BOOMSDAY | BOT_508 | Necrium Vial |  
 BOOMSDAY | BOT_509 | Dead Ringer |  
@@ -1312,7 +1508,7 @@ BOOMSDAY | BOT_912 | Kangor's Endless Army |
 BOOMSDAY | BOT_913 | Demonic Project |  
 BOOMSDAY | BOT_914 | Whizbang the Wonderful |  
 
-- Progress: 0% (1 of 136 Cards)
+- Progress: 1% (2 of 136 Cards)
 
 ## Rastakhan's Rumble
 

--- a/Includes/Rosetta/Common/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/TaskEnums.hpp
@@ -44,6 +44,7 @@ enum class EntityType
     HERO,
     ENEMY_HERO,
     HEROES,
+    HERO_POWER,
     WEAPON,
     ENEMY_WEAPON,
     HAND,

--- a/Includes/Rosetta/Common/Enums/TriggerEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/TriggerEnums.hpp
@@ -51,7 +51,7 @@ enum class TriggerType
     DISCARD,  //!< The effect will be triggered when a card is discarded from
               //!< hand.
     DEATH,    //!< The effect will be triggered when a minion dies.
-    USE_HERO_POWER,  //!< The effect will be triggered when a hero uses power.
+    INSPIRE,  //!< The effect will be triggered when a hero uses power.
     SHUFFLE_INTO_DECK,  //!< The effect will be triggered when a card is
                         //!< shuffled into a deck.
     MULTI_TRIGGER,      //!< The effect for multi trigger.

--- a/Includes/Rosetta/PlayMode/CardSets/LoECardsGen.hpp
+++ b/Includes/Rosetta/PlayMode/CardSets/LoECardsGen.hpp
@@ -1,0 +1,142 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_LOE_CARDS_GEN_HPP
+#define ROSETTASTONE_LOE_CARDS_GEN_HPP
+
+#include <Rosetta/PlayMode/Cards/CardDef.hpp>
+
+#include <map>
+#include <string>
+
+namespace RosettaStone::PlayMode
+{
+//!
+//! \brief LoECardsGen class.
+//!
+//! This structure adds LOE cards to the data storage with powers,
+//! play requirements and entourages.
+//!
+class LoECardsGen
+{
+ public:
+    //! Adds hero cards to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddHeroes(std::map<std::string, CardDef>& cards);
+
+    //! Adds hero power cards to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddHeroPowers(std::map<std::string, CardDef>& cards);
+
+    //! Adds druid cards that are collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddDruid(std::map<std::string, CardDef>& cards);
+
+    //! Adds druid cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddDruidNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds hunter cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddHunter(std::map<std::string, CardDef>& cards);
+
+    //! Adds hunter cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddHunterNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds mage cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddMage(std::map<std::string, CardDef>& cards);
+
+    //! Adds mage cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddMageNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds paladin cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddPaladin(std::map<std::string, CardDef>& cards);
+
+    //! Adds paladin cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddPaladinNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds priest cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddPriest(std::map<std::string, CardDef>& cards);
+
+    //! Adds priest cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddPriestNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds rogue cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddRogue(std::map<std::string, CardDef>& cards);
+
+    //! Adds rogue cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddRogueNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds shaman cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddShaman(std::map<std::string, CardDef>& cards);
+
+    //! Adds shaman cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddShamanNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds warlock cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddWarlock(std::map<std::string, CardDef>& cards);
+
+    //! Adds warlock cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddWarlockNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds warrior cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddWarrior(std::map<std::string, CardDef>& cards);
+
+    //! Adds warrior cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddWarriorNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds neutral cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddNeutral(std::map<std::string, CardDef>& cards);
+
+    //! Adds neutral cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddNeutralNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds all cards to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddAll(std::map<std::string, CardDef>& cards);
+};
+}  // namespace RosettaStone::PlayMode
+
+#endif  // ROSETTASTONE_LOE_CARDS_GEN_HPP

--- a/Includes/Rosetta/PlayMode/CardSets/UngoroCardsGen.hpp
+++ b/Includes/Rosetta/PlayMode/CardSets/UngoroCardsGen.hpp
@@ -1,0 +1,142 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_UNGORO_CARDS_GEN_HPP
+#define ROSETTASTONE_UNGORO_CARDS_GEN_HPP
+
+#include <Rosetta/PlayMode/Cards/CardDef.hpp>
+
+#include <map>
+#include <string>
+
+namespace RosettaStone::PlayMode
+{
+//!
+//! \brief UngoroCardsGen class.
+//!
+//! This structure adds UNGORO cards to the data storage with powers,
+//! play requirements and entourages.
+//!
+class UngoroCardsGen
+{
+ public:
+    //! Adds hero cards to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddHeroes(std::map<std::string, CardDef>& cards);
+
+    //! Adds hero power cards to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddHeroPowers(std::map<std::string, CardDef>& cards);
+
+    //! Adds druid cards that are collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddDruid(std::map<std::string, CardDef>& cards);
+
+    //! Adds druid cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddDruidNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds hunter cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddHunter(std::map<std::string, CardDef>& cards);
+
+    //! Adds hunter cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddHunterNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds mage cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddMage(std::map<std::string, CardDef>& cards);
+
+    //! Adds mage cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddMageNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds paladin cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddPaladin(std::map<std::string, CardDef>& cards);
+
+    //! Adds paladin cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddPaladinNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds priest cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddPriest(std::map<std::string, CardDef>& cards);
+
+    //! Adds priest cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddPriestNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds rogue cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddRogue(std::map<std::string, CardDef>& cards);
+
+    //! Adds rogue cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddRogueNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds shaman cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddShaman(std::map<std::string, CardDef>& cards);
+
+    //! Adds shaman cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddShamanNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds warlock cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddWarlock(std::map<std::string, CardDef>& cards);
+
+    //! Adds warlock cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddWarlockNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds warrior cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddWarrior(std::map<std::string, CardDef>& cards);
+
+    //! Adds warrior cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddWarriorNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds neutral cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddNeutral(std::map<std::string, CardDef>& cards);
+
+    //! Adds neutral cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddNeutralNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds all cards to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddAll(std::map<std::string, CardDef>& cards);
+};
+}  // namespace RosettaStone::PlayMode
+
+#endif  // ROSETTASTONE_UNGORO_CARDS_GEN_HPP

--- a/Includes/Rosetta/PlayMode/Managers/TriggerManager.hpp
+++ b/Includes/Rosetta/PlayMode/Managers/TriggerManager.hpp
@@ -111,7 +111,7 @@ class TriggerManager
 
     //! Callback for trigger when hero uses power.
     //! \param sender An entity that is the source of trigger.
-    void OnUseHeroPowerTrigger(Entity* sender);
+    void OnInspireTrigger(Entity* sender);
 
     //! Callback for trigger when a card is shuffled into a deck.
     //! \param sender An entity that is the source of trigger.
@@ -139,7 +139,7 @@ class TriggerManager
     TriggerEvent targetTrigger;
     TriggerEvent discardTrigger;
     TriggerEvent deathTrigger;
-    TriggerEvent useHeroPowerTrigger;
+    TriggerEvent inspireTrigger;
     TriggerEvent shuffleIntoDeckTrigger;
 };
 }  // namespace RosettaStone::PlayMode

--- a/Includes/Rosetta/PlayMode/Models/Hero.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Hero.hpp
@@ -56,6 +56,10 @@ class Hero : public Character
     //! \param armor The value of armor.
     void SetArmor(int armor);
 
+    //! Returns the value of hero power damage.
+    //! \return The value of hero power damage.
+    int GetHeroPowerDamage() const;
+
     //! Adds weapon to hero.
     //! \param _weapon A weapon card to add.
     void AddWeapon(Weapon& _weapon);

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
@@ -6,17 +6,7 @@
 #ifndef ROSETTASTONE_PLAYMODE_COMPLEX_TASK_HPP
 #define ROSETTASTONE_PLAYMODE_COMPLEX_TASK_HPP
 
-#include <Rosetta/PlayMode/Tasks/SimpleTasks/AddEnchantmentTask.hpp>
-#include <Rosetta/PlayMode/Tasks/SimpleTasks/ConditionTask.hpp>
-#include <Rosetta/PlayMode/Tasks/SimpleTasks/CustomTask.hpp>
-#include <Rosetta/PlayMode/Tasks/SimpleTasks/DestroyTask.hpp>
-#include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
-#include <Rosetta/PlayMode/Tasks/SimpleTasks/FlagTask.hpp>
-#include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeTask.hpp>
-#include <Rosetta/PlayMode/Tasks/SimpleTasks/MoveToGraveyardTask.hpp>
-#include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomTask.hpp>
-#include <Rosetta/PlayMode/Tasks/SimpleTasks/SetGameTagTask.hpp>
-#include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonStackTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 
 #include <utility>
 
@@ -33,6 +23,17 @@ using TaskList = std::vector<std::shared_ptr<ITask>>;
 class ComplexTask
 {
  public:
+    //! Returns a list of task for drawing card(s) from your deck.
+    static TaskList DrawCardFromDeck(int amount, const SelfCondList& list)
+    {
+        return TaskList{ std::make_shared<SimpleTasks::IncludeTask>(
+                             EntityType::DECK),
+                         std::make_shared<SimpleTasks::FilterStackTask>(list),
+                         std::make_shared<SimpleTasks::RandomTask>(
+                             EntityType::STACK, amount),
+                         std::make_shared<SimpleTasks::DrawStackTask>() };
+    }
+
     //! Returns a list of task for summoning a minion from your deck.
     static TaskList SummonMinionFromDeck()
     {

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.hpp
@@ -18,10 +18,9 @@ namespace RosettaStone::PlayMode::SimpleTasks
 class DrawStackTask : public ITask
 {
  public:
-    //! Constructs task with given \p amount and \p addToStack.
-    //! \param amount The amount to draw card.
+    //! Constructs task with given \p addToStack.
     //! \param addToStack A flag to store card to stack.
-    explicit DrawStackTask(std::size_t amount, bool addToStack = false);
+    explicit DrawStackTask(bool addToStack = false);
 
  private:
     //! Processes task logic internally and returns meta data.
@@ -33,7 +32,6 @@ class DrawStackTask : public ITask
     //! \return The cloned task.
     std::unique_ptr<ITask> CloneImpl() override;
 
-    std::size_t m_amount = 0;
     bool m_addToStack = false;
 };
 }  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -97,6 +97,7 @@
 #include <Rosetta/PlayMode/CardSets/HoFCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/IcecrownCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/KaraCardsGen.hpp>
+#include <Rosetta/PlayMode/CardSets/LoECardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/LootapaloozaCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/NaxxCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/OgCardsGen.hpp>

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -106,6 +106,7 @@
 #include <Rosetta/PlayMode/CardSets/TheBarrensCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/TrollCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/UldumCardsGen.hpp>
+#include <Rosetta/PlayMode/CardSets/UngoroCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/VanillaCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/YoDCardsGen.hpp>
 #include <Rosetta/PlayMode/Cards/Card.hpp>

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 13% Core Set (32 of 235 cards)
+  * 20% Core Set (47 of 235 cards)
   * 59% Ashes of Outland (80 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
@@ -50,16 +50,16 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 3% Curse of Naxxramas (1 of 30 Cards)
   * 0% Goblins vs Gnomes (0 of 123 Cards)
   * 3% Blackrock Mountain (1 of 31 Cards)
-  * 0% The Grand Tournament (1 of 132 Cards)
-  * 0% The League of Explorers (0 of 45 Cards)
+  * 2% The Grand Tournament (3 of 132 Cards)
+  * 2% The League of Explorers (1 of 45 Cards)
   * 0% Whispers of the Old Gods (1 of 134 Cards)
-  * 4% One Night in Karazhan (2 of 45 Cards)
+  * 6% One Night in Karazhan (3 of 45 Cards)
   * 0% Mean Streets of Gadgetzan (0 of 132 Cards)
-  * 0% Journey to Un'Goro (0 of 135 Cards)
+  * 0% Journey to Un'Goro (1 of 135 Cards)
   * 0% Knights of the Frozen Throne (1 of 135 Cards)
   * 0% Kobolds & Catacombs (0 of 135 Cards)
-  * 0% The Witchwood (1 of 129 Cards)
-  * 0% The Boomsday Project (1 of 136 Cards)
+  * 1% The Witchwood (2 of 129 Cards)
+  * 1% The Boomsday Project (2 of 136 Cards)
   * 1% Rastakhan's Rumble (2 of 135 Cards)
   * **100% Rise of Shadows (136 of 136 cards)**
   * **99% Saviors of Uldum (134 of 135 cards)**

--- a/Sources/Rosetta/PlayMode/Actions/Generic.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Generic.cpp
@@ -33,6 +33,8 @@ void TakeDamageToCharacter(Playable* source, Character* target, int amount,
     }
     else if (dynamic_cast<HeroPower*>(source))
     {
+        amount += source->player->GetHero()->GetHeroPowerDamage();
+
         if (const auto value = source->player->playerAuraEffects.GetValue(
                 GameTag::HEROPOWER_DAMAGE);
             value > 0)

--- a/Sources/Rosetta/PlayMode/Auras/Aura.cpp
+++ b/Sources/Rosetta/PlayMode/Auras/Aura.cpp
@@ -60,8 +60,8 @@ void Aura::Activate(Playable* owner, bool cloning)
             owner->game->triggerManager.playMinionTrigger +=
                 instance->m_removeHandler;
             break;
-        case TriggerType::USE_HERO_POWER:
-            owner->game->triggerManager.useHeroPowerTrigger +=
+        case TriggerType::INSPIRE:
+            owner->game->triggerManager.inspireTrigger +=
                 instance->m_removeHandler;
             break;
         default:
@@ -181,9 +181,8 @@ void Aura::Remove()
         case TriggerType::CAST_SPELL:
             m_owner->game->triggerManager.castSpellTrigger -= m_removeHandler;
             break;
-        case TriggerType::USE_HERO_POWER:
-            m_owner->game->triggerManager.useHeroPowerTrigger -=
-                m_removeHandler;
+        case TriggerType::INSPIRE:
+            m_owner->game->triggerManager.inspireTrigger -= m_removeHandler;
             break;
         default:
             break;

--- a/Sources/Rosetta/PlayMode/Auras/Aura.cpp
+++ b/Sources/Rosetta/PlayMode/Auras/Aura.cpp
@@ -415,6 +415,11 @@ void Aura::UpdateInternal()
             }
             break;
         }
+        case AuraType::HERO:
+        {
+            Apply(m_owner->player->GetHero());
+            break;
+        }
         case AuraType::HERO_POWER:
         {
             Apply(m_owner->player->GetHero()->heroPower);

--- a/Sources/Rosetta/PlayMode/CardSets/BoomsdayCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BoomsdayCardsGen.cpp
@@ -409,6 +409,8 @@ void BoomsdayCardsGen::AddHunterNonCollect(
 
 void BoomsdayCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------- SPELL - MAGE
     // [BOT_101] Astral Rift - COST:2
     // - Set: BOOMSDAY, Rarity: Rare
@@ -468,6 +470,19 @@ void BoomsdayCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 1 damage to a minion and the minions next to it.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<IncludeAdjacentTask>(EntityType::TARGET, true));
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::STACK, 1, true));
+    cards.emplace(
+        "BOT_453",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ------------------------------------------ MINION - MAGE
     // [BOT_531] Celestial Emissary - COST:2 [ATK:2/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -658,6 +658,19 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 1 damage to a minion and the minions next to it.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<IncludeAdjacentTask>(EntityType::TARGET, true));
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::STACK, 1, true));
+    cards.emplace(
+        "CORE_BOT_453",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ------------------------------------------- SPELL - MAGE
     // [CORE_CS2_023] Arcane Intellect - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -766,6 +766,14 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - COUNTER = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::CAST_SPELL));
+    power.GetTrigger()->triggerSource = TriggerSource::ENEMY_SPELLS;
+    power.GetTrigger()->tasks =
+        ComplexTask::ActivateSecret(TaskList{ std::make_shared<SetGameTagTask>(
+            EntityType::TARGET, GameTag::CANT_PLAY, 1) });
+    power.GetTrigger()->fastExecution = true;
+    cards.emplace("CORE_EX1_287", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [CORE_EX1_289] Ice Barrier - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -786,6 +786,13 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::ATTACK));
+    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
+        SelfCondition::IsProposedDefender(CardType::HERO));
+    power.GetTrigger()->tasks =
+        ComplexTask::ActivateSecret(TaskList{ std::make_shared<ArmorTask>(8) });
+    cards.emplace("CORE_EX1_289", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [CORE_EX1_294] Mirror Entity - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -721,6 +721,9 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CORE_CS2_033", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [CORE_EX1_275] Cone of Cold - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -894,6 +894,11 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(ComplexTask::DrawCardFromDeck(
+        1, SelfCondList{
+               std::make_shared<SelfCondition>(SelfCondition::IsSecret()) }));
+    cards.emplace("CORE_UNG_020", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [CS3_001] Aegwynn, the Guardian - COST:5 [ATK:5/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -736,6 +736,21 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<IncludeAdjacentTask>(EntityType::TARGET, true));
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::STACK,
+                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::STACK, 1, true));
+    cards.emplace(
+        "CORE_EX1_275",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ------------------------------------------- SPELL - MAGE
     // [CORE_EX1_287] Counterspell - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -805,6 +805,24 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_PLAY_MINION));
+    power.GetTrigger()->triggerSource = TriggerSource::ENEMY_MINIONS;
+    power.GetTrigger()->tasks = {
+        std::make_shared<ConditionTask>(
+            EntityType::EVENT_SOURCE,
+            SelfCondList{
+                std::make_shared<SelfCondition>(SelfCondition::IsNotDead()),
+                std::make_shared<SelfCondition>(
+                    SelfCondition::IsNotUntouchable()),
+                std::make_shared<SelfCondition>(
+                    SelfCondition::IsOpFieldNotFull()) }),
+        std::make_shared<FlagTask>(
+            true,
+            ComplexTask::ActivateSecret(TaskList{
+                std::make_shared<SummonCopyTask>(EntityType::EVENT_SOURCE) }))
+    };
+    cards.emplace("CORE_EX1_294", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [CORE_GIL_801] Snap Freeze - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -679,6 +679,9 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Draw 2 cards.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawTask>(2));
+    cards.emplace("CORE_CS2_023", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [CORE_CS2_029] Fireball - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -690,6 +690,15 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 6 damage.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 6, true));
+    cards.emplace(
+        "CORE_CS2_029",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ------------------------------------------- SPELL - MAGE
     // [CORE_CS2_032] Flamestrike - COST:7

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -878,6 +878,9 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - DISCOVER = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DiscoverTask>(DiscoverType::SPELL));
+    cards.emplace("CORE_LOE_003", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [CORE_UNG_020] Arcanologist - COST:2 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -621,6 +621,8 @@ void CoreCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
 void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------ MINION - MAGE
     // [CORE_AT_003] Fallen Hero - COST:2 [ATK:3/HP:2]
     // - Set: CORE, Rarity: Rare
@@ -630,6 +632,12 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - HEROPOWER_DAMAGE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<Aura>(
+        AuraType::HERO,
+        EffectList{ std::make_shared<Effect>(GameTag::HEROPOWER_DAMAGE,
+                                             EffectOperator::ADD, 1) }));
+    cards.emplace("CORE_AT_003", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [CORE_AT_008] Coldarra Drake - COST:6 [ATK:6/HP:7]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -832,9 +832,26 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // Text: <b>Freeze</b> a minion.
     //       If it's already <b>Frozen</b>, destroy it.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
     // RefTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::TARGET, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsFrozen()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<DestroyTask>(EntityType::TARGET) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        false, TaskList{ std::make_shared<SetGameTagTask>(
+                   EntityType::TARGET, GameTag::FROZEN, 1) }));
+    cards.emplace(
+        "CORE_GIL_801",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ------------------------------------------ MINION - MAGE
     // [CORE_KAR_009] Babbling Book - COST:1 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -707,6 +707,10 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 5 damage to all enemy minions.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 5, true));
+    cards.emplace("CORE_CS2_032", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [CORE_CS2_033] Water Elemental - COST:4 [ATK:3/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -862,6 +862,11 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<RandomCardTask>(CardType::SPELL, CardClass::MAGE));
+    power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
+    cards.emplace("CORE_KAR_009", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [CORE_LOE_003] Ethereal Conjurer - COST:5 [ATK:6/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -645,6 +645,11 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: You can use your Hero Power any number of times.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::INSPIRE));
+    power.GetTrigger()->tasks = { std::make_shared<SetGameTagTask>(
+        EntityType::HERO_POWER, GameTag::EXHAUSTED, 0) };
+    cards.emplace("CORE_AT_008", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [CORE_BOT_453] Shooting Star - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
@@ -441,7 +441,7 @@ void DalaranCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
         std::make_shared<FilterStackTask>(SelfCondList{
             std::make_shared<SelfCondition>(SelfCondition::IsSpell()) }),
         std::make_shared<RandomTask>(EntityType::STACK, 1),
-        std::make_shared<DrawStackTask>(1)
+        std::make_shared<DrawStackTask>()
     };
     cards.emplace("DAL_372", CardDef(power));
 

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -2299,7 +2299,7 @@ void DarkmoonFaireCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
         std::make_shared<SelfCondition>(SelfCondition::HasRush()) }));
     power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
-    power.AddPowerTask(std::make_shared<DrawStackTask>(1));
+    power.AddPowerTask(std::make_shared<DrawStackTask>());
     cards.emplace("DMF_526", CardDef(power, "DMF_526a"));
 
     // --------------------------------------- MINION - WARRIOR
@@ -2412,7 +2412,7 @@ void DarkmoonFaireCardsGen::AddWarriorNonCollect(
     power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
         std::make_shared<SelfCondition>(SelfCondition::HasRush()) }));
     power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
-    power.AddPowerTask(std::make_shared<DrawStackTask>(1, true));
+    power.AddPowerTask(std::make_shared<DrawStackTask>(true));
     power.AddPowerTask(
         std::make_shared<AddEnchantmentTask>("DMF_526e", EntityType::STACK));
     cards.emplace("DMF_526a", CardDef(power));

--- a/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
@@ -850,7 +850,7 @@ void DragonsCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // - SECRET = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddTrigger(std::make_shared<Trigger>(TriggerType::USE_HERO_POWER));
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::INSPIRE));
     power.GetTrigger()->tasks = {
         std::make_shared<IncludeTask>(EntityType::DECK),
         std::make_shared<FilterStackTask>(SelfCondList{
@@ -938,7 +938,7 @@ void DragonsCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // - SIDEQUEST = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddTrigger(std::make_shared<Trigger>(TriggerType::USE_HERO_POWER));
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::INSPIRE));
     power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
         TaskList{ std::make_shared<SummonTask>("DRG_255t2", 3) }) };
     cards.emplace("DRG_255", CardDef(power, 3, 0));
@@ -954,7 +954,7 @@ void DragonsCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddTrigger(std::make_shared<Trigger>(TriggerType::USE_HERO_POWER));
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::INSPIRE));
     power.GetTrigger()->tasks = {
         std::make_shared<RandomTask>(EntityType::ENEMIES, 1),
         std::make_shared<DamageTask>(EntityType::STACK, 5)
@@ -4683,7 +4683,7 @@ void DragonsCardsGen::AddNeutralNonCollect(
                                          EffectList{ Effects::SetCost(3) }));
     {
         const auto aura = dynamic_cast<Aura*>(power.GetAura());
-        aura->removeTrigger = { TriggerType::USE_HERO_POWER, nullptr };
+        aura->removeTrigger = { TriggerType::INSPIRE, nullptr };
     }
     cards.emplace("DRG_403e", CardDef(power));
 

--- a/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
@@ -799,7 +799,7 @@ void DragonsCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
         std::make_shared<SelfCondition>(SelfCondition::HasRush()) }));
     power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
-    power.AddPowerTask(std::make_shared<DrawStackTask>(1));
+    power.AddPowerTask(std::make_shared<DrawStackTask>());
     cards.emplace("DRG_010", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
@@ -1354,7 +1354,7 @@ void DragonsCardsGen::AddMage(std::map<std::string, CardDef>& cards)
             std::make_shared<FilterStackTask>(SelfCondList{
                 std::make_shared<SelfCondition>(SelfCondition::IsSpell()) }),
             std::make_shared<RandomTask>(EntityType::STACK, 3),
-            std::make_shared<DrawStackTask>(3) },
+            std::make_shared<DrawStackTask>() },
         ProgressType::PLAY_ELEMENTAL_MINONS) };
     auto trigger4 = std::make_shared<Trigger>(TriggerType::TURN_END);
     trigger4->condition = std::make_shared<SelfCondition>(
@@ -2326,7 +2326,7 @@ void DragonsCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
                                                          GameTag::ENTITY_ID),
                         std::make_shared<AddEnchantmentTask>(
                             "DRG_031e", EntityType::SOURCE, false, true),
-                        std::make_shared<DrawStackTask>(1) }));
+                        std::make_shared<DrawStackTask>() }));
     cards.emplace("DRG_031", CardDef(power));
 
     // ------------------------------------------ SPELL - ROGUE
@@ -2368,7 +2368,8 @@ void DragonsCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::DECK));
     power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
         std::make_shared<SelfCondition>(SelfCondition::IsNotStartInDeck()) }));
-    power.AddPowerTask(std::make_shared<DrawStackTask>(2));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 2));
+    power.AddPowerTask(std::make_shared<DrawStackTask>());
     cards.emplace("DRG_034", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
@@ -3269,7 +3270,7 @@ void DragonsCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
             std::make_shared<SelfCondition>(
                 SelfCondition::IsRace(Race::PIRATE)) }),
         std::make_shared<RandomTask>(EntityType::STACK, 1),
-        std::make_shared<DrawStackTask>(1)
+        std::make_shared<DrawStackTask>()
     };
     cards.emplace("DRG_025", CardDef(power));
 
@@ -4096,7 +4097,7 @@ void DragonsCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
                              SelfCondList{ std::make_shared<SelfCondition>(
                                  SelfCondition::IsGalakrondHero()) }),
                          std::make_shared<RandomTask>(EntityType::STACK, 1),
-                         std::make_shared<DrawStackTask>(1) }));
+                         std::make_shared<DrawStackTask>() }));
     cards.emplace("DRG_099", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -3338,7 +3338,7 @@ void Expert1CardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
                 SelfCondition::IsStackNum(1, RelaSign::GEQ)) }));
         power.AddPowerTask(std::make_shared<FlagTask>(
             true, TaskList{ std::make_shared<RandomTask>(EntityType::STACK, 1),
-                            std::make_shared<DrawStackTask>(1) }));
+                            std::make_shared<DrawStackTask>() }));
         power.AddPowerTask(std::make_shared<FlagTask>(
             false, TaskList{ std::make_shared<AddCardTask>(EntityType::HAND,
                                                            "EX1_317t") }));

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -1367,7 +1367,8 @@ void Expert1CardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - Faction: Neutral, Set: Expert1, Rarity: Rare
     // - Spell School: Arcane
     // --------------------------------------------------------
-    // Text: <b>Secret:</b> When your opponent casts a spell, <b>Counter</b> it.
+    // Text: <b>Secret:</b> When your opponent casts a spell,
+    //       <b>Counter</b> it.
     // --------------------------------------------------------
     // GameTag:
     // - SECRET = 1

--- a/Sources/Rosetta/PlayMode/CardSets/GilneasCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/GilneasCardsGen.cpp
@@ -12,6 +12,7 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 namespace RosettaStone::PlayMode
 {
 using PlayReqs = std::map<PlayReq, int>;
+using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
 
 void GilneasCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
@@ -387,6 +388,8 @@ void GilneasCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
 void GilneasCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------ MINION - MAGE
     // [GIL_116] Arcane Keysmith - COST:4 [ATK:2/HP:2]
     // - Set: Gilneas, Rarity: Epic
@@ -471,6 +474,7 @@ void GilneasCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // ------------------------------------------- SPELL - MAGE
     // [GIL_801] Snap Freeze - COST:2
     // - Set: Gilneas, Rarity: Common
+    // - Spell School: Frost
     // --------------------------------------------------------
     // Text: <b>Freeze</b> a minion.
     //       If it's already <b>Frozen</b>, destroy it.
@@ -482,6 +486,19 @@ void GilneasCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::TARGET, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsFrozen()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<DestroyTask>(EntityType::TARGET) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        false, TaskList{ std::make_shared<SetGameTagTask>(
+                   EntityType::TARGET, GameTag::FROZEN, 1) }));
+    cards.emplace(
+        "GIL_801",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 }
 
 void GilneasCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
@@ -132,6 +132,8 @@ void KaraCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
 void KaraCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------ MINION - MAGE
     // [KAR_009] Babbling Book - COST:1 [ATK:1/HP:1]
     // - Set: Kara, Rarity: Rare
@@ -141,6 +143,11 @@ void KaraCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<RandomCardTask>(CardType::SPELL, CardClass::MAGE));
+    power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
+    cards.emplace("KAR_009", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [KAR_076] Firelands Portal - COST:7

--- a/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
@@ -6,6 +6,8 @@
 #include <Rosetta/PlayMode/CardSets/LoECardsGen.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 
+using namespace RosettaStone::PlayMode::SimpleTasks;
+
 namespace RosettaStone::PlayMode
 {
 void LoECardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
@@ -132,6 +134,8 @@ void LoECardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
 void LoECardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------- SPELL - MAGE
     // [LOE_002] Forgotten Torch - COST:3
     // - Set: LoE, Rarity: Common
@@ -154,6 +158,9 @@ void LoECardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - DISCOVER = 1
     // - USE_DISCOVER_VISUALS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DiscoverTask>(DiscoverType::SPELL));
+    cards.emplace("LOE_003", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [LOE_119] Animated Armor - COST:4 [ATK:4/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
@@ -10,90 +10,801 @@ namespace RosettaStone::PlayMode
 {
 void LoECardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
+    // Do nothing
 }
 
 void LoECardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 {
+    // Do nothing
 }
 
 void LoECardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------------- MINION - DRUID
+    // [LOE_050] Mounted Raptor - COST:3 [ATK:3/HP:2]
+    // - Race: Beast, Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon a random 1-Cost minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [LOE_051] Jungle Moonkin - COST:4 [ATK:4/HP:4]
+    // - Race: Beast, Set: LoE, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Both players have <b>Spell Damage +2</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPELLPOWER = 2
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [LOE_115] Raven Idol - COST:1
+    // - Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Choose One -</b>
+    //       <b>Discover</b> a minion; or <b>Discover</b> a spell.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DISCOVER = 1
+    // - CHOOSE_ONE = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ------------------------------------------ SPELL - DRUID
+    // [LOE_115a] Break Free (*) - COST:1
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: <b>Discover</b> a minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [LOE_115b] Awakened (*) - COST:1
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: <b>Discover</b> a spell.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- MINION - HUNTER
+    // [LOE_020] Desert Camel - COST:3 [ATK:2/HP:4]
+    // - Race: Beast, Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Put a 1-Cost minion from each deck
+    //       into the battlefield.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [LOE_021] Dart Trap - COST:2
+    // - Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Secret:</b> After an opposing Hero Power is used,
+    //       deal 5 damage to a random enemy.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [LOE_105] Explorer's Hat - COST:2
+    // - Set: LoE, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Give a minion +1/+1 and "<b>Deathrattle:</b>
+    //       Add an Explorer's Hat to your hand."
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------- ENCHANTMENT - HUNTER
+    // [LOE_105e] Explorer's Hat (*) - COST:0
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: +1/+1. <b>Deathrattle:</b>
+    //       Add an Explorer's Hat to your hand.
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    // ------------------------------------------- SPELL - MAGE
+    // [LOE_002] Forgotten Torch - COST:3
+    // - Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Deal 3 damage. Shuffle a 'Roaring Torch'
+    //       into your deck that deals 6 damage.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [LOE_003] Ethereal Conjurer - COST:5 [ATK:6/HP:3]
+    // - Set: LoE Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry: Discover</b> a spell.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [LOE_119] Animated Armor - COST:4 [ATK:4/HP:4]
+    // - Set: LoE, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Your hero can only take 1 damage at a time.
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ------------------------------------------- SPELL - MAGE
+    // [LOE_002t] Roaring Torch (*) - COST:3
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: Deal 6 damage.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 {
+    // --------------------------------------- MINION - PALADIN
+    // [LOE_017] Keeper of Uldaman - COST:4 [ATK:3/HP:4]
+    // - Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Set a minion's Attack and Health to 3.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [LOE_026] Anyfin Can Happen - COST:10
+    // - Set: LoE, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Summon 7 Murlocs that died this game.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [LOE_027] Sacred Trial - COST:1
+    // - Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Secret:</b> After your opponent has at least
+    //       3 minions and plays another, destroy it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [LOE_017e] Watched (*) - COST:0
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: Stats changed to 3/3.
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- MINION - PRIEST
+    // [LOE_006] Museum Curator - COST:2 [ATK:1/HP:2]
+    // - Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry: Discover</b> a <b>Deathrattle</b> card.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [LOE_104] Entomb - COST:6
+    // - Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Choose an enemy minion. Shuffle it into your deck.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_ENEMY_TARGET = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [LOE_111] Excavated Evil - COST:5
+    // - Set: LoE, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Deal 3 damage to all minions.
+    //       Shuffle this card into your opponent's deck.
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // Do nothing
 }
 
 void LoECardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------------- MINION - ROGUE
+    // [LOE_010] Pit Snake - COST:1 [ATK:2/HP:1]
+    // - Race: Beast, Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Poisonous</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - POISONOUS = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [LOE_012] Tomb Pillager - COST:4 [ATK:5/HP:4]
+    // - Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Add a Coin to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [LOE_019] Unearthed Raptor - COST:3 [ATK:3/HP:4]
+    // - Set: LoE, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Choose a friendly minion.
+    //       Gain a copy of its <b>Deathrattle</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_TARGET_WITH_DEATHRATTLE = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ------------------------------------ ENCHANTMENT - ROGUE
+    // [LOE_019e] Unearthed Raptor (*) - COST:0
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: Copied Deathrattle from {0}.
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- MINION - SHAMAN
+    // [LOE_016] Rumbling Elemental - COST:4 [ATK:2/HP:6]
+    // - Race: Elemental, Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: After you play a <b>Battlecry</b> minion,
+    //       deal 2 damage to a random enemy.
+    // --------------------------------------------------------
+    // RefTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [LOE_018] Tunnel Trogg - COST:1 [ATK:1/HP:3]
+    // - Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Whenever you <b>Overload</b>,
+    //       gain +1 Attack per locked Mana Crystal.
+    // --------------------------------------------------------
+    // RefTag:
+    // - OVERLOAD = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [LOE_113] Everyfin is Awesome - COST:7
+    // - Set: LoE, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Give your minions +2/+2.
+    //       Costs (1) less for each Murloc you control.
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------- ENCHANTMENT - SHAMAN
+    // [LOE_018e] Trogg No Stupid (*) - COST:0
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: Increased Attack.
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- SPELL - WARLOCK
+    // [LOE_007] Curse of Rafaam - COST:2
+    // - Set: LoE, Rarity: common
+    // --------------------------------------------------------
+    // Text: Give your opponent a 'Cursed!' card.
+    //       While they hold it, they take 2 damage on their turn.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [LOE_023] Dark Peddler - COST:2 [ATK:2/HP:2]
+    // - Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry: Discover</b> a 1-Cost card.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [LOE_116] Reliquary Seeker - COST:1 [ATK:1/HP:1]
+    // - Set: LoE, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you have 6 other minions,
+    //       gain +4/+4.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------- ENCHANTMENT - WARLOCK
+    // [LOE_009e] Sinister Power (*) - COST:0
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: +4/+4.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [LOE_007t] Cursed! (*) - COST:2
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: While this is in your hand,
+    //       take 2 damage at the start of your turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ImmuneToSpellpower = 1
+    // - EVIL_GLOW = 1
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 {
+    // --------------------------------------- MINION - WARRIOR
+    // [LOE_009] Obsidian Destroyer - COST:7 [ATK:7/HP:7]
+    // - Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: At the end of your turn,
+    //       summon a 1/1 Scarab with <b>Taunt</b>.
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [LOE_022] Fierce Monkey - COST:3 [ATK:3/HP:4]
+    // - Race: Beast, Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- WEAPON - WARRIOR
+    // [LOE_118] Cursed Blade - COST:1 [ATK:2/HP:0]
+    // - Set: LoE, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Double all damage dealt to your hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 3
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // --------------------------------------- MINION - WARRIOR
+    // [LOE_009t] Scarab (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Beast, Set: LoE
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARRIOR
+    // [LOE_118e] Cursed Blade (*) - COST:0
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: Double all damage dealt to your hero.
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 {
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_011] Reno Jackson - COST:6 [ATK:4/HP:6]
+    // - Set: LoE, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your deck has no duplicates,
+    //       fully heal your hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - AFFECTED_BY_HEALING_DOES_DAMAGE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_029] Jeweled Scarab - COST:2 [ATK:1/HP:1]
+    // - Race: Beast, Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry: Discover</b> a 3-Cost card.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_038] Naga Sea Witch - COST:8 [ATK:5/HP:5]
+    // - Set: LoE, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Your cards cost (5).
+    // --------------------------------------------------------
+    // GameTag:
+    // - AURA = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_039] Gorillabot A-3 - COST:4 [ATK:3/HP:4]
+    // - Race: Mechanical, Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you control another Mech,
+    //       <b>Discover</b> a Mech.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_046] Huge Toad - COST:2 [ATK:3/HP:2]
+    // - Race: Beast, Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Deal 1 damage to a random enemy.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_047] Tomb Spider - COST:4 [ATK:3/HP:3]
+    // - Race: Beast, Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry: Discover</b> a Beast.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_053] Djinni of Zephyrs - COST:5 [ATK:4/HP:6]
+    // - Race: Elemental, Set: LoE, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: After you cast a spell on another friendly minion,
+    //       cast a copy of it on this one.
+    // --------------------------------------------------------
+    // GameTag:
+    // - 1059 = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_061] Anubisath Sentinel - COST:5 [ATK:4/HP:4]
+    // - Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Give a random friendly minion +3/+3.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_073] Fossilized Devilsaur - COST:8 [ATK:8/HP:8]
+    // - Set: LoE, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you control a Beast,
+    //       gain <b>Taunt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_076] Sir Finley Mrrgglton - COST:1 [ATK:1/HP:3]
+    // - Race: Murloc, Set: LoE, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry: Discover</b> a new basic Hero Power.
+    // --------------------------------------------------------
+    // Entourage: DS1h_292, CS2_056, CS2_101, CS1h_001, CS2_049,
+    //            CS2_102, CS2_083b, CS2_034, CS2_017
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_077] Brann Bronzebeard - COST:3 [ATK:2/HP:4]
+    // - Set: LoE, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Your <b>Battlecries</b> trigger twice.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - AURA = 1
+    // - 1429 = 58400
+    // - TECH_LEVEL = 5
+    // - IS_BACON_POOL_MINION = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_079] Elise Starseeker - COST:4 [ATK:3/HP:5]
+    // - Set: LoE, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Shuffle the
+    //       'Map to the Golden Monkey' into your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_086] Summoning Stone - COST:5 [ATK:0/HP:6]
+    // - Set: LoE, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Whenever you cast a spell,
+    //       summon a random minion of the same Cost.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_089] Wobbling Runts - COST:6 [ATK:2/HP:6]
+    // - Set: LoE, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon three 2/2 Runts.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_092] Arch-Thief Rafaam - COST:9 [ATK:7/HP:8]
+    // - Set: LoE, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry: Discover</b> a powerful Artifact.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_107] Eerie Statue - COST:4 [ATK:7/HP:7]
+    // - Set: LoE, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Can't attack unless it's the only minion
+    //       in the battlefield.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_110] Ancient Shade - COST:4 [ATK:7/HP:4]
+    // - Set: LoE, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Shuffle an 'Ancient Curse'
+    //       into your deck that deals 7 damage to you when drawn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [LOE_008] Eye of Hakkar (*) - COST:1
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: Take a secret from your opponent's deck and
+    //       put it into the battlefield.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [LOE_008H] Eye of Hakkar (*) - COST:1
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: Take a secret from your opponent's deck and
+    //       put it into the battlefield.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_016t] Rock (*) - COST:1 [ATK:0/HP:6]
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [LOE_019t] Map to the Golden Monkey (*) - COST:2
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: Shuffle the Golden Monkey into your deck. Draw a card.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_019t2] Golden Monkey (*) - COST:4 [ATK:6/HP:6]
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> Replace your hand and deck
+    //       with <b>Legendary</b> minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_024t] Rolling Boulder (*) - COST:4 [ATK:0/HP:4]
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: At the end of your turn, destroy the minion to the left.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [LOE_030e] Hollow (*) - COST:0
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: Stats copied.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [LOE_038e] Seawitching (*) - COST:0
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: Costs (5).
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [LOE_061e] Power of the Titans (*) - COST:0
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: +3/+3.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [LOE_073e] Fossilized (*) - COST:0
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: Has <b>Taunt</b>.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [LOE_077e] Bronzebeard Battlecry (*) - COST:0
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: Your <b>Battlecries</b> trigger twice.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_089t] Rascally Runt (*) - COST:2 [ATK:2/HP:2]
+    // - Set: LoE
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_089t2] Wily Runt (*) - COST:2 [ATK:2/HP:2]
+    // - Set: LoE
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [LOE_089t3] Grumbly Runt (*) - COST:2 [ATK:2/HP:2]
+    // - Set: LoE
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [LOE_110t] Ancient Curse (*) - COST:4
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: <b>Casts When Drawn</b>
+    //       You take 7 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ImmuneToSpellpower = 1
+    // - TOPDECK = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - CASTSWHENDRAWN = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [LOE_113e] Mrglllraawrrrglrur! (*) - COST:0
+    // - Set: LoE
+    // --------------------------------------------------------
+    // Text: +2/+2.
+    // --------------------------------------------------------
 }
 
 void LoECardsGen::AddAll(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
@@ -1,0 +1,134 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/PlayMode/CardSets/LoECardsGen.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
+
+namespace RosettaStone::PlayMode
+{
+void LoECardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddDruid(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddHunter(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddMage(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddPriest(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddRogue(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddShaman(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void LoECardsGen::AddAll(std::map<std::string, CardDef>& cards)
+{
+    AddHeroes(cards);
+    AddHeroPowers(cards);
+
+    AddDruid(cards);
+    AddDruidNonCollect(cards);
+
+    AddHunter(cards);
+    AddHunterNonCollect(cards);
+
+    AddMage(cards);
+    AddMageNonCollect(cards);
+
+    AddPaladin(cards);
+    AddPaladinNonCollect(cards);
+
+    AddPriest(cards);
+    AddPriestNonCollect(cards);
+
+    AddRogue(cards);
+    AddRogueNonCollect(cards);
+
+    AddShaman(cards);
+    AddShamanNonCollect(cards);
+
+    AddWarlock(cards);
+    AddWarlockNonCollect(cards);
+
+    AddWarrior(cards);
+    AddWarriorNonCollect(cards);
+
+    AddNeutral(cards);
+    AddNeutralNonCollect(cards);
+}
+}  // namespace RosettaStone::PlayMode

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -3414,7 +3414,7 @@ void ScholomanceCardsGen::AddNeutralNonCollect(
                                          EffectList{ Effects::SetCost(0) }));
     {
         const auto aura = dynamic_cast<Aura*>(power.GetAura());
-        aura->removeTrigger = { TriggerType::USE_HERO_POWER, nullptr };
+        aura->removeTrigger = { TriggerType::INSPIRE, nullptr };
     }
     cards.emplace("SCH_312e", CardDef(power));
 

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -1824,7 +1824,7 @@ void ScholomanceCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
         std::make_shared<SelfCondition>(SelfCondition::IsOutcastCard()) }));
     power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
-    power.AddPowerTask(std::make_shared<DrawStackTask>(1));
+    power.AddPowerTask(std::make_shared<DrawStackTask>());
     cards.emplace("SCH_422", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER

--- a/Sources/Rosetta/PlayMode/CardSets/TgtCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TgtCardsGen.cpp
@@ -592,6 +592,11 @@ void TgtCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: You can use your Hero Power any number of times.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::INSPIRE));
+    power.GetTrigger()->tasks = { std::make_shared<SetGameTagTask>(
+        EntityType::HERO_POWER, GameTag::EXHAUSTED, 0) };
+    cards.emplace("AT_008", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [AT_009] Rhonin - COST:8 [ATK:7/HP:7]

--- a/Sources/Rosetta/PlayMode/CardSets/TgtCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TgtCardsGen.cpp
@@ -11,6 +11,8 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 
 namespace RosettaStone::PlayMode
 {
+using EffectList = std::vector<std::shared_ptr<IEffect>>;
+
 void TgtCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
     // Do nothing
@@ -488,6 +490,8 @@ void TgtCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
 void TgtCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------- SPELL - MAGE
     // [AT_001] Flame Lance - COST:5
     // - Set: Tgt, Rarity: Common
@@ -519,6 +523,12 @@ void TgtCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - HEROPOWER_DAMAGE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<Aura>(
+        AuraType::HERO,
+        EffectList{ std::make_shared<Effect>(GameTag::HEROPOWER_DAMAGE,
+                                             EffectOperator::ADD, 1) }));
+    cards.emplace("AT_003", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [AT_004] Arcane Blast - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UldumCardsGen.cpp
@@ -952,7 +952,7 @@ void UldumCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
     power.AddPowerTask(
         std::make_shared<AddEnchantmentTask>("ULD_726e", EntityType::STACK));
-    power.AddPowerTask(std::make_shared<DrawStackTask>(1));
+    power.AddPowerTask(std::make_shared<DrawStackTask>());
     cards.emplace("ULD_726", CardDef(power));
 }
 
@@ -1097,7 +1097,7 @@ void UldumCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
         std::make_shared<SelfCondition>(SelfCondition::IsCost(1)) }));
     power.AddDeathrattleTask(
         std::make_shared<RandomTask>(EntityType::STACK, 2));
-    power.AddDeathrattleTask(std::make_shared<DrawStackTask>(2));
+    power.AddDeathrattleTask(std::make_shared<DrawStackTask>());
     cards.emplace("ULD_438", CardDef(power));
 
     // --------------------------------------- MINION - PALADIN

--- a/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
@@ -1,0 +1,134 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/PlayMode/CardSets/UngoroCardsGen.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
+
+namespace RosettaStone::PlayMode
+{
+void UngoroCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddMage(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void UngoroCardsGen::AddAll(std::map<std::string, CardDef>& cards)
+{
+    AddHeroes(cards);
+    AddHeroPowers(cards);
+
+    AddDruid(cards);
+    AddDruidNonCollect(cards);
+
+    AddHunter(cards);
+    AddHunterNonCollect(cards);
+
+    AddMage(cards);
+    AddMageNonCollect(cards);
+
+    AddPaladin(cards);
+    AddPaladinNonCollect(cards);
+
+    AddPriest(cards);
+    AddPriestNonCollect(cards);
+
+    AddRogue(cards);
+    AddRogueNonCollect(cards);
+
+    AddShaman(cards);
+    AddShamanNonCollect(cards);
+
+    AddWarlock(cards);
+    AddWarlockNonCollect(cards);
+
+    AddWarrior(cards);
+    AddWarriorNonCollect(cards);
+
+    AddNeutral(cards);
+    AddNeutralNonCollect(cards);
+}
+}  // namespace RosettaStone::PlayMode

--- a/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
@@ -10,90 +10,2500 @@ namespace RosettaStone::PlayMode
 {
 void UngoroCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
+    // Do nothing
 }
 
 void UngoroCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 {
+    // ------------------------------------ HERO_POWER - HUNTER
+    // [UNG_917t1] Dinomancy (*) - COST:2
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b>
+    //       Give a Beast +2/+2.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_TARGET_WITH_RACE = 20
+    // --------------------------------------------------------
+
+    // ----------------------------------- HERO_POWER - NEUTRAL
+    // [UNG_934t2] DIE, INSECT! (*) - COST:2
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Hero Power</b>
+    //       Deal 8 damage to a random enemy.
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------------- MINION - DRUID
+    // [UNG_078] Tortollan Forager - COST:2 [ATK:2/HP:2]
+    // - Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Add a random minion with 5 or
+    //       more Attack to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [UNG_086] Giant Anaconda - COST:7 [ATK:5/HP:3]
+    // - Race: Beast, Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon a minion from your hand
+    //       with 5 or more Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [UNG_100] Verdant Longneck - COST:5 [ATK:5/HP:4]
+    // - Race: Beast, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Adapt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - ADAPT = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [UNG_101] Shellshifter - COST:4 [ATK:3/HP:3]
+    // - Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Choose One - </b>Transform into a 5/3
+    //       with <b>Stealth</b>; or a 3/5 with <b>Taunt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CHOOSE_ONE = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // - STEALTH = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [UNG_103] Evolving Spores - COST:4
+    // - Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Adapt</b> your minions.
+    // --------------------------------------------------------
+    // RefTag:
+    // - ADAPT = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [UNG_108] Earthen Scales - COST:1
+    // - Faction: Neutral, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Give a friendly minion +1/+1,
+    //       then gain Armor equal to its Attack.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [UNG_109] Elder Longneck - COST:3 [ATK:5/HP:1]
+    // - Race: Beast, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you're holding a minion
+    //       with 5 or more Attack, <b>Adapt</b>.
+    // --------------------------------------------------------
+    // Entourage: UNG_999t10, UNG_999t2, UNG_999t3, UNG_999t4,
+    //            UNG_999t5, UNG_999t6, UNG_999t7, UNG_999t8,
+    //            UNG_999t13, UNG_999t14
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - ADAPT = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [UNG_111] Living Mana - COST:5
+    // - Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Transform your Mana Crystals into 2/2 minions.
+    //       Recover the mana when they die.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [UNG_116] Jungle Giants - COST:1
+    // - Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> Summon 5 minions with 5 or more Attack.
+    //       <b>Reward:</b> Barnabus.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 5
+    // - 676 = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [UNG_852] Tyrantus - COST:10 [ATK:12/HP:12]
+    // - Race: Beast, Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Can't be targeted by spells or Hero Powers.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - CANT_BE_TARGETED_BY_SPELLS = 1
+    // - CANT_BE_TARGETED_BY_HERO_POWERS = 1
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ------------------------------------------ SPELL - DRUID
+    // [UNG_101a] Raptor Form (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: +2 Attack and <b>Stealth</b>
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [UNG_101b] Direhorn Form (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: +2 Health and <b>Taunt</b>.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [UNG_101t] Shellshifter (*) - COST:4 [ATK:5/HP:3]
+    // - Race: Beast, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - STEALTH = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [UNG_101t2] Shellshifter (*) - COST:4 [ATK:3/HP:5]
+    // - Race: Beast, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [UNG_101t3] Shellshifter (*) - COST:4 [ATK:5/HP:5]
+    // - Race: Beast, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b>
+    //       <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - STEALTH = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [UNG_108e] It's All Scaley... (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: +1/+1.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [UNG_111t1] Mana Treant (*) - COST:2 [ATK:2/HP:2]
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Gain an empty Mana Crystal.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [UNG_116t] Barnabus the Stomper (*) - COST:5 [ATK:8/HP:8]
+    // - Race: Beast, Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Reduce the Cost of minions
+    //       in your deck to (0).
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [UNG_116te] Romper Stompers (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Costs (0).
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- MINION - HUNTER
+    // [UNG_800] Terrorscale Stalker - COST:3 [ATK:3/HP:3]
+    // - Faction: Neutral, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Trigger a friendly minion's
+    //       <b>Deathrattle</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_WITH_DEATHRATTLE = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [UNG_910] Grievous Bite - COST:2
+    // - Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Deal 2 damage to a minion and 1 damage to adjacent ones.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [UNG_912] Jeweled Macaw - COST:1 [ATK:1/HP:1]
+    // - Race: Beast, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Add a random Beast to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [UNG_913] Tol'vir Warden - COST:5 [ATK:3/HP:5]
+    // - Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Draw two 1-Cost minions
+    //       from your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [UNG_914] Raptor Hatchling - COST:1 [ATK:2/HP:1]
+    // - Race: Beast, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Shuffle a 4/3 Raptor
+    //       into your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [UNG_915] Crackling Razormaw - COST:2 [ATK:3/HP:2]
+    // - Race: Beast, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Adapt</b> a friendly Beast.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_WITH_RACE = 20
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - ADAPT = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [UNG_916] Stampede - COST:1
+    // - Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Each time you play a Beast this turn,
+    //       add a random Beast to_your hand.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [UNG_917] Dinomancy - COST:2
+    // - Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Your Hero Power becomes 'Give a Beast +2/+2.'
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [UNG_919] Swamp King Dred - COST:7 [ATK:9/HP:9]
+    // - Race: Beast, Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: After your opponent plays a minion, attack it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [UNG_920] The Marsh Queen - COST:1
+    // - Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> Play seven 1-Cost minions.
+    //       <b>Reward:</b> Queen Carnassa.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 7
+    // - 676 = 1
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- MINION - HUNTER
+    // [UNG_914t1] Raptor Patriarch (*) - COST:1 [ATK:4/HP:3]
+    // - Race: Beast, Set: Ungoro
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - HUNTER
+    // [UNG_916e] Stampeding (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - HUNTER
+    // [UNG_917e] Well Fed (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: +2/+2.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [UNG_920t1] Queen Carnassa (*) - COST:5 [ATK:8/HP:8]
+    // - Race: Beast, Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Shuffle 15 Raptors into your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [UNG_920t2] Carnassa's Brood (*) - COST:1 [ATK:3/HP:2]
+    // - Race: Beast, Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Draw a card.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    // ------------------------------------------- SPELL - MAGE
+    // [UNG_018] Flame Geyser - COST:2
+    // - Faction: Neutral, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Deal 2 damage.
+    //       Add a 1/2 Elemental to your hand.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [UNG_020] Arcanologist - COST:2 [ATK:2/HP:3]
+    // - Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Draw a <b>Secret</b> from your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [UNG_021] Steam Surger - COST:4 [ATK:5/HP:4]
+    // - Race: Elemental, Faction: Neutral, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you played an Elemental last turn,
+    //       add a 'Flame Geyser' to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [UNG_024] Mana Bind - COST:3
+    // - Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Secret:</b> When your opponent casts a spell,
+    //       add a copy to your hand that costs (0).
+    // --------------------------------------------------------
+    // GameTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [UNG_027] Pyros - COST:2 [ATK:2/HP:2]
+    // - Race: Elemental, Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Return this to your hand
+    //       as a 6/6 that costs (6).
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [UNG_028] Open the Waygate - COST:1
+    // - Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> Cast 6 spells that didn't start
+    //       in your deck.
+    //       <b>Reward:</b> Time Warp.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 6
+    // - 676 = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [UNG_846] Shimmering Tempest - COST:2 [ATK:2/HP:1]
+    // - Race: Elemental, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Add a random Mage spell
+    //       to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [UNG_941] Primordial Glyph - COST:2
+    // - Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Discover</b> a spell. Reduce its Cost by (2).
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [UNG_948] Molten Reflection - COST:4
+    // - Faction: Neutral, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Choose a friendly minion. Summon a copy of it.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [UNG_955] Meteor - COST:6
+    // - Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Deal 15 damage to a minion and 3 damage
+    //       to adjacent ones.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ------------------------------------------ MINION - MAGE
+    // [UNG_027t2] Pyros (*) - COST:6 [ATK:6/HP:6]
+    // - Race: Elemental, Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Return this to your hand
+    //       as a 10/10 that costs (10).
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [UNG_027t4] Pyros (*) - COST:10 [ATK:10/HP:10]
+    // - Race: Elemental, Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------- ENCHANTMENT - MAGE
+    // [UNG_028e] Insightful (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Take an extra turn.
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [UNG_028t] Time Warp (*) - COST:5
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Take an extra turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------- ENCHANTMENT - MAGE
+    // [UNG_941e] Primal Magic (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Cost reduced.
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- SPELL - PALADIN
+    // [UNG_004] Dinosize - COST:8
+    // - Faction: Neutral, Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Set a minion's Attack and Health to 10.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [UNG_011] Hydrologist - COST:2 [ATK:2/HP:2]
+    // - Race: Murloc, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Discover</b> a <b>Secret</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [UNG_015] Sunkeeper Tarim - COST:6 [ATK:3/HP:7]
+    // - Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> Set all other minions' Attack
+    //       and Health to 3.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- WEAPON - PALADIN
+    // [UNG_950] Vinecleaver - COST:7 [ATK:4/HP:0]
+    // - Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: After your hero attacks,
+    //       summon two 1/1 Silver Hand Recruits.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 3
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [UNG_952] Spikeridged Steed - COST:6
+    // - Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Give a minion +2/+6 and <b>Taunt</b>.
+    //       When it dies, summon a Stegodon.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [UNG_953] Primalfin Champion - COST:2 [ATK:1/HP:2]
+    // - Race: Murloc, Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Return any spells you cast
+    //       on this minion to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // - 537 = 1
+    // - 542 = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [UNG_954] The Last Kaleidosaur - COST:1
+    // - Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> Cast 6 spells on your minions.
+    //       <b>Reward:</b> Galvadon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 6
+    // - 676 = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [UNG_960] Lost in the Jungle - COST:1
+    // - Faction: Alliance, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Summon two 1/1 Silver Hand Recruits.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [UNG_961] Adaptation - COST:1
+    // - Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Adapt</b> a friendly minion.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - ADAPT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [UNG_962] Lightfused Stegodon - COST:4 [ATK:3/HP:4]
+    // - Race: Beast, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Adapt</b> your Silver Hand Recruits.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - ADAPT = 1
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [UNG_004e] RAAAAR! (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Stats changed to 10/10.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [UNG_015e] Watched (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Stats changed to 3/3.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [UNG_952e] On a Stegodon (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: +2/+6 and <b>Taunt</b>.
+    //       <b>Deathrattle:</b> Summon a Stegodon.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [UNG_953e] Inspired (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Storing spell.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [UNG_954t1] Galvadon (*) - COST:5 [ATK:5/HP:5]
+    // - Race: Beast, Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Adapt</b> 5 times.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - ADAPT = 1
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- MINION - PRIEST
+    // [UNG_022] Mirage Caller - COST:3 [ATK:2/HP:3]
+    // - Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Choose a friendly minion.
+    //       Summon a 1/1 copy of it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [UNG_029] Shadow Visions - COST:2
+    // - Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Discover</b> a copy of a spell in your deck.
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [UNG_030] Binding Heal - COST:1
+    // - Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Restore 5 Health to a minion and your hero.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [UNG_032] Crystalline Oracle - COST:1 [ATK:1/HP:1]
+    // - Race: Elemental, Faction: Horde, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Copy a card from your
+    //       opponent's deck and add it to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [UNG_034] Radiant Elemental - COST:2 [ATK:2/HP:3]
+    // - Race: Elemental, Faction: Neutral, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Your spells cost (1) less.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AURA = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [UNG_035] Curious Glimmerroot - COST:3 [ATK:3/HP:3]
+    // - Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Look at 3 cards.
+    //       Guess which one started in your opponent's deck
+    //       to get a copy of it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [UNG_037] Tortollan Shellraiser - COST:4 [ATK:2/HP:6]
+    // - Faction: Neutral, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Deathrattle:</b> Give a random friendly minion +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [UNG_854] Free From Amber - COST:8
+    // - Faction: Neutral, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Discover</b> a minion that costs (8) or more.
+    //       Summon it.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_TARGET_WITH_DEATHRATTLE = 0
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [UNG_940] Awaken the Makers - COST:1
+    // - Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> Summon 7 <b>Deathrattle</b> minions.<b>
+    //       Reward:</b> Amara, Warden of Hope.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 7
+    // - 676 = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [UNG_963] Lyra the Sunshard - COST:5 [ATK:3/HP:5]
+    // - Race: Elemental, Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Whenever you cast a spell,
+    //       add a random Priest spell to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------- ENCHANTMENT - PRIEST
+    // [UNG_022e] Mirage (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: 1/1.
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - PRIEST
+    // [UNG_037e] Shellshield (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: +1/+1.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [UNG_940t8] Amara, Warden of Hope (*) - COST:5 [ATK:8/HP:8]
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> Set your hero's Health to 40.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------------- MINION - ROGUE
+    // [UNG_058] Razorpetal Lasher - COST:2 [ATK:2/HP:2]
+    // - Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Add a Razorpetal to your hand
+    //       that deals 1 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- WEAPON - ROGUE
+    // [UNG_061] Obsidian Shard - COST:4 [ATK:3/HP:0]
+    // - Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Costs (1) less for each card you've played from
+    //       another class.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 3a
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [UNG_063] Biteweed - COST:2 [ATK:1/HP:1]
+    // - Faction: Neutral, Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Combo:</b> Gain +1/+1 for each other card
+    //       you've played this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - COMBO = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [UNG_064] Vilespine Slayer - COST:5 [ATK:3/HP:4]
+    // - Faction: Neutral, Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Combo:</b> Destroy a minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - COMBO = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_FOR_COMBO = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [UNG_065] Sherazin, Corpse Flower - COST:4 [ATK:5/HP:3]
+    // - Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Go dormant.
+    //       Play 4 cards in a turn to revive this minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DEATHRATTLE = 10
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [UNG_057] Razorpetal Volley - COST:2
+    // - Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Add two Razorpetals to_your hand that deal 1 damage.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [UNG_060] Mimic Pod - COST:3
+    // - Faction: Neutral, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Draw a card, then add a copy of it to your hand.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [UNG_067] The Caverns Below - COST:1
+    // - Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> Play five minions with the same name.
+    //       <b>Reward:</b> Crystal Core.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 5
+    // - 676 = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [UNG_823] Envenom Weapon - COST:3
+    // - Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Give your weapon <b>Poisonous</b>.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_WEAPON_EQUIPPED = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - POISONOUS = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [UNG_856] Hallucination - COST:1
+    // - Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Discover</b> a card from your opponent's class.
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ------------------------------------------ SPELL - ROGUE
+    // [UNG_057t1] Razorpetal (*) - COST:1
+    // - Faction: Neutral, Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Deal 1 damage.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - ROGUE
+    // [UNG_063e] Sprout (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Increased stats.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [UNG_065t] Sherazin, Seed (*) - COST:11 [ATK:0/HP:1]
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: When you play 4 cards in a turn, revive this minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - HIDE_STATS = 1
+    // - UNTOUCHABLE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [UNG_067t1] Crystal Core (*) - COST:5
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: For the rest of the game, your minions are 4/4.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - RITUAL = 1
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- MINION - SHAMAN
+    // [UNG_019] Air Elemental - COST:1 [ATK:2/HP:1]
+    // - Race: Elemental, Faction: Horde, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Can't be targeted by spells or Hero Powers.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CANT_BE_TARGETED_BY_SPELLS = 1
+    // - CANT_BE_TARGETED_BY_HERO_POWERS = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [UNG_025] Volcano - COST:5
+    // - Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Deal 15 damage randomly split among all minions.
+    //       <b>Overload:</b> (2)
+    // --------------------------------------------------------
+    // GameTag:
+    // - OVERLOAD = 2
+    // - OVERLOAD_OWED = 2
+    // - ImmuneToSpellpower = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [UNG_201] Primalfin Totem - COST:2 [ATK:0/HP:3]
+    // - Race: Totem, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: At the end of your turn, summon a 1/1 Murloc.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [UNG_202] Fire Plume Harbinger - COST:2 [ATK:1/HP:1]
+    // - Race: Elemental, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Reduce the Cost of Elementals
+    //       in your hand by (1).
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [UNG_208] Stone Sentinel - COST:7 [ATK:4/HP:4]
+    // - Race: Elemental, Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you played an Elemental last turn,
+    //       summon two 2/3 Elementals with <b>Taunt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_TARGET_WITH_DEATHRATTLE = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [UNG_211] Kalimos, Primal Lord - COST:8 [ATK:7/HP:7]
+    // - Race: Elemental, Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you played an Elemental last turn,
+    //       cast an Elemental Invocation.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [UNG_817] Tidal Surge - COST:4
+    // - Faction: Neutral, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Deal 4 damage to a minion.
+    //       Restore 4 Health to your hero.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [UNG_938] Hot Spring Guardian - COST:3 [ATK:2/HP:4]
+    // - Race: Elemental, Set: Ungoro, Rarity: common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> Restore 3_Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [UNG_942] Unite the Murlocs - COST:1
+    // - Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> Summon 10 Murlocs.
+    //       <b>Reward:</b> Megafin.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 10
+    // - 676 = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [UNG_956] Spirit Echo - COST:3
+    // - Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Give your minions "<b>Deathrattle:</b>
+    //       Return this to your hand."
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- MINION - SHAMAN
+    // [UNG_208t] Rock Elemental (*) - COST:2 [ATK:2/HP:3]
+    // - Race: Elemental, Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [UNG_211a] Invocation of Earth (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Fill your board with 1/1 Elementals.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [UNG_211aa] Stone Elemental (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Elemental, Faction: Neutral, Set: Ungoro
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [UNG_211b] Invocation of Water (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Restore 12 Health to your hero.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [UNG_211c] Invocation of Fire (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Deal 6 damage to the enemy hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ImmuneToSpellpower = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [UNG_211d] Invocation of Air (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Deal 3 damage to all enemy minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ImmuneToSpellpower = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [UNG_942t] Megafin (*) - COST:5 [ATK:8/HP:8]
+    // - Race: Murloc, Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Fill your hand with random Murlocs.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - SHAMAN
+    // [UNG_956e] Echoed Spirit (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Return to your hand.
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    // --------------------------------------- MINION - WARLOCK
+    // [UNG_047] Ravenous Pterrordax - COST:4 [ATK:4/HP:4]
+    // - Race: Beast, Faction: Neutral, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Destroy a friendly minion
+    //       to <b>Adapt</b> twice.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - ADAPT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [UNG_049] Tar Lurker - COST:5 [ATK:1/HP:7]
+    // - Race: Elemental, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       Has +3 Attack during your opponent's turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [UNG_829] Lakkari Sacrifice - COST:1
+    // - Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> Discard 6 cards.
+    //       <b>Reward:</b> Nether Portal.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 6
+    // - 676 = 1
+    // - 839 = 1
+    // - QUEST_REWARD_DATABASE_ID = 41942
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [UNG_830] Cruel Dinomancer - COST:6 [ATK:5/HP:5]
+    // - Faction: Neutral, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon a random minion
+    //       you discarded this game.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [UNG_831] Corrupting Mist - COST:2
+    // - Faction: Neutral, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Corrupt every minion.
+    //       Destroy them at the start of your next turn.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [UNG_832] Bloodbloom - COST:2
+    // - Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: The next spell you cast this turn costs Health
+    //       instead of Mana.
+    // --------------------------------------------------------
+    // Entourage: UNG_999t10, UNG_999t2, UNG_999t3, UNG_999t4,
+    //            UNG_999t5, UNG_999t6, UNG_999t7, UNG_999t8,
+    //            UNG_999t13, UNG_999t14
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [UNG_833] Lakkari Felhound - COST:4 [ATK:3/HP:8]
+    // - Race: Demon, Faction: Neutral, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> Discard two random cards.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // - 890 = 2
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [UNG_834] Feeding Time - COST:5
+    // - Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Deal 3 damage to a minion. Summon three 1/1 Pterrordaxes.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [UNG_835] Chittering Tunneler - COST:3 [ATK:3/HP:3]
+    // - Race: Beast, Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Discover</b> a spell.
+    //       Deal damage to your hero equal to its Cost.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [UNG_836] Clutchmother Zavas - COST:2 [ATK:2/HP:2]
+    // - Race: Beast, Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Whenever you discard this,
+    //       give it +2/+2 and return it to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - InvisibleDeathrattle = 1
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- SPELL - WARLOCK
+    // [UNG_829t1] Nether Portal (*) - COST:5
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Open a permanent portal that summons 3/2 Imps.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [UNG_829t2] Nether Portal (*) - COST:11 [ATK:0/HP:1]
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: At the end of your turn, summon two 3/2 Imps.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - HIDE_STATS = 1
+    // - UNTOUCHABLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [UNG_829t3] Nether Imp (*) - COST:2 [ATK:3/HP:2]
+    // - Race: Demon, Set: Ungoro
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [UNG_834t1] Pterrordax (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Beast, Set: Ungoro
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARLOCK
+    // [UNG_831e] Corrupting Mist (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: At the start of the corrupting player's turn,
+    //       destroy this minion.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARLOCK
+    // [UNG_836e] Remembrance (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: +2/+2 each time this is discarded.
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 {
+    // --------------------------------------- MINION - WARRIOR
+    // [UNG_838] Tar Lord - COST:7 [ATK:1/HP:11]
+    // - Race: Elemental, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       Has +4 Attack during your opponent's turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [UNG_922] Explore Un'Goro - COST:2
+    // - Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Replace your deck with copies of "<b>Discover</b> a card."
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [UNG_923] Iron Hide - COST:1
+    // - Faction: Neutral, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Gain 5 Armor.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [UNG_925] Ornery Direhorn - COST:6 [ATK:5/HP:5]
+    // - Race: Beast, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> <b>Adapt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - ADAPT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [UNG_926] Cornered Sentry - COST:2 [ATK:2/HP:6]
+    // - Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>.
+    //       <b>Battlecry:</b> Summon three 1/1 Raptors for
+    //       your opponent.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [UNG_927] Sudden Genesis - COST:5
+    // - Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Summon copies of your damaged minions.
+    // --------------------------------------------------------
+
+    // --------------------------------------- WEAPON - WARRIOR
+    // [UNG_929] Molten Blade - COST:1 [ATK:1/HP:0]
+    // - Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Each turn this is in your hand,
+    //       transform it into a new weapon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [UNG_933] King Mosh - COST:9 [ATK:9/HP:7]
+    // - Race: Beast, Faction: Neutral, Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Destroy all damaged minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [UNG_934] Fire Plume's Heart - COST:1
+    // - Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Quest:</b> Play 7 <b>Taunt</b> minions.
+    //       <b>Reward:</b> Sulfuras.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - QUEST = 1
+    // - QUEST_PROGRESS_TOTAL = 7
+    // - 676 = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [UNG_957] Direhorn Hatchling - COST:5 [ATK:3/HP:6]
+    // - Race: Beast, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Deathrattle:</b> Shuffle a 6/9 Direhorn with
+    //       <b>Taunt</b> into your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- SPELL - WARRIOR
+    // [UNG_922t1] Choose Your Path (*) - COST:1
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Discover</b> a card.
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARRIOR
+    // [UNG_929e] Magmic (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Transforming into random weapons.
+    // --------------------------------------------------------
+
+    // --------------------------------------- WEAPON - WARRIOR
+    // [UNG_934t1] Sulfuras (*) - COST:3 [ATK:4/HP:0]
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Your Hero Power becomes
+    //       'Deal 8 damage to a random enemy.'
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DURABILITY = 2
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [UNG_957t1] Direhorn Matriarch (*) - COST:5 [ATK:6/HP:9]
+    // - Race: Beast, Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 {
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_001] Pterrordax Hatchling - COST:3 [ATK:2/HP:2]
+    // - Race: Beast, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b><b>Battlecry:</b> Adapt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - ADAPT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_002] Volcanosaur - COST:7 [ATK:5/HP:6]
+    // - Race: Beast, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Adapt</b>, then <b>Adapt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - ADAPT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_009] Ravasaur Runt - COST:2 [ATK:2/HP:2]
+    // - Race: Beast, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you control at least
+    //       2 other minions, <b>Adapt.</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - ADAPT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_010] Sated Threshadon - COST:7 [ATK:5/HP:7]
+    // - Race: Beast, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon three 1/1 Murlocs.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_070] Tol'vir Stoneshaper - COST:4 [ATK:3/HP:5]
+    // - Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you played an Elemental last turn,
+    //       gain <b>Taunt</b> and <b>Divine Shield</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // - DIVINE_SHIELD = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_071] Giant Mastodon - COST:9 [ATK:6/HP:10]
+    // - Race: Beast, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_072] Stonehill Defender - COST:3 [ATK:1/HP:4]
+    // - Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> <b>Discover</b> a <b>Taunt</b> minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_073] Rockpool Hunter - COST:2 [ATK:2/HP:3]
+    // - Race: Murloc, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a friendly Murloc +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_WITH_RACE = 14
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_075] Vicious Fledgling - COST:3 [ATK:3/HP:3]
+    // - Race: Beast, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: After this minion attacks a hero, <b>Adapt</b>.
+    // --------------------------------------------------------
+    // RefTag:
+    // - ADAPT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_076] Eggnapper - COST:3 [ATK:3/HP:1]
+    // - Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon two 1/1 Raptors.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_079] Frozen Crusher - COST:6 [ATK:8/HP:8]
+    // - Race: Elemental, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: After this minion attacks, <b>Freeze</b> it.
+    // --------------------------------------------------------
+    // RefTag:
+    // - FREEZE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_082] Thunder Lizard - COST:3 [ATK:3/HP:3]
+    // - Race: Beast, Faction: Neutral, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry</b>: If you played an Elemental last turn,
+    //       <b>Adapt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - ADAPT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_083] Devilsaur Egg - COST:3 [ATK:0/HP:3]
+    // - Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon a 5/5 Devilsaur.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_084] Fire Plume Phoenix - COST:4 [ATK:3/HP:3]
+    // - Race: Elemental, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Deal 2 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_NONSELF_TARGET = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_085] Emerald Hive Queen - COST:1 [ATK:2/HP:3]
+    // - Race: Beast, Faction: Horde, Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Your minions cost (2) more.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AURA = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_087] Bittertide Hydra - COST:5 [ATK:8/HP:8]
+    // - Race: Beast, Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Whenever this minion takes damage,
+    //       deal 3 damage to your hero.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_088] Tortollan Primalist - COST:8 [ATK:5/HP:4]
+    // - Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Discover</b> a spell and
+    //       cast it with random targets.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_089] Gentle Megasaur - COST:4 [ATK:5/HP:4]
+    // - Race: Beast, Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Adapt</b> your Murlocs.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - ADAPT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_099] Charged Devilsaur - COST:8 [ATK:7/HP:7]
+    // - Race: Beast, Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Charge</b>
+    //       <b>Battlecry:</b> Can't attack heroes this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CHARGE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_113] Bright-Eyed Scout - COST:4 [ATK:3/HP:4]
+    // - Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Draw a card. Change its Cost to (5).
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_205] Glacial Shard - COST:1 [ATK:2/HP:1]
+    // - Race: Elemental, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Freeze</b> an enemy.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_ENEMY_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - FREEZE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_801] Nesting Roc - COST:5 [ATK:4/HP:7]
+    // - Race: Beast, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you control at least
+    //       2 other minions, gain <b>Taunt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_803] Emerald Reaver - COST:1 [ATK:2/HP:1]
+    // - Race: Beast, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Deal 1 damage to each hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_806] Ultrasaur - COST:10 [ATK:7/HP:14]
+    // - Race: Beast, Faction: Neutral, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_807] Golakka Crawler - COST:2 [ATK:2/HP:3]
+    // - Race: Beast, Faction: Neutral, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Destroy a Pirate and gain +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_TARGET_WITH_RACE = 23
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_808] Stubborn Gastropod - COST:2 [ATK:1/HP:2]
+    // - Race: Beast, Faction: Neutral, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Poisonous</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - POISONOUS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_809] Fire Fly - COST:1 [ATK:1/HP:2]
+    // - Race: Elemental, Faction: Alliance, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry</b>: Add a 1/2 Elemental to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_810] Stegodon - COST:4 [ATK:2/HP:6]
+    // - Race: Beast, Faction: Neutral, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_812] Sabretooth Stalker - COST:6 [ATK:8/HP:2]
+    // - Race: Beast, Faction: Neutral, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - STEALTH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_813] Stormwatcher - COST:7 [ATK:4/HP:8]
+    // - Race: Elemental, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Windfury</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - WINDFURY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_814] Giant Wasp - COST:3 [ATK:2/HP:2]
+    // - Race: Beast, Faction: Neutral, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b>
+    //       <b>Poisonous</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - STEALTH = 1
+    // - POISONOUS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_816] Servant of Kalimos - COST:5 [ATK:4/HP:5]
+    // - Race: Elemental, Faction: Neutral, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you played an Elemental last turn,
+    //       <b>Discover</b> an Elemental.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_TARGET_WITH_DEATHRATTLE = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_818] Volatile Elemental - COST:2 [ATK:1/HP:1]
+    // - Race: Elemental, Faction: Neutral, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Deal 3 damage to a random enemy minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_840] Hemet, Jungle Hunter - COST:6 [ATK:6/HP:6]
+    // - Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Destroy all cards in your deck
+    //       that cost (3) or less.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_843] The Voraxx - COST:4 [ATK:3/HP:3]
+    // - Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: After you cast a spell on this minion,
+    //       summon a 1/1 Plant and cast another copy on it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_844] Humongous Razorleaf - COST:3 [ATK:4/HP:8]
+    // - Faction: Alliance, Set: Ungoro, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Can't attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CANT_ATTACK = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_845] Igneous Elemental - COST:3 [ATK:2/HP:3]
+    // - Race: Elemental, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Add two 1/2 Elementals to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_847] Blazecaller - COST:7 [ATK:6/HP:6]
+    // - Race: Elemental, Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you played an Elemental last turn,
+    //       deal 5 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NONSELF_TARGET = 0
+    // - REQ_TARGET_IF_AVAILABE_AND_ELEMENTAL_PLAYED_LAST_TURN = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_848] Primordial Drake - COST:8 [ATK:4/HP:8]
+    // - Race: Dragon, Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> Deal 2 damage to all other minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_851] Elise the Trailblazer - COST:5 [ATK:5/HP:5]
+    // - Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Shuffle a sealed <b>Un'Goro</b>
+    //       pack into your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_900] Spiritsinger Umbra - COST:4 [ATK:3/HP:4]
+    // - Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: After you summon a minion,
+    //       trigger its <b>Deathrattle</b> effect.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_907] Ozruk - COST:9 [ATK:5/HP:5]
+    // - Race: Elemental, Set: Ungoro, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> Gain +5 Health for each Elemental
+    //       you played last turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_928] Tar Creeper - COST:3 [ATK:1/HP:5]
+    // - Race: Elemental, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       Has +2 Attack during your opponent's turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_937] Primalfin Lookout - COST:3 [ATK:3/HP:2]
+    // - Race: Murloc, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you control another Murloc,
+    //       <b>Discover</b> a Murloc.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_946] Gluttonous Ooze - COST:3 [ATK:3/HP:3]
+    // - Set: Ungoro, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Destroy your opponent's weapon
+    //       and gain Armor equal to its Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_WITH_DEATHRATTLE = 0
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // --------------------------------------- MINION - NEUTRAL
+    // [ICC_828t2] Stubborn Gastropod (*) - COST:2 [ATK:1/HP:2]
+    // - Race: Beast, Faction: Neutral, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Poisonous</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - POISONOUS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [ICC_828t3] Giant Wasp (*) - COST:3 [ATK:2/HP:2]
+    // - Race: Beast, Fac: Neutral, Set: Ungoro, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b>
+    //       <b>Poisonous</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - STEALTH = 1
+    // - POISONOUS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_076t1] Raptor (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Beast, Set: Ungoro
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_067t1e] Crystallized (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Your minions are 4/4.
+    // --------------------------------------------------------
+    // GameTag:
+    // - 758 = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_067t1e2] Crystallized (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: 4/4.
+    // --------------------------------------------------------
+    // GameTag:
+    // - 758 = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_070e] Stonewall (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Divine Shield</b> and <b>Taunt</b>.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_073e] Trained (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: +1/+1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_083t1] Devilsaur (*) - COST:5 [ATK:5/HP:5]
+    // - Race: Beast, Set: Ungoro
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_113e] Scouted (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Costs (5).
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_201t] Primalfin (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Murloc, Set: Ungoro
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_202e] Fiery (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Costs (1) less.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_807e] Overfull Belly (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Increased stats.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_809t1] Flame Elemental (*) - COST:1 [ATK:1/HP:2]
+    // - Race: Elemental, Faction: Alliance, Set: Ungoro
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_823e] Envenomed (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Poisonous</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - POISONOUS = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_823ed] Envenomed (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Poisonous</b>
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_832e] Dark Power (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Your next spell costs Health instead of Mana.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [UNG_851t1] Un'Goro Pack (*) - COST:2
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Add 5 <b>Journey to Un'Goro</b> cards to your hand.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_907e] Just Blaze (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: +5 Health
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [UNG_999t2] Living Spores (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon two 1/1 Plants.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_999t2e] Living Spores (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon two 1/1 Plants.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [UNG_999t2t1] Plant (*) - COST:1 [ATK:1/HP:1]
+    // - Set: Ungoro
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [UNG_999t3] Flaming Claws (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: +3 Attack
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_999t3e] Flaming Claws (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: +3 Attack.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [UNG_999t4] Rocky Carapace (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: +3 Health
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_999t4e] Rocky Carapace (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: +3 Health.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [UNG_999t5] Liquid Membrane (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Can't be targeted by spells or Hero Powers.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CANT_BE_TARGETED_BY_SPELLS = 1
+    // - CANT_BE_TARGETED_BY_HERO_POWERS = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_999t5e] Liquid Membrane (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Can't be targeted by spells or Hero Powers.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CANT_BE_TARGETED_BY_SPELLS = 1
+    // - CANT_BE_TARGETED_BY_HERO_POWERS = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [UNG_999t6] Massive (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_999t6e] Massive (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [UNG_999t7] Lightning Speed (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Windfury</b>
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_999t7e] Lightning Speed (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Windfury</b>
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [UNG_999t8] Crackling Shield (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Divine Shield</b>
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_999t8e] Crackling Shield (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Divine Shield</b>
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [UNG_999t10] Shrouding Mist (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b> until your next turn.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_999t10e] Shrouding Mist (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: Stealthed until your next turn.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [UNG_999t13] Poison Spit (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Poisonous</b>
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_999t13e] Poison Spit (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: <b>Poisonous</b>
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [UNG_999t14] Volcanic Might (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: +1/+1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [UNG_999t14e] Volcanic Might (*) - COST:0
+    // - Set: Ungoro
+    // --------------------------------------------------------
+    // Text: +1/+1.
+    // --------------------------------------------------------
 }
 
 void UngoroCardsGen::AddAll(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
@@ -4,6 +4,7 @@
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 #include <Rosetta/PlayMode/CardSets/UngoroCardsGen.hpp>
+#include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 
 namespace RosettaStone::PlayMode
@@ -419,6 +420,8 @@ void UngoroCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
 void UngoroCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------- SPELL - MAGE
     // [UNG_018] Flame Geyser - COST:2
     // - Faction: Neutral, Set: Ungoro, Rarity: Common
@@ -442,6 +445,11 @@ void UngoroCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(ComplexTask::DrawCardFromDeck(
+        1, SelfCondList{
+               std::make_shared<SelfCondition>(SelfCondition::IsSecret()) }));
+    cards.emplace("UNG_020", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [UNG_021] Steam Surger - COST:4 [ATK:5/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
@@ -298,7 +298,7 @@ void YoDCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddAura(std::make_shared<Aura>(
-        AuraType::PLAYER,
+        AuraType::HERO,
         EffectList{ std::make_shared<Effect>(GameTag::HEROPOWER_DAMAGE,
                                              EffectOperator::ADD, 2) }));
     cards.emplace("YOD_008", CardDef(power));

--- a/Sources/Rosetta/PlayMode/Cards/CardDefs.cpp
+++ b/Sources/Rosetta/PlayMode/Cards/CardDefs.cpp
@@ -18,6 +18,7 @@
 #include <Rosetta/PlayMode/CardSets/HoFCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/IcecrownCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/KaraCardsGen.hpp>
+#include <Rosetta/PlayMode/CardSets/LoECardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/LootapaloozaCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/NaxxCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/OgCardsGen.hpp>
@@ -46,6 +47,7 @@ CardDefs::CardDefs()
     GvgCardsGen::AddAll(m_data);
     BrmCardsGen::AddAll(m_data);
     TgtCardsGen::AddAll(m_data);
+    LoECardsGen::AddAll(m_data);
     OgCardsGen::AddAll(m_data);
     KaraCardsGen::AddAll(m_data);
     IcecrownCardsGen::AddAll(m_data);

--- a/Sources/Rosetta/PlayMode/Cards/CardDefs.cpp
+++ b/Sources/Rosetta/PlayMode/Cards/CardDefs.cpp
@@ -27,6 +27,7 @@
 #include <Rosetta/PlayMode/CardSets/TheBarrensCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/TrollCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/UldumCardsGen.hpp>
+#include <Rosetta/PlayMode/CardSets/UngoroCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/VanillaCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/YoDCardsGen.hpp>
 #include <Rosetta/PlayMode/Cards/CardDefs.hpp>
@@ -50,6 +51,7 @@ CardDefs::CardDefs()
     LoECardsGen::AddAll(m_data);
     OgCardsGen::AddAll(m_data);
     KaraCardsGen::AddAll(m_data);
+    UngoroCardsGen::AddAll(m_data);
     IcecrownCardsGen::AddAll(m_data);
     LootapaloozaCardsGen::AddAll(m_data);
     GilneasCardsGen::AddAll(m_data);

--- a/Sources/Rosetta/PlayMode/Managers/TriggerManager.cpp
+++ b/Sources/Rosetta/PlayMode/Managers/TriggerManager.cpp
@@ -118,9 +118,9 @@ void TriggerManager::OnDeathTrigger(Entity* sender)
     deathTrigger(sender);
 }
 
-void TriggerManager::OnUseHeroPowerTrigger(Entity* sender)
+void TriggerManager::OnInspireTrigger(Entity* sender)
 {
-    useHeroPowerTrigger(sender);
+    inspireTrigger(sender);
 }
 
 void TriggerManager::OnShuffleIntoDeckTrigger(Entity* sender)

--- a/Sources/Rosetta/PlayMode/Models/Hero.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Hero.cpp
@@ -40,6 +40,11 @@ void Hero::SetArmor(int armor)
     SetGameTag(GameTag::ARMOR, armor);
 }
 
+int Hero::GetHeroPowerDamage() const
+{
+    return GetGameTag(GameTag::HEROPOWER_DAMAGE);
+}
+
 void Hero::AddWeapon(Weapon& _weapon)
 {
     RemoveWeapon();

--- a/Sources/Rosetta/PlayMode/Tasks/PlayerTasks/HeroPowerTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/PlayerTasks/HeroPowerTask.cpp
@@ -73,9 +73,9 @@ TaskStatus HeroPowerTask::Impl(Player* player)
 
     power.SetExhausted(true);
 
-    // Process use hero power trigger
+    // Process inspire trigger
     player->game->taskQueue.StartEvent();
-    player->game->triggerManager.OnUseHeroPowerTrigger(player);
+    player->game->triggerManager.OnInspireTrigger(player);
     player->game->ProcessTasks();
     player->game->taskQueue.EndEvent();
 

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.cpp
@@ -9,27 +9,22 @@
 
 namespace RosettaStone::PlayMode::SimpleTasks
 {
-DrawStackTask::DrawStackTask(std::size_t amount, bool addToStack)
-    : m_amount(amount), m_addToStack(addToStack)
+DrawStackTask::DrawStackTask(bool addToStack) : m_addToStack(addToStack)
 {
     // Do nothing
 }
 
 TaskStatus DrawStackTask::Impl(Player* player)
 {
-    auto& stack = player->game->taskStack.playables;
-    const std::size_t amount =
-        (m_amount <= stack.size()) ? m_amount : stack.size();
-
-    for (std::size_t i = 0; i < amount; ++i)
+    std::vector<Playable*>& playables = player->game->taskStack.playables;
+    for (const auto& card : playables)
     {
-        Playable* card = stack.at(i);
         Generic::Draw(player, card);
     }
 
     if (!m_addToStack)
     {
-        stack.clear();
+        playables.clear();
     }
 
     return TaskStatus::COMPLETE;
@@ -37,6 +32,6 @@ TaskStatus DrawStackTask::Impl(Player* player)
 
 std::unique_ptr<ITask> DrawStackTask::CloneImpl()
 {
-    return std::make_unique<DrawStackTask>(m_amount, m_addToStack);
+    return std::make_unique<DrawStackTask>(m_addToStack);
 }
 }  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/IncludeTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/IncludeTask.cpp
@@ -125,6 +125,9 @@ std::vector<Playable*> IncludeTask::GetEntities(EntityType entityType,
             entities.emplace_back(player->GetHero());
             entities.emplace_back(player->opponent->GetHero());
             break;
+        case EntityType::HERO_POWER:
+            entities.emplace_back(player->GetHero()->heroPower);
+            break;
         case EntityType::WEAPON:
             if (player->GetHero()->HasWeapon())
             {
@@ -388,6 +391,9 @@ std::vector<Playable*> IncludeTask::GetEntities(EntityType entityType,
         case EntityType::HEROES:
             entities.emplace_back(player->GetHero());
             entities.emplace_back(player->opponent->GetHero());
+            break;
+        case EntityType::HERO_POWER:
+            entities.emplace_back(player->GetHero()->heroPower);
             break;
         case EntityType::WEAPON:
             if (player->GetHero()->HasWeapon())

--- a/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
+++ b/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
@@ -231,8 +231,8 @@ std::shared_ptr<Trigger> Trigger::Activate(Playable* source,
         case TriggerType::DEATH:
             game->triggerManager.deathTrigger += instance->handler;
             break;
-        case TriggerType::USE_HERO_POWER:
-            game->triggerManager.useHeroPowerTrigger += instance->handler;
+        case TriggerType::INSPIRE:
+            game->triggerManager.inspireTrigger += instance->handler;
             break;
         case TriggerType::SHUFFLE_INTO_DECK:
             game->triggerManager.shuffleIntoDeckTrigger += instance->handler;
@@ -386,8 +386,8 @@ void Trigger::Remove() const
         case TriggerType::DEATH:
             game->triggerManager.deathTrigger -= handler;
             break;
-        case TriggerType::USE_HERO_POWER:
-            game->triggerManager.useHeroPowerTrigger -= handler;
+        case TriggerType::INSPIRE:
+            game->triggerManager.inspireTrigger -= handler;
             break;
         case TriggerType::SHUFFLE_INTO_DECK:
             game->triggerManager.shuffleIntoDeckTrigger -= handler;

--- a/Tests/UnitTests/PlayMode/CardSets/BoomsdayCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BoomsdayCardsGenTests.cpp
@@ -30,7 +30,7 @@ using namespace SimpleTasks;
 TEST_CASE("[Druid : Spell] - BOT_420 : Landscaping")
 {
     GameConfig config;
-    config.player1Class = CardClass::MAGE;
+    config.player1Class = CardClass::DRUID;
     config.player2Class = CardClass::MAGE;
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = true;
@@ -77,4 +77,62 @@ TEST_CASE("[Druid : Spell] - BOT_420 : Landscaping")
     game.Process(curPlayer, PlayCardTask::Spell(card3));
     CHECK_EQ(curField.GetCount(), 7);
     CHECK_EQ(curField[6]->card->name, "Treant");
+}
+
+// ------------------------------------------- SPELL - MAGE
+// [BOT_453] Shooting Star - COST:1
+// - Set: BOOMSDAY, Rarity: Common
+// - Spell School: Arcane
+// --------------------------------------------------------
+// Text: Deal 1 damage to a minion and the minions next to it.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - BOT_453 : Shooting Star")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Shooting Star"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opField.GetCount(), 3);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3));
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 11);
 }

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -2559,3 +2559,44 @@ TEST_CASE("[Mage : Spell] - CORE_GIL_801 : Snap Freeze")
     game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card3));
     CHECK_EQ(opField.GetCount(), 0);
 }
+
+// ------------------------------------------ MINION - MAGE
+// [CORE_KAR_009] Babbling Book - COST:1 [ATK:1/HP:1]
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Add a random Mage spell to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - CORE_KAR_009 : Babbling Book")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Babbling Book"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->GetCardType(), CardType::SPELL);
+    CHECK(curHand[0]->card->IsCardClass(CardClass::MAGE));
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -2013,3 +2013,78 @@ TEST_CASE("[Mage : Spell] - CORE_CS2_023 : Arcane Intellect")
     game.Process(curPlayer, PlayCardTask::Spell(card1));
     CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
 }
+
+// ------------------------------------------- SPELL - MAGE
+// [CORE_CS2_029] Fireball - COST:4
+// - Set: CORE, Rarity: Common
+// - Spell School: Fire
+// --------------------------------------------------------
+// Text: Deal 6 damage.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - CORE_CS2_029 : Fireball")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    const auto card5 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+    const auto card6 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card6));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card6));
+    CHECK_EQ(opPlayer->GetFieldZone()->GetCount(), 0);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 24);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card5));
+    CHECK_EQ(curPlayer->GetFieldZone()->GetCount(), 0);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card4, curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 24);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -2198,3 +2198,86 @@ TEST_CASE("[Mage : Minion] - CORE_CS2_033 : Water Elemental")
     CHECK_EQ(curField[0]->IsFrozen(), false);
     CHECK_EQ(opField[0]->IsFrozen(), true);
 }
+
+// ------------------------------------------- SPELL - MAGE
+// [CORE_EX1_275] Cone of Cold - COST:3
+// - Set: CORE, Rarity: Common
+// - Spell School: Frost
+// --------------------------------------------------------
+// Text: <b>Freeze</b> a minion and the minions next to it,
+//       and deal 1 damage to them.
+// --------------------------------------------------------
+// GameTag:
+// - FREEZE = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - CORE_EX1_275 : Cone of Cold")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flame Imp"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flame Imp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flame Imp"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flame Imp"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flame Imp"));
+    const auto card6 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Cone of Cold"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->IsFrozen(), false);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+    CHECK_EQ(curField[1]->IsFrozen(), false);
+    CHECK_EQ(curField[2]->GetHealth(), 2);
+    CHECK_EQ(curField[2]->IsFrozen(), false);
+    CHECK_EQ(curField[3]->GetHealth(), 2);
+    CHECK_EQ(curField[3]->IsFrozen(), false);
+    CHECK_EQ(curField[4]->GetHealth(), 2);
+    CHECK_EQ(curField[4]->IsFrozen(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card6, card3));
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->IsFrozen(), false);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->IsFrozen(), true);
+    CHECK_EQ(curField[2]->GetHealth(), 1);
+    CHECK_EQ(curField[2]->IsFrozen(), true);
+    CHECK_EQ(curField[3]->GetHealth(), 1);
+    CHECK_EQ(curField[3]->IsFrozen(), true);
+    CHECK_EQ(curField[4]->GetHealth(), 2);
+    CHECK_EQ(curField[4]->IsFrozen(), false);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -1918,3 +1918,62 @@ TEST_CASE("[Mage : Minion] - CORE_AT_008 : Coldarra Drake")
     game.Process(curPlayer, HeroPowerTask(opHero));
     CHECK_EQ(opHero->GetHealth(), 27);
 }
+
+// ------------------------------------------- SPELL - MAGE
+// [CORE_BOT_453] Shooting Star - COST:1
+// - Set: CORE, Rarity: Common
+// - Spell School: Arcane
+// --------------------------------------------------------
+// Text: Deal 1 damage to a minion and the minions next to it.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - CORE_BOT_453 : Shooting Star")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Shooting Star"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opField.GetCount(), 3);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3));
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 11);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -1804,3 +1804,65 @@ TEST_CASE("[Hunter : Minion] - CS3_015 : Selective Breeder")
     CHECK_EQ(curHand.GetCount(), 5);
     CHECK_EQ(curHand[4]->card->GetRace(), Race::BEAST);
 }
+
+// ------------------------------------------ MINION - MAGE
+// [CORE_AT_003] Fallen Hero - COST:2 [ATK:3/HP:2]
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: Your Hero Power deals 1 extra damage.
+// --------------------------------------------------------
+// GameTag:
+// - HEROPOWER_DAMAGE = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - CORE_AT_003 : Fallen Hero")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto opHero = opPlayer->GetHero();
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fallen Hero"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, HeroPowerTask(opHero));
+    CHECK_EQ(opHero->GetHealth(), 29);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, HeroPowerTask(opHero));
+    CHECK_EQ(opHero->GetHealth(), 27);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, HeroPowerTask(opHero));
+    CHECK_EQ(opHero->GetHealth(), 26);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -2600,3 +2600,54 @@ TEST_CASE("[Mage : Minion] - CORE_KAR_009 : Babbling Book")
     CHECK_EQ(curHand[0]->card->GetCardType(), CardType::SPELL);
     CHECK(curHand[0]->card->IsCardClass(CardClass::MAGE));
 }
+
+// ------------------------------------------ MINION - MAGE
+// [CORE_LOE_003] Ethereal Conjurer - COST:5 [ATK:6/HP:4]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry: Discover</b> a spell.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - DISCOVER = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - CORE_LOE_003 : Ethereal Conjurer")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Ethereal Conjurer"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK(curPlayer->choice != nullptr);
+    CHECK_EQ(curPlayer->choice->choices.size(), 3);
+
+    auto cards = TestUtils::GetChoiceCards(game);
+    for (auto& card : cards)
+    {
+        CHECK_EQ(card->GetCardType(), CardType::SPELL);
+        CHECK_EQ(card->IsCardClass(CardClass::MAGE), true);
+    }
+
+    TestUtils::ChooseNthChoice(game, 1);
+    CHECK_EQ(curHand.GetCount(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -2140,3 +2140,61 @@ TEST_CASE("[Mage : Spell] - CORE_CS2_032 : Flamestrike")
     CHECK_EQ(opField.GetCount(), 1);
     CHECK_EQ(opField[0]->GetHealth(), 2);
 }
+
+// ------------------------------------------ MINION - MAGE
+// [CORE_CS2_033] Water Elemental - COST:4 [ATK:3/HP:6]
+// - Race: Elemental, Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Freeze</b> any character damaged by this minion.
+// --------------------------------------------------------
+// GameTag:
+// - FREEZE = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - CORE_CS2_033 : Water Elemental")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Water Elemental"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Chillwind Yeti"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(card1, card2));
+
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(opField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->IsFrozen(), false);
+    CHECK_EQ(opField[0]->IsFrozen(), true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -1977,3 +1977,39 @@ TEST_CASE("[Mage : Spell] - CORE_BOT_453 : Shooting Star")
     CHECK_EQ(opField.GetCount(), 1);
     CHECK_EQ(opField[0]->GetHealth(), 11);
 }
+
+// ------------------------------------------- SPELL - MAGE
+// [CORE_CS2_023] Arcane Intellect - COST:3
+// - Set: CORE, Rarity: Common
+// - Spell School: Arcane
+// --------------------------------------------------------
+// Text: Draw 2 cards.
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - CORE_CS2_023 : Arcane Intellect")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Arcane Intellect"));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -2651,3 +2651,53 @@ TEST_CASE("[Mage : Minion] - CORE_LOE_003 : Ethereal Conjurer")
     TestUtils::ChooseNthChoice(game, 1);
     CHECK_EQ(curHand.GetCount(), 1);
 }
+
+// ------------------------------------------ MINION - MAGE
+// [CORE_UNG_020] Arcanologist - COST:2 [ATK:2/HP:3]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Draw a <b>Secret</b>.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - SECRET = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - CORE_UNG_020 : Arcanologist")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Bloodfen Raptor");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Young Dragonhawk");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Ice Barrier");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Arcanologist"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->card->IsSecret(), true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -2350,3 +2350,56 @@ TEST_CASE("[Mage : Spell] - CORE_EX1_287 : Counterspell")
                  PlayCardTask::SpellTarget(card4, curPlayer->GetHero()));
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 27);
 }
+
+// ------------------------------------------- SPELL - MAGE
+// [CORE_EX1_289] Ice Barrier - COST:3
+// - Set: CORE, Rarity: Common
+// - Spell School: Frost
+// --------------------------------------------------------
+// Text: <b>Secret:</b> When your hero is attacked,
+//       gain 8 Armor.
+// --------------------------------------------------------
+// GameTag:
+// - SECRET = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - CORE_EX1_289 : Ice Barrier")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto curSecret = curPlayer->GetSecretZone();
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ice Barrier"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fiery War Axe"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curSecret->GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Weapon(card2));
+    game.Process(opPlayer,
+                 AttackTask(opPlayer->GetHero(), curPlayer->GetHero()));
+    CHECK_EQ(curSecret->GetCount(), 0);
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -2403,3 +2403,98 @@ TEST_CASE("[Mage : Spell] - CORE_EX1_289 : Ice Barrier")
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
 }
+
+// ------------------------------------------- SPELL - MAGE
+// [CORE_EX1_294] Mirror Entity - COST:3
+// - Set: CORE, Rarity: Common
+// - Spell School: Arcane
+// --------------------------------------------------------
+// Text: <b>Secret:</b> After your opponent plays a minion,
+//       summon a copy of it.
+// --------------------------------------------------------
+// GameTag:
+// - SECRET = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - CORE_EX1_294 : Mirror Entity")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto curSecret = curPlayer->GetSecretZone();
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mirror Entity"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mirror Entity"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card6 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card7 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card8 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card9 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Injured Blademaster"));
+    const auto card10 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Injured Blademaster"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curSecret->GetCount(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curSecret->GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card9));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curSecret->GetCount(), 0);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curSecret->GetCount(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+    game.Process(curPlayer, PlayCardTask::Minion(card6));
+    CHECK_EQ(curField.GetCount(), 5);
+    game.Process(curPlayer, PlayCardTask::Minion(card7));
+    CHECK_EQ(curField.GetCount(), 6);
+    game.Process(curPlayer, PlayCardTask::Minion(card8));
+    CHECK_EQ(curField.GetCount(), 7);
+    CHECK_EQ(curSecret->GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card10));
+    CHECK_EQ(curField.GetCount(), 7);
+    CHECK_EQ(curSecret->GetCount(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -2088,3 +2088,55 @@ TEST_CASE("[Mage : Spell] - CORE_CS2_029 : Fireball")
                  PlayCardTask::SpellTarget(card4, curPlayer->GetHero()));
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 24);
 }
+
+// ------------------------------------------- SPELL - MAGE
+// [CORE_CS2_032] Flamestrike - COST:7
+// - Set: CORE, Rarity: Epic
+// - Spell School: Fire
+// --------------------------------------------------------
+// Text: Deal 5 damage to all enemy minions.
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - CORE_CS2_032 : Flamestrike")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flamestrike"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 2);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -1866,3 +1866,55 @@ TEST_CASE("[Mage : Minion] - CORE_AT_003 : Fallen Hero")
     game.Process(curPlayer, HeroPowerTask(opHero));
     CHECK_EQ(opHero->GetHealth(), 26);
 }
+
+// ------------------------------------------ MINION - MAGE
+// [CORE_AT_008] Coldarra Drake - COST:6 [ATK:6/HP:7]
+// - Race: Dragon, Set: CORE, Rarity: Epic
+// --------------------------------------------------------
+// Text: You can use your Hero Power any number of times.
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - CORE_AT_008 : Coldarra Drake")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto opHero = opPlayer->GetHero();
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Coldarra Drake"));
+
+    game.Process(curPlayer, HeroPowerTask(opHero));
+    CHECK_EQ(opHero->GetHealth(), 29);
+
+    game.Process(curPlayer, HeroPowerTask(opHero));
+    CHECK_EQ(opHero->GetHealth(), 29);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, HeroPowerTask(opHero));
+    CHECK_EQ(opHero->GetHealth(), 28);
+
+    game.Process(curPlayer, HeroPowerTask(opHero));
+    CHECK_EQ(opHero->GetHealth(), 27);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -2498,3 +2498,64 @@ TEST_CASE("[Mage : Spell] - CORE_EX1_294 : Mirror Entity")
     CHECK_EQ(curField.GetCount(), 7);
     CHECK_EQ(curSecret->GetCount(), 1);
 }
+
+// ------------------------------------------- SPELL - MAGE
+// [CORE_GIL_801] Snap Freeze - COST:1
+// - Set: CORE, Rarity: Common
+// - Spell School: Frost
+// --------------------------------------------------------
+// Text: <b>Freeze</b> a minion.
+//       If it's already <b>Frozen</b>, destroy it.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+// RefTag:
+// - FREEZE = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - CORE_GIL_801 : Snap Freeze")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Snap Freeze"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Snap Freeze"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField[0]->IsFrozen(), false);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3));
+    CHECK_EQ(opField[0]->IsFrozen(), true);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card3));
+    CHECK_EQ(opField.GetCount(), 0);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -2400,7 +2400,8 @@ TEST_CASE("[Mage : Spell] - EX1_279 : Pyroblast")
 // - Faction: Neutral, Set: Expert1, Rarity: Rare
 // - Spell School: Arcane
 // --------------------------------------------------------
-// Text: <b>Secret:</b> When your opponent casts a spell, <b>Counter</b> it.
+// Text: <b>Secret:</b> When your opponent casts a spell,
+//       <b>Counter</b> it.
 // --------------------------------------------------------
 // GameTag:
 // - SECRET = 1

--- a/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
@@ -89,3 +89,43 @@ TEST_CASE("[Druid : Minion] - KAR_300 : Enchanted Raven")
 {
     // Do nothing
 }
+
+// ------------------------------------------ MINION - MAGE
+// [KAR_009] Babbling Book - COST:1 [ATK:1/HP:1]
+// - Set: Kara, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Add a random Mage spell to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - KAR_009 : Babbling Book")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Babbling Book"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->GetCardType(), CardType::SPELL);
+    CHECK(curHand[0]->card->IsCardClass(CardClass::MAGE));
+}

--- a/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
@@ -7,8 +7,64 @@
 #include "doctest_proxy.hpp"
 
 #include <Utils/CardSetUtils.hpp>
+#include <Utils/TestUtils.hpp>
 
-TEST_CASE("[LoECardsGen] - Temp")
+#include <Rosetta/PlayMode/Actions/Draw.hpp>
+#include <Rosetta/PlayMode/Cards/Cards.hpp>
+#include <Rosetta/PlayMode/Zones/HandZone.hpp>
+
+using namespace RosettaStone;
+using namespace PlayMode;
+using namespace PlayerTasks;
+using namespace SimpleTasks;
+
+// ------------------------------------------ MINION - MAGE
+// [LOE_003] Ethereal Conjurer - COST:5 [ATK:6/HP:3]
+// - Set: LoE Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry: Discover</b> a spell.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - DISCOVER = 1
+// - USE_DISCOVER_VISUALS = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - LOE_003 : Ethereal Conjurer")
 {
-    CHECK(true);
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Ethereal Conjurer"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK(curPlayer->choice != nullptr);
+    CHECK_EQ(curPlayer->choice->choices.size(), 3);
+
+    auto cards = TestUtils::GetChoiceCards(game);
+    for (auto& card : cards)
+    {
+        CHECK_EQ(card->GetCardType(), CardType::SPELL);
+        CHECK_EQ(card->IsCardClass(CardClass::MAGE), true);
+    }
+
+    TestUtils::ChooseNthChoice(game, 1);
+    CHECK_EQ(curHand.GetCount(), 1);
 }

--- a/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#include "doctest_proxy.hpp"
+
+#include <Utils/CardSetUtils.hpp>
+
+TEST_CASE("[LoECardsGen] - Temp")
+{
+    CHECK(true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TgtCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TgtCardsGenTests.cpp
@@ -76,3 +76,64 @@ TEST_CASE("[Hunter : Spell] - AT_061 : Lock and Load")
                  PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
     CHECK_EQ(curHand.GetCount(), 1);
 }
+
+// ------------------------------------------ MINION - MAGE
+// [AT_003] Fallen Hero - COST:2 [ATK:3/HP:2]
+// - Set: Tgt, Rarity: Rare
+// --------------------------------------------------------
+// Text: Your Hero Power deals 1 extra damage.
+// --------------------------------------------------------
+// GameTag:
+// - HEROPOWER_DAMAGE = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - AT_003 : Fallen Hero")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto opHero = opPlayer->GetHero();
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fallen Hero"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, HeroPowerTask(opHero));
+    CHECK_EQ(opHero->GetHealth(), 29);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, HeroPowerTask(opHero));
+    CHECK_EQ(opHero->GetHealth(), 27);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, HeroPowerTask(opHero));
+    CHECK_EQ(opHero->GetHealth(), 26);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TgtCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TgtCardsGenTests.cpp
@@ -137,3 +137,54 @@ TEST_CASE("[Mage : Minion] - AT_003 : Fallen Hero")
     game.Process(curPlayer, HeroPowerTask(opHero));
     CHECK_EQ(opHero->GetHealth(), 26);
 }
+
+// ------------------------------------------ MINION - MAGE
+// [AT_008] Coldarra Drake - COST:6 [ATK:6/HP:6]
+// - Race: Dragon, Set: Tgt, Rarity: Epic
+// --------------------------------------------------------
+// Text: You can use your Hero Power any number of times.
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - AT_008 : Coldarra Drake")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto opHero = opPlayer->GetHero();
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Coldarra Drake"));
+
+    game.Process(curPlayer, HeroPowerTask(opHero));
+    CHECK_EQ(opHero->GetHealth(), 29);
+
+    game.Process(curPlayer, HeroPowerTask(opHero));
+    CHECK_EQ(opHero->GetHealth(), 29);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, HeroPowerTask(opHero));
+    CHECK_EQ(opHero->GetHealth(), 28);
+
+    game.Process(curPlayer, HeroPowerTask(opHero));
+    CHECK_EQ(opHero->GetHealth(), 27);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
@@ -8,7 +8,60 @@
 
 #include <Utils/CardSetUtils.hpp>
 
-TEST_CASE("[UngoroCardsGen] - Temp")
+#include <Rosetta/PlayMode/Actions/Draw.hpp>
+#include <Rosetta/PlayMode/Cards/Cards.hpp>
+#include <Rosetta/PlayMode/Zones/HandZone.hpp>
+
+using namespace RosettaStone;
+using namespace PlayMode;
+using namespace PlayerTasks;
+using namespace SimpleTasks;
+
+// ------------------------------------------ MINION - MAGE
+// [UNG_020] Arcanologist - COST:2 [ATK:2/HP:3]
+// - Set: Ungoro, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Draw a <b>Secret</b> from your deck.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - SECRET = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - UNG_020 : Arcanologist")
 {
-    CHECK(true);
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Bloodfen Raptor");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Young Dragonhawk");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Ice Barrier");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Arcanologist"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->card->IsSecret(), true);
 }

--- a/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#include "doctest_proxy.hpp"
+
+#include <Utils/CardSetUtils.hpp>
+
+TEST_CASE("[UngoroCardsGen] - Temp")
+{
+    CHECK(true);
+}


### PR DESCRIPTION
This revision includes:
- Implement 15 CORE cards
  - Fallen Hero (CORE_AT_003)
  - Coldarra Drake (CORE_AT_008)
  - Shooting Star (CORE_BOT_453)
  - Arcane Intellect (CORE_CS2_023)
  - Fireball (CORE_CS2_029)
  - Flamestrike (CORE_CS2_032)
  - Water Elemental (CORE_CS2_033)
  - Cone of Cold (CORE_EX1_275)
  - Counterspell (CORE_EX1_287)
  - Ice Barrier (CORE_EX1_289)
  - Mirror Entity (CORE_EX1_294)
  - Snap Freeze (CORE_GIL_801)
  - Babbling Book (CORE_KAR_009)
  - Ethereal Conjurer (CORE_LOE_003)
  - Arcanologist (CORE_UNG_020)
- Implement 2 TGT cards
  - Fallen Hero (AT_003)
  - Coldarra Drake (AT_008)
- Implement 1 BOOMSDAY card
  - Shooting Star (BOT_453)
- Implement 1 GILNEAS card
  - Snap Freeze (GIL_801)
- Implement 1 KARA card
  - Babbling Book (KAR_009)
- Implement 1 LOE card
  - Ethereal Conjurer (LOE_003)
- Implement 1 UNGORO card
  - Arcanologist (UNG_020)
- Create card generation and unit test files for some card sets
  - LOE
  - UNGORO
- Add methods
  - Hero::GetHeroPowerDamage(): Returns the value of hero power damage
  - ComplexTask::DrawCardFromDeck(): Returns a list of task for drawing card(s) from your deck
- Refactor and correct code
  - Add code to add hero power damage by an aura
  - Add code to process 'AuraType::HERO'
  - Correct the logic of card 'Arcane Amplifier' (YOD_008)
  - Change name 'TriggerType::USE_HERO_POWER' to 'TriggerType::INSPIRE'
  - Add enum value 'EntityType::HERO_POWER' and code to process it
  - Delete variable 'm_amount' and code to process it in class 'DrawStackTask'