### PR TITLE
Update Hearthstone Patch 20.2.2

### DIFF
--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -67,7 +67,7 @@ constexpr std::array<CardSet, 1> CLASSIC_CARD_SETS = {
 };
 
 //! The number of all cards.
-constexpr int NUM_ALL_CARDS = 12659;
+constexpr int NUM_ALL_CARDS = 12660;
 
 //! The number of player class.
 //! \note Druid, Hunter, Mage, Paladin, Priest, Rogue, Shaman, Warlock, Warrior,

--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -135,7 +135,7 @@ constexpr int NUM_TIER1_MINIONS = 19;
 constexpr int NUM_TIER2_MINIONS = 26;
 
 //! The number of tier 3 minions in Battlegrounds.
-constexpr int NUM_TIER3_MINIONS = 31;
+constexpr int NUM_TIER3_MINIONS = 30;
 
 //! The number of tier 4 minions in Battlegrounds.
 constexpr int NUM_TIER4_MINIONS = 26;
@@ -260,13 +260,12 @@ constexpr std::array<int, NUM_TIER2_MINIONS> TIER2_MINIONS = {
 // Necrolyte (70151)
 // Neutral
 // Arm of the Empire (63622)
-// Barrens Blacksmith (62582)
 // Khadgar (52502)
 // Warden of Old (65660)
 constexpr std::array<int, NUM_TIER3_MINIONS> TIER3_MINIONS = {
-    38734, 62230, 1003,  40428, 2288,  40391, 61059, 59660, 60558, 60552, 60626,
-    64297, 64054, 64069, 61930, 1992,  2023,  48536, 453,   56393, 61053, 62734,
-    61048, 70171, 70144, 70175, 70151, 63622, 62582, 52502, 65660
+    38734, 62230, 1003,  40428, 2288,  40391, 61059, 59660, 60558, 60552,
+    60626, 64297, 64054, 64069, 61930, 1992,  2023,  48536, 453,   56393,
+    61053, 62734, 61048, 70171, 70144, 70175, 70151, 63622, 52502, 65660
 };
 
 //! A list of Tier 4 minion dbfIDs in Battlegrounds.

--- a/Resources/cards.collectible.json
+++ b/Resources/cards.collectible.json
@@ -3157,7 +3157,6 @@
         "name": "Barrens Blacksmith",
         "rarity": "EPIC",
         "set": "THE_BARRENS",
-        "techLevel": 3,
         "text": "<b>Frenzy:</b> Give your other minions +2/+2.",
         "type": "MINION"
     },
