### PR TITLE
Update Hearthstone Patch 20.0.2

### DIFF
--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -68,7 +68,7 @@ constexpr std::array<CardSet, 1> CLASSIC_CARD_SETS = {
 };
 
 //! The number of all cards.
-constexpr int NUM_ALL_CARDS = 12429;
+constexpr int NUM_ALL_CARDS = 12430;
 
 //! The number of player class.
 //! \note Druid, Hunter, Mage, Paladin, Priest, Rogue, Shaman, Warlock, Warrior,

--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -34,8 +34,8 @@ constexpr std::array<CardSet, 5> STANDARD_CARD_SETS = {
 
 //! Specifies which card sets combine into the WILD set.
 constexpr std::array<CardSet, 27> WILD_CARD_SETS = {
-    CardSet::BASIC,                  // Basic, 2014
     CardSet::EXPERT1,                // Classic, 2014
+    CardSet::LEGACY,                 // Legacy, 2021
     CardSet::NAXX,                   // Curse of Naxxramas, 2014
     CardSet::GVG,                    // Goblins vs Gnomes, 2014
     CardSet::BRM,                    // Blackrock Mountain, 2015
@@ -44,7 +44,6 @@ constexpr std::array<CardSet, 27> WILD_CARD_SETS = {
     CardSet::OG,                     // Whispers of the Old Gods, 2016
     CardSet::KARA,                   // One Night in Karazhan, 2016
     CardSet::GANGS,                  // Mean Streets of Gadgetzan, 2016
-    CardSet::HOF,                    // Hall of Fame, 2017
     CardSet::UNGORO,                 // Journey to Un'Goro, 2017
     CardSet::ICECROWN,               // Knights of the Frozen Throne, 2017
     CardSet::LOOTAPALOOZA,           // Kobolds & Catacombs, 2017

--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -106,7 +106,7 @@ constexpr int MAX_SECERT_SIZE = 5;
 constexpr int NUM_BATTLEGROUNDS_PLAYERS = 8;
 
 //! The number of heroes in Battlegrounds.
-constexpr int NUM_BATTLEGROUNDS_HEROES = 54;
+constexpr int NUM_BATTLEGROUNDS_HEROES = 56;
 
 //! The number of heroes on the selection list in Battlegrounds.
 constexpr int NUM_HEROES_ON_SELECTION_LIST = 4;

--- a/Resources/cards.collectible.json
+++ b/Resources/cards.collectible.json
@@ -2772,7 +2772,7 @@
         "name": "Warsong Wrangler",
         "rarity": "EPIC",
         "set": "THE_BARRENS",
-        "text": "[x]<b>Battlecry:</b> <b>Discover</b> a\nBeast in your deck. Give\nall copies of it +2/+1 \n<i>(wherever they are)</i>.",
+        "text": "[x]<b>Battlecry:</b> <b>Discover</b> a\nBeast from your deck. Give\nall copies of it +2/+1 \n<i>(wherever they are)</i>.",
         "type": "MINION"
     },
     {
@@ -3167,7 +3167,7 @@
         "cost": 2,
         "dbfId": 62583,
         "flavor": "Dabu, man. Like, far out.",
-        "health": 4,
+        "health": 3,
         "id": "BAR_074",
         "mechanics": [
             "CANT_ATTACK",
@@ -3207,7 +3207,7 @@
         "cost": 3,
         "dbfId": 62585,
         "flavor": "Pushing into Ashenvale made this post uneventful.",
-        "health": 5,
+        "health": 4,
         "howToEarnGolden": "Unlocked on the Forged in the Barrens Reward Track.",
         "id": "BAR_076",
         "mechanics": [
@@ -4727,7 +4727,7 @@
         "collectible": true,
         "cost": 2,
         "dbfId": 62926,
-        "durability": 3,
+        "durability": 2,
         "flavor": "Hoarding secrets is no fun, so play each and every one.",
         "id": "BAR_875",
         "mechanics": [
@@ -8721,7 +8721,7 @@
         "id": "BT_035",
         "name": "Chaos Strike",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "FEL",
         "text": "Give your hero +2 Attack this turn. Draw a card.",
         "type": "SPELL"
@@ -8739,7 +8739,7 @@
         "referencedTags": [
             "RUSH"
         ],
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Summon three 1/1 Illidari with <b>Rush</b>.",
         "type": "SPELL"
     },
@@ -9284,7 +9284,7 @@
         "name": "Shadowhoof Slayer",
         "race": "DEMON",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Give your hero +1 Attack this turn.",
         "type": "MINION"
     },
@@ -9772,7 +9772,7 @@
         "id": "BT_235",
         "name": "Chaos Nova",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "FEL",
         "text": "Deal $4 damage to all minions.",
         "type": "SPELL"
@@ -10186,7 +10186,7 @@
         "name": "Sightless Watcher",
         "race": "DEMON",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Look at 3 cards in your deck. Choose one to put on top.",
         "type": "MINION"
     },
@@ -10267,7 +10267,7 @@
         "name": "Satyr Overseer",
         "race": "DEMON",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "After your hero attacks, summon a 2/2 Satyr.",
         "type": "MINION"
     },
@@ -10586,7 +10586,7 @@
         ],
         "name": "Glaivebound Adept",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "targetingArrowText": "Deal 4 damage.",
         "text": "<b>Battlecry:</b> If your hero attacked this turn,\ndeal 4 damage.",
         "type": "MINION"
@@ -10664,7 +10664,7 @@
         "id": "BT_512",
         "name": "Inner Demon",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Give your hero +8 Attack this turn.",
         "type": "SPELL"
     },
@@ -11290,7 +11290,7 @@
         ],
         "name": "Soul Cleave",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "SHADOW",
         "text": "<b>Lifesteal</b>\nDeal $2 damage to two random enemy minions.",
         "type": "SPELL"
@@ -11445,7 +11445,7 @@
         ],
         "name": "Aldrachi Warblades",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Lifesteal</b>",
         "type": "WEAPON"
     },
@@ -18320,7 +18320,7 @@
         ],
         "name": "Goldshire Footman",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Taunt</b>",
         "type": "MINION"
     },
@@ -18354,7 +18354,7 @@
         "id": "CS1_112",
         "name": "Holy Nova",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "HOLY",
         "text": "Deal $2 damage to all enemy minions. Restore #2 Health to all friendly characters.",
         "type": "SPELL"
@@ -18369,7 +18369,7 @@
         "id": "CS1_113",
         "name": "Mind Control",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "SHADOW",
         "text": "Take control of an enemy minion.",
         "type": "SPELL"
@@ -18398,7 +18398,7 @@
         "id": "CS1_130",
         "name": "Holy Smite",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "HOLY",
         "text": "Deal $3 damage\nto a minion.",
         "type": "SPELL"
@@ -18413,7 +18413,7 @@
         "id": "CS2_003",
         "name": "Mind Vision",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "SHADOW",
         "text": "Put a copy of a random card in your opponent's hand into your hand.",
         "type": "SPELL"
@@ -18428,7 +18428,7 @@
         "id": "CS2_004",
         "name": "Power Word: Shield",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "HOLY",
         "text": "Give a minion +2 Health.\nDraw a card.",
         "type": "SPELL"
@@ -18443,7 +18443,7 @@
         "id": "CS2_005",
         "name": "Claw",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Give your hero +2 Attack this turn. Gain 2 Armor.",
         "type": "SPELL"
     },
@@ -18457,7 +18457,7 @@
         "id": "CS2_007",
         "name": "Healing Touch",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "NATURE",
         "text": "Restore #8 Health.",
         "type": "SPELL"
@@ -18472,7 +18472,7 @@
         "id": "CS2_008",
         "name": "Moonfire",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "ARCANE",
         "text": "Deal $1 damage.",
         "type": "SPELL"
@@ -18490,7 +18490,7 @@
         "referencedTags": [
             "TAUNT"
         ],
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "NATURE",
         "text": "Give a minion <b>Taunt</b> and +2/+3.<i>\n(+2 Attack/+3 Health)</i>",
         "type": "SPELL"
@@ -18505,7 +18505,7 @@
         "id": "CS2_011",
         "name": "Savage Roar",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Give your characters +2 Attack this turn.",
         "type": "SPELL"
     },
@@ -18519,7 +18519,7 @@
         "id": "CS2_012",
         "name": "Swipe",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Deal $4 damage to an enemy and $1 damage to all other enemies.",
         "type": "SPELL"
     },
@@ -18533,7 +18533,7 @@
         "id": "CS2_013",
         "name": "Wild Growth",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "NATURE",
         "text": "Gain an empty Mana Crystal.",
         "type": "SPELL"
@@ -18548,7 +18548,7 @@
         "id": "CS2_022",
         "name": "Polymorph",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "ARCANE",
         "text": "Transform a minion\ninto a 1/1 Sheep.",
         "type": "SPELL"
@@ -18563,7 +18563,7 @@
         "id": "CS2_023",
         "name": "Arcane Intellect",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "ARCANE",
         "text": "Draw 2 cards.",
         "type": "SPELL"
@@ -18581,7 +18581,7 @@
         ],
         "name": "Frostbolt",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "FROST",
         "text": "Deal $3 damage to a character and <b>Freeze</b> it.",
         "type": "SPELL"
@@ -18596,7 +18596,7 @@
         "id": "CS2_025",
         "name": "Arcane Explosion",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "ARCANE",
         "text": "Deal $1 damage to all enemy minions.",
         "type": "SPELL"
@@ -18614,7 +18614,7 @@
         ],
         "name": "Frost Nova",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "FROST",
         "text": "<b>Freeze</b> all enemy minions.",
         "type": "SPELL"
@@ -18632,7 +18632,7 @@
         "referencedTags": [
             "TAUNT"
         ],
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Summon two 0/2 minions with <b>Taunt</b>.",
         "type": "SPELL"
     },
@@ -18664,7 +18664,7 @@
         "id": "CS2_029",
         "name": "Fireball",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "FIRE",
         "text": "Deal $6 damage.",
         "type": "SPELL"
@@ -18682,7 +18682,7 @@
         ],
         "name": "Ice Lance",
         "rarity": "COMMON",
-        "set": "HOF",
+        "set": "EXPERT1",
         "spellSchool": "FROST",
         "text": "<b>Freeze</b> a character. If it was already <b>Frozen</b>, deal $4 damage instead.",
         "type": "SPELL"
@@ -18697,7 +18697,7 @@
         "id": "CS2_032",
         "name": "Flamestrike",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "FIRE",
         "text": "Deal $5 damage to all enemy minions.",
         "type": "SPELL"
@@ -18718,7 +18718,7 @@
         "name": "Water Elemental",
         "race": "ELEMENTAL",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Freeze</b> any character damaged by this minion.",
         "type": "MINION"
     },
@@ -18735,7 +18735,7 @@
         ],
         "name": "Frost Shock",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "FROST",
         "text": "Deal $1 damage to an enemy character and <b>Freeze</b> it.",
         "type": "SPELL"
@@ -18770,7 +18770,7 @@
         "referencedTags": [
             "WINDFURY"
         ],
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "NATURE",
         "text": "Give a minion <b>Windfury</b>.",
         "type": "SPELL"
@@ -18788,7 +18788,7 @@
         "referencedTags": [
             "TAUNT"
         ],
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "NATURE",
         "text": "Restore a minion\nto full Health and\ngive it <b>Taunt</b>.",
         "type": "SPELL"
@@ -18809,7 +18809,7 @@
         "name": "Fire Elemental",
         "race": "ELEMENTAL",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "targetingArrowText": "Deal 4 damage.",
         "text": "<b>Battlecry:</b> Deal 4 damage.",
         "type": "MINION"
@@ -18824,7 +18824,7 @@
         "id": "CS2_045",
         "name": "Rockbiter Weapon",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "NATURE",
         "text": "Give a friendly character +3 Attack this turn.",
         "type": "SPELL"
@@ -18839,7 +18839,7 @@
         "id": "CS2_046",
         "name": "Bloodlust",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Give your minions +3 Attack this turn.",
         "type": "SPELL"
     },
@@ -18867,7 +18867,7 @@
         "id": "CS2_057",
         "name": "Shadow Bolt",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "SHADOW",
         "text": "Deal $4 damage\nto a minion.",
         "type": "SPELL"
@@ -18903,7 +18903,7 @@
         "id": "CS2_061",
         "name": "Drain Life",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "SHADOW",
         "text": "Deal $2 damage. Restore #2 Health to your hero.",
         "type": "SPELL"
@@ -18918,7 +18918,7 @@
         "id": "CS2_062",
         "name": "Hellfire",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "FIRE",
         "text": "Deal $3 damage to ALL characters.",
         "type": "SPELL"
@@ -18933,7 +18933,7 @@
         "id": "CS2_063",
         "name": "Corruption",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Choose an enemy minion. At the start of your turn, destroy it.",
         "type": "SPELL"
     },
@@ -18953,7 +18953,7 @@
         "name": "Dread Infernal",
         "race": "DEMON",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Deal 1 damage to ALL other characters.",
         "type": "MINION"
     },
@@ -18973,7 +18973,7 @@
         "name": "Voidwalker",
         "race": "DEMON",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Taunt</b>",
         "type": "MINION"
     },
@@ -18987,7 +18987,7 @@
         "id": "CS2_072",
         "name": "Backstab",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Deal $2 damage to an undamaged minion.",
         "type": "SPELL"
     },
@@ -19018,7 +19018,7 @@
         "id": "CS2_074",
         "name": "Deadly Poison",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "NATURE",
         "text": "Give your weapon +2 Attack.",
         "type": "SPELL"
@@ -19033,7 +19033,7 @@
         "id": "CS2_075",
         "name": "Sinister Strike",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Deal $3 damage to the enemy hero.",
         "type": "SPELL"
     },
@@ -19047,7 +19047,7 @@
         "id": "CS2_076",
         "name": "Assassinate",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Destroy an enemy minion.",
         "type": "SPELL"
     },
@@ -19061,7 +19061,7 @@
         "id": "CS2_077",
         "name": "Sprint",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Draw 4 cards.",
         "type": "SPELL"
     },
@@ -19077,7 +19077,7 @@
         "id": "CS2_080",
         "name": "Assassin's Blade",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "type": "WEAPON"
     },
     {
@@ -19090,7 +19090,7 @@
         "id": "CS2_084",
         "name": "Hunter's Mark",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Change a minion's Health to 1.",
         "type": "SPELL"
     },
@@ -19104,7 +19104,7 @@
         "id": "CS2_087",
         "name": "Blessing of Might",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "HOLY",
         "text": "Give a minion +3 Attack.",
         "type": "SPELL"
@@ -19125,7 +19125,7 @@
         ],
         "name": "Guardian of Kings",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Taunt</b>\n<b>Battlecry:</b> Restore #6 Health to your hero.",
         "type": "MINION"
     },
@@ -19139,7 +19139,7 @@
         "id": "CS2_089",
         "name": "Holy Light",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "HOLY",
         "text": "Restore #8 Health to your hero.",
         "type": "SPELL"
@@ -19156,7 +19156,7 @@
         "id": "CS2_091",
         "name": "Light's Justice",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "type": "WEAPON"
     },
     {
@@ -19169,7 +19169,7 @@
         "id": "CS2_092",
         "name": "Blessing of Kings",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "HOLY",
         "text": "Give a minion +4/+4. <i>(+4 Attack/+4 Health)</i>",
         "type": "SPELL"
@@ -19184,7 +19184,7 @@
         "id": "CS2_093",
         "name": "Consecration",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "HOLY",
         "text": "Deal $2 damage to all enemies.",
         "type": "SPELL"
@@ -19199,7 +19199,7 @@
         "id": "CS2_094",
         "name": "Hammer of Wrath",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "HOLY",
         "text": "Deal $3 damage.\nDraw a card.",
         "type": "SPELL"
@@ -19219,7 +19219,7 @@
         ],
         "name": "Truesilver Champion",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Whenever your hero attacks, restore #2 Health to it.",
         "type": "WEAPON"
     },
@@ -19236,7 +19236,7 @@
         "referencedTags": [
             "CHARGE"
         ],
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Give a friendly minion +2 Attack and <b>Charge</b>.",
         "type": "SPELL"
     },
@@ -19264,7 +19264,7 @@
         "id": "CS2_105",
         "name": "Heroic Strike",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Give your hero +4 Attack this turn.",
         "type": "SPELL"
     },
@@ -19280,7 +19280,7 @@
         "id": "CS2_106",
         "name": "Fiery War Axe",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "type": "WEAPON"
     },
     {
@@ -19293,7 +19293,7 @@
         "id": "CS2_108",
         "name": "Execute",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Destroy a damaged enemy minion.",
         "type": "SPELL"
     },
@@ -19309,7 +19309,7 @@
         "id": "CS2_112",
         "name": "Arcanite Reaper",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "type": "WEAPON"
     },
     {
@@ -19322,7 +19322,7 @@
         "id": "CS2_114",
         "name": "Cleave",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "[x]Deal $2 damage to\ntwo random enemy\nminions.",
         "type": "SPELL"
     },
@@ -19359,7 +19359,7 @@
         "name": "Magma Rager",
         "race": "ELEMENTAL",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "type": "MINION"
     },
     {
@@ -19375,7 +19375,7 @@
         "name": "Oasis Snapjaw",
         "race": "BEAST",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "type": "MINION"
     },
     {
@@ -19391,7 +19391,7 @@
         "name": "River Crocolisk",
         "race": "BEAST",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "type": "MINION"
     },
     {
@@ -19409,7 +19409,7 @@
         ],
         "name": "Frostwolf Grunt",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Taunt</b>",
         "type": "MINION"
     },
@@ -19428,7 +19428,7 @@
         ],
         "name": "Raid Leader",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Your other minions have +1 Attack.",
         "type": "MINION"
     },
@@ -19448,7 +19448,7 @@
         ],
         "name": "Wolfrider",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Charge</b>",
         "type": "MINION"
     },
@@ -19469,7 +19469,7 @@
         "name": "Ironfur Grizzly",
         "race": "BEAST",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Taunt</b>",
         "type": "MINION"
     },
@@ -19490,7 +19490,7 @@
         "name": "Silverback Patriarch",
         "race": "BEAST",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Taunt</b>",
         "type": "MINION"
     },
@@ -19510,7 +19510,7 @@
         ],
         "name": "Stormwind Knight",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Charge</b>",
         "type": "MINION"
     },
@@ -19530,7 +19530,7 @@
         ],
         "name": "Ironforge Rifleman",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "targetingArrowText": "Deal 1 damage.",
         "text": "<b>Battlecry:</b> Deal 1 damage.",
         "type": "MINION"
@@ -19551,7 +19551,7 @@
         ],
         "name": "Kobold Geomancer",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellDamage": 1,
         "text": "<b>Spell Damage +1</b>",
         "type": "MINION"
@@ -19593,7 +19593,7 @@
         ],
         "name": "Gnomish Inventor",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Draw a card.",
         "type": "MINION"
     },
@@ -19613,7 +19613,7 @@
         ],
         "name": "Stormpike Commando",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "targetingArrowText": "Deal 2 damage.",
         "text": "<b>Battlecry:</b> Deal 2 damage.",
         "type": "MINION"
@@ -19654,7 +19654,7 @@
         ],
         "name": "Archmage",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellDamage": 1,
         "text": "<b>Spell Damage +1</b>",
         "type": "MINION"
@@ -19695,7 +19695,7 @@
         ],
         "name": "Lord of the Arena",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Taunt</b>",
         "type": "MINION"
     },
@@ -19713,7 +19713,7 @@
         "name": "Murloc Raider",
         "race": "MURLOC",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "type": "MINION"
     },
     {
@@ -19753,7 +19753,7 @@
         "name": "Stonetusk Boar",
         "race": "BEAST",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Charge</b>",
         "type": "MINION"
     },
@@ -19771,7 +19771,7 @@
         "name": "Bloodfen Raptor",
         "race": "BEAST",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "type": "MINION"
     },
     {
@@ -19790,7 +19790,7 @@
         "name": "Bluegill Warrior",
         "race": "MURLOC",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Charge</b>",
         "type": "MINION"
     },
@@ -19810,7 +19810,7 @@
         ],
         "name": "Sen'jin Shieldmasta",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Taunt</b>",
         "type": "MINION"
     },
@@ -19846,7 +19846,7 @@
         "id": "CS2_182",
         "name": "Chillwind Yeti",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "type": "MINION"
     },
     {
@@ -19861,7 +19861,7 @@
         "id": "CS2_186",
         "name": "War Golem",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "type": "MINION"
     },
     {
@@ -19880,7 +19880,7 @@
         ],
         "name": "Booty Bay Bodyguard",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Taunt</b>",
         "type": "MINION"
     },
@@ -19921,7 +19921,7 @@
         ],
         "name": "Elven Archer",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "targetingArrowText": "Deal 1 damage.",
         "text": "<b>Battlecry:</b> Deal 1 damage.",
         "type": "MINION"
@@ -19942,7 +19942,7 @@
         ],
         "name": "Razorfen Hunter",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Summon a 1/1 Boar.",
         "type": "MINION"
     },
@@ -19961,7 +19961,7 @@
         ],
         "name": "Ogre Magi",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellDamage": 1,
         "text": "<b>Spell Damage +1</b>",
         "type": "MINION"
@@ -19978,7 +19978,7 @@
         "id": "CS2_200",
         "name": "Boulderfist Ogre",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "type": "MINION"
     },
     {
@@ -19994,7 +19994,7 @@
         "name": "Core Hound",
         "race": "BEAST",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "type": "MINION"
     },
     {
@@ -20038,7 +20038,7 @@
         ],
         "name": "Reckless Rocketeer",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Charge</b>",
         "type": "MINION"
     },
@@ -20078,7 +20078,7 @@
         ],
         "name": "Stormwind Champion",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Your other minions have +1/+1.",
         "type": "MINION"
     },
@@ -20098,7 +20098,7 @@
         ],
         "name": "Frostwolf Warlord",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Gain +1/+1 for each other friendly minion on the battlefield.",
         "type": "MINION"
     },
@@ -20152,7 +20152,7 @@
         ],
         "name": "Ironbark Protector",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Taunt</b>",
         "type": "MINION"
     },
@@ -20183,7 +20183,7 @@
         "id": "CS2_234",
         "name": "Shadow Word: Pain",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "SHADOW",
         "text": "Destroy a minion with 3 or less Attack.",
         "type": "SPELL"
@@ -20205,7 +20205,7 @@
         ],
         "name": "Northshire Cleric",
         "rarity": "COMMON",
-        "set": "HOF",
+        "set": "LEGACY",
         "text": "Whenever a minion is healed, draw a card.",
         "type": "MINION"
     },
@@ -20221,7 +20221,7 @@
         "id": "CS2_236",
         "name": "Divine Spirit",
         "rarity": "COMMON",
