### PR TITLE
Update Hearthstone Patch 20.2

### DIFF
--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -67,7 +67,7 @@ constexpr std::array<CardSet, 1> CLASSIC_CARD_SETS = {
 };
 
 //! The number of all cards.
-constexpr int NUM_ALL_CARDS = 12430;
+constexpr int NUM_ALL_CARDS = 12659;
 
 //! The number of player class.
 //! \note Druid, Hunter, Mage, Paladin, Priest, Rogue, Shaman, Warlock, Warrior,

--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -105,7 +105,7 @@ constexpr int MAX_SECERT_SIZE = 5;
 constexpr int NUM_BATTLEGROUNDS_PLAYERS = 8;
 
 //! The number of heroes in Battlegrounds.
-constexpr int NUM_BATTLEGROUNDS_HEROES = 56;
+constexpr int NUM_BATTLEGROUNDS_HEROES = 59;
 
 //! The number of heroes on the selection list in Battlegrounds.
 constexpr int NUM_HEROES_ON_SELECTION_LIST = 4;
@@ -129,22 +129,22 @@ constexpr int NUM_COPIES_OF_EACH_TIER5_MINIONS = 9;
 constexpr int NUM_COPIES_OF_EACH_TIER6_MINIONS = 7;
 
 //! The number of tier 1 minions in Battlegrounds.
-constexpr int NUM_TIER1_MINIONS = 17;
+constexpr int NUM_TIER1_MINIONS = 19;
 
 //! The number of tier 2 minions in Battlegrounds.
-constexpr int NUM_TIER2_MINIONS = 23;
+constexpr int NUM_TIER2_MINIONS = 26;
 
 //! The number of tier 3 minions in Battlegrounds.
-constexpr int NUM_TIER3_MINIONS = 27;
+constexpr int NUM_TIER3_MINIONS = 31;
 
 //! The number of tier 4 minions in Battlegrounds.
-constexpr int NUM_TIER4_MINIONS = 23;
+constexpr int NUM_TIER4_MINIONS = 26;
 
 //! The number of tier 5 minions in Battlegrounds.
-constexpr int NUM_TIER5_MINIONS = 22;
+constexpr int NUM_TIER5_MINIONS = 25;
 
 //! The number of tier 6 minions in Battlegrounds.
-constexpr int NUM_TIER6_MINIONS = 15;
+constexpr int NUM_TIER6_MINIONS = 17;
 
 //! A list of Tier 1 minion dbfIDs in Battlegrounds.
 // Beast Pool
@@ -170,11 +170,14 @@ constexpr int NUM_TIER6_MINIONS = 15;
 // Pirate Pool
 // Deck Swabbie (61055)
 // Scallywag (61061)
+// Quilboar Pool
+// Razorfen Geomancer (70143)
+// Sun-Bacon Relaxer (70147)
 // Neutral
 // Acolyte of C'Thun (63614)
 constexpr std::array<int, NUM_TIER1_MINIONS> TIER1_MINIONS = {
-    40426, 1281,  56112, 43121, 59670, 60628, 59968, 64042, 64038,
-    60055, 53445, 475,   976,   41245, 61055, 61061, 63614
+    40426, 1281, 56112, 43121, 59670, 60628, 59968, 64042, 64038, 60055,
+    53445, 475,  976,   41245, 61055, 61061, 70143, 70147, 63614
 };
 
 //! A list of Tier 2 minion dbfIDs in Battlegrounds.