@@ -3714,7 +3713,7 @@
     },
     {
         "artist": "Akkapoj T.",
-        "attack": 2,
+        "attack": 3,
         "cardClass": "DEMONHUNTER",
         "collectible": true,
         "cost": 2,
@@ -4078,7 +4077,7 @@
         "artist": "Dave Allsop",
         "cardClass": "MAGE",
         "collectible": true,
-        "cost": 4,
+        "cost": 5,
         "dbfId": 63057,
         "flavor": "\"Mana\" is just another name for \"electrolytes.\"",
         "id": "BAR_542",
@@ -4481,7 +4480,7 @@
     },
     {
         "artist": "Nicola Saviori",
-        "attack": 2,
+        "attack": 3,
         "cardClass": "WARRIOR",
         "collectible": true,
         "cost": 4,
@@ -4625,13 +4624,13 @@
     },
     {
         "artist": "Matt Dixon",
-        "attack": 4,
+        "attack": 5,
         "cardClass": "SHAMAN",
         "collectible": true,
         "cost": 5,
         "dbfId": 63279,
         "flavor": "Honestly, the frog did nothing wrong.",
-        "health": 5,
+        "health": 6,
         "id": "BAR_848",
         "mechanics": [
             "BATTLECRY"
@@ -16427,7 +16426,7 @@
     },
     {
         "artist": "Matt Gaser",
-        "attack": 2,
+        "attack": 3,
         "cardClass": "SHAMAN",
         "collectible": true,
         "cost": 3,
@@ -17436,7 +17435,7 @@
         "artist": "Ivan Fomin",
         "cardClass": "WARLOCK",
         "collectible": true,
-        "cost": 4,
+        "cost": 3,
         "dbfId": 69734,
         "flavor": "Like a knitting circle, but less evil.",
         "howToEarn": "Unlocked at level 1.",
@@ -17526,7 +17525,7 @@
         "attack": 5,
         "cardClass": "WARRIOR",
         "collectible": true,
-        "cost": 6,
+        "cost": 5,
         "dbfId": 69741,
         "flavor": "She has three shieldbearers in her party to supply her with back ups when she gets low on durability.",
         "health": 5,
@@ -18253,7 +18252,7 @@
         "artist": "Max Grecke",
         "cardClass": "SHAMAN",
         "collectible": true,
-        "cost": 4,
+        "cost": 3,
         "dbfId": 69744,
         "flavor": "Also good for removing pesky stains.",
         "howToEarn": "Unlocked at level 1.",
@@ -23556,7 +23555,7 @@
         "attack": 5,
         "cardClass": "NEUTRAL",
         "collectible": true,
-        "cost": 10,
+        "cost": 9,
         "dbfId": 60443,
         "elite": true,
         "flavor": "It really just wants to cuddle all the creatures of Azeroth.",
@@ -25931,7 +25930,7 @@
         "artist": "Evgeniy Dlinnov",
         "cardClass": "WARLOCK",
         "collectible": true,
-        "cost": 6,
+        "cost": 5,
         "dbfId": 61885,
         "elite": true,
         "flavor": "Yeah, it's chaos, but it's organized chaos.",
@@ -31321,7 +31320,7 @@
     },
     {
         "artist": "Matt Gaser",
-        "attack": 2,
+        "attack": 3,
         "cardClass": "SHAMAN",
         "collectible": true,
         "cost": 3,
@@ -34860,7 +34859,7 @@
         "artist": "Ivan Fomin",
         "cardClass": "WARLOCK",
         "collectible": true,
-        "cost": 4,
+        "cost": 3,
         "dbfId": 46864,
         "flavor": "Like a knitting circle, but less evil.",
         "id": "GIL_191",
@@ -36416,7 +36415,7 @@
         "race": "ALL",
         "rarity": "EPIC",
         "set": "GILNEAS",
-        "text": "[x]<i>This is an Elemental, Mech,\nDemon, Murloc, Dragon,\nBeast, Pirate and Totem.</i>",
+        "text": "<i>This has all minion types.</i>",
         "type": "MINION"
     },
     {
@@ -38055,7 +38054,7 @@
         "attack": 5,
         "cardClass": "WARRIOR",
         "collectible": true,
-        "cost": 6,
+        "cost": 5,
         "dbfId": 2021,
         "flavor": "She has three shieldbearers in her party to supply her with back ups when she gets low on durability.",
         "health": 5,
@@ -51545,14 +51544,14 @@
         "artist": "L. Lullabi & K. Turovec",
         "cardClass": "PALADIN",
         "collectible": true,
-        "cost": 0,
+        "cost": 1,
         "dbfId": 59038,
         "flavor": "\"Report to the bookstore to buy your books, the alchemist to buy your potions, and then get your wands at the… wandryroom?\"",
         "id": "SCH_247",
         "name": "First Day of School",
         "rarity": "COMMON",
         "set": "SCHOLOMANCE",
-        "text": "Add 2 random 1-Cost minions to your hand.",
+        "text": "Add 3 random 1-Cost minions to your hand.",
         "type": "SPELL"
     },
     {
@@ -52379,13 +52378,11 @@
         "health": 3,
         "id": "SCH_507",
         "mechanics": [
-            "BATTLECRY"
+            "BATTLECRY",
+            "DISCOVER"
         ],
         "name": "Instructor Fireheart",
         "rarity": "LEGENDARY",
-        "referencedTags": [
-            "DISCOVER"
-        ],
         "set": "SCHOLOMANCE",
         "text": "[x]<b>Battlecry:</b> <b>Discover</b> a spell\nthat costs (1) or more.\nIf you play it this turn,\nrepeat this effect.",
         "type": "MINION"
@@ -60248,7 +60245,7 @@
         "artist": "Max Grecke",
         "cardClass": "SHAMAN",
         "collectible": true,
-        "cost": 4,
+        "cost": 3,
         "dbfId": 41521,
         "flavor": "Also good for removing pesky stains.",
         "id": "UNG_817",
@@ -69140,7 +69137,7 @@
             "WARLOCK"
         ],
         "collectible": true,
-        "cost": 3,
+        "cost": 4,
         "dbfId": 61944,
         "flavor": "\"My mount and I share a special connection. Just not a good one.\"",
         "id": "YOP_006",
@@ -69172,7 +69169,7 @@
             "CORRUPT"
         ],
         "set": "DARKMOON_FAIRE",