-        "set": "HOF",
+        "set": "LEGACY",
         "spellSchool": "HOLY",
         "text": "Double a minion's Health.",
         "type": "SPELL"
@@ -20242,7 +20242,7 @@
         "name": "Starving Buzzard",
         "race": "BEAST",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Whenever you summon a Beast, draw a card.",
         "type": "MINION"
     },
@@ -24450,7 +24450,7 @@
         "artist": "Ivan Fomin",
         "cardClass": "MAGE",
         "collectible": true,
-        "cost": 2,
+        "cost": 4,
         "dbfId": 61587,
         "elite": true,
         "flavor": "Voted \"Most Lunacy\" in Madness Monthly magazine.",
@@ -25995,7 +25995,6 @@
         "name": "Pit Master",
         "rarity": "RARE",
         "set": "DARKMOON_FAIRE",
-        "spellSchool": "NATURE",
         "text": "<b>Battlecry:</b> Summon a 3/2 Duelist.\n<b>Corrupt:</b> Summon two.",
         "type": "MINION"
     },
@@ -27764,7 +27763,6 @@
             "TAUNT"
         ],
         "set": "DRAGONS",
-        "spellSchool": "NATURE",
         "text": "Summon two 2/3 Spirit Wolves with <b>Taunt</b>. If you've <b>Invoked</b> twice, give them +3/+3.",
         "type": "SPELL"
     },
@@ -28899,7 +28897,7 @@
         ],
         "name": "Darkscale Healer",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Restore #2 Health to all friendly characters.",
         "type": "MINION"
     },
@@ -28922,7 +28920,7 @@
         "referencedTags": [
             "TAUNT"
         ],
-        "set": "BASIC",
+        "set": "LEGACY",
         "targetingArrowText": "Give a Beast +2/+2 and Taunt.",
         "techLevel": 3,
         "text": "<b>Battlecry:</b> Give a friendly Beast +2/+2 and <b>Taunt</b>.",
@@ -28944,7 +28942,7 @@
         "name": "Timber Wolf",
         "race": "BEAST",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Your other Beasts have +1 Attack.",
         "type": "MINION"
     },
@@ -28967,7 +28965,7 @@
         "referencedTags": [
             "CHARGE"
         ],
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Your Beasts have <b>Charge</b>.",
         "type": "MINION"
     },
@@ -28981,7 +28979,7 @@
         "id": "DS1_183",
         "name": "Multi-Shot",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Deal $3 damage to two random enemy minions.",
         "type": "SPELL"
     },
@@ -28998,7 +28996,7 @@
         ],
         "name": "Tracking",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Discover</b> a card from your deck.",
         "type": "SPELL"
     },
@@ -29012,7 +29010,7 @@
         "id": "DS1_185",
         "name": "Arcane Shot",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "ARCANE",
         "text": "Deal $2 damage.",
         "type": "SPELL"
@@ -29048,7 +29046,7 @@
         "id": "DS1_233",
         "name": "Mind Blast",
         "rarity": "COMMON",
-        "set": "HOF",
+        "set": "LEGACY",
         "spellSchool": "SHADOW",
         "text": "Deal $5 damage to the enemy hero.",
         "type": "SPELL"
@@ -29170,7 +29168,7 @@
         ],
         "name": "Acolyte of Pain",
         "rarity": "COMMON",
-        "set": "HOF",
+        "set": "EXPERT1",
         "text": "Whenever this minion takes damage, draw a card.",
         "type": "MINION"
     },
@@ -29250,7 +29248,7 @@
         ],
         "name": "Voodoo Doctor",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "targetingArrowText": "Restore 2 Health.",
         "text": "<b>Battlecry:</b> Restore #2 Health.",
         "type": "MINION"
@@ -29314,7 +29312,7 @@
         ],
         "name": "Novice Engineer",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Draw a card.",
         "type": "MINION"
     },
@@ -29334,7 +29332,7 @@
         ],
         "name": "Sylvanas Windrunner",
         "rarity": "LEGENDARY",
-        "set": "HOF",
+        "set": "EXPERT1",
         "text": "<b>Deathrattle:</b> Take\ncontrol of a random\nenemy minion.",
         "type": "MINION"
     },
@@ -29374,7 +29372,7 @@
         ],
         "name": "Shattered Sun Cleric",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "targetingArrowText": "Give +1/+1.",
         "text": "<b>Battlecry:</b> Give a friendly minion +1/+1.",
         "type": "MINION"
@@ -29455,7 +29453,7 @@
         ],
         "name": "Dragonling Mechanic",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Summon a 2/1 Mechanical Dragonling.",
         "type": "MINION"
     },
@@ -29640,7 +29638,7 @@
         "referencedTags": [
             "SILENCE"
         ],
-        "set": "HOF",
+        "set": "EXPERT1",
         "targetingArrowText": "<b>Silence</b> a minion.",
         "text": "<b>Battlecry:</b> <b>Silence</b> a minion.",
         "type": "MINION"
@@ -29682,7 +29680,7 @@
         "name": "Coldlight Oracle",
         "race": "MURLOC",
         "rarity": "RARE",
-        "set": "HOF",
+        "set": "EXPERT1",
         "text": "<b>Battlecry:</b> Each player draws 2 cards.",
         "type": "MINION"
     },
@@ -29789,7 +29787,7 @@
         "name": "Old Murk-Eye",
         "race": "MURLOC",
         "rarity": "LEGENDARY",
-        "set": "HOF",
+        "set": "LEGACY",
         "techLevel": 2,
         "text": "<b>Charge</b>. Has +1 Attack for each other Murloc on the battlefield.",
         "type": "MINION"
@@ -29810,7 +29808,7 @@
         ],
         "name": "Acidic Swamp Ooze",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Destroy your opponent's weapon.",
         "type": "MINION"
     },
@@ -29934,7 +29932,7 @@
         "referencedTags": [
             "RUSH"
         ],
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "After you summon another minion, give it <b>Rush</b>.",
         "type": "MINION"
     },
@@ -29954,7 +29952,7 @@
         ],
         "name": "Mind Control Tech",
         "rarity": "RARE",
-        "set": "HOF",
+        "set": "EXPERT1",
         "text": "[x]<b>Battlecry:</b> If your opponent\nhas 4 or more minions, take\n control of one at random.",
         "type": "MINION"
     },
@@ -30156,7 +30154,7 @@
         "name": "Mountain Giant",
         "race": "ELEMENTAL",
         "rarity": "EPIC",
-        "set": "HOF",
+        "set": "EXPERT1",
         "text": "Costs (1) less for each other card in your hand.",
         "type": "MINION"
     },
@@ -30199,7 +30197,7 @@
         ],
         "name": "Gelbin Mekkatorque",
         "rarity": "LEGENDARY",
-        "set": "HOF",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Summon an AWESOME invention.",
         "type": "MINION"
     },
@@ -30221,7 +30219,7 @@
         ],
         "name": "Leeroy Jenkins",
         "rarity": "LEGENDARY",
-        "set": "HOF",
+        "set": "EXPERT1",
         "text": "<b>Charge</b>. <b>Battlecry:</b> Summon two 1/1 Whelps for your opponent.",
         "type": "MINION"
     },
@@ -30269,7 +30267,7 @@
         "referencedTags": [
             "STEALTH"
         ],
-        "set": "HOF",
+        "set": "EXPERT1",
         "spellSchool": "SHADOW",
         "text": "Give your minions <b>Stealth</b> until your next turn.",
         "type": "SPELL"
@@ -30284,7 +30282,7 @@
         "id": "EX1_129",
         "name": "Fan of Knives",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Deal $1 damage to all enemy minions. Draw a card.",
         "type": "SPELL"
     },
@@ -30531,7 +30529,7 @@
         "id": "EX1_161",
         "name": "Naturalize",
         "rarity": "COMMON",
-        "set": "HOF",
+        "set": "EXPERT1",
         "spellSchool": "NATURE",
         "text": "Destroy a minion.\nYour opponent draws 2 cards.",
         "type": "SPELL"
@@ -30631,7 +30629,7 @@
         "id": "EX1_169",
         "name": "Innervate",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "NATURE",
         "text": "Gain 1 Mana Crystal this turn only.",
         "type": "SPELL"
@@ -30666,7 +30664,7 @@
         "id": "EX1_173",
         "name": "Starfire",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "ARCANE",
         "text": "Deal $5 damage.\nDraw a card.",
         "type": "SPELL"
@@ -30708,7 +30706,7 @@
         "referencedTags": [
             "FREEZE"
         ],
-        "set": "EXPERT1",
+        "set": "LEGACY",
         "spellSchool": "FROST",
         "text": "Deal $2 damage to a minion. If it's <b>Frozen</b>, draw a card.",
         "type": "SPELL"
@@ -30725,7 +30723,7 @@
         "id": "EX1_180",
         "name": "Tome of Intellect",
         "rarity": "COMMON",
-        "set": "EXPERT1",
+        "set": "LEGACY",
         "spellSchool": "ARCANE",
         "text": "Add a random Mage spell to your hand.",
         "type": "SPELL"
@@ -30742,7 +30740,7 @@
         "id": "EX1_181",
         "name": "Call of the Void",
         "rarity": "COMMON",
-        "set": "EXPERT1",
+        "set": "LEGACY",
         "spellSchool": "SHADOW",
         "text": "Add a random Demon to your hand.",
         "type": "SPELL"
@@ -30759,7 +30757,7 @@
         "id": "EX1_182",
         "name": "Pilfer",
         "rarity": "COMMON",
-        "set": "EXPERT1",
+        "set": "LEGACY",
         "text": "Add a random card from another class to your hand.",
         "type": "SPELL"
     },
@@ -30778,7 +30776,7 @@
         "referencedTags": [
             "TAUNT"
         ],
-        "set": "EXPERT1",
+        "set": "LEGACY",
         "spellSchool": "NATURE",
         "text": "Give your minions +2/+2 and <b>Taunt</b>.",
         "type": "SPELL"
@@ -30798,7 +30796,7 @@
         "referencedTags": [
             "DIVINE_SHIELD"
         ],
-        "set": "EXPERT1",
+        "set": "LEGACY",
         "spellSchool": "HOLY",
         "text": "Give your minions <b>Divine Shield</b>.",
         "type": "SPELL"
@@ -30823,7 +30821,7 @@
         "name": "Siegebreaker",
         "race": "DEMON",
         "rarity": "RARE",
-        "set": "EXPERT1",
+        "set": "LEGACY",
         "techLevel": 4,
         "text": "<b>Taunt</b>\nYour other Demons have +1 Attack.",
         "type": "MINION"
@@ -30848,7 +30846,7 @@
         "referencedTags": [
             "SECRET"
         ],
-        "set": "EXPERT1",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Destroy a random enemy <b>Secret</b>.",
         "type": "MINION"
     },
@@ -30870,7 +30868,7 @@
         "name": "Arcane Devourer",
         "race": "ELEMENTAL",
         "rarity": "RARE",
-        "set": "EXPERT1",
+        "set": "LEGACY",
         "text": "Whenever you cast a spell, gain +2/+2.",
         "type": "MINION"
     },
@@ -30891,7 +30889,7 @@
         ],
         "name": "Barrens Stablehand",
         "rarity": "EPIC",
-        "set": "EXPERT1",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Summon a random Beast.",
         "type": "MINION"
     },
@@ -30914,7 +30912,7 @@
         "name": "Brightwing",
         "race": "DRAGON",
         "rarity": "LEGENDARY",
-        "set": "EXPERT1",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Add a random <b>Legendary</b> minion to your hand.",
         "type": "MINION"
     },
@@ -30936,7 +30934,7 @@
         ],
         "name": "High Inquisitor Whitemane",
         "rarity": "LEGENDARY",
-        "set": "EXPERT1",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Summon all friendly minions that died this turn.",
         "type": "MINION"
     },
@@ -30958,7 +30956,7 @@
         "referencedTags": [
             "POISONOUS"
         ],
-        "set": "BASIC",
+        "set": "LEGACY",
         "targetingArrowText": "Give Poisonous.",
         "text": "<b>Battlecry:</b> Give a friendly minion <b>Poisonous</b>.",
         "type": "MINION"
@@ -30973,7 +30971,7 @@
         "id": "EX1_192",
         "name": "Radiance",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "HOLY",
         "text": "Restore #5 Health to your hero.",
         "type": "SPELL"
@@ -30993,7 +30991,7 @@
         ],
         "name": "Psychic Conjurer",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Copy a card in your opponent’s deck and add it to your hand.",
         "type": "MINION"
     },
@@ -31007,7 +31005,7 @@
         "id": "EX1_194",
         "name": "Power Infusion",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "HOLY",
         "text": "Give a minion +2/+6.",
         "type": "SPELL"
@@ -31029,7 +31027,7 @@
         ],
         "name": "Kul Tiran Chaplain",
         "rarity": "RARE",
-        "set": "EXPERT1",
+        "set": "LEGACY",
         "targetingArrowText": "Give +2 Health.",
         "text": "<b>Battlecry:</b> Give a friendly minion +2 Health.",
         "type": "MINION"
@@ -31051,7 +31049,7 @@
         ],
         "name": "Scarlet Subjugator",
         "rarity": "RARE",
-        "set": "EXPERT1",
+        "set": "LEGACY",
         "targetingArrowText": "Give -2 Attack\nuntil next turn.",
         "text": "<b>Battlecry:</b> Give an enemy minion -2 Attack until your next turn.",
         "type": "MINION"
@@ -31068,7 +31066,7 @@
         "id": "EX1_197",
         "name": "Shadow Word: Ruin",
         "rarity": "EPIC",
-        "set": "EXPERT1",
+        "set": "LEGACY",
         "spellSchool": "SHADOW",
         "text": "Destroy all minions with 5 or more Attack.",
         "type": "SPELL"
@@ -31091,7 +31089,7 @@
         ],
         "name": "Natalie Seline",
         "rarity": "LEGENDARY",
-        "set": "EXPERT1",
+        "set": "LEGACY",
         "targetingArrowText": "Destroy a minion.",
         "text": "<b>Battlecry:</b> Destroy a minion and gain its Health.",
         "type": "MINION"
@@ -31166,7 +31164,7 @@
         "id": "EX1_244",
         "name": "Totemic Might",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Give your Totems +2 Health.",
         "type": "SPELL"
     },
@@ -31201,7 +31199,7 @@
         "referencedTags": [
             "TAUNT"
         ],
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "NATURE",
         "text": "Transform a minion into a 0/1 Frog with <b>Taunt</b>.",
         "type": "SPELL"
@@ -31404,7 +31402,7 @@
         ],
         "name": "Arcane Missiles",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "ARCANE",
         "text": "Deal $3 damage randomly split among all enemies.",
         "type": "SPELL"
@@ -31419,7 +31417,7 @@
         "id": "EX1_278",
         "name": "Shiv",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Deal $1 damage.\nDraw a card.",
         "type": "SPELL"
     },
@@ -31477,7 +31475,7 @@
         "name": "Azure Drake",
         "race": "DRAGON",
         "rarity": "RARE",
-        "set": "HOF",
+        "set": "EXPERT1",
         "spellDamage": 1,
         "text": "<b>Spell Damage +1</b>\n<b>Battlecry:</b> Draw a card.",
         "type": "MINION"
@@ -31555,7 +31553,7 @@
         "referencedTags": [
             "IMMUNE"
         ],
-        "set": "HOF",
+        "set": "EXPERT1",
         "spellSchool": "FROST",
         "text": "<b>Secret:</b> When your hero takes fatal damage, prevent it and become <b>Immune</b> this turn.",
         "type": "SPELL"
@@ -31578,7 +31576,7 @@
         "name": "Ragnaros the Firelord",
         "race": "ELEMENTAL",
         "rarity": "LEGENDARY",
-        "set": "HOF",
+        "set": "EXPERT1",
         "text": "Can't attack. At the end of your turn, deal 8 damage to a random enemy.",
         "type": "MINION"
     },
@@ -31613,7 +31611,7 @@
         "id": "EX1_302",
         "name": "Mortal Coil",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "SHADOW",
         "text": "Deal $1 damage to a minion. If that kills it, draw a card.",
         "type": "SPELL"
@@ -31672,7 +31670,7 @@
         "name": "Felstalker",
         "race": "DEMON",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Discard a random card.",
         "type": "MINION"
     },
@@ -31686,7 +31684,7 @@
         "id": "EX1_308",
         "name": "Soulfire",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "FIRE",
         "text": "[x]Deal $4 damage.\nDiscard a random card.",
         "type": "SPELL"
@@ -31723,7 +31721,7 @@
         "name": "Doomguard",
         "race": "DEMON",
         "rarity": "RARE",
-        "set": "HOF",
+        "set": "EXPERT1",
         "text": "<b>Charge</b>. <b>Battlecry:</b> Discard two random cards.",
         "type": "MINION"
     },
@@ -31791,7 +31789,7 @@
         "id": "EX1_316",
         "name": "Power Overwhelming",
         "rarity": "COMMON",
-        "set": "HOF",
+        "set": "EXPERT1",
         "spellSchool": "SHADOW",
         "text": "Give a friendly minion +4/+4 until end of turn. Then, it dies. Horribly.",
         "type": "SPELL"
@@ -31975,7 +31973,7 @@
         "id": "EX1_349",
         "name": "Divine Favor",
         "rarity": "RARE",
-        "set": "HOF",
+        "set": "EXPERT1",
         "spellSchool": "HOLY",
         "text": "Draw cards until you have as many in hand as your opponent.",
         "type": "SPELL"
@@ -31993,7 +31991,7 @@
         "id": "EX1_350",
         "name": "Prophet Velen",
         "rarity": "LEGENDARY",
-        "set": "HOF",
+        "set": "EXPERT1",
         "text": "Double the damage and healing of your spells and Hero Power.",
         "type": "MINION"
     },
@@ -32037,7 +32035,7 @@
         "id": "EX1_360",
         "name": "Humility",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Change a minion's Attack to 1.",
         "type": "SPELL"
     },
@@ -32093,6 +32091,7 @@
         "name": "Holy Wrath",
         "rarity": "RARE",
         "set": "EXPERT1",
+        "spellSchool": "HOLY",
         "text": "Draw a card and deal damage equal to its Cost.",
         "type": "SPELL"
     },
@@ -32128,7 +32127,7 @@
         "referencedTags": [
             "DIVINE_SHIELD"
         ],
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "HOLY",
         "text": "Give a minion <b>Divine Shield</b>.",
         "type": "SPELL"
@@ -32331,7 +32330,7 @@
         ],
         "name": "Gurubashi Berserker",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Whenever this minion takes damage, gain +3 Attack.",
         "type": "MINION"
     },
@@ -32345,7 +32344,7 @@
         "id": "EX1_400",
         "name": "Whirlwind",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Deal $1 damage to ALL minions.",
         "type": "SPELL"
     },
@@ -32522,7 +32521,7 @@
         "name": "Murloc Tidehunter",
         "race": "MURLOC",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "techLevel": 1,
         "text": "<b>Battlecry:</b> Summon a 1/1 Murloc Scout.",
         "type": "MINION"
@@ -32565,7 +32564,7 @@
         "name": "Grimscale Oracle",
         "race": "MURLOC",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Your other Murlocs have +1 Attack.",
         "type": "MINION"
     },
@@ -32736,7 +32735,7 @@
         "id": "EX1_539",
         "name": "Kill Command",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Deal $3 damage. If you control a Beast, deal\n$5 damage instead.",
         "type": "SPELL"
     },
@@ -33015,7 +33014,7 @@
         "name": "Flametongue Totem",
         "race": "TOTEM",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Adjacent minions have +2 Attack.",
         "type": "MINION"
     },
@@ -33182,7 +33181,7 @@
         "id": "EX1_581",
         "name": "Sap",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Return an enemy minion to your opponent's hand.",
         "type": "SPELL"
     },
@@ -33201,7 +33200,7 @@
         ],
         "name": "Dalaran Mage",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellDamage": 1,
         "text": "<b>Spell Damage +1</b>",
         "type": "MINION"
@@ -33281,7 +33280,7 @@
         "referencedTags": [
             "WINDFURY"
         ],
-        "set": "BASIC",
+        "set": "LEGACY",
         "targetingArrowText": "Give <b>Windfury</b>.",
         "text": "<b>Battlecry:</b> Give a friendly minion <b>Windfury</b>.",
         "type": "MINION"
@@ -33320,7 +33319,7 @@
         "id": "EX1_591",
         "name": "Auchenai Soulpriest",
         "rarity": "RARE",
-        "set": "HOF",
+        "set": "EXPERT1",
         "text": "Your cards and powers that restore Health now deal damage instead.",
         "type": "MINION"
     },
@@ -33339,7 +33338,7 @@
         ],
         "name": "Nightblade",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Battlecry: </b>Deal 3 damage to the enemy hero.",
         "type": "MINION"
     },
@@ -33463,7 +33462,7 @@
         "id": "EX1_606",
         "name": "Shield Block",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Gain 5 Armor.\nDraw a card.",
         "type": "SPELL"
     },
@@ -33677,7 +33676,7 @@
         "name": "Molten Giant",
         "race": "ELEMENTAL",
         "rarity": "EPIC",
-        "set": "HOF",
+        "set": "EXPERT1",
         "text": "Costs (1) less for each damage your hero has taken.",
         "type": "MINION"
     },
@@ -33706,7 +33705,7 @@
         "id": "EX1_622",
         "name": "Shadow Word: Death",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "SHADOW",
         "text": "Destroy a minion with 5 or more Attack.",
         "type": "SPELL"
@@ -33741,7 +33740,7 @@
         "id": "EX1_624",
         "name": "Holy Fire",
         "rarity": "RARE",
-        "set": "HOF",
+        "set": "EXPERT1",
         "spellSchool": "HOLY",
         "text": "Deal $5 damage. Restore #5 Health to your hero.",
         "type": "SPELL"
@@ -34650,7 +34649,7 @@
         "name": "Gloom Stag",
         "race": "BEAST",
         "rarity": "EPIC",
-        "set": "HOF",
+        "set": "GILNEAS",
         "text": "<b>Taunt</b>\n<b>Battlecry:</b> If your deck has only odd-Cost cards, gain +2/+2.",
         "type": "MINION"
     },
@@ -35260,7 +35259,7 @@
         "name": "Murkspark Eel",
         "race": "BEAST",
         "rarity": "RARE",
-        "set": "HOF",
+        "set": "GILNEAS",
         "targetingArrowText": "Deal 2 damage.",
         "text": "<b>Battlecry:</b> If your deck has only even-Cost cards, deal 2 damage.",
         "type": "MINION"
@@ -36521,7 +36520,7 @@
         ],
         "name": "Genn Greymane",
         "rarity": "LEGENDARY",