@@ -203,6 +206,10 @@ constexpr std::array<int, NUM_TIER1_MINIONS> TIER1_MINIONS = {
 // Freedealing Gambler (61049)
 // Southsea Captain (680)
 // Yo-Ho-Ogre (61060)
+// Quilboar Pool
+// Roadboar (70157)
+// Tough Tusk (70162)
+// Prophet of the Boar (70153)
 // Neutral
 // Menagerie Mug (63435)
 // Spawn of N'Zoth (38797)
@@ -210,9 +217,9 @@ constexpr std::array<int, NUM_TIER1_MINIONS> TIER1_MINIONS = {
 // Tormented Ritualist (65661)
 // Unstable Ghoul (1808)
 constexpr std::array<int, NUM_TIER2_MINIONS> TIER2_MINIONS = {
-    39481, 59940, 62162, 59937, 59186, 61029, 60621, 60559,
-    64296, 64056, 778,   49279, 2016,  1063,  736,   61049,
-    680,   61060, 63435, 38797, 38740, 65661, 1808
+    39481, 59940, 62162, 59937, 59186, 61029, 60621, 60559, 64296,
+    64056, 778,   49279, 2016,  1063,  736,   61049, 680,   61060,
+    70157, 70162, 70153, 63435, 38797, 38740, 65661, 1808
 };
 
 //! A list of Tier 3 minion dbfIDs in Battlegrounds.
@@ -246,15 +253,20 @@ constexpr std::array<int, NUM_TIER2_MINIONS> TIER2_MINIONS = {
 // Bloodsail Cannoneer (61053)
 // Salty Looter (62734)
 // Southsea Strongarm (61048)
+// Quilboar Pool
+// Bristleback Brute (70171)
+// Bannerboar (70144)
+// Thorncaller (70175)
+// Necrolyte (70151)
 // Neutral
 // Arm of the Empire (63622)
 // Barrens Blacksmith (62582)
 // Khadgar (52502)
 // Warden of Old (65660)
 constexpr std::array<int, NUM_TIER3_MINIONS> TIER3_MINIONS = {
-    38734, 62230, 1003,  40428, 2288,  40391, 61059, 59660, 60558,
-    60552, 60626, 64297, 64054, 64069, 61930, 1992,  2023,  48536,
-    453,   56393, 61053, 62734, 61048, 63622, 62582, 52502, 65660
+    38734, 62230, 1003,  40428, 2288,  40391, 61059, 59660, 60558, 60552, 60626,
+    64297, 64054, 64069, 61930, 1992,  2023,  48536, 453,   56393, 61053, 62734,
+    61048, 70171, 70144, 70175, 70151, 63622, 62582, 52502, 65660
 };
 
 //! A list of Tier 4 minion dbfIDs in Battlegrounds.
@@ -283,6 +295,10 @@ constexpr std::array<int, NUM_TIER3_MINIONS> TIER3_MINIONS = {
 // Pirate Pool
 // Goldgrubber (61066)
 // Ripsnarl Captain (61056)
+// Quilboar Pool
+// Dynamic Duo (70184)
+// Bonker (70173)
+// Groundshaker (70188)
 // Neutral
 // Bolvar, Fireblood (45392)
 // Champion of Y'Shaarj (63623)
@@ -290,9 +306,9 @@ constexpr std::array<int, NUM_TIER3_MINIONS> TIER3_MINIONS = {
 // Menagerie Jug (63487)
 // Qiraji Harbinger (63619)
 constexpr std::array<int, NUM_TIER4_MINIONS> TIER4_MINIONS = {
-    43358, 1261,  40641, 66227, 61884, 54835, 42442, 61072,
-    60498, 63630, 64189, 48993, 49169, 48100, 60028, 52277,
-    61066, 61056, 45392, 63623, 763,   63487, 63619
+    43358, 1261,  40641, 66227, 61884, 54835, 42442, 61072, 60498,
+    63630, 64189, 48993, 49169, 48100, 60028, 52277, 61066, 61056,
+    70184, 70173, 70188, 45392, 63623, 763,   63487, 63619
 };
 
 //! A list of Tier 5 minion dbfIDs in Battlegrounds.
@@ -318,6 +334,10 @@ constexpr std::array<int, NUM_TIER4_MINIONS> TIER4_MINIONS = {
 // Cap'n Hoggarr (61989)
 // Nat Pagle, Extreme Angler (61046)
 // Seabreaker Goliath (62458)
+// Quilboar Pool
+// Bristleback Knight (70158)
+// Aggem Thorncurse (70163)
+// Agamaggan, The Great Boar (70176)
 // Neutral
 // Baron Rivendare (1915)
 // Brann Bronzebeard (2949)
@@ -327,8 +347,9 @@ constexpr std::array<int, NUM_TIER4_MINIONS> TIER4_MINIONS = {
 // Mythrax the Unraveler (65662)
 // Strongshell Scavenger (43022)
 constexpr std::array<int, NUM_TIER5_MINIONS> TIER5_MINIONS = {
-    49973, 60036, 59714, 1986,  46056, 60637, 60561, 63626, 64077, 2074,  59682,
-    60247, 61989, 61046, 62458, 1915,  2949,  65031, 63627, 59707, 65662, 43022
+    49973, 60036, 59714, 1986,  46056, 60637, 60561, 63626, 64077,
+    2074,  59682, 60247, 61989, 61046, 62458, 70158, 70163, 70176,
+    1915,  2949,  65031, 63627, 59707, 65662, 43022
 };
 
 //! A list of Tier 6 minion dbfIDs in Battlegrounds.
@@ -353,12 +374,15 @@ constexpr std::array<int, NUM_TIER5_MINIONS> TIER5_MINIONS = {
 // Pirate Pool
 // Dread Admiral Eliza (61047)
 // The Tide Razor (62232)
+// Quilboar Pool
+// Charlga (70165)
+// Captain Flat Tusk (70179)
 // Neutral
 // Amalgadon (61444)
 // Zapp Slywick (60040)
 constexpr std::array<int, NUM_TIER6_MINIONS> TIER6_MINIONS = {
-    59687, 59955, 1791,  61028, 60630, 60629, 64062, 64081,
-    63624, 2081,  59935, 61047, 62232, 61444, 60040
+    59687, 59955, 1791,  61028, 60630, 60629, 64062, 64081, 63624,
+    2081,  59935, 61047, 62232, 70165, 70179, 61444, 60040
 };
 
 //! The total number of tier minions in Battlegrounds Tavern.

--- a/Resources/cards.collectible.json
+++ b/Resources/cards.collectible.json
@@ -10579,6 +10579,26 @@
         "type": "MINION"
     },
     {
+        "artist": "Paul Mafayon",
+        "attack": 6,
+        "cardClass": "DEMONHUNTER",
+        "collectible": true,
+        "cost": 5,
+        "dbfId": 58494,
+        "flavor": "\"Initiate, this is your glaive. Think of it as an extension of yourself... Did you just throw it?!\"",
+        "health": 4,
+        "id": "BT_495",
+        "mechanics": [
+            "BATTLECRY"
+        ],
+        "name": "Glaivebound Adept",
+        "rarity": "FREE",
+        "set": "LEGACY",
+        "targetingArrowText": "Deal 4 damage.",
+        "text": "<b>Battlecry:</b> If your hero attacked this turn,\ndeal 4 damage.",
+        "type": "MINION"
+    },
+    {
         "artist": "Matt Dixon",
         "attack": 3,
         "cardClass": "DEMONHUNTER",

--- a/Resources/cards.collectible.json
+++ b/Resources/cards.collectible.json
@@ -2510,6 +2510,7 @@
             "FRENZY"
         ],
         "name": "Razormane Raider",
+        "race": "QUILBOAR",
         "rarity": "COMMON",
         "set": "THE_BARRENS",
         "text": "<b>Frenzy:</b> Attack a\nrandom enemy.",
@@ -2612,6 +2613,7 @@
             "TAUNT"
         ],
         "name": "Death's Head Cultist",
+        "race": "QUILBOAR",
         "rarity": "COMMON",
         "set": "THE_BARRENS",
         "text": "<b>Taunt</b>\n<b>Deathrattle:</b> Restore 4 Health to your hero.",
@@ -3103,7 +3105,7 @@
         "collectible": true,
         "cost": 6,
         "dbfId": 62550,
-        "flavor": "Consider Harth's wisdom: \"If ye had tha chance ta change yer stats, wouldja?\"",
+        "flavor": "\"He's brave, but splinters will make any Tauren cry.\"",
         "health": 8,
         "id": "BAR_071",
         "mechanics": [
@@ -3744,6 +3746,7 @@
             "DEATHRATTLE"
         ],
         "name": "Razorfen Beastmaster",
+        "race": "QUILBOAR",
         "rarity": "RARE",
         "set": "THE_BARRENS",
         "text": "<b>Deathrattle:</b> Summon a <b>Deathrattle</b> minion that costs (4) or less from your hand.",
@@ -3803,6 +3806,7 @@
             "BATTLECRY"
         ],
         "name": "Death Speaker Blackthorn",
+        "race": "QUILBOAR",
         "rarity": "LEGENDARY",
         "referencedTags": [
             "DEATHRATTLE"
@@ -3967,7 +3971,7 @@
         "type": "SPELL"
     },
     {
-        "artist": "Daniil Kudriavtsez",
+        "artist": "Daniil Kudriavtsev",
         "attack": 2,
         "cardClass": "DRUID",
         "collectible": true,
@@ -3980,6 +3984,7 @@
             "AURA"
         ],
         "name": "Razormane Battleguard",
+        "race": "QUILBOAR",
         "rarity": "RARE",
         "referencedTags": [
             "TAUNT"
@@ -4042,6 +4047,7 @@
             "TRIGGER_VISUAL"
         ],
         "name": "Plaguemaw the Rotting",
+        "race": "QUILBOAR",
         "rarity": "LEGENDARY",
         "referencedTags": [
             "TAUNT"
@@ -5054,6 +5060,7 @@
             "LIFESTEAL"
         ],
         "name": "Blood Shard Bristleback",
+        "race": "QUILBOAR",
         "rarity": "RARE",
         "referencedTags": [
             "BATTLECRY"
@@ -10572,26 +10579,6 @@
         "type": "MINION"
     },
     {
-        "artist": "Paul Mafayon",
-        "attack": 6,
-        "cardClass": "DEMONHUNTER",
-        "collectible": true,
-        "cost": 5,
-        "dbfId": 58494,
-        "flavor": "\"Initiate, this is your glaive. Think of it as an extension of yourself... Did you just throw it?!\"",
-        "health": 4,
-        "id": "BT_495",
-        "mechanics": [
-            "BATTLECRY"
-        ],
-        "name": "Glaivebound Adept",
-        "rarity": "FREE",
-        "set": "LEGACY",
-        "targetingArrowText": "Deal 4 damage.",
-        "text": "<b>Battlecry:</b> If your hero attacked this turn,\ndeal 4 damage.",
-        "type": "MINION"
-    },
-    {
         "artist": "Matt Dixon",
         "attack": 3,
         "cardClass": "DEMONHUNTER",
@@ -13271,6 +13258,7 @@
             "BATTLECRY"
         ],
         "name": "Spiked Hogrider",
+        "race": "QUILBOAR",
         "rarity": "RARE",
         "referencedTags": [
             "CHARGE",
@@ -13834,6 +13822,7 @@
             "BATTLECRY"
         ],
         "name": "Tanaris Hogchopper",
+        "race": "QUILBOAR",
         "rarity": "COMMON",
         "referencedTags": [
             "CHARGE"
@@ -13856,6 +13845,7 @@
             "BATTLECRY"
         ],
         "name": "Leatherclad Hogleader",
+        "race": "QUILBOAR",
         "rarity": "EPIC",
         "referencedTags": [
             "CHARGE"
@@ -21053,6 +21043,7 @@
             "DEATHRATTLE"
         ],
         "name": "Hench-Clan Shadequill",
+        "race": "QUILBOAR",
         "rarity": "COMMON",
         "set": "DALARAN",
         "text": "<b>Deathrattle:</b> Restore 5 Health to the enemy hero.",
@@ -21467,6 +21458,7 @@
             "STEALTH"
         ],
         "name": "Hench-Clan Sneak",
+        "race": "QUILBOAR",
         "rarity": "COMMON",
         "set": "DALARAN",
         "text": "<b>Stealth</b>",
@@ -35299,6 +35291,7 @@
             "TRIGGER_VISUAL"
         ],
         "name": "Hench-Clan Thug",
+        "race": "QUILBOAR",
         "rarity": "COMMON",
         "set": "GILNEAS",
         "text": "After your hero attacks, give this minion +1/+1.",
@@ -39549,6 +39542,17 @@
     {
         "cardClass": "WARRIOR",
         "collectible": true,
+        "dbfId": 71070,
+        "health": 30,
+        "id": "HERO_01h",
+        "name": "Garrosh of Wrath",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "WARRIOR",
+        "collectible": true,
         "dbfId": 71071,
         "health": 30,
         "id": "HERO_01i",
@@ -39701,6 +39705,17 @@
         "type": "HERO"
     },
     {
+        "cardClass": "SHAMAN",
+        "collectible": true,
+        "dbfId": 71068,
+        "health": 30,
+        "id": "HERO_02k",
+        "name": "Ten Storm Thrall",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
         "cardClass": "ROGUE",
         "collectible": true,
         "dbfId": 930,
@@ -39762,6 +39777,17 @@
         "health": 30,
         "id": "HERO_03f",
         "name": "Gladiator Valeera",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "ROGUE",
+        "collectible": true,
+        "dbfId": 71067,
+        "health": 30,
+        "id": "HERO_03g",
+        "name": "Deathmantle Valeera",
         "rarity": "FREE",
         "set": "HERO_SKINS",
         "type": "HERO"
@@ -39866,6 +39892,17 @@
         "type": "HERO"
     },
     {
+        "cardClass": "PALADIN",
+        "collectible": true,
+        "dbfId": 71065,
+        "health": 30,
+        "id": "HERO_04i",
+        "name": "Judgement Uther",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
         "cardClass": "HUNTER",
         "collectible": true,
         "dbfId": 31,
@@ -39927,6 +39964,17 @@
         "health": 30,
         "id": "HERO_05e",
         "name": "Giantstalker Rexxar",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "HUNTER",
+        "collectible": true,
+        "dbfId": 71063,
+        "health": 30,
+        "id": "HERO_05f",
+        "name": "Dragonstalker Rexxar",
         "rarity": "FREE",
         "set": "HERO_SKINS",
         "type": "HERO"
@@ -40021,6 +40069,17 @@
         "type": "HERO"
     },
     {
+        "cardClass": "DRUID",
+        "collectible": true,
+        "dbfId": 71062,
+        "health": 30,
+        "id": "HERO_06g",
+        "name": "Storm's Rage Malfurion",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
         "cardClass": "WARLOCK",
         "collectible": true,
         "dbfId": 893,
@@ -40082,6 +40141,17 @@
         "health": 30,
         "id": "HERO_07e",
         "name": "Felheart Gul'dan",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "WARLOCK",
+        "collectible": true,
+        "dbfId": 71069,
+        "health": 30,
+        "id": "HERO_07f",
+        "name": "Nemesis Gul'dan",
         "rarity": "FREE",
         "set": "HERO_SKINS",
         "type": "HERO"
@@ -40197,6 +40267,17 @@
         "type": "HERO"
     },
     {
+        "cardClass": "MAGE",
+        "collectible": true,
+        "dbfId": 71064,
+        "health": 30,
+        "id": "HERO_08k",
+        "name": "Netherwind Jaina",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
         "cardClass": "PRIEST",
         "collectible": true,
         "dbfId": 813,
@@ -40276,6 +40357,17 @@
     {
         "cardClass": "PRIEST",
         "collectible": true,
+        "dbfId": 71066,
+        "health": 30,
+        "id": "HERO_09g",
+        "name": "Transcendence Anduin",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "PRIEST",
+        "collectible": true,
         "dbfId": 71074,
         "health": 30,
         "id": "HERO_09h",
@@ -40347,6 +40439,17 @@
         "health": 30,
         "id": "HERO_10c",
         "name": "Demonbane Illidan",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "DEMONHUNTER",
+        "collectible": true,
+        "dbfId": 71061,
+        "health": 30,
+        "id": "HERO_10d",
+        "name": "Felravager Illidan",
         "rarity": "FREE",
         "set": "HERO_SKINS",
         "type": "HERO"
@@ -66397,7 +66500,6 @@
     {
         "artist": "Jaemin Kim",
         "attack": 1,
-        "battlegroundsPremiumDbfId": 58138,
         "cardClass": "NEUTRAL",
         "collectible": true,
         "cost": 1,
@@ -66412,7 +66514,6 @@
         "race": "MURLOC",
         "rarity": "RARE",
         "set": "VANILLA",
-        "techLevel": 1,
         "text": "Whenever a Murloc is summoned, gain +1 Attack.",
         "type": "MINION"
     },

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -10,6 +10,7 @@
 #include <Rosetta/PlayMode/Zones/HandZone.hpp>
 #include <Rosetta/PlayMode/Zones/SecretZone.hpp>
 
+#include <limits>
 #include <string>
 #include <utility>
 

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/NumberConditionTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/NumberConditionTask.cpp
@@ -6,6 +6,8 @@
 #include <Rosetta/PlayMode/Games/Game.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/NumberConditionTask.hpp>
 
+#include <limits>
+
 namespace RosettaStone::PlayMode::SimpleTasks
 {
 NumberConditionTask::NumberConditionTask(int referenceValue, RelaSign relaSign)


### PR DESCRIPTION
This revision includes:
- Update Hearthstone Patch 20.2 (#583)
  - Card update
    - NUM_ALL_CARDS: 12430 -> 12659
  - Battlegrounds update
    - NEW & UPDATED HEROES: Death Speaker Blackthorn, Vol’jin, Xyrella, Rat King (Updated)
    - NEW MINIONS: Razorfen Geomancer, Sun-Bacon Relaxer, Roadboar, Tough Tusk, Prophet of the Boar, Bristleback Brute, Bannerboar, Thorncaller, Necrolyte, Dynamic Duo, Bonker, Groundshaker, Bristleback Knight, Aggem Thorncurse, Agamaggan, The Great Boar, Charlga, Captain Flat Tusk