-        "text": "[x]<b>Battlecry:</b> Reduce the Cost\nof all <b>Corrupt</b> cards in your\nhand and deck by (2).",
+        "text": "[x]<b>Battlecry:</b> Reduce the\nCost of all <b>Corrupt</b> and\n<b>Corrupted</b> cards in your\nhand and deck by (2).",
         "type": "MINION"
     },
     {
@@ -69653,14 +69650,13 @@
         "health": 4,
         "id": "YOP_031",
         "mechanics": [
-            "RUSH",
-            "WINDFURY"
+            "RUSH"
         ],
         "name": "Crabrider",
         "race": "MURLOC",
         "rarity": "COMMON",
         "set": "DARKMOON_FAIRE",
-        "text": "<b>Rush</b>\n<b>Windfury</b>",
+        "text": "[x]<b>Rush</b>\n<b>Battlecry:</b> Gain <b>Windfury</b>\nthis turn only.",
         "type": "MINION"
     },
     {

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1643,7 +1643,7 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [CORE_EX1_258] Unbound Elemental - COST:3 [ATK:2/HP:4]
+    // [CORE_EX1_258] Unbound Elemental - COST:3 [ATK:3/HP:4]
     // - Race: Elemental, Set: CORE, Rarity: Common
     // --------------------------------------------------------
     // Text: Whenever you play a card with <b>Overload</b>,
@@ -1704,7 +1704,7 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - SHAMAN
-    // [CORE_UNG_817] Tidal Surge - COST:4
+    // [CORE_UNG_817] Tidal Surge - COST:3
     // - Set: CORE, Rarity: Common
     // - Spell School: Nature
     // --------------------------------------------------------
@@ -1809,7 +1809,7 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARLOCK
-    // [CORE_GIL_191] Fiendish Circle - COST:4
+    // [CORE_GIL_191] Fiendish Circle - COST:3
     // - Set: CORE, Rarity: Common
     // - Spell School: Fel
     // --------------------------------------------------------
@@ -2004,7 +2004,7 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [CORE_GVG_053] Shieldmaiden - COST:6 [ATK:5/HP:5]
+    // [CORE_GVG_053] Shieldmaiden - COST:5 [ATK:5/HP:5]
     // - Set: CORE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Gain 5 Armor.

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1329,7 +1329,8 @@ void DarkmoonFaireCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Reduce the Cost of all
-    //       <b>Corrupt</b> cards in your hand and deck by (2).
+    //       <b>Corrupt</b> and <b>Corrupted</b> cards
+    //       in your hand and deck by (2).
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
@@ -2102,7 +2103,7 @@ void DarkmoonFaireCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     cards.emplace("DMF_533", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
-    // [DMF_534] Deck of Chaos - COST:6
+    // [DMF_534] Deck of Chaos - COST:5
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // - Spell School: Shadow
     // --------------------------------------------------------
@@ -2740,7 +2741,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     Power power;
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DMF_002] N'Zoth, God of the Deep - COST:10 [ATK:5/HP:7]
+    // [DMF_002] N'Zoth, God of the Deep - COST:9 [ATK:5/HP:7]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Resurrect a friendly minion
@@ -3173,7 +3174,7 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - NEUTRAL
-    // [YOP_006] Hysteria - COST:3
+    // [YOP_006] Hysteria - COST:4
     // - Set: DARKMOON_FAIRE, Rarity: Rare
     // - Spell School: Shadow
     // --------------------------------------------------------
@@ -3293,14 +3294,15 @@ void DarkmoonFaireCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - Race: Murloc, Set: DARKMOON_FAIRE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Rush</b>
-    //       <b>Windfury</b>
+    //       <b>Battlecry:</b> Gain <b>Windfury</b> this turn only.
     // --------------------------------------------------------
     // GameTag:
     // - RUSH = 1
     // - WINDFURY = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(nullptr);
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("YOP_031e", EntityType::SOURCE));
     cards.emplace("YOP_031", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
@@ -3969,6 +3971,19 @@ void DarkmoonFaireCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: Costs (1) less.
     // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [YOP_031e] Crabriding - COST:0
+    // - Set: DARKMOON_FAIRE
+    // --------------------------------------------------------
+    // Text: <b>Windfury</b> this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("YOP_031e"));
+    cards.emplace("YOP_031e", CardDef(power));
 }
 
 void DarkmoonFaireCardsGen::AddAll(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -2999,7 +2999,7 @@ void Expert1CardsGen::AddShaman(std::map<std::string, CardDef>& cards)
         CardDef(power, PlayReqs{ { PlayReq::REQ_MINIMUM_ENEMY_MINIONS, 1 } }));
 
     // ---------------------------------------- MINION - SHAMAN