-        "set": "HOF",
+        "set": "GILNEAS",
         "text": "[x]<b>Start of Game:</b>\nIf your deck has only even-\nCost cards, your starting\nHero Power costs (1).",
         "type": "MINION"
     },
@@ -36850,7 +36849,7 @@
         "name": "Baku the Mooneater",
         "race": "BEAST",
         "rarity": "LEGENDARY",
-        "set": "HOF",
+        "set": "GILNEAS",
         "text": "[x]<b>Start of Game:</b>\nIf your deck has only odd-\nCost cards, upgrade\nyour Hero Power.",
         "type": "MINION"
     },
@@ -36964,7 +36963,7 @@
         "name": "Glitter Moth",
         "race": "BEAST",
         "rarity": "EPIC",
-        "set": "HOF",
+        "set": "GILNEAS",
         "text": "<b>Battlecry:</b> If your deck has only odd-Cost cards, double the Health of your other minions.",
         "type": "MINION"
     },
@@ -36985,7 +36984,7 @@
         "name": "Black Cat",
         "race": "BEAST",
         "rarity": "COMMON",
-        "set": "HOF",
+        "set": "GILNEAS",
         "spellDamage": 1,
         "text": "<b>Spell Damage +1</b>\n <b>Battlecry:</b> If your deck has only odd-Cost cards, draw a card.",
         "type": "MINION"
@@ -47486,7 +47485,7 @@
         "id": "NEW1_003",
         "name": "Sacrificial Pact",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "spellSchool": "SHADOW",
         "text": "Destroy a friendly Demon. Restore #5 Health to your hero.",
         "type": "SPELL"
@@ -47502,7 +47501,7 @@
         "id": "NEW1_004",
         "name": "Vanish",
         "rarity": "COMMON",
-        "set": "HOF",
+        "set": "LEGACY",
         "text": "Return all minions to their owner's hand.",
         "type": "SPELL"
     },
@@ -47602,7 +47601,7 @@
         ],
         "name": "Kor'kron Elite",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "<b>Charge</b>",
         "type": "MINION"
     },
@@ -47665,7 +47664,7 @@
         "name": "Captain's Parrot",
         "race": "BEAST",
         "rarity": "EPIC",
-        "set": "HOF",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Draw a Pirate from your deck.",
         "type": "MINION"
     },
@@ -47941,7 +47940,7 @@
         "id": "NEW1_031",
         "name": "Animal Companion",
         "rarity": "FREE",
-        "set": "BASIC",
+        "set": "LEGACY",
         "text": "Summon a random Beast Companion.",
         "type": "SPELL"
     },
@@ -50610,7 +50609,7 @@
         ],
         "name": "Elite Tauren Chieftain",
         "rarity": "LEGENDARY",
-        "set": "HOF",
+        "set": "LEGACY",
         "text": "<b>Battlecry:</b> Give both players the power to ROCK! (with a Power Chord card)",
         "type": "MINION"
     },
@@ -51451,7 +51450,7 @@
         "rarity": "COMMON",
         "set": "SCHOLOMANCE",
         "targetingArrowText": "Deal 1 damage.",
-        "text": "<b>Battlecry:</b> Deal 1 damage. <b>Spellburst:</b> Return this to your hand.",
+        "text": "[x]<b>Battlecry:</b> Deal 1 damage\nto a minion.\n <b><b>Spellburst</b>:</b> Return this\nto your hand.",
         "type": "MINION"
     },
     {
@@ -51986,7 +51985,7 @@
             "ROGUE"
         ],
         "collectible": true,
-        "cost": 5,
+        "cost": 6,
         "dbfId": 59609,
         "elite": true,
         "flavor": "Her parents own Scholomance. Of course she's going to play tricks on the students!",

--- a/Sources/Rosetta/PlayMode/CardSets/BasicCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BasicCardsGen.cpp
@@ -36,7 +36,7 @@ void BasicCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- HERO - WARRIOR
     // [HERO_01] Garrosh Hellscream - COST:0 [ATK:0/HP:30]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // GameTag:
     // - HERO_POWER = 725
@@ -47,7 +47,7 @@ void BasicCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ HERO - SHAMAN
     // [HERO_02] Thrall - COST:0 [ATK:0/HP:30]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // GameTag:
     // - HERO_POWER = 687
@@ -58,7 +58,7 @@ void BasicCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------- HERO - ROGUE
     // [HERO_03] Valeera Sanguinar - COST:0 [ATK:0/HP:30]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // GameTag:
     // - HERO_POWER = 730
@@ -69,7 +69,7 @@ void BasicCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- HERO - PALADIN
     // [HERO_04] Uther Lightbringer - COST:0 [ATK:0/HP:30]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // GameTag:
     // - HERO_POWER = 472
@@ -80,7 +80,7 @@ void BasicCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ HERO - HUNTER
     // [HERO_05] Rexxar - COST:0 [ATK:0/HP:30]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // GameTag:
     // - HERO_POWER = 229
@@ -91,7 +91,7 @@ void BasicCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------- HERO - DRUID
     // [HERO_06] Malfurion Stormrage - COST:0 [ATK:0/HP:30]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // GameTag:
     // - HERO_POWER = 1123
@@ -102,7 +102,7 @@ void BasicCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- HERO - WARLOCK
     // [HERO_07] Gul'dan - COST:0 [ATK:0/HP:30]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // GameTag:
     // - HERO_POWER = 300
@@ -113,7 +113,7 @@ void BasicCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 
     // -------------------------------------------- HERO - MAGE
     // [HERO_08] Jaina Proudmoore - COST:0 [ATK:0/HP:30]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // GameTag:
     // - HERO_POWER = 807
@@ -124,7 +124,7 @@ void BasicCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ HERO - PRIEST
     // [HERO_09] Anduin Wrynn - COST:0 [ATK:0/HP:30]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // GameTag:
     // - HERO_POWER = 479
@@ -135,7 +135,7 @@ void BasicCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------- HERO - DEMONHUNTER
     // [HERO_10] Illidan Stormrage - COST:0 [ATK:0/HP:30]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // GameTag:
     // - HERO_POWER = 60224
@@ -151,7 +151,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- HERO_POWER - WARRIOR
     // [HERO_01bp] Armor Up! (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Gain 2 Armor.
     // --------------------------------------------------------
@@ -161,7 +161,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- HERO_POWER - WARRIOR
     // [HERO_01bp2] Tank Up! (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Gain 4 Armor.
     // --------------------------------------------------------
@@ -171,7 +171,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------ HERO_POWER - SHAMAN
     // [HERO_02bp] Totemic Call (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Summon a random Totem.
     // --------------------------------------------------------
@@ -227,7 +227,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------ HERO_POWER - SHAMAN
     // [HERO_02bp2] Totemic Slam (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Summon a Totem of your choice.
     // --------------------------------------------------------
@@ -243,7 +243,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------- HERO_POWER - ROGUE
     // [HERO_03bp] Dagger Mastery (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Equip a 1/2 Dagger.
     // --------------------------------------------------------
@@ -253,7 +253,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------- HERO_POWER - ROGUE
     // [HERO_03bp2] Poisoned Daggers (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Equip a 2/2 Weapon.
     // --------------------------------------------------------
@@ -263,7 +263,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- HERO_POWER - PALADIN
     // [HERO_04bp] Reinforce (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Summon a 1/1 Silver Hand Recruit.
     // --------------------------------------------------------
@@ -279,7 +279,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- HERO_POWER - PALADIN
     // [HERO_04bp2] The Silver Hand (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Summon two 1/1 Recruits.
     // --------------------------------------------------------
@@ -295,7 +295,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------ HERO_POWER - HUNTER
     // [HERO_05bp] Steady Shot (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Deal 2 damage to the enemy hero.
     // --------------------------------------------------------
@@ -313,7 +313,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------ HERO_POWER - HUNTER
     // [HERO_05bp2] Ballista Shot (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Deal 3 damage to the enemy hero.
     // --------------------------------------------------------
@@ -331,7 +331,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------- HERO_POWER - DRUID
     // [HERO_06bp] Shapeshift (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> +1 Attack this turn. +1 Armor.
     // --------------------------------------------------------
@@ -343,7 +343,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------- HERO_POWER - DRUID
     // [HERO_06bp2] Dire Shapeshift (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> +2 Attack this turn. +2 Armor.
     // --------------------------------------------------------
@@ -355,7 +355,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- HERO_POWER - WARLOCK
     // [HERO_07bp] Life Tap (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Draw a card and take 2 damage.
     // --------------------------------------------------------
@@ -367,7 +367,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- HERO_POWER - WARLOCK
     // [HERO_07bp2] Soul Tap (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Draw a card.
     // --------------------------------------------------------
@@ -377,7 +377,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // -------------------------------------- HERO_POWER - MAGE
     // [HERO_08bp] Fireblast (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Deal 1 damage.
     // --------------------------------------------------------
@@ -393,7 +393,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // -------------------------------------- HERO_POWER - MAGE
     // [HERO_08bp2] Fireblast Rank 2 (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Deal 2 damage.
     // --------------------------------------------------------
@@ -409,7 +409,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------ HERO_POWER - PRIEST
     // [HERO_09bp] Lesser Heal (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Restore 2 Health.
     // --------------------------------------------------------
@@ -424,7 +424,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------ HERO_POWER - PRIEST
     // [HERO_09bp2] Heal (*) - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Restore 4 Health.
     // --------------------------------------------------------
@@ -439,7 +439,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ------------------------------- HERO_POWER - DEMONHUNTER
     // [HERO_10bp] Demon Claws (*) - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> +1 Attack this turn.
     // --------------------------------------------------------
@@ -450,7 +450,7 @@ void BasicCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
     // ------------------------------- HERO_POWER - DEMONHUNTER
     // [HERO_10bp2] Demon's Bite (*) - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> +2 Attack this turn.
     // --------------------------------------------------------
@@ -466,7 +466,7 @@ void BasicCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - DRUID
     // [CS2_005] Claw - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Give your hero +2 Attack this turn. Gain 2 Armor.
     // --------------------------------------------------------
@@ -478,7 +478,7 @@ void BasicCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - DRUID
     // [CS2_007] Healing Touch - COST:3
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Nature
     // --------------------------------------------------------
     // Text: Restore 8 Health.
@@ -494,7 +494,7 @@ void BasicCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - DRUID
     // [CS2_008] Moonfire - COST:0
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Arcane
     // --------------------------------------------------------
     // Text: Deal 1 damage.
@@ -511,7 +511,7 @@ void BasicCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - DRUID
     // [CS2_009] Mark of the Wild - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Nature
     // --------------------------------------------------------
     // Text: Give a minion <b>Taunt</b> and +2/+3.<i>
@@ -534,7 +534,7 @@ void BasicCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - DRUID
     // [CS2_011] Savage Roar - COST:3
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Give your characters +2 Attack this turn.
     // --------------------------------------------------------
@@ -545,7 +545,7 @@ void BasicCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - DRUID
     // [CS2_012] Swipe - COST:4
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Deal 4 damage to an enemy and 1 damage to all other enemies.
     // --------------------------------------------------------
@@ -564,7 +564,7 @@ void BasicCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - DRUID
     // [CS2_013] Wild Growth - COST:3
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Nature
     // --------------------------------------------------------
     // Text: Gain an empty Mana Crystal.
@@ -575,7 +575,7 @@ void BasicCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- MINION - DRUID
     // [CS2_232] Ironbark Protector - COST:8 [ATK:8/HP:8]
-    // - Faction: neutral, Set: Basic, Rarity: Free
+    // - Faction: neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------
@@ -588,7 +588,7 @@ void BasicCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - DRUID
     // [EX1_169] Innervate - COST:0
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Nature
     // --------------------------------------------------------
     // Text: Gain 1 Mana Crystal this turn only.
@@ -599,7 +599,7 @@ void BasicCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - DRUID
     // [EX1_173] Starfire - COST:6
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Arcane
     // --------------------------------------------------------
     // Text: Deal 5 damage. Draw a card.