-    // [EX1_258] Unbound Elemental - COST:3 [ATK:2/HP:4]
+    // [EX1_258] Unbound Elemental - COST:3 [ATK:3/HP:4]
     // - Race: Elemental, Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
     // Text: Whenever you play a card with <b>Overload</b>, gain +1/+1.

--- a/Sources/Rosetta/PlayMode/CardSets/GilneasCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/GilneasCardsGen.cpp
@@ -1002,7 +1002,7 @@ void GilneasCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 void GilneasCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
     // ---------------------------------------- SPELL - WARLOCK
-    // [GIL_191] Fiendish Circle - COST:4
+    // [GIL_191] Fiendish Circle - COST:3
     // - Set: Gilneas, Rarity: Common
     // --------------------------------------------------------
     // Text: Summon four 1/1 Imps.

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -671,14 +671,14 @@ void ScholomanceCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [SCH_247] First Day of School - COST:0
+    // [SCH_247] First Day of School - COST:1
     // - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Add 2 random 1-Cost minions to your hand.
+    // Text: Add 3 random 1-Cost minions to your hand.
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(std::make_shared<RandomMinionTask>(
-        TagValues{ { GameTag::COST, 1, RelaSign::EQ } }, 2));
+        TagValues{ { GameTag::COST, 1, RelaSign::EQ } }, 3));
     power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
     cards.emplace("SCH_247", CardDef(power));
 

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -440,7 +440,7 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------- SPELL - MAGE
-    // [BAR_542] Refreshing Spring Water - COST:4
+    // [BAR_542] Refreshing Spring Water - COST:5
     // - Set: THE_BARRENS, Rarity: Common
     // --------------------------------------------------------
     // Text: Draw 2 cards.
@@ -1195,7 +1195,7 @@ void TheBarrensCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [BAR_848] Lilypad Lurker - COST:5 [ATK:4/HP:5]
+    // [BAR_848] Lilypad Lurker - COST:5 [ATK:5/HP:6]
     // - Race: Elemental, Set: THE_BARRENS, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> If you played an Elemental
@@ -1451,7 +1451,7 @@ void TheBarrensCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [BAR_840] Whirling Combatant - COST:4 [ATK:2/HP:6]
+    // [BAR_840] Whirling Combatant - COST:4 [ATK:3/HP:6]
     // - Set: THE_BARRENS, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry and Frenzy:</b>
@@ -1594,7 +1594,7 @@ void TheBarrensCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [BAR_325] Razorboar - COST:2 [ATK:2/HP:2]
+    // [BAR_325] Razorboar - COST:2 [ATK:3/HP:2]
     // - Race: Beast, Set: THE_BARRENS, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Summon a <b>Deathrattle</b>
@@ -2626,7 +2626,7 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // - Set: THE_BARRENS
     // --------------------------------------------------------
     // Text: <b>Casts When Drawn</b>
-    //       Summon a 3/10 Mankrik, who immediately attacks
+    //       Summon a 3/7 Mankrik, who immediately attacks
     //       the enemy hero.
     // --------------------------------------------------------
     // GameTag:

--- a/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
@@ -1167,7 +1167,7 @@ void UngoroCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - SHAMAN
-    // [UNG_817] Tidal Surge - COST:4
+    // [UNG_817] Tidal Surge - COST:3
     // - Faction: Neutral, Set: Ungoro, Rarity: Common
     // --------------------------------------------------------
     // Text: Deal 4 damage to a minion.

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -2092,7 +2092,7 @@ void VanillaCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [VAN_EX1_258] Unbound Elemental - COST:3 [ATK:2/HP:4]
+    // [VAN_EX1_258] Unbound Elemental - COST:3 [ATK:3/HP:4]
     // - Set: VANILLA, Rarity: Common
     // --------------------------------------------------------
     // Text: Whenever you play a card with <b>Overload</b>,

--- a/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DarkmoonFaireCardsGenTests.cpp
@@ -4449,7 +4449,7 @@ TEST_CASE("[Neutral : Minion] - YOP_021 : Imprisoned Phoenix")
 // - Race: Murloc, Set: DARKMOON_FAIRE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Rush</b>
-//       <b>Windfury</b>
+//       <b>Battlecry:</b> Gain <b>Windfury</b> this turn only.
 // --------------------------------------------------------
 // GameTag:
 // - RUSH = 1
@@ -4457,7 +4457,41 @@ TEST_CASE("[Neutral : Minion] - YOP_021 : Imprisoned Phoenix")
 // --------------------------------------------------------
 TEST_CASE("[Neutral : Minion] - YOP_031 : Crabrider")
 {
-    // Do nothing
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Crabrider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasRush(), true);
+    CHECK_EQ(curField[0]->HasWindfury(), true);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->HasRush(), true);
+    CHECK_EQ(curField[0]->HasWindfury(), false);
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -6274,7 +6274,7 @@ TEST_CASE("[Shaman : Spell] - EX1_251 : Forked Lightning")
 }
 
 // ---------------------------------------- MINION - SHAMAN
-// [EX1_258] Unbound Elemental - COST:3 [ATK:2/HP:4]
+// [EX1_258] Unbound Elemental - COST:3 [ATK:3/HP:4]
 // - Race: Elemental, Faction: Neutral, Set: Expert1, Rarity: Common
 // --------------------------------------------------------
 // Text: Whenever you play a card with <b>Overload</b>, gain +1/+1.
@@ -6312,11 +6312,11 @@ TEST_CASE("[Shaman : Minion] - EX1_258 : Unbound Elemental")
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Feral Spirit"));
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
-    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetAttack(), 3);
     CHECK_EQ(curField[0]->GetHealth(), 4);
 
     game.Process(curPlayer, PlayCardTask::Minion(card2));
-    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetAttack(), 4);
     CHECK_EQ(curField[0]->GetHealth(), 5);
 
     game.Process(curPlayer, EndTurnTask());
@@ -6326,7 +6326,7 @@ TEST_CASE("[Shaman : Minion] - EX1_258 : Unbound Elemental")
     game.ProcessUntil(Step::MAIN_ACTION);
 
     game.Process(curPlayer, PlayCardTask::Spell(card3));
-    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetAttack(), 5);
     CHECK_EQ(curField[0]->GetHealth(), 6);
 }
 

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -931,10 +931,10 @@ TEST_CASE("[Mage : Minion] - SCH_310 : Lab Partner")
 }
 
 // ---------------------------------------- SPELL - PALADIN
-// [SCH_247] First Day of School - COST:0
+// [SCH_247] First Day of School - COST:1
 // - Set: SCHOLOMANCE, Rarity: Common
 // --------------------------------------------------------