@@ -621,7 +621,7 @@ void BasicCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [CS2_005o] Claw (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +2 Attack this turn.
     // --------------------------------------------------------
@@ -634,7 +634,7 @@ void BasicCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [CS2_009e] Mark of the Wild (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +2/+3 and <b>Taunt</b>.
     // --------------------------------------------------------
@@ -644,7 +644,7 @@ void BasicCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [CS2_011o] Savage Roar (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +2 Attack this turn.
     // --------------------------------------------------------
@@ -657,7 +657,7 @@ void BasicCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [CS2_017o] Claws (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: Your hero has +1 Attack this turn.
     // --------------------------------------------------------
@@ -675,7 +675,7 @@ void BasicCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - HUNTER
     // [CS2_084] Hunter's Mark - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Change a minion's Health to 1.
     // --------------------------------------------------------
@@ -693,7 +693,7 @@ void BasicCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - HUNTER
     // [CS2_237] Starving Buzzard - COST:2 [ATK:2/HP:1]
-    // - Race: Beast, Set: Basic, Rarity: Free
+    // - Race: Beast, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Whenever you summon a Beast, draw a card.
     // --------------------------------------------------------
@@ -707,7 +707,7 @@ void BasicCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - HUNTER
     // [DS1_070] Houndmaster - COST:4 [ATK:4/HP:3]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give a friendly Beast +2/+2 and <b>Taunt</b>.
     // --------------------------------------------------------
@@ -733,7 +733,7 @@ void BasicCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - HUNTER
     // [DS1_175] Timber Wolf - COST:1 [ATK:1/HP:1]
-    // - Race: Beast, Faction: Neutral, Set: Basic, Rarity: Free
+    // - Race: Beast, Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Your other Beasts have +1 Attack.
     // --------------------------------------------------------
@@ -752,7 +752,7 @@ void BasicCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - HUNTER
     // [DS1_178] Tundra Rhino - COST:5 [ATK:2/HP:5]
-    // - Race: Beast, Faction: Neutral, Set: Basic, Rarity: Free
+    // - Race: Beast, Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Your Beasts have <b>Charge</b>.
     // --------------------------------------------------------
@@ -773,7 +773,7 @@ void BasicCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - HUNTER
     // [DS1_183] Multi-Shot - COST:4
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Deal 3 damage to two random enemy minions.
     // --------------------------------------------------------
@@ -791,7 +791,7 @@ void BasicCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - HUNTER
     // [DS1_184] Tracking - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Discover</b> a card from your deck.
     // --------------------------------------------------------
@@ -801,7 +801,7 @@ void BasicCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - HUNTER
     // [DS1_185] Arcane Shot - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Arcane
     // --------------------------------------------------------
     // Text: Deal 2 damage.
@@ -818,7 +818,7 @@ void BasicCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - HUNTER
     // [EX1_539] Kill Command - COST:3
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Deal 3 damage. If you control a Beast,
     //       deal 5 damage instead.
@@ -843,7 +843,7 @@ void BasicCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - HUNTER
     // [NEW1_031] Animal Companion - COST:3
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Summon a random Beast Companion.
     // --------------------------------------------------------
@@ -868,7 +868,7 @@ void BasicCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [CS2_084e] Hunter's Mark (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: This minion has 1 Health.
     // --------------------------------------------------------
@@ -879,7 +879,7 @@ void BasicCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [DS1_070o] Master's Presence (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +2/+2 and <b>Taunt</b>.
     // --------------------------------------------------------
@@ -889,7 +889,7 @@ void BasicCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [DS1_175o] Furious Howl (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +1 Attack from Timber Wolf.
     // --------------------------------------------------------
@@ -899,7 +899,7 @@ void BasicCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [DS1_178e] Charge (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: Tundra Rhino grants <b>Charge</b>.
     // --------------------------------------------------------
@@ -909,7 +909,7 @@ void BasicCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - HUNTER
     // [NEW1_032] Misha (*) - COST:3 [ATK:4/HP:4]
-    // - Race: Beast, Set: Basic, Rarity: Common
+    // - Race: Beast, Set: Legacy, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------
@@ -922,7 +922,7 @@ void BasicCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - HUNTER
     // [NEW1_033] Leokk (*) - COST:3 [ATK:2/HP:4]
-    // - Race: Beast, Set: Basic, Rarity: Common
+    // - Race: Beast, Set: Legacy, Rarity: Common
     // --------------------------------------------------------
     // Text: Your other minions have +1 Attack.
     // --------------------------------------------------------
@@ -936,7 +936,7 @@ void BasicCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [NEW1_033o] Eye In The Sky (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: Leokk is granting this minion +1 Attack.
     // --------------------------------------------------------
@@ -946,7 +946,7 @@ void BasicCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - HUNTER
     // [NEW1_034] Huffer (*) - COST:3 [ATK:4/HP:2]
-    // - Race: Beast, Set: Basic, Rarity: Common
+    // - Race: Beast, Set: Legacy, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Charge</b>
     // --------------------------------------------------------
@@ -964,7 +964,7 @@ void BasicCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------- SPELL - MAGE
     // [CS2_022] Polymorph - COST:4
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Arcane
     // --------------------------------------------------------
     // Text: Transform a minion
@@ -984,7 +984,7 @@ void BasicCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------- SPELL - MAGE
     // [CS2_023] Arcane Intellect - COST:3
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Arcane
     // --------------------------------------------------------
     // Text: Draw 2 cards.
@@ -995,7 +995,7 @@ void BasicCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------- SPELL - MAGE
     // [CS2_024] Frostbolt - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Frost
     // --------------------------------------------------------
     // Text: Deal 3 damage to a character and <b>Freeze</b> it.
@@ -1017,7 +1017,7 @@ void BasicCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------- SPELL - MAGE
     // [CS2_025] Arcane Explosion - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Deal 1 damage to all enemy minions.
     // --------------------------------------------------------
@@ -1028,7 +1028,7 @@ void BasicCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------- SPELL - MAGE
     // [CS2_026] Frost Nova - COST:3
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Frost
     // --------------------------------------------------------
     // Text: <b>Freeze</b> all enemy minions.
@@ -1043,7 +1043,7 @@ void BasicCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------- SPELL - MAGE
     // [CS2_027] Mirror Image - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Summon two 0/2 minions with <b>Taunt</b>.
     // --------------------------------------------------------
@@ -1061,7 +1061,7 @@ void BasicCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------- SPELL - MAGE
     // [CS2_029] Fireball - COST:4
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Fire
     // --------------------------------------------------------
     // Text: Deal 6 damage.
@@ -1078,7 +1078,7 @@ void BasicCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------- SPELL - MAGE
     // [CS2_032] Flamestrike - COST:7
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Fire
     // --------------------------------------------------------
     // Text: Deal 5 damage to all enemy minions.
@@ -1090,7 +1090,7 @@ void BasicCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ MINION - MAGE
     // [CS2_033] Water Elemental - COST:4 [ATK:3/HP:6]
-    // - Race: Elemental, Faction: Neutral, Set: Basic, Rarity: Free
+    // - Race: Elemental, Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Freeze</b> any character damaged by this minion.
     // --------------------------------------------------------
@@ -1103,7 +1103,7 @@ void BasicCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------- SPELL - MAGE
     // [EX1_277] Arcane Missiles - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Deal 3 damage randomly split among all enemies.
     // --------------------------------------------------------
@@ -1132,7 +1132,7 @@ void BasicCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - PALADIN
     // [CS2_087] Blessing of Might - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Holy
     // --------------------------------------------------------
     // Text: Give a minion +3 Attack.
@@ -1151,7 +1151,7 @@ void BasicCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - PALADIN
     // [CS2_088] Guardian of Kings - COST:7 [ATK:5/HP:7]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     //       <b>Battlecry:</b> Restore 6 Health to your hero.
@@ -1166,7 +1166,7 @@ void BasicCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - PALADIN
     // [CS2_089] Holy Light - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Holy
     // --------------------------------------------------------
     // Text: Restore 8 Health to your hero.
@@ -1177,7 +1177,7 @@ void BasicCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- WEAPON - PALADIN
     // [CS2_091] Light's Justice - COST:1 [ATK:1/HP:0]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // GameTag:
     // - DURABILITY = 4
@@ -1188,7 +1188,7 @@ void BasicCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - PALADIN
     // [CS2_092] Blessing of Kings - COST:4
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Holy
     // --------------------------------------------------------
     // Text: Give a minion +4/+4. <i>(+4 Attack/+4 Health)</i>
@@ -1207,7 +1207,7 @@ void BasicCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - PALADIN
     // [CS2_093] Consecration - COST:4
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Holy
     // --------------------------------------------------------
     // Text: Deal 2 damage to all enemies.
@@ -1219,7 +1219,7 @@ void BasicCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - PALADIN
     // [CS2_094] Hammer of Wrath - COST:4
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Holy
     // --------------------------------------------------------
     // Text: Deal 3 damage. Draw a card.
@@ -1237,7 +1237,7 @@ void BasicCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- WEAPON - PALADIN
     // [CS2_097] Truesilver Champion - COST:4 [ATK:4/HP:0]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Whenever your hero attacks, restore 2 Health to it.
     // --------------------------------------------------------
@@ -1253,7 +1253,7 @@ void BasicCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - PALADIN
     // [EX1_360] Humility - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Change a minion's Attack to 1.
     // --------------------------------------------------------
@@ -1271,7 +1271,7 @@ void BasicCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - PALADIN
     // [EX1_371] Hand of Protection - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Holy
     // --------------------------------------------------------
     // Text: Give a minion <b>Divine Shield</b>.
@@ -1298,7 +1298,7 @@ void BasicCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------- ENCHANTMENT - PALADIN
     // [CS2_087e] Blessing of Might (*) - COST:0
-    // - Faction: Neutral, Set: Basic
+    // - Faction: Neutral, Set: Legacy
     // --------------------------------------------------------
     // Text: +3 Attack.
     // --------------------------------------------------------
@@ -1308,7 +1308,7 @@ void BasicCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------- ENCHANTMENT - PALADIN
     // [CS2_092e] Blessing of Kings (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +4/+4.
     // --------------------------------------------------------
@@ -1318,7 +1318,7 @@ void BasicCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - PALADIN
     // [CS2_101t] Silver Hand Recruit (*) - COST:1 [ATK:1/HP:1]
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -1326,7 +1326,7 @@ void BasicCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------- ENCHANTMENT - PALADIN
     // [EX1_360e] Humility (*) - COST:0
-    // - Faction: Neutral, Set: Basic
+    // - Faction: Neutral, Set: Legacy
     // --------------------------------------------------------
     // Text: Attack has been changed to 1.
     // --------------------------------------------------------
@@ -1342,7 +1342,7 @@ void BasicCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - PRIEST
     // [CS1_112] Holy Nova - COST:4
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Holy
     // --------------------------------------------------------
     // Text: Deal 2 damage to all enemy minions.
@@ -1356,7 +1356,7 @@ void BasicCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - PRIEST
     // [CS1_113] Mind Control - COST:10
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Shadow
     // --------------------------------------------------------
     // Text: Take control of an enemy minion.
@@ -1378,7 +1378,7 @@ void BasicCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - PRIEST
     // [CS1_130] Holy Smite - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Holy
     // --------------------------------------------------------
     // Text: Deal 3 damage to a minion.
@@ -1397,7 +1397,7 @@ void BasicCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - PRIEST
     // [CS2_003] Mind Vision - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Shadow
     // --------------------------------------------------------
     // Text: Put a copy of a random card in your opponent's hand into your hand.
@@ -1410,7 +1410,7 @@ void BasicCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - PRIEST
     // [CS2_004] Power Word: Shield - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Holy
     // --------------------------------------------------------
     // Text: Give a minion +2 Health. Draw a card.
@@ -1430,7 +1430,7 @@ void BasicCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - PRIEST
     // [CS2_234] Shadow Word: Pain - COST:2
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // - Spell School: Shadow
     // --------------------------------------------------------
     // Text: Destroy a minion with 3 or less Attack.
@@ -1450,7 +1450,7 @@ void BasicCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - PRIEST
     // [EX1_192] Radiance - COST:1
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // - Spell School: Holy
     // --------------------------------------------------------
     // Text: Restore 5 Health to your hero.
@@ -1461,7 +1461,7 @@ void BasicCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - PRIEST
     // [EX1_193] Psychic Conjurer - COST:1 [ATK:1/HP:1]
-    // - Set: Basic, Rarity: Common
+    // - Set: Legacy, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Copy a card in your opponent's deck
     //       and add it to your hand.
@@ -1477,7 +1477,7 @@ void BasicCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - PRIEST
     // [EX1_194] Power Infusion - COST:4
-    // - Set: Basic, Rarity: Common
+    // - Set: Legacy, Rarity: Common
     // - Spell School: Holy
     // --------------------------------------------------------
     // Text: Give a minion +2/+6.
@@ -1496,7 +1496,7 @@ void BasicCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - PRIEST
     // [EX1_622] Shadow Word: Death - COST:2
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // - Spell School: Shadow
     // --------------------------------------------------------
     // Text: Destroy a minion with 5 or more Attack.
@@ -1521,7 +1521,7 @@ void BasicCardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- ENCHANTMENT - PRIEST
     // [CS2_004e] Power Word: Shield (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +2 Health.
     // --------------------------------------------------------
@@ -1531,7 +1531,7 @@ void BasicCardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- ENCHANTMENT - PRIEST
     // [EX1_194e] Power Infusion (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +2/+6.
     // --------------------------------------------------------
@@ -1546,7 +1546,7 @@ void BasicCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - ROGUE
     // [CS2_072] Backstab - COST:0
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Deal 2 damage to an undamaged minion.
     // --------------------------------------------------------
@@ -1566,7 +1566,7 @@ void BasicCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - ROGUE
     // [CS2_074] Deadly Poison - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Nature
     // --------------------------------------------------------
     // Text: Give your weapon +2 Attack.
@@ -1583,7 +1583,7 @@ void BasicCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - ROGUE
     // [CS2_075] Sinister Strike - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Deal 3 damage to the enemy hero.
     // --------------------------------------------------------
@@ -1594,7 +1594,7 @@ void BasicCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - ROGUE
     // [CS2_076] Assassinate - COST:4
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Destroy an enemy minion.
     // --------------------------------------------------------
@@ -1612,7 +1612,7 @@ void BasicCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - ROGUE
     // [CS2_077] Sprint - COST:6
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Draw 4 cards.
     // --------------------------------------------------------
@@ -1622,7 +1622,7 @@ void BasicCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- WEAPON - ROGUE
     // [CS2_080] Assassin's Blade - COST:4 [ATK:2/HP:0]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // GameTag:
     // - DURABILITY = 5
@@ -1633,7 +1633,7 @@ void BasicCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - ROGUE
     // [EX1_129] Fan of Knives - COST:3
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Deal 1 damage to all enemy minions. Draw a card.
     // --------------------------------------------------------
@@ -1645,7 +1645,7 @@ void BasicCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- MINION - ROGUE
     // [EX1_191] Plaguebringer - COST:4 [ATK:3/HP:3]
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give a friendly minion <b>Poisonous</b>.
     // --------------------------------------------------------
@@ -1671,7 +1671,7 @@ void BasicCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - ROGUE
     // [EX1_278] Shiv - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Deal 1 damage. Draw a card.
     // --------------------------------------------------------
@@ -1688,7 +1688,7 @@ void BasicCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - ROGUE
     // [EX1_581] Sap - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Return an enemy minion to your opponent's hand.
     // --------------------------------------------------------
@@ -1711,7 +1711,7 @@ void BasicCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- WEAPON - ROGUE
     // [CS2_082] Wicked Knife (*) - COST:1 [ATK:1/HP:0]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // GameTag:
     // - DURABILITY = 2
@@ -1722,7 +1722,7 @@ void BasicCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------ ENCHANTMENT - ROGUE
     // [EX1_191e] Plaguetouched (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: <b>Poisonous</b>
     // --------------------------------------------------------
@@ -1740,7 +1740,7 @@ void BasicCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - SHAMAN
     // [CS2_037] Frost Shock - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Frost
     // --------------------------------------------------------
     // Text: Deal 1 damage to an enemy character and <b>Freeze</b> it.
@@ -1763,7 +1763,7 @@ void BasicCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - SHAMAN
     // [CS2_039] Windfury - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Nature
     // --------------------------------------------------------
     // Text: Give a minion <b>Windfury</b>.
@@ -1785,7 +1785,7 @@ void BasicCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - SHAMAN
     // [CS2_041] Ancestral Healing - COST:0
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Nature
     // --------------------------------------------------------
     // Text: Restore a minion
@@ -1810,7 +1810,7 @@ void BasicCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - SHAMAN
     // [CS2_042] Fire Elemental - COST:6 [ATK:6/HP:5]
-    // - Race: Elemental, Faction: Neutral, Set: Basic, Rarity: Free
+    // - Race: Elemental, Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Deal 4 damage.
     // --------------------------------------------------------
@@ -1828,7 +1828,7 @@ void BasicCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - SHAMAN
     // [CS2_045] Rockbiter Weapon - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Nature
     // --------------------------------------------------------
     // Text: Give a friendly character +3 Attack this turn.
@@ -1847,7 +1847,7 @@ void BasicCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - SHAMAN
     // [CS2_046] Bloodlust - COST:5
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Give your minions +3 Attack this turn.
     // --------------------------------------------------------
@@ -1858,7 +1858,7 @@ void BasicCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - SHAMAN
     // [EX1_244] Totemic Might - COST:0
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Give your Totems +2 Health.
     // --------------------------------------------------------
@@ -1872,7 +1872,7 @@ void BasicCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - SHAMAN
     // [EX1_246] Hex - COST:4
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Nature
     // --------------------------------------------------------
     // Text: Transform a minion into a 0/1 Frog with <b>Taunt</b>.
@@ -1894,7 +1894,7 @@ void BasicCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - SHAMAN
     // [EX1_565] Flametongue Totem - COST:2 [ATK:0/HP:2]
-    // - Race: Totem, Faction: Neutral, Set: Basic, Rarity: Free
+    // - Race: Totem, Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Adjacent minions have +2 Attack.
     // --------------------------------------------------------
@@ -1908,7 +1908,7 @@ void BasicCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - SHAMAN
     // [EX1_587] Windspeaker - COST:4 [ATK:3/HP:3]
-    // - Faction: Neutral, Set: Basic, Rarity: free
+    // - Faction: Neutral, Set: Legacy, Rarity: free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give a friendly minion <b>Windfury</b>.
     // --------------------------------------------------------
@@ -1939,7 +1939,7 @@ void BasicCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [CS2_041e] Ancestral Infusion (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: Taunt.
     // --------------------------------------------------------
@@ -1952,7 +1952,7 @@ void BasicCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [CS2_045e] Rockbiter Weapon (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: This character has +3 Attack this turn.
     // --------------------------------------------------------
@@ -1965,7 +1965,7 @@ void BasicCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [CS2_046e] Bloodlust (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +3 Attack this turn.
     // --------------------------------------------------------
@@ -1978,7 +1978,7 @@ void BasicCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - SHAMAN
     // [CS2_050] Searing Totem (*) - COST:1 [ATK:1/HP:1]
-    // - Race: Totem, Faction: Neutral, Set: Basic, Rarity: Free
+    // - Race: Totem, Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -1986,7 +1986,7 @@ void BasicCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - SHAMAN
     // [CS2_051] Stoneclaw Totem (*) - COST:1 [ATK:0/HP:2]
-    // - Race: Totem, Faction: Neutral, Set: Basic, Rarity: Free
+    // - Race: Totem, Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------
@@ -1999,7 +1999,7 @@ void BasicCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - SHAMAN
     // [CS2_052] Wrath of Air Totem (*) - COST:1 [ATK:0/HP:2]
-    // - Race: Totem, Faction: Neutral, Set: Basic, Rarity: Free
+    // - Race: Totem, Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Spell Damage +1</b>
     // --------------------------------------------------------
@@ -2012,7 +2012,7 @@ void BasicCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - SHAMAN
     // [CS2_058] Strength Totem (*) - COST:1 [ATK:0/HP:2]
-    // - Race: Totem, Faction: Neutral, Set: Basic, Rarity: Free
+    // - Race: Totem, Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: At the end of your turn,
     //       give another friendly minion +1 Attack.
@@ -2027,7 +2027,7 @@ void BasicCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [CS2_058e] Strength of Earth (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +1 Attack.
     // --------------------------------------------------------
@@ -2037,7 +2037,7 @@ void BasicCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [EX1_244e] Totemic Might (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +2 Health.
     // --------------------------------------------------------
@@ -2047,7 +2047,7 @@ void BasicCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [EX1_565o] Flametongue (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +2 Attack from Flametongue Totem.
     // --------------------------------------------------------
@@ -2057,7 +2057,7 @@ void BasicCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - SHAMAN
     // [NEW1_009] Healing Totem (*) - COST:1 [ATK:0/HP:2]
-    // - Race: Totem, Set: Basic, Rarity: Free
+    // - Race: Totem, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: At the end of your turn, restore 1 Health to all friendly minions.
     // --------------------------------------------------------
@@ -2074,7 +2074,7 @@ void BasicCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - WARLOCK
     // [CS2_057] Shadow Bolt - COST:3
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Shadow
     // --------------------------------------------------------
     // Text: Deal 4 damage to a minion.
@@ -2093,7 +2093,7 @@ void BasicCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - WARLOCK
     // [CS2_061] Drain Life - COST:3
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Shadow
     // --------------------------------------------------------
     // Text: Deal 2 damage. Restore 2 Health to your hero.
@@ -2111,7 +2111,7 @@ void BasicCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - WARLOCK
     // [CS2_062] Hellfire - COST:4
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Fire
     // --------------------------------------------------------
     // Text: Deal 3 damage to all characters.
@@ -2122,7 +2122,7 @@ void BasicCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - WARLOCK
     // [CS2_063] Corruption - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Choose an enemy minion. At the start of your turn, destroy it.
     // --------------------------------------------------------
@@ -2141,7 +2141,7 @@ void BasicCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - WARLOCK
     // [CS2_064] Dread Infernal - COST:6 [ATK:6/HP:6]
-    // - Race: Demon, Faction: Neutral, Set: Basic, Rarity: Free
+    // - Race: Demon, Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Deal 1 damage to all other characters.
     // --------------------------------------------------------
@@ -2154,7 +2154,7 @@ void BasicCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - WARLOCK
     // [CS2_065] Voidwalker - COST:1 [ATK:1/HP:3]
-    // - Race: Demon, Faction: Neutral, Set: Basic, Rarity: Free
+    // - Race: Demon, Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------
@@ -2167,7 +2167,7 @@ void BasicCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - WARLOCK
     // [EX1_302] Mortal Coil - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Shadow
     // --------------------------------------------------------
     // Text: Deal 1 damage to a minion. If that kills it, draw a card.
@@ -2191,7 +2191,7 @@ void BasicCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - WARLOCK
     // [EX1_306] Felstalker - COST:2 [ATK:4/HP:3]
-    // - Faction: Horde, Set: Basic, Rarity: Free
+    // - Faction: Horde, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Discard a random card.
     // --------------------------------------------------------
@@ -2204,7 +2204,7 @@ void BasicCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - WARLOCK
     // [EX1_308] Soulfire - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Fire
     // --------------------------------------------------------
     // Text: Deal 4 damage. Discard a random card.
@@ -2221,7 +2221,7 @@ void BasicCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - WARLOCK
     // [NEW1_003] Sacrificial Pact - COST:0
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // - Spell School: Shadow
     // --------------------------------------------------------
     // Text: Destroy a friendly Demon. Restore 5 Health to your hero.
@@ -2247,7 +2247,7 @@ void BasicCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------- ENCHANTMENT - WARLOCK
     // [CS2_063e] Corruption (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: At the start of the corrupting player's turn, destroy this minion.
     // --------------------------------------------------------
@@ -2264,7 +2264,7 @@ void BasicCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - WARRIOR
     // [CS2_103] Charge - COST:3
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Give a friendly minion +2 Attack and <b>Charge</b>.
     // --------------------------------------------------------
@@ -2287,7 +2287,7 @@ void BasicCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - WARRIOR
     // [CS2_105] Heroic Strike - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Give your hero +4 Attack this turn.
     // --------------------------------------------------------
@@ -2298,7 +2298,7 @@ void BasicCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- WEAPON - WARRIOR
     // [CS2_106] Fiery War Axe - COST:3 [ATK:3/HP:0]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // GameTag:
     // - DURABILITY = 2
@@ -2309,7 +2309,7 @@ void BasicCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - WARRIOR
     // [CS2_108] Execute - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Destroy a damaged enemy minion.
     // --------------------------------------------------------
@@ -2330,7 +2330,7 @@ void BasicCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- WEAPON - WARRIOR
     // [CS2_112] Arcanite Reaper - COST:5 [ATK:5/HP:0]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // GameTag:
     // - DURABILITY = 2
@@ -2341,7 +2341,7 @@ void BasicCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - WARRIOR
     // [CS2_114] Cleave - COST:2
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Deal 2 damage to two random enemy minions.
     // --------------------------------------------------------
@@ -2359,7 +2359,7 @@ void BasicCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - WARRIOR
     // [EX1_084] Warsong Commander - COST:3 [ATK:2/HP:3]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: After you summon another minion, give it <b>Rush</b>.
     // --------------------------------------------------------
@@ -2378,7 +2378,7 @@ void BasicCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - WARRIOR
     // [EX1_400] Whirlwind - COST:1
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Deal 1 damage to all minions.
     // --------------------------------------------------------
@@ -2389,7 +2389,7 @@ void BasicCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - WARRIOR
     // [EX1_606] Shield Block - COST:3
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Gain 5 Armor.
     //       Draw a card.
@@ -2401,7 +2401,7 @@ void BasicCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - WARRIOR
     // [NEW1_011] Kor'kron Elite - COST:4 [ATK:4/HP:3]
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Charge</b>
     // --------------------------------------------------------
@@ -2419,7 +2419,7 @@ void BasicCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [CS2_103e2] Charge (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +2 Attack and <b>Charge</b>.
     // --------------------------------------------------------
@@ -2429,7 +2429,7 @@ void BasicCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [CS2_105e] Heroic Strike (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +4 Attack this turn.
     // --------------------------------------------------------
@@ -2442,7 +2442,7 @@ void BasicCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [EX1_084e] Rush (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: Has <b>Rush</b>.
     // --------------------------------------------------------
@@ -2457,7 +2457,7 @@ void BasicCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [BT_035] Chaos Strike - COST:2
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // - Spell School: Fel
     // --------------------------------------------------------
     // Text: Give your hero +2 Attack this turn. Draw a card.
@@ -2470,7 +2470,7 @@ void BasicCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [BT_036] Coordinated Strike - COST:3
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Summon three 1/1 Illidari with <b>Rush</b>.
     // --------------------------------------------------------
@@ -2480,7 +2480,7 @@ void BasicCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [BT_142] Shadowhoof Slayer (*) - COST:1 [ATK:2/HP:1]
-    // - Race: Demon, Set: Basic, Rarity: Free
+    // - Race: Demon, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give your hero +1 Attack this turn.
     // --------------------------------------------------------
@@ -2494,7 +2494,7 @@ void BasicCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [BT_235] Chaos Nova - COST:5
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // - Spell School: Fel
     // --------------------------------------------------------
     // Text: Deal 4 damage to all minions.
@@ -2506,7 +2506,7 @@ void BasicCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [BT_323] Sightless Watcher (*) - COST:2 [ATK:3/HP:2]
-    // - Race: Demon, Set: Basic, Rarity: Free
+    // - Race: Demon, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Look at 3 cards in your deck.
     //       Choose one to put on top.
@@ -2536,7 +2536,7 @@ void BasicCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [BT_352] Satyr Overseer (*) - COST:3 [ATK:4/HP:2]
-    // - Race: Demon, Set: Basic, Rarity: Free
+    // - Race: Demon, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: After your hero attacks, summon a 2/2 Satyr.
     // --------------------------------------------------------
@@ -2552,7 +2552,7 @@ void BasicCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [BT_495] Glaivebound Adept (*) - COST:5 [ATK:6/HP:4]
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> If your hero attacked this turn,
     //       deal 4 damage.
@@ -2575,7 +2575,7 @@ void BasicCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [BT_512] Inner Demon - COST:8
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Give your hero +8 Attack this turn.
     // --------------------------------------------------------
@@ -2586,7 +2586,7 @@ void BasicCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [BT_740] Soul Cleave - COST:3
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // - Spell School: Shadow
     // --------------------------------------------------------
     // Text: <b>Lifesteal</b> Deal 2 damage to two random enemy minions.
@@ -2608,7 +2608,7 @@ void BasicCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- WEAPON - DEMONHUNTER
     // [BT_921] Aldrachi Warblades - COST:3 [ATK:2/HP:0]
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Lifesteal</b>
     // --------------------------------------------------------
@@ -2628,7 +2628,7 @@ void BasicCardsGen::AddDemonHunterNonCollect(
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [BT_035e] Chaos Strike (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +2 Attack this turn.
     // --------------------------------------------------------
@@ -2641,7 +2641,7 @@ void BasicCardsGen::AddDemonHunterNonCollect(
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [BT_036t] Illidari Initiate (*) - COST:1 [ATK:1/HP:1]
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -2649,7 +2649,7 @@ void BasicCardsGen::AddDemonHunterNonCollect(
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [BT_142e] Sharpened Claws (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +1 Attack this turn.
     // --------------------------------------------------------
@@ -2662,7 +2662,7 @@ void BasicCardsGen::AddDemonHunterNonCollect(
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [BT_352t] Illidari Satyr (*) - COST:2 [ATK:2/HP:2]
-    // - Race: Demon, Set: Basic, Rarity: Free
+    // - Race: Demon, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -2670,7 +2670,7 @@ void BasicCardsGen::AddDemonHunterNonCollect(
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [BT_512e] Demon Power (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +8 Attack.
     // --------------------------------------------------------
@@ -2683,7 +2683,7 @@ void BasicCardsGen::AddDemonHunterNonCollect(
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [HERO_10bpe] Demon Claws (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: Your hero has +1 Attack this turn.
     // --------------------------------------------------------
@@ -2696,7 +2696,7 @@ void BasicCardsGen::AddDemonHunterNonCollect(
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [HERO_10pe2] Demon's Bite (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: Your hero has +2 Attack this turn.
     // --------------------------------------------------------
@@ -2714,7 +2714,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS1_042] Goldshire Footman - COST:1 [ATK:1/HP:2]
-    // - Faction: Alliance, Set: Basic, Rarity: Free
+    // - Faction: Alliance, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------
@@ -2727,7 +2727,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_118] Magma Rager - COST:3 [ATK:5/HP:1]
-    // - Race: Elemental, Set: Basic, Rarity: Free
+    // - Race: Elemental, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -2735,7 +2735,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_119] Oasis Snapjaw - COST:4 [ATK:2/HP:7]
-    // - Race: Beast, Set: Basic, Rarity: Free
+    // - Race: Beast, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -2743,7 +2743,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_120] River Crocolisk - COST:2 [ATK:2/HP:3]
-    // - Race: Beast, Set: Basic, Rarity: Free
+    // - Race: Beast, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -2751,7 +2751,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_121] Frostwolf Grunt - COST:2 [ATK:2/HP:2]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------
@@ -2764,7 +2764,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_122] Raid Leader - COST:3 [ATK:2/HP:3]
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Your other minions have +1 Attack.
     // --------------------------------------------------------
@@ -2778,7 +2778,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_124] Wolfrider - COST:3 [ATK:3/HP:1]
-    // - Faction: Horde, Set: Basic, Rarity: Free
+    // - Faction: Horde, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Charge</b>
     // --------------------------------------------------------
@@ -2791,7 +2791,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_125] Ironfur Grizzly - COST:3 [ATK:3/HP:3]
-    // - Race: Beast, Faction: Neutral, Set: Basic, Rarity: Free
+    // - Race: Beast, Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------
@@ -2804,7 +2804,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_127] Silverback Patriarch - COST:3 [ATK:1/HP:4]
-    // - Race: Beast, Faction: Horde, Set: Basic, Rarity: Free
+    // - Race: Beast, Faction: Horde, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------
@@ -2817,7 +2817,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_131] Stormwind Knight - COST:4 [ATK:2/HP:5]
-    // - Faction: Alliance, Set: Basic, Rarity: Free
+    // - Faction: Alliance, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Charge</b>
     // --------------------------------------------------------
@@ -2830,7 +2830,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_141] Ironforge Rifleman - COST:3 [ATK:2/HP:2]
-    // - Faction: Alliance, Set: Basic, Rarity: Free
+    // - Faction: Alliance, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Deal 1 damage.
     // --------------------------------------------------------
@@ -2850,7 +2850,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_142] Kobold Geomancer - COST:2 [ATK:2/HP:2]
-    // - Faction: Horde, Set: Basic, Rarity: Free
+    // - Faction: Horde, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Spell Damage +1</b>
     // --------------------------------------------------------
@@ -2863,7 +2863,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_147] Gnomish Inventor - COST:4 [ATK:2/HP:4]
-    // - Faction: Alliance, Set: Basic, Rarity: Free
+    // - Faction: Alliance, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Draw a card.
     // --------------------------------------------------------
@@ -2876,7 +2876,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_150] Stormpike Commando - COST:5 [ATK:4/HP:2]
-    // - Faction: Alliance, Set: Basic, Rarity: Free
+    // - Faction: Alliance, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Deal 2 damage.
     // --------------------------------------------------------
@@ -2896,7 +2896,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_155] Archmage - COST:6 [ATK:4/HP:7]
-    // - Faction: Alliance, Set: Basic, Rarity: Free
+    // - Faction: Alliance, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Spell Damage +1</b>
     // --------------------------------------------------------
@@ -2909,7 +2909,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_162] Lord of the Arena - COST:6 [ATK:6/HP:5]
-    // - Faction: Alliance, Set: Basic, Rarity: Free
+    // - Faction: Alliance, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------
@@ -2922,7 +2922,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_168] Murloc Raider - COST:1 [ATK:2/HP:1]
-    // - Race: Murloc, Faction: Alliance, Set: Basic, Rarity: Free
+    // - Race: Murloc, Faction: Alliance, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -2930,7 +2930,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_171] Stonetusk Boar - COST:1 [ATK:1/HP:1]
-    // - Race: Beast, Faction: Neutral, Set: Basic, Rarity: Free
+    // - Race: Beast, Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Charge</b>
     // --------------------------------------------------------
@@ -2943,7 +2943,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_172] Bloodfen Raptor - COST:2 [ATK:3/HP:2]
-    // - Race: Beast, Faction: Horde, Set: Basic, Rarity: Free
+    // - Race: Beast, Faction: Horde, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -2951,7 +2951,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_173] Bluegill Warrior - COST:2 [ATK:2/HP:1]
-    // - Race: Murloc, Faction: Neutral, Set: Basic, Rarity: Free
+    // - Race: Murloc, Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Charge</b>
     // --------------------------------------------------------
@@ -2964,7 +2964,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_179] Sen'jin Shieldmasta - COST:4 [ATK:3/HP:5]
-    // - Faction: Horde, Set: Basic, Rarity: Free
+    // - Faction: Horde, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------
@@ -2977,7 +2977,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_182] Chillwind Yeti - COST:4 [ATK:4/HP:5]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -2985,7 +2985,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_186] War Golem - COST:7 [ATK:7/HP:7]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -2993,7 +2993,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_187] Booty Bay Bodyguard - COST:5 [ATK:5/HP:4]
-    // - Faction: Horde, Set: Basic, Rarity: Free
+    // - Faction: Horde, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------
@@ -3006,7 +3006,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_189] Elven Archer - COST:1 [ATK:1/HP:1]
-    // - Faction: Horde, Set: Basic, Rarity: Free
+    // - Faction: Horde, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Deal 1 damage.
     // --------------------------------------------------------
@@ -3026,7 +3026,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_196] Razorfen Hunter - COST:3 [ATK:2/HP:3]
-    // - Faction: Horde, Set: Basic, Rarity: Free
+    // - Faction: Horde, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Summon a 1/1 Boar.
     // --------------------------------------------------------
@@ -3040,7 +3040,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_197] Ogre Magi - COST:4 [ATK:4/HP:4]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Spell Damage +1</b>
     // --------------------------------------------------------
@@ -3053,7 +3053,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_200] Boulderfist Ogre - COST:6 [ATK:6/HP:7]
-    // - Set: Basic, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -3061,7 +3061,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_201] Core Hound - COST:7 [ATK:9/HP:5]
-    // - Race: Beast, Set: Basic, Rarity: Free
+    // - Race: Beast, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -3069,7 +3069,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_213] Reckless Rocketeer - COST:6 [ATK:5/HP:2]
-    // - Faction: Horde, Set: Basic, Rarity: Free
+    // - Faction: Horde, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Charge</b>
     // --------------------------------------------------------
@@ -3082,7 +3082,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_222] Stormwind Champion - COST:7 [ATK:7/HP:7]
-    // - Faction: Alliance, Set: Basic, Rarity: Free
+    // - Faction: Alliance, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Your other minions have +1/+1.
     // --------------------------------------------------------
@@ -3096,7 +3096,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_226] Frostwolf Warlord - COST:5 [ATK:4/HP:4]
-    // - Faction: Horde, Set: Basic, Rarity: Free
+    // - Faction: Horde, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Gain +1/+1 for each other friendly minion on the
     // battlefield.
@@ -3113,7 +3113,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [DS1_055] Darkscale Healer - COST:5 [ATK:4/HP:5]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Restore 2 Health to all friendly characters.
     // --------------------------------------------------------
@@ -3126,7 +3126,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_011] Voodoo Doctor - COST:1 [ATK:2/HP:1]
-    // - Faction: Horde, Set: Basic, Rarity: Free
+    // - Faction: Horde, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Restore 2 Health.
     // --------------------------------------------------------