-// Text: Add 2 random 1-Cost minions to your hand.
+// Text: Add 3 random 1-Cost minions to your hand.
 // --------------------------------------------------------
 TEST_CASE("[Paladin : Spell] - SCH_247 : First Day of School")
 {
@@ -962,11 +962,13 @@ TEST_CASE("[Paladin : Spell] - SCH_247 : First Day of School")
         curPlayer, Cards::FindCardByName("First Day of School"));
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
-    CHECK_EQ(curHand.GetCount(), 2);
+    CHECK_EQ(curHand.GetCount(), 3);
     CHECK_EQ(curHand[0]->card->GetCardType(), CardType::MINION);
     CHECK_EQ(curHand[0]->card->GetCost(), 1);
     CHECK_EQ(curHand[1]->card->GetCardType(), CardType::MINION);
     CHECK_EQ(curHand[1]->card->GetCost(), 1);
+    CHECK_EQ(curHand[2]->card->GetCardType(), CardType::MINION);
+    CHECK_EQ(curHand[2]->card->GetCost(), 1);
 }
 
 // ---------------------------------------- SPELL - PALADIN


### PR DESCRIPTION
This revision includes:
- Update Hearthstone Patch 20.2.2 (#586)
  - Card update
    - NUM_ALL_CARDS: 12659 -> 12660
    - Refreshing Spring Water: Old: [Costs 4] → New: [Costs 5]
    - First Day of School: Old: [Costs 0] Add 2 random 1-Cost minions to your hand → New: [Costs 1] Add 3 random 1-Cost minions to your hand.
    - Hysteria: Old: [Costs 3] → New: [Costs 4]
    - Crabrider: Old: Rush Windfury → New: Rush Battlecry: Gain Windfury this turn only.
    - Olgra, Mankrik’s Wife: Old: Casts When Drawn Summon a 3/10 Mankrik, who immediately attacks the enemy hero. → New: Casts When Drawn Summon a 3/7 Mankrik, who immediately attacks the enemy hero.
    - Razorboar: Old: 2 Attack, 2 Health → New: 3 Attack, 2 Health
    - Dark Inquisitor Xanesh: Old: Reduce the Cost of all Corrupt cards in your hand and deck by (2). → New: Reduce the Cost of all Corrupt and Corrupted cards in your hand and deck by (2).
    - Unbound Elemental: Old: 2 Attack, 4 Health → New: 3 Attack, 4 Health
    - Tidal Surge: Old: [Costs 4] → New: [Costs 3]
    - Lilypad Lurker: Old: 4 Attack, 5 Health → New: 5 Attack, 6 Health
    - Fiendish Circle: Old: [Costs 4] → New: [Costs 3]
    - Deck of Chaos: Old: [Costs 6] → New: [Costs 5]
    - Whirling Combatant: Old: 2 Attack, 6 Health → New: 3 Attack, 6 Health
    - Shieldmaiden: Old: [Costs 6] → New: [Costs 5]
    - N’Zoth, God of the Deep: Old: [Costs 10] → New: [Costs 9]
  - Battlegrounds update
    - Barrens Blacksmith will be removed from the minion pool.
    - Roadboar: Old: 2 Attack, 4 Health → New: 1 Attack, 4 Health
    - Prophet of the Boar: Old: 3 Attack, 3 Health → New: 2 Attack, 3 Health
    - Bannerboar: Old: 2 Attack, 5 Health → New: 1 Attack, 4 Health
    - Bristleback Brute: Old: The first Blood Gem played on this each turn gives an extra +3/+3. → New: The first Blood Gem played on this each turn gives an extra +2/+2.
    - Groundshaker: Old: After a Blood Gem is played on this, give your minions +2 Attack for next combat only. → New: After a Blood Gem is played on this, give your other minions +2 Attack for next combat only.
    - Dynamic Duo: Old: 5 Attack, 6 Health → New: 3 Attack, 4 Health
    - Bonker: Old: 4 Attack, 7 Health → New: 3 Attack, 7 Health, Old (Golden): Mega-Windfury. After this attacks, gain 2 Blood Gems. → New: Mega-Windfury. After this attacks, gain a Blood Gem.
    - Charlga: Old: 7 Attack, 7 Health. At the end of your turn, play a Blood Gem on all friendly minions. → New: 4 Attack, 4 Health. At the end of your turn, play a Blood Gem on all other friendly minions.