@@ -3144,7 +3144,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_015] Novice Engineer - COST:2 [ATK:1/HP:1]
-    // - Faction: Alliance, Set: Basic, Rarity: Free
+    // - Faction: Alliance, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Draw a card.
     // --------------------------------------------------------
@@ -3157,7 +3157,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_019] Shattered Sun Cleric - COST:3 [ATK:3/HP:2]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give a friendly minion +1/+1.
     // --------------------------------------------------------
@@ -3180,7 +3180,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_025] Dragonling Mechanic - COST:4 [ATK:2/HP:4]
-    // - Faction: Alliance, Set: Basic, Rarity: Free
+    // - Faction: Alliance, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Summon a 2/1 Mechanical Dragonling.
     // --------------------------------------------------------
@@ -3194,7 +3194,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_066] Acidic Swamp Ooze - COST:2 [ATK:3/HP:2]
-    // - Faction: Alliance, Set: Basic, Rarity: Free
+    // - Faction: Alliance, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Destroy your opponent's weapon.
     // --------------------------------------------------------
@@ -3207,7 +3207,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_399] Gurubashi Berserker - COST:5 [ATK:2/HP:8]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Whenever this minion takes damage, gain +3 Attack.
     // --------------------------------------------------------
@@ -3220,7 +3220,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_506] Murloc Tidehunter - COST:2 [ATK:2/HP:1]
-    // - Race: Murloc, Faction: Neutral, Set: Basic, Rarity: Free
+    // - Race: Murloc, Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Summon a 1/1 Murloc Scout.
     // --------------------------------------------------------
@@ -3234,7 +3234,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_508] Grimscale Oracle - COST:1 [ATK:1/HP:1]
-    // - Race: Murloc, Faction: Neutral, Set: Basic, Rarity: Free
+    // - Race: Murloc, Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Your other Murlocs have +1 Attack.
     // --------------------------------------------------------
@@ -3250,7 +3250,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_582] Dalaran Mage - COST:3 [ATK:1/HP:4]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Spell Damage +1</b>
     // --------------------------------------------------------
@@ -3263,7 +3263,7 @@ void BasicCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_593] Nightblade - COST:5 [ATK:4/HP:4]
-    // - Faction: Neutral, Set: Basic, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Battlecry: </b>Deal 3 damage to the enemy hero.
     // --------------------------------------------------------
@@ -3281,7 +3281,7 @@ void BasicCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [CS2_074e] Deadly Poison (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +2 Attack.
     // --------------------------------------------------------
@@ -3291,7 +3291,7 @@ void BasicCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [CS2_122e] Enhanced (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: Raid Leader is granting this minion +1 Attack.
     // --------------------------------------------------------
@@ -3301,7 +3301,7 @@ void BasicCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [CS2_222o] Might of Stormwind (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: Has +1/+1.
     // --------------------------------------------------------
@@ -3311,7 +3311,7 @@ void BasicCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [CS2_226e] Frostwolf Banner (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: Increased stats.
     // --------------------------------------------------------
@@ -3322,7 +3322,7 @@ void BasicCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_boar] Boar (*) - COST:1 [ATK:1/HP:1]
-    // - Race: Beast, Faction: Neutral, Set: Basic, Rarity: Common
+    // - Race: Beast, Faction: Neutral, Set: Legacy, Rarity: Common
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -3330,7 +3330,7 @@ void BasicCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS2_tk1] Sheep (*) - COST:1 [ATK:1/HP:1]
-    // - Race: Beast, Faction: Neutral, Set: Basic, Rarity: Common
+    // - Race: Beast, Faction: Neutral, Set: Legacy, Rarity: Common
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -3338,7 +3338,7 @@ void BasicCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------- ENCHANTMENT - PRIEST
     // [EX1_019e] Cleric's Blessing (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
@@ -3348,7 +3348,7 @@ void BasicCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_025t] Mechanical Dragonling (*) - COST:1 [ATK:2/HP:1]
-    // - Race: Mechanical, Faction: Neutral, Set: Basic, Rarity: Common
+    // - Race: Mechanical, Faction: Neutral, Set: Legacy, Rarity: Common
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -3356,7 +3356,7 @@ void BasicCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_506a] Murloc Scout (*) - COST:1 [ATK:1/HP:1]
-    // - Race: Murloc, Faction: Neutral, Set: Basic, Rarity: Common
+    // - Race: Murloc, Faction: Neutral, Set: Legacy, Rarity: Common
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(nullptr);
@@ -3364,7 +3364,7 @@ void BasicCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [EX1_508o] Mlarggragllabl! (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: This Murloc has +1 Attack.
     // --------------------------------------------------------
@@ -3374,7 +3374,7 @@ void BasicCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [EX1_399e] Berserking (*) - COST:0
-    // - Set: Basic
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: This minion has increased Attack.
     // --------------------------------------------------------
@@ -3384,7 +3384,7 @@ void BasicCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [hexfrog] Frog (*) - COST:0 [ATK:0/HP:1]
-    // - Race: Beast, Faction: Neutral, Set: Basic, Rarity: Common
+    // - Race: Beast, Faction: Neutral, Set: Legacy, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
     // --------------------------------------------------------

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -764,7 +764,7 @@ void DarkmoonFaireCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------- SPELL - MAGE
-    // [DMF_108] Deck of Lunacy - COST:2
+    // [DMF_108] Deck of Lunacy - COST:4
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: Transform spells in your deck into ones that cost (3) more.

--- a/Sources/Rosetta/PlayMode/CardSets/HoFCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/HoFCardsGen.cpp
@@ -40,7 +40,7 @@ void HoFCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - DRUID
     // [EX1_161] Naturalize - COST:1
-    // - Faction: Neutral, Set: HoF, Rarity: Common
+    // - Faction: Neutral, Set: Legacy, Rarity: Common
     // - Spell School: Nature
     // --------------------------------------------------------
     // Text: Destroy a minion. Your opponent draws 2 cards.
@@ -79,7 +79,7 @@ void HoFCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------- SPELL - MAGE
     // [CS2_031] Ice Lance - COST:1
-    // - Faction: Neutral, Set: HoF, Rarity: Common
+    // - Faction: Neutral, Set: Legacy, Rarity: Common
     // - Spell School: Frost
     // --------------------------------------------------------
     // Text: <b>Freeze</b> a character. If it was already <b>Frozen</b>,
@@ -117,7 +117,7 @@ void HoFCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - PALADIN
     // [EX1_349] Divine Favor - COST:3
-    // - Faction: Neutral, Set: HoF, Rarity: Rare
+    // - Faction: Neutral, Set: Legacy, Rarity: Rare
     // - Spell School: Holy
     // --------------------------------------------------------
     // Text: Draw cards until you have as many in hand
@@ -145,7 +145,7 @@ void HoFCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - PRIEST
     // [CS2_235] Northshire Cleric - COST:1 [ATK:1/HP:3]
-    // - Set: HoF, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Whenever a minion is healed, draw a card.
     // --------------------------------------------------------
@@ -157,7 +157,7 @@ void HoFCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - PRIEST
     // [CS2_236] Divine Spirit - COST:2
-    // - Set: HoF, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // - Spell School: Holy
     // --------------------------------------------------------
     // Text: Double a minion's Health.
@@ -182,7 +182,7 @@ void HoFCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - PRIEST
     // [DS1_233] Mind Blast - COST:2
-    // - Faction: Neutral, Set: HoF, Rarity: Free
+    // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Shadow
     // --------------------------------------------------------
     // Text: Deal 5 damage to the enemy hero.
@@ -194,7 +194,7 @@ void HoFCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - PRIEST
     // [EX1_350] Prophet Velen - COST:7 [ATK:7/HP:7]
-    // - Faction: Neutral, Set: HoF, Rarity: Legendary
+    // - Faction: Neutral, Set: Legacy, Rarity: Legendary
     // --------------------------------------------------------
     // Text: Double the damage and healing of your spells and Hero Power.
     // --------------------------------------------------------
@@ -210,7 +210,7 @@ void HoFCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- MINION - PRIEST
     // [EX1_591] Auchenai Soulpriest - COST:4 [ATK:3/HP:5]
-    // - Faction: Neutral, Set: HoF, Rarity: Rare
+    // - Faction: Neutral, Set: Legacy, Rarity: Rare
     // --------------------------------------------------------
     // Text: Your cards and powers that restore Health
     //       now deal damage instead.
@@ -227,7 +227,7 @@ void HoFCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 
     // ----------------------------------------- SPELL - PRIEST
     // [EX1_624] Holy Fire - COST:6
-    // - Faction: Priest, Set: HoF, Rarity: Rare
+    // - Faction: Priest, Set: Legacy, Rarity: Rare
     // - Spell School: Holy
     // --------------------------------------------------------
     // Text: Deal 5 damage. Restore 5 Health to your hero.
@@ -265,7 +265,7 @@ void HoFCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - ROGUE
     // [EX1_128] Conceal - COST:1
-    // - Faction: Neutral, Set: HoF, Rarity: Common
+    // - Faction: Neutral, Set: Legacy, Rarity: Common
     // - Spell School: Shadow
     // --------------------------------------------------------
     // Text: Give your minions <b>Stealth</b> until your next turn.
@@ -281,7 +281,7 @@ void HoFCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - ROGUE
     // [NEW1_004] Vanish - COST:6
-    // - Set: HoF, Rarity: Free
+    // - Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Return all minions to their owner's hand.
     // --------------------------------------------------------
@@ -297,7 +297,7 @@ void HoFCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 
     // ------------------------------------------ SPELL - ROGUE
     // [EX1_128e] Conceal - COST:1
-    // - Set: HoF
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: Stealthed until your next turn.
     // --------------------------------------------------------
@@ -328,7 +328,7 @@ void HoFCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - WARLOCK
     // [EX1_310] Doomguard - COST:5 [ATK:5/HP:7]
-    // - Race: Demon, Set: HoF, Rarity: Rare
+    // - Race: Demon, Set: Legacy, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Charge</b>. <b>Battlecry:</b> Discard two random cards.
     // --------------------------------------------------------
@@ -342,7 +342,7 @@ void HoFCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- SPELL - WARLOCK
     // [EX1_316] Power Overwhelming - COST:1
-    // - Faction: Neutral, Set: HoF, Rarity: Common
+    // - Faction: Neutral, Set: Legacy, Rarity: Common
     // - Spell School: Shadow
     // --------------------------------------------------------
     // Text: Give a friendly minion +4/+4 until end of turn.
@@ -369,7 +369,7 @@ void HoFCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------- ENCHANTMENT - WARLOCK
     // [EX1_316e] Power Overwhelming (*) - COST:0
-    // - Faction: Neutral, Set: HoF
+    // - Faction: Neutral, Set: Legacy
     // --------------------------------------------------------
     // Text: This minion has +4/+4, but will die a horrible death
     //       at the end of the turn.
@@ -398,7 +398,7 @@ void HoFCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_007] Acolyte of Pain - COST:3 [ATK:1/HP:3]
-    // - Set: HoF, Rarity: Common
+    // - Set: Legacy, Rarity: Common
     // --------------------------------------------------------
     // Text: Whenever this minion takes damage, draw a card.
     // --------------------------------------------------------
@@ -410,7 +410,7 @@ void HoFCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_016] Sylvanas Windrunner - COST:6 [ATK:5/HP:5]
-    // - Set: HoF, Rarity: Legendary
+    // - Set: Legacy, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Take control of a random enemy minion.
     // --------------------------------------------------------
@@ -426,7 +426,7 @@ void HoFCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_048] Spellbreaker - COST:4 [ATK:4/HP:3]
-    // - Faction: Horde, Set: HoF, Rarity: Common
+    // - Faction: Horde, Set: Legacy, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> <b>Silence</b> a minion.
     // --------------------------------------------------------
@@ -451,7 +451,7 @@ void HoFCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_050] Coldlight Oracle - COST:3 [ATK:2/HP:2]
-    // - Faction: Neutral, Set: HoF, Rarity: Rare
+    // - Faction: Neutral, Set: Legacy, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Each player draws 2 cards.
     // --------------------------------------------------------
@@ -465,7 +465,7 @@ void HoFCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_062] Old Murk-Eye - COST:4 [ATK:2/HP:4]
-    // - Race: Murloc, Faction: Neutral. Set: HoF, Rarity: Legendary
+    // - Race: Murloc, Faction: Neutral. Set: Legacy, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Charge</b>. Has +1 Attack for each other Murloc on the
     // battlefield.
@@ -509,7 +509,7 @@ void HoFCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_085] Mind Control Tech - COST:3 [ATK:3/HP:3]
-    // - Faction: Alliance, Set: HoF, Rarity: Rare
+    // - Faction: Alliance, Set: Legacy, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> If your opponent has 4 or
     //       more minions, take control of one at random.
@@ -536,7 +536,7 @@ void HoFCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_105] Mountain Giant - COST:12 [ATK:8/HP:8]
-    // - Race: Elemental, Faction: Neutral, Set: HoF, Rarity: Epic
+    // - Race: Elemental, Faction: Neutral, Set: Legacy, Rarity: Epic
     // --------------------------------------------------------
     // Text: Costs (1) less for each other card in your hand.
     // --------------------------------------------------------
@@ -548,7 +548,7 @@ void HoFCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_116] Leeroy Jenkins - COST:5 [ATK:6/HP:2]
-    // - Faction: Alliance, Set: HoF, Rarity: Legendary
+    // - Faction: Alliance, Set: Legacy, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Charge</b>. <b>Battlecry:</b> Summon two 1/1 Whelps
     //       for your opponent.
@@ -565,7 +565,7 @@ void HoFCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_284] Azure Drake - COST:5 [ATK:4/HP:4]
-    // - Race: Dragon, Faction: Neutral, Set: HoF, Rarity: Rare
+    // - Race: Dragon, Faction: Neutral, Set: Legacy, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Spell Damage +1</b>
     //       <b>Battlecry:</b> Draw a card.
@@ -580,7 +580,7 @@ void HoFCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_298] Ragnaros the Firelord - COST:8 [ATK:8/HP:8]
-    // - Race: Elemental, Faction: Neutral, Set: HoF, Rarity: Legendary
+    // - Race: Elemental, Faction: Neutral, Set: Legacy, Rarity: Legendary
     // --------------------------------------------------------
     // Text: Can't attack. At the end of your turn, deal 8 damage
     //       to a random enemy.
@@ -598,7 +598,7 @@ void HoFCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
     // --------------------------------------- MINION - NEUTRAL
     // [EX1_620] Molten Giant - COST:20 [ATK:8/HP:8]
-    // - Race: Elemental, Faction: Neutral, Set: HoF, Rarity: Epic
+    // - Race: Elemental, Faction: Neutral, Set: Legacy, Rarity: Epic
     // --------------------------------------------------------
     // Text: Costs (1) less for each damage your hero has taken.
     // --------------------------------------------------------
@@ -615,7 +615,7 @@ void HoFCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [NEW1_027e] Yarrr! (*) - COST:0
-    // - Set: HoF
+    // - Set: Legacy
     // --------------------------------------------------------
     // Text: Southsea Captain is granting +1/+1.
     // --------------------------------------------------------

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -2302,7 +2302,7 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [SCH_248] Pen Flinger - COST:1 [ATK:1/HP:1]
     // - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Deal 1 damage.
+    // Text: <b>Battlecry:</b> Deal 1 damage to a minion.
     //       <b>Spellburst:</b> Return this to your hand.
     // --------------------------------------------------------
     // GameTag:
@@ -2310,6 +2310,7 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // PlayReq:
     // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(std::make_shared<DamageTask>(EntityType::TARGET, 1));
@@ -2317,7 +2318,8 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
         std::make_shared<ReturnHandTask>(EntityType::SOURCE));
     cards.emplace(
         "SCH_248",
-        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // --------------------------------------- WEAPON - NEUTRAL
     // [SCH_259] Sphere of Sapience - COST:1
@@ -2495,7 +2497,7 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cards.emplace("SCH_350", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SCH_351] Jandice Barov - COST:5 [ATK:2/HP:1]
+    // [SCH_351] Jandice Barov - COST:6 [ATK:2/HP:1]
     // - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Summon two random 5-Cost minions.

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -293,7 +293,7 @@ void TheBarrensCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // [BAR_037] Warsong Wrangler - COST:4 [ATK:3/HP:4]
     // - Set: THE_BARRENS, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> <b>Discover</b> a Beast in your deck.
+    // Text: <b>Battlecry:</b> <b>Discover</b> a Beast from your deck.
     //       Give all copies of it +2/+1 <i>(wherever they are)</i>.
     // --------------------------------------------------------
     // GameTag:
@@ -1985,7 +1985,7 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BAR_074] Far Watch Post - COST:2 [ATK:2/HP:4]
+    // [BAR_074] Far Watch Post - COST:2 [ATK:2/HP:3]
     // - Set: THE_BARRENS, Rarity: Common
     // --------------------------------------------------------
     // Text: Can't attack. After your opponent draws a card,
@@ -2009,7 +2009,7 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BAR_076] Mor'shan Watch Post - COST:3 [ATK:3/HP:5]
+    // [BAR_076] Mor'shan Watch Post - COST:3 [ATK:3/HP:4]
     // - Set: THE_BARRENS, Rarity: Rare
     // --------------------------------------------------------
     // Text: Can't attack. After your opponent plays a minion,

--- a/Tests/PythonTests/test_cards.py
+++ b/Tests/PythonTests/test_cards.py
@@ -80,7 +80,7 @@ def test_find_card_by_class():
 def test_find_card_by_set():
 	cards1 = pyRosetta.Cards.find_card_by_set(pyRosetta.CardSet.CORE)
 	cards2 = pyRosetta.Cards.find_card_by_set(pyRosetta.CardSet.EXPERT1)
-	cards3 = pyRosetta.Cards.find_card_by_set(pyRosetta.CardSet.HOF)
+	cards3 = pyRosetta.Cards.find_card_by_set(pyRosetta.CardSet.LEGACY)
 	cards4 = pyRosetta.Cards.find_card_by_set(pyRosetta.CardSet.NAXX)
 	cards5 = pyRosetta.Cards.find_card_by_set(pyRosetta.CardSet.GVG)
 	cards6 = pyRosetta.Cards.find_card_by_set(pyRosetta.CardSet.BRM)
@@ -98,7 +98,7 @@ def test_find_card_by_set():
 
 	assert cards1[0].card_set() == pyRosetta.CardSet.CORE
 	assert cards2[0].card_set() == pyRosetta.CardSet.EXPERT1
-	assert cards3[0].card_set() == pyRosetta.CardSet.HOF
+	assert cards3[0].card_set() == pyRosetta.CardSet.LEGACY
 	assert cards4[0].card_set() == pyRosetta.CardSet.NAXX
 	assert cards5[0].card_set() == pyRosetta.CardSet.GVG
 	assert cards6[0].card_set() == pyRosetta.CardSet.BRM

--- a/Tests/UnitTests/PlayMode/CardSets/BasicCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BasicCardsGenTests.cpp
@@ -22,7 +22,7 @@ using namespace SimpleTasks;
 
 // ----------------------------------- HERO_POWER - WARRIOR
 // [HERO_01bp] Armor Up! (*) - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Hero Power</b> Gain 2 Armor.
 // --------------------------------------------------------
@@ -55,7 +55,7 @@ TEST_CASE("[Warrior : Hero Power] - HERO_01bp : Armor Up!")
 
 // ------------------------------------ HERO_POWER - SHAMAN
 // [HERO_02bp] Totemic Call (*) - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Hero Power</b> Summon a random Totem.
 // --------------------------------------------------------
@@ -126,7 +126,7 @@ TEST_CASE("[Shaman : Hero Power] - HERO_02bp : Totemic Call")
 
 // ------------------------------------- HERO_POWER - ROGUE
 // [HERO_03bp] Dagger Mastery (*) - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Hero Power</b> Equip a 1/2 Dagger.
 // --------------------------------------------------------
@@ -165,7 +165,7 @@ TEST_CASE("[Rogue : Hero Power] - HERO_03bp : Dagger Mastery")
 
 // ----------------------------------- HERO_POWER - PALADIN
 // [HERO_04bp] Reinforce (*) - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Hero Power</b> Summon a 1/1 Silver Hand Recruit.
 // --------------------------------------------------------
@@ -203,7 +203,7 @@ TEST_CASE("[Paladin : Hero Power] - HERO_04bp : Reinforce")
 
 // ------------------------------------ HERO_POWER - HUNTER
 // [HERO_05bp] Steady Shot (*) - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Hero Power</b> Deal 2 damage to the enemy hero.
 // --------------------------------------------------------
@@ -238,7 +238,7 @@ TEST_CASE("[Hunter : Hero Power] - HERO_05bp : Steady Shot")
 
 // ------------------------------------- HERO_POWER - DRUID
 // [HERO_06bp] Shapeshift (*) - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Hero Power</b> +1 Attack this turn. +1 Armor.
 // --------------------------------------------------------
@@ -298,7 +298,7 @@ TEST_CASE("[Druid : Hero Power] - HERO_06bp : Shapeshift")
 
 // ----------------------------------- HERO_POWER - WARLOCK
 // [HERO_07bp] Life Tap (*) - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Hero Power</b> Draw a card and take 2 damage.
 // --------------------------------------------------------
@@ -332,7 +332,7 @@ TEST_CASE("[Warlock : Hero Power] - HERO_07bp : Life Tap")
 
 // -------------------------------------- HERO_POWER - MAGE
 // [HERO_08bp] Fireblast (*) - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Hero Power</b> Deal 1 damage.
 // --------------------------------------------------------
@@ -380,7 +380,7 @@ TEST_CASE("[Mage : Hero Power] - HERO_08bp : Fireblast")
 
 // ------------------------------------ HERO_POWER - PRIEST
 // [HERO_09bp] Lesser Heal (*) - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Hero Power</b> Restore 2 Health.
 // --------------------------------------------------------
@@ -423,7 +423,7 @@ TEST_CASE("[Priest : Hero Power] - HERO_09bp : Lesser Heal")
 
 // ------------------------------- HERO_POWER - DEMONHUNTER
 // [HERO_10bp] Demon Claws (*) - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Hero Power</b> +1 Attack this turn.
 // --------------------------------------------------------
@@ -479,7 +479,7 @@ TEST_CASE("[Demon Hunter : Hero Power] - HERO_10bp : Demon Claws")
 
 // ------------------------------------------ SPELL - DRUID
 // [CS2_005] Claw - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Give your hero +2 Attack this turn. Gain 2 Armor.
 // --------------------------------------------------------
@@ -523,7 +523,7 @@ TEST_CASE("[Druid : Spell] - CS2_005 : Claw")
 
 // ------------------------------------------ SPELL - DRUID
 // [CS2_007] Healing Touch - COST:3
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Nature
 // --------------------------------------------------------
 // Text: Restore 8 Health.
@@ -581,7 +581,7 @@ TEST_CASE("[Druid : Spell] - CS2_007 : Healing Touch")
 
 // ------------------------------------------ SPELL - DRUID
 // [CS2_008] Moonfire - COST:0
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Arcane
 // --------------------------------------------------------
 // Text: Deal 1 damage.
@@ -652,7 +652,7 @@ TEST_CASE("[Druid : Spell] - CS2_008 : Moonfire")
 
 // ------------------------------------------ SPELL - DRUID
 // [CS2_009] Mark of the Wild - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Nature
 // --------------------------------------------------------
 // Text: Give a minion <b>Taunt</b> and +2/+3.<i>
@@ -705,7 +705,7 @@ TEST_CASE("[Druid : Spell] - CS2_009 : Mark of the Wild")
 
 // ------------------------------------------ SPELL - DRUID
 // [CS2_011] Savage Roar - COST:3
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Give your characters +2 Attack this turn.
 // --------------------------------------------------------
@@ -759,7 +759,7 @@ TEST_CASE("[Druid : Spell] - CS2_011 : Savage Roar")
 
 // ------------------------------------------ SPELL - DRUID
 // [CS2_012] Swipe - COST:4
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Deal 4 damage to an enemy and 1 damage to all other enemies.
 // --------------------------------------------------------
@@ -823,7 +823,7 @@ TEST_CASE("[Druid : Spell] - CS2_012 : Swipe")
 
 // ------------------------------------------ SPELL - DRUID
 // [CS2_013] Wild Growth - COST:3
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Nature
 // --------------------------------------------------------
 // Text: Gain an empty Mana Crystal.
@@ -864,7 +864,7 @@ TEST_CASE("[Druid : Spell] - CS2_013 : Wild Growth")
 
 // ----------------------------------------- MINION - DRUID
 // [CS2_232] Ironbark Protector - COST:8 [ATK:8/HP:8]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Taunt</b>
 // --------------------------------------------------------
@@ -878,7 +878,7 @@ TEST_CASE("[Druid : Minion] - CS2_232 : Ironbark Protector")
 
 // ------------------------------------------ SPELL - DRUID
 // [EX1_169] Innervate - COST:0
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Nature
 // --------------------------------------------------------
 // Text: Gain 1 Mana Crystal this turn only.
@@ -937,7 +937,7 @@ TEST_CASE("[Druid : Spell] - EX1_169 : Innervate")
 
 // ------------------------------------------ SPELL - DRUID
 // [EX1_173] Starfire - COST:6
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Arcane
 // --------------------------------------------------------
 // Text: Deal 5 damage. Draw a card.
@@ -988,7 +988,7 @@ TEST_CASE("[Druid : Spell] - EX1_173 : Starfire")
 
 // ----------------------------------------- SPELL - HUNTER
 // [CS2_084] Hunter's Mark - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Change a minion's Health to 1.
 // --------------------------------------------------------
@@ -1035,7 +1035,7 @@ TEST_CASE("[Hunter : Spell] - CS2_084 : Hunter's Mark")
 
 // ---------------------------------------- MINION - HUNTER
 // [CS2_237] Starving Buzzard - COST:2 [ATK:2/HP:1]
-// - Race: Beast, Set: Basic, Rarity: Free
+// - Race: Beast, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Whenever you summon a Beast, draw a card.
 // --------------------------------------------------------
@@ -1083,7 +1083,7 @@ TEST_CASE("[Hunter : Minion] - CS2_237 : Starving Buzzard")
 
 // ---------------------------------------- MINION - HUNTER
 // [DS1_070] Houndmaster - COST:4 [ATK:4/HP:3]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Give a friendly Beast +2/+2 and <b>Taunt</b>.
 // --------------------------------------------------------
@@ -1151,7 +1151,7 @@ TEST_CASE("[Hunter : Minion] - DS1_070 : Houndmaster")
 
 // ---------------------------------------- MINION - HUNTER
 // [DS1_175] Timber Wolf - COST:1 [ATK:1/HP:1]
-// - Race: Beast, Faction: Neutral, Set: Basic, Rarity: Free
+// - Race: Beast, Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Your other Beasts have +1 Attack.
 // --------------------------------------------------------
@@ -1228,7 +1228,7 @@ TEST_CASE("[Hunter : Minion] - DS1_175 : Timber Wolf")
 
 // ---------------------------------------- MINION - HUNTER
 // [DS1_178] Tundra Rhino - COST:5 [ATK:2/HP:5]
-// - Race: Beast, Faction: Neutral, Set: Basic, Rarity: Free
+// - Race: Beast, Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Your Beasts have <b>Charge</b>.
 // --------------------------------------------------------
@@ -1288,7 +1288,7 @@ TEST_CASE("[Hunter : Minion] - DS1_178 : Tundra Rhino")
 
 // ----------------------------------------- SPELL - HUNTER
 // [DS1_183] Multi-Shot - COST:4
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Deal 3 damage to two random enemy minions.
 // --------------------------------------------------------
@@ -1361,7 +1361,7 @@ TEST_CASE("[Hunter : Spell] - DS1_183 : Multi-Shot")
 
 // ----------------------------------------- SPELL - HUNTER
 // [DS1_184] Tracking - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Discover</b> a card from your deck.
 // --------------------------------------------------------
@@ -1402,7 +1402,7 @@ TEST_CASE("[Hunter : Spell] - DS1_184 : Tracking")
 
 // ----------------------------------------- SPELL - HUNTER
 // [DS1_185] Arcane Shot - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Arcane
 // --------------------------------------------------------
 // Text: Deal 2 damage.
@@ -1470,7 +1470,7 @@ TEST_CASE("[Hunter : Spell] - DS1_185 : Arcane Shot")
 
 // ----------------------------------------- SPELL - HUNTER
 // [EX1_539] Kill Command - COST:3
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Deal 3 damage. If you control a Beast,
 //       deal 5 damage instead.
@@ -1517,7 +1517,7 @@ TEST_CASE("[Hunter : Spell] - EX1_539 : Kill Command")
 
 // ----------------------------------------- SPELL - HUNTER
 // [NEW1_031] Animal Companion - COST:3
-// - Set: Basic, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Summon a random Beast Companion.
 // --------------------------------------------------------
@@ -1619,7 +1619,7 @@ TEST_CASE("[Hunter : Spell] - NEW1_031 : Animal Companion")
 
 // ------------------------------------------- SPELL - MAGE
 // [CS2_022] Polymorph - COST:4
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Arcane
 // --------------------------------------------------------
 // Text: Transform a minion
@@ -1684,7 +1684,7 @@ TEST_CASE("[Mage : Spell] - CS2_022 : Polymorph")
 
 // ------------------------------------------- SPELL - MAGE
 // [CS2_023] Arcane Intellect - COST:3
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Arcane
 // --------------------------------------------------------
 // Text: Draw 2 cards.
@@ -1719,7 +1719,7 @@ TEST_CASE("[Mage : Spell] - CS2_023 : Arcane Intellect")
 
 // ------------------------------------------- SPELL - MAGE
 // [CS2_024] Frostbolt - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Frost
 // --------------------------------------------------------
 // Text: Deal 3 damage to a character and <b>Freeze</b> it.
@@ -1801,7 +1801,7 @@ TEST_CASE("[Mage : Spell] - CS2_024 : Frostbolt")
 
 // ------------------------------------------- SPELL - MAGE
 // [CS2_025] Arcane Explosion - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Deal 1 damage to all enemy minions.
 // --------------------------------------------------------
@@ -1859,7 +1859,7 @@ TEST_CASE("[Mage : Spell] - CS2_025 : Arcane Explosion")
 
 // ------------------------------------------- SPELL - MAGE
 // [CS2_026] Frost Nova - COST:3
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Frost
 // --------------------------------------------------------
 // Text: <b>Freeze</b> all enemy minions.
@@ -1917,7 +1917,7 @@ TEST_CASE("[Mage : Spell] - CS2_026 : Frost Nova")
 
 // ------------------------------------------- SPELL - MAGE
 // [CS2_027] Mirror Image - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Summon two 0/2 minions with <b>Taunt</b>.
 // --------------------------------------------------------
@@ -1980,7 +1980,7 @@ TEST_CASE("[Mage : Spell] - CS2_027 : Mirror Image")
 
 // ------------------------------------------- SPELL - MAGE
 // [CS2_029] Fireball - COST:4
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Fire
 // --------------------------------------------------------
 // Text: Deal 6 damage.
@@ -2054,7 +2054,7 @@ TEST_CASE("[Mage : Spell] - CS2_029 : Fireball")
 
 // ------------------------------------------- SPELL - MAGE
 // [CS2_032] Flamestrike - COST:7
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Fire
 // --------------------------------------------------------
 // Text: Deal 5 damage to all enemy minions.
@@ -2105,7 +2105,7 @@ TEST_CASE("[Mage : Spell] - CS2_032 : Flamestrike")
 
 // ------------------------------------------ MINION - MAGE
 // [CS2_033] Water Elemental - COST:4 [ATK:3/HP:6]
-// - Race: Elemental, Faction: Neutral, Set: Basic, Rarity: Free
+// - Race: Elemental, Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Freeze</b> any character damaged by this minion.
 // --------------------------------------------------------
@@ -2162,7 +2162,7 @@ TEST_CASE("[Mage : Minion] - CS2_033 : Water Elemental")
 
 // ------------------------------------------- SPELL - MAGE
 // [EX1_277] Arcane Missiles - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Deal 3 damage randomly split among all enemies.
 // --------------------------------------------------------
@@ -2222,7 +2222,7 @@ TEST_CASE("[Mage : Spell] - EX1_277 : Arcane Missiles")
 
 // ---------------------------------------- SPELL - PALADIN
 // [CS2_087] Blessing of Might - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Holy
 // --------------------------------------------------------
 // Text: Give a minion +3 Attack.
@@ -2267,7 +2267,7 @@ TEST_CASE("[Paladin : SPell] - CS2_087 : Blessing of Might")
 
 // --------------------------------------- MINION - PALADIN
 // [CS2_088] Guardian of Kings - COST:7 [ATK:5/HP:7]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Taunt</b>
 //       <b>Battlecry:</b> Restore 6 Health to your hero.
@@ -2308,7 +2308,7 @@ TEST_CASE("[Paladin : Minion] - CS2_088 : Guardian of Kings")
 
 // ---------------------------------------- SPELL - PALADIN
 // [CS2_089] Holy Light - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Holy
 // --------------------------------------------------------
 // Text: Restore 8 Health to your hero.
@@ -2344,7 +2344,7 @@ TEST_CASE("[Paladin : Spell] - CS2_089 : Holy Light")
 
 // --------------------------------------- WEAPON - PALADIN
 // [CS2_091] Light's Justice - COST:1 [ATK:1/HP:0]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // GameTag:
 // - DURABILITY = 4
@@ -2356,7 +2356,7 @@ TEST_CASE("[Paladin : Weapon] - CS2_091 : Light's Justice")
 
 // ---------------------------------------- SPELL - PALADIN
 // [CS2_092] Blessing of Kings - COST:4
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Holy
 // --------------------------------------------------------
 // Text: Give a minion +4/+4. <i>(+4 Attack/+4 Health)</i>
@@ -2403,7 +2403,7 @@ TEST_CASE("[Paladin : Spell] - CS2_092 : Blessing of Kings")
 
 // ---------------------------------------- SPELL - PALADIN
 // [CS2_093] Consecration - COST:4
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Holy
 // --------------------------------------------------------
 // Text: Deal 2 damage to all enemies.
@@ -2455,7 +2455,7 @@ TEST_CASE("[Paladin : Spell] - CS2_093 : Consecration")
 
 // ---------------------------------------- SPELL - PALADIN
 // [CS2_094] Hammer of Wrath - COST:4
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Holy
 // --------------------------------------------------------
 // Text: Deal 3 damage. Draw a card.
@@ -2506,7 +2506,7 @@ TEST_CASE("[Paladin : Spell] - CS2_094 : Hammer of Wrath")
 
 // --------------------------------------- WEAPON - PALADIN
 // [CS2_097] Truesilver Champion - COST:4 [ATK:4/HP:0]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Whenever your hero attacks, restore 2 Health to it.
 // --------------------------------------------------------
@@ -2551,7 +2551,7 @@ TEST_CASE("[Paladin : Weapon] - CS2_097 : Truesilver Champion")
 
 // ---------------------------------------- SPELL - PALADIN
 // [EX1_360] Humility - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Change a minion's Attack to 1.
 // --------------------------------------------------------
@@ -2601,7 +2601,7 @@ TEST_CASE("[Paladin : Spell] - EX1_360 : Humility")
 
 // ---------------------------------------- SPELL - PALADIN
 // [EX1_371] Hand of Protection - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Holy
 // --------------------------------------------------------
 // Text: Give a minion <b>Divine Shield</b>.
@@ -2663,7 +2663,7 @@ TEST_CASE("[Paladin : Spell] - EX1_371 : Hand of Protection")
 
 // ----------------------------------------- SPELL - PRIEST
 // [CS1_112] Holy Nova - COST:4
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Holy
 // --------------------------------------------------------
 // Text: Deal 2 damage to all enemy minions.
@@ -2739,7 +2739,7 @@ TEST_CASE("[Priest : Spell] - CS1_112 : Holy Nova")
 
 // ----------------------------------------- SPELL - PRIEST
 // [CS1_113] Mind Control - COST:10
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Shadow
 // --------------------------------------------------------
 // Text: Take control of an enemy minion.
@@ -2808,7 +2808,7 @@ TEST_CASE("[Priest : Spell] - CS1_113 : Mind Control")
 
 // ----------------------------------------- SPELL - PRIEST
 // [CS1_130] Holy Smite - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Holy
 // --------------------------------------------------------
 // Text: Deal 3 damage to a minion.
@@ -2880,7 +2880,7 @@ TEST_CASE("[Priest : Spell] - CS1_130 : Holy Smite")
 
 // ----------------------------------------- SPELL - PRIEST
 // [CS2_003] Mind Vision - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Shadow
 // --------------------------------------------------------
 // Text: Put a copy of a random card in your opponent's hand into your hand.
@@ -2928,7 +2928,7 @@ TEST_CASE("[Priest : Spell] - CS2_003 : Mind Vision")
 
 // ----------------------------------------- SPELL - PRIEST
 // [CS2_004] Power Word: Shield - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Holy
 // --------------------------------------------------------
 // Text: Give a minion +2 Health. Draw a card.
@@ -2978,7 +2978,7 @@ TEST_CASE("[Priest : Spell] - CS2_004 : Power Word: Shield")
 
 // ----------------------------------------- SPELL - PRIEST
 // [CS2_234] Shadow Word: Pain - COST:2
-// - Set: Basic, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // - Spell School: Shadow
 // --------------------------------------------------------
 // Text: Destroy a minion with 3 or less Attack.
@@ -3044,7 +3044,7 @@ TEST_CASE("[Priest : Spell] - CS2_234 : Shadow Word: Pain")
 
 // ----------------------------------------- SPELL - PRIEST
 // [EX1_192] Radiance - COST:1
-// - Set: Basic, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // - Spell School: Holy
 // --------------------------------------------------------
 // Text: Restore 5 Health to your hero.
@@ -3086,7 +3086,7 @@ TEST_CASE("[Priest : Spell] - EX1_192 : Radiance")
 
 // ---------------------------------------- MINION - PRIEST
 // [EX1_193] Psychic Conjurer - COST:1 [ATK:1/HP:1]
-// - Set: Basic, Rarity: Common
+// - Set: Legacy, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Copy a card in your opponent's deck
 //       and add it to your hand.
@@ -3135,7 +3135,7 @@ TEST_CASE("[Priest : Minion] - EX1_193 : Psychic Conjurer")
 
 // ----------------------------------------- SPELL - PRIEST
 // [EX1_194] Power Infusion - COST:4
-// - Set: Basic, Rarity: Common
+// - Set: Legacy, Rarity: Common
 // - Spell School: Holy
 // --------------------------------------------------------
 // Text: Give a minion +2/+6.
@@ -3182,7 +3182,7 @@ TEST_CASE("[Priest : Spell] - EX1_194 : Power Infusion")
 
 // ----------------------------------------- SPELL - PRIEST
 // [EX1_622] Shadow Word: Death - COST:2
-// - Set: Basic, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // - Spell School: Shadow
 // --------------------------------------------------------
 // Text: Destroy a minion with 5 or more Attack.
@@ -3250,7 +3250,7 @@ TEST_CASE("[Priest : Spell] - EX1_622 : Shadow Word: Death")
 
 // ------------------------------------------ SPELL - ROGUE
 // [CS2_072] Backstab - COST:0
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Deal 2 damage to an undamaged minion.
 // --------------------------------------------------------
@@ -3307,7 +3307,7 @@ TEST_CASE("[Rogue : Spell] - CS2_072 : Backstab")
 
 // ------------------------------------------ SPELL - ROGUE
 // [CS2_074] Deadly Poison - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Nature
 // --------------------------------------------------------
 // Text: Give your weapon +2 Attack.
@@ -3358,7 +3358,7 @@ TEST_CASE("[Rogue : Spell] - CS2_074 : Deadly Poison")
 
 // ------------------------------------------ SPELL - ROGUE
 // [CS2_075] Sinister Strike - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Deal 3 damage to the enemy hero.
 // --------------------------------------------------------
@@ -3391,7 +3391,7 @@ TEST_CASE("[Rogue : Spell] - CS2_075 : Sinister Strike")
 
 // ------------------------------------------ SPELL - ROGUE
 // [CS2_076] Assassinate - COST:4
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Destroy an enemy minion.
 // --------------------------------------------------------
@@ -3447,7 +3447,7 @@ TEST_CASE("[Rogue : Spell] - CS2_076 : Assassinate")
 
 // ------------------------------------------ SPELL - ROGUE
 // [CS2_077] Sprint - COST:6
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Draw 4 cards.
 // --------------------------------------------------------
@@ -3481,7 +3481,7 @@ TEST_CASE("[Rogue : Spell] - CS2_077 : Sprint")
 
 // ----------------------------------------- WEAPON - ROGUE
 // [CS2_080] Assassin's Blade - COST:4 [ATK:2/HP:0]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // GameTag:
 // - DURABILITY = 5
@@ -3493,7 +3493,7 @@ TEST_CASE("[Rogue : Weapon] - CS2_080 : Assassin's Blade")
 
 // ------------------------------------------ SPELL - ROGUE
 // [EX1_129] Fan of Knives - COST:3
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Deal 1 damage to all enemy minions. Draw a card.
 // --------------------------------------------------------
@@ -3555,7 +3555,7 @@ TEST_CASE("[Rogue : Spell] - EX1_129 : Fan of Knives")
 
 // ----------------------------------------- MINION - ROGUE
 // [EX1_191] Plaguebringer - COST:4 [ATK:3/HP:3]
-// - Set: Basic, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Give a friendly minion <b>Poisonous</b>.
 // --------------------------------------------------------
@@ -3612,7 +3612,7 @@ TEST_CASE("[Rogue : Minion] - EX1_191 : Plaguebringer")
 
 // ------------------------------------------ SPELL - ROGUE
 // [EX1_278] Shiv - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Deal 1 damage. Draw a card.
 // --------------------------------------------------------
@@ -3674,7 +3674,7 @@ TEST_CASE("[Rogue : Spell] - EX1_278 : Shiv")
 
 // ------------------------------------------ SPELL - ROGUE
 // [EX1_581] Sap - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Return an enemy minion to your opponent's hand.
 // --------------------------------------------------------
@@ -3747,7 +3747,7 @@ TEST_CASE("[Rogue : Spell] - EX1_581 : Sap")
 
 // ----------------------------------------- SPELL - SHAMAN
 // [CS2_037] Frost Shock - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Frost
 // --------------------------------------------------------
 // Text: Deal 1 damage to an enemy character and <b>Freeze</b> it.
@@ -3810,7 +3810,7 @@ TEST_CASE("[Shaman : Spell] - CS2_037 : Frost Shock")
 
 // ----------------------------------------- SPELL - SHAMAN
 // [CS2_039] Windfury - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Nature
 // --------------------------------------------------------
 // Text: Give a minion <b>Windfury</b>.
@@ -3873,7 +3873,7 @@ TEST_CASE("[Shaman : Spell] - CS2_039 : Windfury")
 
 // ----------------------------------------- SPELL - SHAMAN
 // [CS2_041] Ancestral Healing - COST:0
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Nature
 // --------------------------------------------------------
 // Text: Restore a minion
@@ -3937,7 +3937,7 @@ TEST_CASE("[Shaman : Spell] - CS2_041 : Ancestral Healing")
 
 // ---------------------------------------- MINION - SHAMAN
 // [CS2_042] Fire Elemental - COST:6 [ATK:6/HP:5]
-// - Race: Elemental, Faction: Neutral, Set: Basic, Rarity: Free
+// - Race: Elemental, Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Deal 4 damage.
 // --------------------------------------------------------
@@ -3995,7 +3995,7 @@ TEST_CASE("[Shaman : Minion] - CS2_042 : Fire Elemental")
 
 // ----------------------------------------- SPELL - SHAMAN
 // [CS2_045] Rockbiter Weapon - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Nature
 // --------------------------------------------------------
 // Text: Give a friendly character +3 Attack this turn.
@@ -4053,7 +4053,7 @@ TEST_CASE("[Shaman : Spell] - CS2_045 : Rockbiter Weapon")
 
 // ----------------------------------------- SPELL - SHAMAN
 // [CS2_046] Bloodlust - COST:5
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Give your minions +3 Attack this turn.
 // --------------------------------------------------------
@@ -4111,7 +4111,7 @@ TEST_CASE("[Shaman : Spell] - CS2_046 : Bloodlust")
 
 // ----------------------------------------- SPELL - SHAMAN
 // [EX1_244] Totemic Might - COST:0
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Give your Totems +2 Health.
 // --------------------------------------------------------
@@ -4165,7 +4165,7 @@ TEST_CASE("[Shaman : Spell] - EX1_244 : Totemic Might")
 
 // ----------------------------------------- SPELL - SHAMAN
 // [EX1_246] Hex - COST:4
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Nature
 // --------------------------------------------------------
 // Text: Transform a minion into a 0/1 Frog with <b>Taunt</b>.
@@ -4234,7 +4234,7 @@ TEST_CASE("[Shaman : Spell] - EX1_246 : Hex")
 
 // ---------------------------------------- MINION - SHAMAN
 // [EX1_565] Flametongue Totem - COST:2 [ATK:0/HP:2]
-// - Race: Totem, Faction: Neutral, Set: Basic, Rarity: Free
+// - Race: Totem, Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Adjacent minions have +2 Attack.
 // --------------------------------------------------------
@@ -4347,7 +4347,7 @@ TEST_CASE("[Shaman : Minion] - EX1_565 : Flametongue Totem")
 
 // ---------------------------------------- MINION - SHAMAN
 // [EX1_587] Windspeaker - COST:4 [ATK:3/HP:3]
-// - Faction: Neutral, Set: Basic, Rarity: free
+// - Faction: Neutral, Set: Legacy, Rarity: free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Give a friendly minion <b>Windfury</b>.
 // --------------------------------------------------------
@@ -4415,7 +4415,7 @@ TEST_CASE("[Shaman : Minion] - EX1_587 : Windspeaker")
 
 // ---------------------------------------- SPELL - WARLOCK
 // [CS2_057] Shadow Bolt - COST:3
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Shadow
 // --------------------------------------------------------
 // Text: Deal 4 damage to a minion.
@@ -4471,7 +4471,7 @@ TEST_CASE("[Warlock : Spell] - CS2_057 : Shadow Bolt")
 
 // ---------------------------------------- SPELL - WARLOCK
 // [CS2_061] Drain Life - COST:3
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Shadow
 // --------------------------------------------------------
 // Text: Deal 2 damage. Restore 2 Health to your hero.
@@ -4520,7 +4520,7 @@ TEST_CASE("[Warlock : Spell] - CS2_061 : Drain Life")
 
 // ---------------------------------------- SPELL - WARLOCK
 // [CS2_062] Hellfire - COST:4
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Fire
 // --------------------------------------------------------
 // Text: Deal 3 damage to all characters.
@@ -4584,7 +4584,7 @@ TEST_CASE("[Warlock : Spell] - CS2_062 : Hellfire")
 
 // ---------------------------------------- SPELL - WARLOCK
 // [CS2_063] Corruption - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Choose an enemy minion. At the start of your turn, destroy it.
 // --------------------------------------------------------
@@ -4645,7 +4645,7 @@ TEST_CASE("[Warlock : Spell] - CS2_063 : Corruption")
 
 // --------------------------------------- MINION - WARLOCK
 // [CS2_064] Dread Infernal - COST:6 [ATK:6/HP:6]
-// - Race: Demon, Faction: Neutral, Set: Basic, Rarity: Free
+// - Race: Demon, Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Deal 1 damage to all other characters.
 // --------------------------------------------------------
@@ -4693,7 +4693,7 @@ TEST_CASE("[Warlock : Minion] - CS2_064 : Dread Infernal")
 
 // --------------------------------------- MINION - WARLOCK
 // [CS2_065] Voidwalker - COST:1 [ATK:1/HP:3]
-// - Race: Demon, Faction: Neutral, Set: Basic, Rarity: Free
+// - Race: Demon, Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Taunt</b>
 // --------------------------------------------------------
@@ -4707,7 +4707,7 @@ TEST_CASE("[Warlock : Minion] - CS2_065 : Voidwalker")
 
 // ---------------------------------------- SPELL - WARLOCK
 // [EX1_302] Mortal Coil - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Shadow
 // --------------------------------------------------------
 // Text: Deal 1 damage to a minion. If that kills it, draw a card.
@@ -4764,7 +4764,7 @@ TEST_CASE("[Warlock : Spell] - EX1_302 : Mortal Coil")
 
 // --------------------------------------- MINION - WARLOCK
 // [EX1_306] Felstalker - COST:2 [ATK:4/HP:3]
-// - Faction: Horde, Set: Basic, Rarity: Free
+// - Faction: Horde, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Discard a random card.
 // --------------------------------------------------------
@@ -4808,7 +4808,7 @@ TEST_CASE("[Warlock : Minion] - EX1_306 : Felstalker")
 
 // ---------------------------------------- SPELL - WARLOCK
 // [EX1_308] Soulfire - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Fire
 // --------------------------------------------------------
 // Text: Deal 4 damage. Discard a random card.
@@ -4868,7 +4868,7 @@ TEST_CASE("[Warlock : Spell] - EX1_308 : Soulfire")
 
 // ---------------------------------------- SPELL - WARLOCK
 // [NEW1_003] Sacrificial Pact - COST:0
-// - Set: Basic, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // - Spell School: Shadow
 // --------------------------------------------------------
 // Text: Destroy a friendly Demon. Restore 5 Health to your hero.
@@ -4923,7 +4923,7 @@ TEST_CASE("[Warlock : Spell] - NEW1_003 : Sacrificial Pact")
 
 // ---------------------------------------- SPELL - WARRIOR
 // [CS2_103] Charge - COST:3
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Give a friendly minion +2 Attack and <b>Charge</b>.
 // --------------------------------------------------------
@@ -4979,7 +4979,7 @@ TEST_CASE("[Warrior : Spell] - CS2_103 : Charge")
 
 // ---------------------------------------- SPELL - WARRIOR
 // [CS2_105] Heroic Strike - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Give your hero +4 Attack this turn.
 // --------------------------------------------------------
@@ -5043,7 +5043,7 @@ TEST_CASE("[Warrior : Spell] - CS2_105 : Heroic Strike")
 
 // --------------------------------------- WEAPON - WARRIOR
 // [CS2_106] Fiery War Axe - COST:3 [ATK:3/HP:0]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // GameTag:
 // - DURABILITY = 2
@@ -5055,7 +5055,7 @@ TEST_CASE("[Warrior : Weapon] - CS2_106 : Fiery War Axe")
 
 // ---------------------------------------- SPELL - WARRIOR
 // [CS2_108] Execute - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Destroy a damaged enemy minion.
 // --------------------------------------------------------
@@ -5114,7 +5114,7 @@ TEST_CASE("[Warrior : Spell] - CS2_108 : Execute")
 
 // --------------------------------------- WEAPON - WARRIOR
 // [CS2_112] Arcanite Reaper - COST:5 [ATK:5/HP:0]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // GameTag:
 // - DURABILITY = 2
@@ -5126,7 +5126,7 @@ TEST_CASE("[Warrior : Weapon] - CS2_112 : Arcanite Reaper")
 
 // ---------------------------------------- SPELL - WARRIOR
 // [CS2_114] Cleave - COST:2
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Deal 2 damage to two random enemy minions.
 // --------------------------------------------------------
@@ -5193,7 +5193,7 @@ TEST_CASE("[Warrior : Spell] - CS2_114 : Cleave")
 
 // --------------------------------------- MINION - WARRIOR
 // [EX1_084] Warsong Commander - COST:3 [ATK:2/HP:3]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: After you summon another minion, give it <b>Rush</b>.
 // --------------------------------------------------------
@@ -5242,7 +5242,7 @@ TEST_CASE("[Warrior : Minion] - EX1_084 : Warsong Commander")
 
 // ---------------------------------------- SPELL - WARRIOR
 // [EX1_400] Whirlwind - COST:1
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Deal 1 damage to all minions.
 // --------------------------------------------------------
@@ -5309,7 +5309,7 @@ TEST_CASE("[Warrior : Spell] - EX1_400 : Whirlwind")
 
 // ---------------------------------------- SPELL - WARRIOR
 // [EX1_606] Shield Block - COST:3
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Gain 5 Armor.
 //       Draw a card.
@@ -5345,7 +5345,7 @@ TEST_CASE("[Warrior : Spell] - EX1_606 : Shield Block")
 
 // --------------------------------------- MINION - WARRIOR
 // [NEW1_011] Kor'kron Elite - COST:4 [ATK:4/HP:3]
-// - Set: Basic, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Charge</b>
 // --------------------------------------------------------
@@ -5359,7 +5359,7 @@ TEST_CASE("[Warrior : Minion] - NEW1_011 : Kor'kron Elite")
 
 // ------------------------------------ SPELL - DEMONHUNTER
 // [BT_035] Chaos Strike - COST:2
-// - Set: Basic, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // - Spell School: Fel
 // --------------------------------------------------------
 // Text: Give your hero +2 Attack this turn. Draw a card.
@@ -5404,7 +5404,7 @@ TEST_CASE("[Demon Hunter : Spell] - BT_035 : Chaos Strike")
 
 // ------------------------------------ SPELL - DEMONHUNTER
 // [BT_036] Coordinated Strike - COST:3
-// - Set: Basic, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Summon three 1/1 Illidari with <b>Rush</b>.
 // --------------------------------------------------------
@@ -5465,7 +5465,7 @@ TEST_CASE("[Demon Hunter : Spell] - BT_036 : Coordinated Strike")
 
 // ----------------------------------- MINION - DEMONHUNTER
 // [BT_142] Shadowhoof Slayer (*) - COST:1 [ATK:2/HP:1]
-// - Race: Demon, Set: Basic, Rarity: Free
+// - Race: Demon, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Give your hero +1 Attack this turn.
 // --------------------------------------------------------
@@ -5509,7 +5509,7 @@ TEST_CASE("[Demon Hunter : Minion] - BT_142 : Shadowhoof Slayer")
 
 // ------------------------------------ SPELL - DEMONHUNTER
 // [BT_235] Chaos Nova - COST:5
-// - Set: Basic, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // - Spell School: Fel
 // --------------------------------------------------------
 // Text: Deal 4 damage to all minions.
@@ -5565,7 +5565,7 @@ TEST_CASE("[Demon Hunter : Spell] - BT_235 : Chaos Nova")
 
 // ----------------------------------- MINION - DEMONHUNTER
 // [BT_323] Sightless Watcher (*) - COST:2 [ATK:3/HP:2]
-// - Race: Demon, Set: Basic, Rarity: Free
+// - Race: Demon, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Look at 3 cards in your deck.
 //       Choose one to put on top.
@@ -5633,7 +5633,7 @@ TEST_CASE("[Demon Hunter : Minion] - BT_323 : Sightless Watcher")
 
 // ----------------------------------- MINION - DEMONHUNTER
 // [BT_352] Satyr Overseer (*) - COST:3 [ATK:4/HP:2]
-// - Race: Demon, Set: Basic, Rarity: Free
+// - Race: Demon, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: After your hero attacks, summon a 2/2 Satyr.
 // --------------------------------------------------------
@@ -5679,7 +5679,7 @@ TEST_CASE("[Demon Hunter : Minion] - BT_352 : Satyr Overseer")
 
 // ----------------------------------- MINION - DEMONHUNTER
 // [BT_495] Glaivebound Adept (*) - COST:5 [ATK:6/HP:4]
-// - Set: Basic, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> If your hero attacked this turn,
 //       deal 4 damage.
@@ -5733,7 +5733,7 @@ TEST_CASE("[Demon Hunter : Minion] - BT_495 : Glaivebound Adept")
 
 // ------------------------------------ SPELL - DEMONHUNTER
 // [BT_512] Inner Demon - COST:8
-// - Set: Basic, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Give your hero +8 Attack this turn.
 // --------------------------------------------------------
@@ -5774,7 +5774,7 @@ TEST_CASE("[Demon Hunter : Spell] - BT_512 : Inner Demon")
 
 // ------------------------------------ SPELL - DEMONHUNTER
 // [BT_740] Soul Cleave - COST:3
-// - Set: Basic, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // - Spell School: Shadow
 // --------------------------------------------------------
 // Text: <b>Lifesteal</b> Deal 2 damage to two random enemy minions.
@@ -5850,7 +5850,7 @@ TEST_CASE("[Demon Hunter : Spell] - BT_740 : Soul Cleave")
 
 // ----------------------------------- WEAPON - DEMONHUNTER
 // [BT_921] Aldrachi Warblades - COST:3 [ATK:2/HP:0]
-// - Set: Basic, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Lifesteal</b>
 // --------------------------------------------------------
@@ -5903,7 +5903,7 @@ TEST_CASE("[Demon Hunter : Weapon] - BT_921 : Aldrachi Warblades")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS1_042] Goldshire Footman - COST:1 [ATK:1/HP:2]
-// - Faction: Alliance, Set: Basic, Rarity: Free
+// - Faction: Alliance, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Taunt</b>
 // --------------------------------------------------------
@@ -5917,7 +5917,7 @@ TEST_CASE("[Neutral : Minion] - CS1_042 : Goldshire Footman")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_118] Magma Rager - COST:3 [ATK:5/HP:1]
-// - Race: Elemental, Set: Basic, Rarity: Free
+// - Race: Elemental, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 TEST_CASE("[Neutral : Minion] - CS2_118 : Magma Rager")
 {
@@ -5926,7 +5926,7 @@ TEST_CASE("[Neutral : Minion] - CS2_118 : Magma Rager")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_119] Oasis Snapjaw - COST:4 [ATK:2/HP:7]
-// - Race: Beast, Set: Basic, Rarity: Free
+// - Race: Beast, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 TEST_CASE("[Neutral : Minion] - CS2_119 : Oasis Snapjaw")
 {
@@ -5935,7 +5935,7 @@ TEST_CASE("[Neutral : Minion] - CS2_119 : Oasis Snapjaw")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_120] River Crocolisk - COST:2 [ATK:2/HP:3]
-// - Race: Beast, Set: Basic, Rarity: Free
+// - Race: Beast, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 TEST_CASE("[Neutral : Minion] - CS2_120 : River Crocolisk")
 {
@@ -5944,7 +5944,7 @@ TEST_CASE("[Neutral : Minion] - CS2_120 : River Crocolisk")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_121] Frostwolf Grunt - COST:2 [ATK:2/HP:2]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Taunt</b>
 // --------------------------------------------------------
@@ -5958,7 +5958,7 @@ TEST_CASE("[Neutral : Minion] - CS2_121 : Frostwolf Grunt")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_122] Raid Leader - COST:3 [ATK:2/HP:3]
-// - Set: Basic, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Your other minions have +1 Attack.
 // --------------------------------------------------------
@@ -6010,7 +6010,7 @@ TEST_CASE("[Neutral : Minion] - CS2_122 : Raid Leader")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_124] Wolfrider - COST:3 [ATK:3/HP:1]
-// - Faction: Horde, Set: Basic, Rarity: Free
+// - Faction: Horde, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Charge</b>
 // --------------------------------------------------------
@@ -6024,7 +6024,7 @@ TEST_CASE("[Neutral : Minion] - CS2_124 : Wolfrider")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_125] Ironfur Grizzly - COST:3 [ATK:3/HP:3]
-// - Race: Beast, Faction: Neutral, Set: Basic, Rarity: Free
+// - Race: Beast, Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Taunt</b>
 // --------------------------------------------------------
@@ -6038,7 +6038,7 @@ TEST_CASE("[Neutral : Minion] - CS2_125 : Ironfur Grizzly")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_127] Silverback Patriarch - COST:3 [ATK:1/HP:4]
-// - Race: Beast, Faction: Horde, Set: Basic, Rarity: Free
+// - Race: Beast, Faction: Horde, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Taunt</b>
 // --------------------------------------------------------
@@ -6052,7 +6052,7 @@ TEST_CASE("[Neutral : Minion] - CS2_127 : Silverback Patriarch")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_131] Stormwind Knight - COST:4 [ATK:2/HP:5]
-// - Faction: Alliance, Set: Basic, Rarity: Free
+// - Faction: Alliance, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Charge</b>
 // --------------------------------------------------------
@@ -6066,7 +6066,7 @@ TEST_CASE("[Neutral : Minion] - CS2_131 : Stormwind Knight")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_141] Ironforge Rifleman - COST:3 [ATK:2/HP:2]
-// - Faction: Alliance, Set: Basic, Rarity: Free
+// - Faction: Alliance, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Deal 1 damage.
 // --------------------------------------------------------
@@ -6119,7 +6119,7 @@ TEST_CASE("[Neutral : Minion] - CS2_141 : Ironforge Rifleman")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_142] Kobold Geomancer - COST:2 [ATK:2/HP:2]
-// - Faction: Horde, Set: Basic, Rarity: Free
+// - Faction: Horde, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Spell Damage +1</b>
 // --------------------------------------------------------
@@ -6133,7 +6133,7 @@ TEST_CASE("[Neutral : Minion] - CS2_142 : Kobold Geomancer")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_147] Gnomish Inventor - COST:4 [ATK:2/HP:4]
-// - Faction: Alliance, Set: Basic, Rarity: Free
+// - Faction: Alliance, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Draw a card.
 // --------------------------------------------------------
@@ -6170,7 +6170,7 @@ TEST_CASE("[Neutral : Minion] - CS2_147 : Gnomish Inventor")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_150] Stormpike Commando - COST:5 [ATK:4/HP:2]
-// - Faction: Alliance, Set: Basic, Rarity: Free
+// - Faction: Alliance, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Deal 2 damage.
 // --------------------------------------------------------
@@ -6229,7 +6229,7 @@ TEST_CASE("[Neutral : Minion] - CS2_150 : Stormpike Commando")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_155] Archmage - COST:6 [ATK:4/HP:7]
-// - Faction: Alliance, Set: Basic, Rarity: Free
+// - Faction: Alliance, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Spell Damage +1</b>
 // --------------------------------------------------------
@@ -6243,7 +6243,7 @@ TEST_CASE("[Neutral : Minion] - CS2_155 : Archmage")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_162] Lord of the Arena - COST:6 [ATK:6/HP:5]
-// - Faction: Alliance, Set: Basic, Rarity: Free
+// - Faction: Alliance, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Taunt</b>
 // --------------------------------------------------------
@@ -6257,7 +6257,7 @@ TEST_CASE("[Neutral : Minion] - CS2_162 : Lord of the Arena")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_168] Murloc Raider - COST:1 [ATK:2/HP:1]
-// - Race: Murloc, Faction: Alliance, Set: Basic, Rarity: Free
+// - Race: Murloc, Faction: Alliance, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 TEST_CASE("[Neutral : Minion] - CS2_168 : Murloc Raider")
 {
@@ -6266,7 +6266,7 @@ TEST_CASE("[Neutral : Minion] - CS2_168 : Murloc Raider")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_171] Stonetusk Boar - COST:1 [ATK:1/HP:1]
-// - Race: Beast, Faction: Neutral, Set: Basic, Rarity: Free
+// - Race: Beast, Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Charge</b>
 // --------------------------------------------------------
@@ -6280,7 +6280,7 @@ TEST_CASE("[Neutral : Minion] - CS2_171 : Stonetusk Boar")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_172] Bloodfen Raptor - COST:2 [ATK:3/HP:2]
-// - Race: Beast, Faction: Horde, Set: Basic, Rarity: Free
+// - Race: Beast, Faction: Horde, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 TEST_CASE("[Neutral : Minion] - CS2_172 : Bloodfen Raptor")
 {
@@ -6289,7 +6289,7 @@ TEST_CASE("[Neutral : Minion] - CS2_172 : Bloodfen Raptor")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_173] Bluegill Warrior - COST:2 [ATK:2/HP:1]
-// - Race: Murloc, Faction: Neutral, Set: Basic, Rarity: Free
+// - Race: Murloc, Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Charge</b>
 // --------------------------------------------------------
@@ -6303,7 +6303,7 @@ TEST_CASE("[Neutral : Minion] - CS2_173 : Bluegill Warrior")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_179] Sen'jin Shieldmasta - COST:4 [ATK:3/HP:5]
-// - Faction: Horde, Set: Basic, Rarity: Free
+// - Faction: Horde, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Taunt</b>
 // --------------------------------------------------------
@@ -6317,7 +6317,7 @@ TEST_CASE("[Neutral : Minion] - CS2_179 : Sen'jin Shieldmasta")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_182] Chillwind Yeti - COST:4 [ATK:4/HP:5]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 TEST_CASE("[Neutral : Minion] - CS2_182 : Chillwind Yeti")
 {
@@ -6326,7 +6326,7 @@ TEST_CASE("[Neutral : Minion] - CS2_182 : Chillwind Yeti")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_186] War Golem - COST:7 [ATK:7/HP:7]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 TEST_CASE("[Neutral : Minion] - CS2_186 : War Golem")
 {
@@ -6335,7 +6335,7 @@ TEST_CASE("[Neutral : Minion] - CS2_186 : War Golem")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_187] Booty Bay Bodyguard - COST:5 [ATK:5/HP:4]
-// - Faction: Horde, Set: Basic, Rarity: Free
+// - Faction: Horde, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Taunt</b>
 // --------------------------------------------------------
@@ -6349,7 +6349,7 @@ TEST_CASE("[Neutral : Minion] - CS2_187 : Booty Bay Bodyguard")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_189] Elven Archer - COST:1 [ATK:1/HP:1]
-// - Faction: Horde, Set: Basic, Rarity: Free
+// - Faction: Horde, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Deal 1 damage.
 // --------------------------------------------------------
@@ -6402,7 +6402,7 @@ TEST_CASE("[Neutral : Minion] - CS2_189 : Elven Archer")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_196] Razorfen Hunter - COST:3 [ATK:2/HP:3]
-// - Faction: Horde, Set: Basic, Rarity: Free
+// - Faction: Horde, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Summon a 1/1 Boar.
 // --------------------------------------------------------
@@ -6443,7 +6443,7 @@ TEST_CASE("[Neutral : Minion] - CS2_196 : Razorfen Hunter")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_197] Ogre Magi - COST:4 [ATK:4/HP:4]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Spell Damage +1</b>
 // --------------------------------------------------------
@@ -6457,7 +6457,7 @@ TEST_CASE("[Neutral : Minion] - CS2_197 : Ogre Magi")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_200] Boulderfist Ogre - COST:6 [ATK:6/HP:7]
-// - Set: Basic, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 TEST_CASE("[Neutral : Minion] - CS2_200 : Boulderfist Ogre")
 {
@@ -6466,7 +6466,7 @@ TEST_CASE("[Neutral : Minion] - CS2_200 : Boulderfist Ogre")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_201] Core Hound - COST:7 [ATK:9/HP:5]
-// - Race: Beast, Set: Basic, Rarity: Free
+// - Race: Beast, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 TEST_CASE("[Neutral : Minion] - CS2_201 : Core Hound")
 {
@@ -6475,7 +6475,7 @@ TEST_CASE("[Neutral : Minion] - CS2_201 : Core Hound")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_213] Reckless Rocketeer - COST:6 [ATK:5/HP:2]
-// - Faction: Horde, Set: Basic, Rarity: Free
+// - Faction: Horde, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Charge</b>
 // --------------------------------------------------------
@@ -6489,7 +6489,7 @@ TEST_CASE("[Neutral : Minion] - CS2_213 : Reckless Rocketeer")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_222] Stormwind Champion - COST:7 [ATK:7/HP:7]
-// - Faction: Alliance, Set: Basic, Rarity: Free
+// - Faction: Alliance, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Your other minions have +1/+1.
 // --------------------------------------------------------
@@ -6559,7 +6559,7 @@ TEST_CASE("[Neutral : Minion] - CS2_222 : Stormwind Champion")
 
 // --------------------------------------- MINION - NEUTRAL
 // [CS2_226] Frostwolf Warlord - COST:5 [ATK:4/HP:4]
-// - Faction: Horde, Set: Basic, Rarity: Free
+// - Faction: Horde, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Gain +1/+1 for each other friendly minion on the
 // battlefield.
@@ -6617,7 +6617,7 @@ TEST_CASE("[Neutral : Minion] - CS2_226 : Frostwolf Warlord")
 
 // --------------------------------------- MINION - NEUTRAL
 // [DS1_055] Darkscale Healer - COST:5 [ATK:4/HP:5]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Restore 2 Health to all friendly characters.
 // --------------------------------------------------------
@@ -6675,7 +6675,7 @@ TEST_CASE("[Neutral : Minion] - DS1_055 : Darkscale Healer")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_011] Voodoo Doctor - COST:1 [ATK:2/HP:1]
-// - Faction: Horde, Set: Basic, Rarity: Free
+// - Faction: Horde, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Restore 2 Health.
 // --------------------------------------------------------
@@ -6734,7 +6734,7 @@ TEST_CASE("[Neutral : Minion] - EX1_011 : Voodoo Doctor")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_015] Novice Engineer - COST:2 [ATK:1/HP:1]
-// - Faction: Alliance, Set: Basic, Rarity: Free
+// - Faction: Alliance, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Draw a card.
 // --------------------------------------------------------
@@ -6771,7 +6771,7 @@ TEST_CASE("[Neutral : Minion] - EX1_015 : Novice Engineer")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_019] Shattered Sun Cleric - COST:3 [ATK:3/HP:2]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Give a friendly minion +1/+1.
 // --------------------------------------------------------
@@ -6821,7 +6821,7 @@ TEST_CASE("[Neutral : Minion] - EX1_019 : Shattered Sun Cleric")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_025] Dragonling Mechanic - COST:4 [ATK:2/HP:4]
-// - Faction: Alliance, Set: Basic, Rarity: Free
+// - Faction: Alliance, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Summon a 2/1 Mechanical Dragonling.
 // --------------------------------------------------------
@@ -6861,7 +6861,7 @@ TEST_CASE("[Neutral : Minion] - EX1_025 : Dragonling Mechanic")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_066] Acidic Swamp Ooze - COST:2 [ATK:3/HP:2]
-// - Faction: Alliance, Set: Basic, Rarity: Free
+// - Faction: Alliance, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Destroy your opponent's weapon.
 // --------------------------------------------------------
@@ -6905,7 +6905,7 @@ TEST_CASE("[Neutral : Minion] - EX1_066 : Acidic Swamp Ooze")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_399] Gurubashi Berserker - COST:5 [ATK:2/HP:8]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Whenever this minion takes damage, gain +3 Attack.
 // --------------------------------------------------------
@@ -6955,7 +6955,7 @@ TEST_CASE("[Neutral : Minion] - EX1_399 : Gurubashi Berserker")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_506] Murloc Tidehunter - COST:2 [ATK:2/HP:1]
-// - Race: Murloc, Faction: Neutral, Set: Basic, Rarity: Free
+// - Race: Murloc, Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Summon a 1/1 Murloc Scout.
 // --------------------------------------------------------
@@ -6995,7 +6995,7 @@ TEST_CASE("[Neutral : Minion] - EX1_506 : Murloc Tidehunter")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_508] Grimscale Oracle - COST:1 [ATK:1/HP:1]
-// - Race: Murloc, Faction: Neutral, Set: Basic, Rarity: Free
+// - Race: Murloc, Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Your other Murlocs have +1 Attack.
 // --------------------------------------------------------
@@ -7069,7 +7069,7 @@ TEST_CASE("[Neutral : Minion] - EX1_508 : Grimscale Oracle")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_582] Dalaran Mage - COST:3 [ATK:1/HP:4]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Spell Damage +1</b>
 // --------------------------------------------------------
@@ -7083,7 +7083,7 @@ TEST_CASE("[Neutral : Minion] - EX1_582 : Dalaran Mage")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_593] Nightblade - COST:5 [ATK:4/HP:4]
-// - Faction: Neutral, Set: Basic, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry: </b>Deal 3 damage to the enemy hero.
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/HoFCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/HoFCardsGenTests.cpp
@@ -20,7 +20,7 @@ using namespace SimpleTasks;
 
 // ------------------------------------------ SPELL - DRUID
 // [EX1_161] Naturalize - COST:1
-// - Faction: Neutral, Set: HoF, Rarity: Common
+// - Faction: Neutral, Set: Legacy, Rarity: Common
 // - Spell School: Nature
 // --------------------------------------------------------
 // Text: Destroy a minion. Your opponent draws 2 cards.
@@ -68,7 +68,7 @@ TEST_CASE("[Druid : Spell] - EX1_161 : Naturalize")
 
 // ------------------------------------------- SPELL - MAGE
 // [CS2_031] Ice Lance - COST:1
-// - Faction: Neutral, Set: HoF, Rarity: Common
+// - Faction: Neutral, Set: Legacy, Rarity: Common
 // - Spell School: Frost
 // --------------------------------------------------------
 // Text: <b>Freeze</b> a character. If it was already <b>Frozen</b>,
@@ -140,7 +140,7 @@ TEST_CASE("[Mage : Spell] - CS2_031 : Ice Lance")
 
 // ----------------------------------------- SPELL - PALADIN
 // [EX1_349] Divine Favor - COST:3
-// - Faction: Neutral, Set: HoF, Rarity: Rare
+// - Faction: Neutral, Set: Legacy, Rarity: Rare
 // - Spell School: Holy
 // --------------------------------------------------------
 // Text: Draw cards until you have as many in hand
@@ -182,7 +182,7 @@ TEST_CASE("[Paladin : Spell] - EX1_349 : Divine Favor")
 
 // ---------------------------------------- MINION - PRIEST
 // [CS2_235] Northshire Cleric - COST:1 [ATK:1/HP:3]
-// - Set: HoF, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Whenever a minion is healed, draw a card.
 // --------------------------------------------------------
@@ -233,7 +233,7 @@ TEST_CASE("[Priest : Minion] - CS2_235 : Northshire Cleric")
 
 // ----------------------------------------- SPELL - PRIEST
 // [CS2_236] Divine Spirit - COST:2
-// - Set: HoF, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // - Spell School: Holy
 // --------------------------------------------------------
 // Text: Double a minion's Health.
@@ -290,7 +290,7 @@ TEST_CASE("[Priest : Spell] - CS2_236 : Divine Spirit")
 
 // ----------------------------------------- SPELL - PRIEST
 // [DS1_233] Mind Blast - COST:2
-// - Faction: Neutral, Set: HoF, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Shadow
 // --------------------------------------------------------
 // Text: Deal 5 damage to the enemy hero.
@@ -324,7 +324,7 @@ TEST_CASE("[Priest : Spell] - DS1_233 : Mind Blast")
 
 // ---------------------------------------- MINION - PRIEST
 // [EX1_350] Prophet Velen - COST:7 [ATK:7/HP:7]
-// - Faction: Neutral, Set: HoF, Rarity: Legendary
+// - Faction: Neutral, Set: Legacy, Rarity: Legendary
 // --------------------------------------------------------
 // Text: Double the damage and healing of your spells and Hero Power.
 // --------------------------------------------------------
@@ -415,7 +415,7 @@ TEST_CASE("[Priest : Minion] - EX1_350 : Prophet Velen")
 
 // ---------------------------------------- MINION - PRIEST
 // [EX1_591] Auchenai Soulpriest - COST:4 [ATK:3/HP:5]
-// - Faction: Neutral, Set: HoF, Rarity: Rare
+// - Faction: Neutral, Set: Legacy, Rarity: Rare
 // --------------------------------------------------------
 // Text: Your cards and powers that restore Health
 //       now deal damage instead.
@@ -484,7 +484,7 @@ TEST_CASE("[Priest : Minion] - EX1_591 : Auchenai Soulpriest")
 
 // ----------------------------------------- SPELL - PRIEST
 // [EX1_624] Holy Fire - COST:6
-// - Faction: Priest, Set: HoF, Rarity: Rare
+// - Faction: Priest, Set: Legacy, Rarity: Rare
 // - Spell School: Holy
 // --------------------------------------------------------
 // Text: Deal 5 damage. Restore 5 Health to your hero.
@@ -524,7 +524,7 @@ TEST_CASE("[Priest : Spell] - EX1_624 : Holy Fire")
 
 // ------------------------------------------ SPELL - ROGUE
 // [EX1_128] Conceal - COST:1
-// - Faction: Neutral, Set: HoF, Rarity: Common
+// - Faction: Neutral, Set: Legacy, Rarity: Common
 // - Spell School: Shadow
 // --------------------------------------------------------
 // Text: Give your minions <b>Stealth</b> until your next turn.
@@ -594,7 +594,7 @@ TEST_CASE("[Rogue : Spell] - EX1_128 : Conceal")
 
 // ------------------------------------------ SPELL - ROGUE
 // [NEW1_004] Vanish - COST:6
-// - Set: HoF, Rarity: Free
+// - Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Return all minions to their owner's hand.
 // --------------------------------------------------------
@@ -651,7 +651,7 @@ TEST_CASE("[Rogue : Spell] - NEW1_004 : Vanish")
 
 // --------------------------------------- MINION - WARLOCK
 // [EX1_310] Doomguard - COST:5 [ATK:5/HP:7]
-// - Race: Demon, Set: HoF, Rarity: Rare
+// - Race: Demon, Set: Legacy, Rarity: Rare
 // --------------------------------------------------------
 // Text: <b>Charge</b>. <b>Battlecry:</b> Discard two random cards.
 // --------------------------------------------------------
@@ -699,7 +699,7 @@ TEST_CASE("[Warlock : Minion] - EX1_310 : Doomguard")
 
 // ---------------------------------------- SPELL - WARLOCK
 // [EX1_316] Power Overwhelming - COST:1
-// - Faction: Neutral, Set: HoF, Rarity: Common
+// - Faction: Neutral, Set: Legacy, Rarity: Common
 // - Spell School: Shadow
 // --------------------------------------------------------
 // Text: Give a friendly minion +4/+4 until end of turn.
@@ -763,7 +763,7 @@ TEST_CASE("[Warlock : Spell] - EX1_316 : Power Overwhelming")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_007] Acolyte of Pain - COST:3 [ATK:1/HP:3]
-// - Set: HoF, Rarity: Common
+// - Set: Legacy, Rarity: Common
 // --------------------------------------------------------
 // Text: Whenever this minion takes damage, draw a card.
 // --------------------------------------------------------
@@ -806,7 +806,7 @@ TEST_CASE("[Neutral : Minion] - EX1_007 : Acolyte of Pain")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_016] Sylvanas Windrunner - COST:6 [ATK:5/HP:5]
-// - Set: HoF, Rarity: Legendary
+// - Set: Legacy, Rarity: Legendary
 // --------------------------------------------------------
 // Text: <b>Deathrattle:</b> Take control of a random enemy minion.
 // --------------------------------------------------------
@@ -862,7 +862,7 @@ TEST_CASE("[Neutral : Minion] - EX1_016 : Sylvanas Windrunner")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_048] Spellbreaker - COST:4 [ATK:4/HP:3]
-// - Faction: Horde, Set: HoF, Rarity: Common
+// - Faction: Horde, Set: Legacy, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> <b>Silence</b> a minion.
 // --------------------------------------------------------
@@ -930,7 +930,7 @@ TEST_CASE("[Neutral : Minion] - EX1_048 : Spellbreaker")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_050] Coldlight Oracle - COST:3 [ATK:2/HP:2]
-// - Faction: Neutral, Set: HoF, Rarity: Free
+// - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Each player draws 2 cards.
 // --------------------------------------------------------
@@ -968,7 +968,7 @@ TEST_CASE("[Neutral : Minion] - EX1_050 : Coldlight Oracle")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_062] Old Murk-Eye - COST:4 [ATK:2/HP:4]
-// - Race: Murloc, Faction: Neutral. Set: HoF, Rarity: Legendary
+// - Race: Murloc, Faction: Neutral. Set: Legacy, Rarity: Legendary
 // --------------------------------------------------------
 // Text: <b>Charge</b>. Has +1 Attack for each other Murloc on the battlefield.
 // --------------------------------------------------------
@@ -1026,7 +1026,7 @@ TEST_CASE("[Neutral : Minion] - EX1_062 : Old Murk-Eye")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_085] Mind Control Tech - COST:3 [ATK:3/HP:3]
-// - Faction: Alliance, Set: HoF, Rarity: Rare
+// - Faction: Alliance, Set: Legacy, Rarity: Rare
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> If your opponent has 4 or
 //       more minions, take control of one at random.
@@ -1112,7 +1112,7 @@ TEST_CASE("[Neutral : Minion] - EX1_085 : Mind Control Tech")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_105] Mountain Giant - COST:12 [ATK:8/HP:8]
-// - Race: Elemental, Faction: Neutral, Set: HoF, Rarity: Epic
+// - Race: Elemental, Faction: Neutral, Set: Legacy, Rarity: Epic
 // --------------------------------------------------------
 // Text: Costs (1) less for each other card in your hand.
 // --------------------------------------------------------
@@ -1178,7 +1178,7 @@ TEST_CASE("[Neutral : Minion] - EX1_105 : Mountain Giant")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_116] Leeroy Jenkins - COST:5 [ATK:6/HP:2]
-// - Faction: Alliance, Set: HoF, Rarity: Legendary
+// - Faction: Alliance, Set: Legacy, Rarity: Legendary
 // --------------------------------------------------------
 // Text: <b>Charge</b>. <b>Battlecry:</b> Summon two 1/1 Whelps
 //       for your opponent.
@@ -1223,7 +1223,7 @@ TEST_CASE("[Neutral : Minion] - EX1_116 : Leeroy Jenkins")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_284] Azure Drake - COST:5 [ATK:4/HP:4]
-// - Race: Dragon, Faction: Neutral, Set: HoF, Rarity: Rare
+// - Race: Dragon, Faction: Neutral, Set: Legacy, Rarity: Rare
 // --------------------------------------------------------
 // Text: <b>Spell Damage +1</b>
 //       <b>Battlecry:</b> Draw a card.
@@ -1280,7 +1280,7 @@ TEST_CASE("[Neutral : Minion] - EX1_284 : Azure Drake")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_298] Ragnaros the Firelord - COST:8 [ATK:8/HP:8]
-// - Race: Elemental, Faction: Neutral, Set: HoF, Rarity: Legendary
+// - Race: Elemental, Faction: Neutral, Set: Legacy, Rarity: Legendary
 // --------------------------------------------------------
 // Text: Can't attack. At the end of your turn, deal 8 damage
 //       to a random enemy.
@@ -1335,7 +1335,7 @@ TEST_CASE("[Neutral : Minion] - EX1_298 : Ragnaros the Firelord")
 
 // --------------------------------------- MINION - NEUTRAL
 // [EX1_620] Molten Giant - COST:20 [ATK:8/HP:8]
-// - Race: Elemental, Faction: Neutral, Set: HoF, Rarity: Epic
+// - Race: Elemental, Faction: Neutral, Set: Legacy, Rarity: Epic
 // --------------------------------------------------------
 // Text: Costs (1) less for each damage your hero has taken.
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -2997,7 +2997,7 @@ TEST_CASE("[Neutral : Minion] - SCH_248 : Pen Flinger")
     CHECK_EQ(opField[0]->GetHealth(), 12);
 
     game.Process(opPlayer, EndTurnTask());
-    game.ProcessUntil(Step::MAIN_RESOURCE);
+    game.ProcessUntil(Step::MAIN_ACTION);
 
     game.Process(curPlayer,
                  PlayCardTask::MinionTarget(card1, opPlayer->GetHero()));
@@ -3021,7 +3021,7 @@ TEST_CASE("[Neutral : Minion] - SCH_248 : Pen Flinger")
     CHECK_EQ(curHand[5]->card->name, "Pen Flinger");
     CHECK_EQ(opField[0]->GetHealth(), 1);
 
-    game.Process(curPlayer, PlayCardTask::MinionTarget(curHand[4], card4));
+    game.Process(curPlayer, PlayCardTask::MinionTarget(curHand[5], card4));
     CHECK_EQ(curHand.GetCount(), 5);
     CHECK_EQ(opField.GetCount(), 0);
 }

--- a/Tests/UnitTests/PlayMode/Cards/CardsTests.cpp
+++ b/Tests/UnitTests/PlayMode/Cards/CardsTests.cpp
@@ -114,7 +114,7 @@ TEST_CASE("[Cards] - FindCardBySet")
 
     std::vector<Card*> cards1 = instance.FindCardBySet(CardSet::CORE);
     std::vector<Card*> cards2 = instance.FindCardBySet(CardSet::EXPERT1);
-    std::vector<Card*> cards3 = instance.FindCardBySet(CardSet::HOF);
+    std::vector<Card*> cards3 = instance.FindCardBySet(CardSet::LEGACY);
     std::vector<Card*> cards4 = instance.FindCardBySet(CardSet::NAXX);
     std::vector<Card*> cards5 = instance.FindCardBySet(CardSet::GVG);
     std::vector<Card*> cards6 = instance.FindCardBySet(CardSet::BRM);
@@ -132,7 +132,7 @@ TEST_CASE("[Cards] - FindCardBySet")
 
     CHECK_EQ(CardSet::CORE, cards1.front()->GetCardSet());
     CHECK_EQ(CardSet::EXPERT1, cards2.front()->GetCardSet());
-    CHECK_EQ(CardSet::HOF, cards3.front()->GetCardSet());
+    CHECK_EQ(CardSet::LEGACY, cards3.front()->GetCardSet());
     CHECK_EQ(CardSet::NAXX, cards4.front()->GetCardSet());
     CHECK_EQ(CardSet::GVG, cards5.front()->GetCardSet());
     CHECK_EQ(CardSet::BRM, cards6.front()->GetCardSet());


### PR DESCRIPTION
This revision includes:
- Update Hearthstone Patch 20.0.2 (#581)
  - Card update
    - NUM_ALL_CARDS: 14249 -> 12430
    - Deck of Lunacy: Old: [Costs 2] → New: [Costs 4]
    - Sword of the Fallen: Old: 1 Attack, 3 Durability → New: 1 Attack, 2 Durability
    - Jandice Barov: Old: [Costs 5] → New: [Costs 6]
    - Pen Flinger: Old: Battlecry: Deal 1 damage. Spellburst: Return this to your hand. → New: Battlecry: Deal 1 damage to a minion. Spellburst: Return this to your hand.
    - Far Watch Post: Old: 2 Attack, 4 Health → New: 2 Attack, 3 Health
    - Mor’shan Watch Post: Old: 3 Attack, 5 Health → New: 3 Attack, 4 Health
  - Battlegrounds update
    - RETURNING HEROES: Queen Wagtoggle, Captain Hooktusk
  - Replace card set 'Basic' and 'HoF' with 'Legacy'