### PR TITLE
Implement 16 CORE cards

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build-macos:
+  build-windows:
     strategy:
       matrix:
         include:

--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -14,7 +14,7 @@ CORE | CORE_AT_003 | Fallen Hero | O
 CORE | CORE_AT_008 | Coldarra Drake | O
 CORE | CORE_AT_021 | Tiny Knight of Evil |  
 CORE | CORE_AT_047 | Draenei Totemcarver |  
-CORE | CORE_AT_055 | Flash Heal |  
+CORE | CORE_AT_055 | Flash Heal | O
 CORE | CORE_AT_061 | Lock and Load | O
 CORE | CORE_AT_075 | Warhorse Trainer | O
 CORE | CORE_AT_092 | Ice Rager |  
@@ -36,8 +36,8 @@ CORE | CORE_BT_480 | Crimson Sigil Runner |
 CORE | CORE_BT_491 | Spectral Sight |  
 CORE | CORE_BT_801 | Eye Beam |  
 CORE | CORE_BT_921 | Aldrachi Warblades |  
-CORE | CORE_CS1_112 | Holy Nova |  
-CORE | CORE_CS1_130 | Holy Smite |  
+CORE | CORE_CS1_112 | Holy Nova | O
+CORE | CORE_CS1_130 | Holy Smite | O
 CORE | CORE_CS2_009 | Mark of the Wild | O
 CORE | CORE_CS2_013 | Wild Growth | O
 CORE | CORE_CS2_023 | Arcane Intellect | O
@@ -113,11 +113,11 @@ CORE | CORE_EX1_187 | Arcane Devourer |
 CORE | CORE_EX1_188 | Barrens Stablehand |  
 CORE | CORE_EX1_189 | Brightwing |  
 CORE | CORE_EX1_190 | High Inquisitor Whitemane |  
-CORE | CORE_EX1_193 | Psychic Conjurer |  
-CORE | CORE_EX1_194 | Power Infusion |  
-CORE | CORE_EX1_195 | Kul Tiran Chaplain |  
-CORE | CORE_EX1_197 | Shadow Word: Ruin |  
-CORE | CORE_EX1_198 | Natalie Seline |  
+CORE | CORE_EX1_193 | Psychic Conjurer | O
+CORE | CORE_EX1_194 | Power Infusion | O
+CORE | CORE_EX1_195 | Kul Tiran Chaplain | O
+CORE | CORE_EX1_197 | Shadow Word: Ruin | O
+CORE | CORE_EX1_198 | Natalie Seline | O
 CORE | CORE_EX1_238 | Lightning Bolt |  
 CORE | CORE_EX1_246 | Hex |  
 CORE | CORE_EX1_248 | Feral Spirit |  
@@ -135,7 +135,7 @@ CORE | CORE_EX1_309 | Siphon Soul |
 CORE | CORE_EX1_312 | Twisting Nether |  
 CORE | CORE_EX1_319 | Flame Imp |  
 CORE | CORE_EX1_323 | Lord Jaraxxus |  
-CORE | CORE_EX1_335 | Lightspawn |  
+CORE | CORE_EX1_335 | Lightspawn | O
 CORE | CORE_EX1_362 | Argent Protector | O
 CORE | CORE_EX1_382 | Aldor Peacekeeper | O
 CORE | CORE_EX1_383 | Tirion Fordring | O
@@ -165,9 +165,9 @@ CORE | CORE_EX1_610 | Explosive Trap | O
 CORE | CORE_EX1_611 | Freezing Trap | O
 CORE | CORE_EX1_617 | Deadly Shot | O
 CORE | CORE_EX1_619 | Equality | O
-CORE | CORE_EX1_622 | Shadow Word: Death |  
-CORE | CORE_EX1_623 | Temple Enforcer |  
-CORE | CORE_EX1_625 | Shadowform |  
+CORE | CORE_EX1_622 | Shadow Word: Death | O
+CORE | CORE_EX1_623 | Temple Enforcer | O
+CORE | CORE_EX1_625 | Shadowform | O
 CORE | CORE_FP1_007 | Nerubian Egg |  
 CORE | CORE_FP1_011 | Webspinner | O
 CORE | CORE_FP1_020 | Avenge | O
@@ -222,8 +222,8 @@ CORE | CS3_007 | Novice Zapper |
 CORE | CS3_008 | Bloodsail Deckhand |  
 CORE | CS3_009 | War Cache |  
 CORE | CS3_012 | Nordrassil Druid | O
-CORE | CS3_013 | Shadowed Spirit |  
-CORE | CS3_014 | Crimson Clergy |  
+CORE | CS3_013 | Shadowed Spirit | O
+CORE | CS3_014 | Crimson Clergy | O
 CORE | CS3_015 | Selective Breeder | O
 CORE | CS3_016 | Reckoning |  
 CORE | CS3_017 | Gan'arg Glaivesmith |  
@@ -233,8 +233,8 @@ CORE | CS3_021 | Enslaved Fel Lord |
 CORE | CS3_022 | Fogsail Freebooter |  
 CORE | CS3_024 | Taelan Fordring |  
 CORE | CS3_025 | Overlord Runthak |  
-CORE | CS3_027 | Focused Will |  
-CORE | CS3_028 | Thrive in the Shadows |  
+CORE | CS3_027 | Focused Will | O
+CORE | CS3_028 | Thrive in the Shadows | O
 CORE | CS3_029 | Pursuit of Justice |  
 CORE | CS3_030 | Warsong Outrider |  
 CORE | CS3_031 | Alexstrasza the Life-Binder |  
@@ -246,7 +246,7 @@ CORE | CS3_036 | Deathwing the Destroyer |
 CORE | CS3_037 | Emerald Skytalon |  
 CORE | CS3_038 | Redgill Razorjaw |  
 
-- Progress: 25% (61 of 235 Cards)
+- Progress: 32% (77 of 235 Cards)
 
 ## Ashes of Outland
 

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -621,7 +621,7 @@ TGT | AT_051 | Elemental Destruction |
 TGT | AT_052 | Totem Golem |  
 TGT | AT_053 | Ancestral Knowledge |  
 TGT | AT_054 | The Mistcaller |  
-TGT | AT_055 | Flash Heal |  
+TGT | AT_055 | Flash Heal | O
 TGT | AT_056 | Powershot |  
 TGT | AT_057 | Stablemaster |  
 TGT | AT_058 | King's Elekk |  
@@ -700,7 +700,7 @@ TGT | AT_131 | Eydis Darkbane |
 TGT | AT_132 | Justicar Trueheart |  
 TGT | AT_133 | Gadgetzan Jouster |  
 
-- Progress: 3% (4 of 132 Cards)
+- Progress: 3% (5 of 132 Cards)
 
 ## The League of Explorers
 

--- a/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
@@ -14,6 +14,7 @@ enum class DiscoverType
 {
     INVALID,
     DECK,
+    SPELL_FROM_DECK,
     BASIC_TOTEM,
     CHOOSE_ONE,
     FOUR_COST_CARD,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="./Medias/Logos/Logo.png" width=256 height=256 />
 
-[![License](https://img.shields.io/badge/Licence-AGPLv3-blue.svg)](https://github.com/utilForever/RosettaStone/blob/master/LICENSE) ![Windows](https://github.com/utilForever/RosettaStone/workflows/Windows/badge.svg) ![Ubuntu](https://github.com/utilForever/RosettaStone/workflows/Ubuntu/badge.svg) ![macOS](https://github.com/utilForever/RosettaStone/workflows/macOS/badge.svg) ![Ubuntu - Codecov](https://github.com/utilForever/RosettaStone/workflows/Ubuntu%20-%20Codecov/badge.svg) [![Build Status](https://travis-ci.com/utilForever/RosettaStone.svg?branch=main)](https://travis-ci.com/utilForever/RosettaStone)
+[![License](https://img.shields.io/badge/Licence-AGPLv3-blue.svg)](https://github.com/utilForever/RosettaStone/blob/main/LICENSE) ![Windows](https://github.com/utilForever/RosettaStone/workflows/Windows/badge.svg) ![Ubuntu](https://github.com/utilForever/RosettaStone/workflows/Ubuntu/badge.svg) ![macOS](https://github.com/utilForever/RosettaStone/workflows/macOS/badge.svg) ![Ubuntu - Codecov](https://github.com/utilForever/RosettaStone/workflows/Ubuntu%20-%20Codecov/badge.svg) [![Build Status](https://travis-ci.com/utilForever/RosettaStone.svg?branch=main)](https://travis-ci.com/utilForever/RosettaStone)
 
 [![codecov](https://codecov.io/gh/utilForever/RosettaStone/branch/main/graph/badge.svg)](https://codecov.io/gh/utilForever/RosettaStone)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/df6a02e1358f4e719e7bebb9a728d2ab)](https://www.codacy.com/app/utilForever/RosettaStone?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=utilForever/RosettaStone&amp;utm_campaign=Badge_Grade)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 25% Core Set (61 of 235 cards)
+  * 32% Core Set (77 of 235 cards)
   * 59% Ashes of Outland (80 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
@@ -50,7 +50,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 6% Curse of Naxxramas (2 of 30 Cards)
   * 0% Goblins vs Gnomes (0 of 123 Cards)
   * 3% Blackrock Mountain (1 of 31 Cards)
-  * 3% The Grand Tournament (4 of 132 Cards)
+  * 3% The Grand Tournament (5 of 132 Cards)
   * 2% The League of Explorers (1 of 45 Cards)
   * 1% Whispers of the Old Gods (2 of 134 Cards)
   * 6% One Night in Karazhan (3 of 45 Cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1454,6 +1454,10 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 3));
+    cards.emplace("CS3_013", CardDef(power));
 
     // ---------------------------------------- MINION - PRIEST
     // [CS3_014] Crimson Clergy - COST:1 [ATK:1/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1340,6 +1340,13 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Destroy all minions with 5 or more Attack.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::ALL_MINIONS));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsTagValue(GameTag::ATK, 5, RelaSign::GEQ)) }));
+    power.AddPowerTask(std::make_shared<DestroyTask>(EntityType::STACK));
+    cards.emplace("CORE_EX1_197", CardDef(power));
 
     // ---------------------------------------- MINION - PRIEST
     // [CORE_EX1_198] Natalie Seline - COST:8 [ATK:8/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1358,6 +1358,24 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DestroyTask>(EntityType::TARGET));
+    power.AddPowerTask(
+        std::make_shared<GetGameTagTask>(EntityType::TARGET, GameTag::HEALTH));
+    power.AddPowerTask(std::make_shared<GetGameTagTask>(EntityType::TARGET,
+                                                        GameTag::DAMAGE, 0, 1));
+    power.AddPowerTask(
+        std::make_shared<MathNumberIndexTask>(0, 1, MathOperation::SUB));
+    power.AddPowerTask(std::make_shared<SetGameTagNumberTask>(
+        EntityType::SOURCE, GameTag::HEALTH));
+    cards.emplace(
+        "CORE_EX1_198",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } }));
 
     // ---------------------------------------- MINION - PRIEST
     // [CORE_EX1_335] Lightspawn - COST:3 [ATK:0/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1319,6 +1319,19 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("EX1_195e", EntityType::TARGET));
+    cards.emplace(
+        "CORE_EX1_195",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_FRIENDLY_TARGET, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } }));
 
     // ----------------------------------------- SPELL - PRIEST
     // [CORE_EX1_197] Shadow Word: Ruin - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1224,6 +1224,8 @@ void CoreCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 
 void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- SPELL - PRIEST
     // [CORE_AT_055] Flash Heal - COST:1
     // - Set: CORE, Rarity: Common
@@ -1231,6 +1233,14 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Restore 5 Health.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<HealTask>(EntityType::TARGET, 5));
+    cards.emplace(
+        "CORE_AT_055",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ----------------------------------------- SPELL - PRIEST
     // [CORE_CS1_112] Holy Nova - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1263,6 +1263,17 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 3 damage to a minion.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
+    cards.emplace(
+        "CORE_CS1_130",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ---------------------------------------- MINION - PRIEST
     // [CORE_EX1_193] Psychic Conjurer - COST:1 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1298,6 +1298,17 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Give a minion +2/+6.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("EX1_194e", EntityType::TARGET));
+    cards.emplace(
+        "CORE_EX1_194",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ---------------------------------------- MINION - PRIEST
     // [CORE_EX1_195] Kul Tiran Chaplain - COST:2 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1279,12 +1279,17 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // [CORE_EX1_193] Psychic Conjurer - COST:1 [ATK:1/HP:1]
     // - Set: CORE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Copy a card in your opponent’s deck
+    // Text: <b>Battlecry:</b> Copy a card in your opponent's deck
     //       and add it to your hand.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::ENEMY_DECK, 1));
+    power.AddPowerTask(
+        std::make_shared<CopyTask>(EntityType::STACK, ZoneType::HAND));
+    cards.emplace("CORE_EX1_193", CardDef(power));
 
     // ----------------------------------------- SPELL - PRIEST
     // [CORE_EX1_194] Power Infusion - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1441,6 +1441,9 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Your Hero Power becomes 'Deal 2 damage.'
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ChangeHeroPowerTask>("EX1_625t"));
+    cards.emplace("CORE_EX1_625", CardDef(power));
 
     // ---------------------------------------- MINION - PRIEST
     // [CS3_013] Shadowed Spirit - COST:3 [ATK:4/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1482,9 +1482,21 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Silence</b> a minion, then give it +3 Health.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
     // RefTag:
     // - SILENCE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SilenceTask>(EntityType::TARGET));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("CS3_027e", EntityType::TARGET));
+    cards.emplace(
+        "CS3_027",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ----------------------------------------- SPELL - PRIEST
     // [CS3_028] Thrive in the Shadows - COST:2
@@ -1518,6 +1530,9 @@ void CoreCardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: +3 Health.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("CS3_027e"));
+    cards.emplace("CS3_027e", CardDef(power));
 }
 
 void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -6,6 +6,7 @@
 #include <Rosetta/PlayMode/Auras/AdaptiveEffect.hpp>
 #include <Rosetta/PlayMode/CardSets/CoreCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Effects.hpp>
+#include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 
@@ -1468,6 +1469,12 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TAKE_HEAL));
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "CS3_014e", EntityType::SOURCE) };
+    cards.emplace("CS3_014", CardDef(power));
 
     // ----------------------------------------- SPELL - PRIEST
     // [CS3_027] Focused Will - COST:1
@@ -1493,12 +1500,17 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 
 void CoreCardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------- ENCHANTMENT - PRIEST
     // [CS3_014e] Holy Affinity - COST:0
     // - Set: CORE
     // --------------------------------------------------------
     // Text: +1 Attack.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("CS3_014e"));
+    cards.emplace("CS3_014e", CardDef(power));
 
     // ----------------------------------- ENCHANTMENT - PRIEST
     // [CS3_027e] Focused Will - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1508,6 +1508,10 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DISCOVER = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DiscoverTask>(DiscoverType::SPELL_FROM_DECK));
+    cards.emplace("CS3_028", CardDef(power));
 }
 
 void CoreCardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1250,6 +1250,11 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // Text: Deal 2 damage to all enemy minions.
     //       Restore 2 Health to all friendly characters.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 2, true));
+    power.AddPowerTask(std::make_shared<HealTask>(EntityType::FRIENDS, 2));
+    cards.emplace("CORE_CS1_112", CardDef(power));
 
     // ----------------------------------------- SPELL - PRIEST
     // [CORE_CS1_130] Holy Smite - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -3,6 +3,7 @@
 // Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
+#include <Rosetta/PlayMode/Auras/AdaptiveEffect.hpp>
 #include <Rosetta/PlayMode/CardSets/CoreCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Effects.hpp>
 #include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
@@ -1383,6 +1384,12 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: This minion's Attack is always equal to its Health.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<AdaptiveEffect>(
+        GameTag::ATK, EffectOperator::SET, [=](Playable* playable) {
+            return dynamic_cast<Minion*>(playable)->GetHealth();
+        }));
+    cards.emplace("CORE_EX1_335", CardDef(power));
 
     // ----------------------------------------- SPELL - PRIEST
     // [CORE_EX1_622] Shadow Word: Death - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1398,6 +1398,18 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Destroy a minion with 5 or more Attack.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_MIN_ATTACK = 5
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DestroyTask>(EntityType::TARGET));
+    cards.emplace(
+        "CORE_EX1_622",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_TARGET_MIN_ATTACK, 5 } }));
 
     // ---------------------------------------- MINION - PRIEST
     // [CORE_EX1_623] Temple Enforcer - COST:5 [ATK:5/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1420,6 +1420,19 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("EX1_623e", EntityType::TARGET));
+    cards.emplace(
+        "CORE_EX1_623",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_FRIENDLY_TARGET, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } }));
 
     // ----------------------------------------- SPELL - PRIEST
     // [CORE_EX1_625] Shadowform - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/TgtCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TgtCardsGen.cpp
@@ -11,6 +11,7 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 
 namespace RosettaStone::PlayMode
 {
+using PlayReqs = std::map<PlayReq, int>;
 using EffectList = std::vector<std::shared_ptr<IEffect>>;
 
 void TgtCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
@@ -767,6 +768,8 @@ void TgtCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 
 void TgtCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- MINION - PRIEST
     // [AT_011] Holy Champion - COST:4 [ATK:3/HP:5]
     // - Set: Tgt, Rarity: Common
@@ -842,6 +845,11 @@ void TgtCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // PlayReq:
     // - REQ_TARGET_TO_PLAY = 0
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<HealTask>(EntityType::TARGET, 5));
+    cards.emplace(
+        "AT_055",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ---------------------------------------- MINION - PRIEST
     // [AT_116] Wyrmrest Agent - COST:2 [ATK:1/HP:4]

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
@@ -256,6 +256,19 @@ auto DiscoverTask::Discover(Game* game, Player* player,
             }
             break;
         }
+        case DiscoverType::SPELL_FROM_DECK:
+        {
+            choiceAction = ChoiceAction::DRAW_FROM_DECK;
+            for (auto& playable : player->GetDeckZone()->GetAll())
+            {
+                if (playable->card->GetCardType() == CardType::SPELL)
+                {
+                    cardsForOtherEffect.emplace_back(
+                        playable->GetGameTag(GameTag::ENTITY_ID));
+                }
+            }
+            break;
+        }
         case DiscoverType::BASIC_TOTEM:
             choiceAction = ChoiceAction::SUMMON;
             cardsForGeneration = { Cards::FindCardByID("AT_132_SHAMANa"),

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -3445,3 +3445,52 @@ TEST_CASE("[Paladin : Spell] - CORE_OG_273 : Stand Against Darkness")
     CHECK_EQ(curField[5]->card->name, "Silver Hand Recruit");
     CHECK_EQ(curField[6]->card->name, "Silver Hand Recruit");
 }
+
+// ----------------------------------------- SPELL - PRIEST
+// [CORE_AT_055] Flash Heal - COST:1
+// - Set: CORE, Rarity: Common
+// - Spell School: Holy
+// --------------------------------------------------------
+// Text: Restore 5 Health.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - CORE_AT_055 : Flash Heal")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto curHero = curPlayer->GetHero();
+    auto opHero = opPlayer->GetHero();
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flash Heal"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flash Heal"));
+
+    CHECK_EQ(curHero->GetHealth(), 20);
+    CHECK_EQ(opHero->GetHealth(), 20);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, curHero));
+    CHECK_EQ(curHero->GetHealth(), 25);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, opHero));
+    CHECK_EQ(opHero->GetHealth(), 25);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -3742,3 +3742,54 @@ TEST_CASE("[Priest : Spell] - CORE_EX1_194 : Power Infusion")
     CHECK_EQ(curField[0]->GetAttack(), 8);
     CHECK_EQ(curField[0]->GetHealth(), 13);
 }
+
+// ---------------------------------------- MINION - PRIEST
+// [CORE_EX1_195] Kul Tiran Chaplain - COST:2 [ATK:2/HP:3]
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give a friendly minion +2 Health.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_FRIENDLY_TARGET = 0
+// - REQ_MINION_TARGET = 0
+// - REQ_TARGET_IF_AVAILABLE = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - CORE_EX1_195 : Kul Tiran Chaplain")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Kul Tiran Chaplain"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card1, card2));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -3793,3 +3793,73 @@ TEST_CASE("[Priest : Minion] - CORE_EX1_195 : Kul Tiran Chaplain")
     CHECK_EQ(curField[0]->GetAttack(), 3);
     CHECK_EQ(curField[0]->GetHealth(), 3);
 }
+
+// ----------------------------------------- SPELL - PRIEST
+// [CORE_EX1_197] Shadow Word: Ruin - COST:4
+// - Set: CORE, Rarity: Epic
+// - Spell School: Shadow
+// --------------------------------------------------------
+// Text: Destroy all minions with 5 or more Attack.
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - CORE_EX1_197 : Shadow Word: Ruin")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Shadow Word: Ruin"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Leeroy Jenkins"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Leeroy Jenkins"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetAttack(), 6);
+    CHECK_EQ(opField.GetCount(), 2);
+    CHECK_EQ(opField[0]->GetAttack(), 1);
+    CHECK_EQ(opField[1]->GetAttack(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[0]->GetAttack(), 6);
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[2]->GetAttack(), 1);
+    CHECK_EQ(opField.GetCount(), 3);
+    CHECK_EQ(opField[0]->GetAttack(), 1);
+    CHECK_EQ(opField[1]->GetAttack(), 1);
+    CHECK_EQ(opField[2]->GetAttack(), 6);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(opField.GetCount(), 2);
+    CHECK_EQ(opField[0]->GetAttack(), 1);
+    CHECK_EQ(opField[1]->GetAttack(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4092,3 +4092,54 @@ TEST_CASE("[Priest : Minion] - CORE_EX1_623 : Temple Enforcer")
     CHECK_EQ(curField[1]->GetAttack(), 5);
     CHECK_EQ(curField[1]->GetHealth(), 6);
 }
+
+// ----------------------------------------- SPELL - PRIEST
+// [CORE_EX1_625] Shadowform - COST:2
+// - Set: CORE, Rarity: Epic
+// - Spell School: Shadow
+// --------------------------------------------------------
+// Text: Your Hero Power becomes 'Deal 2 damage.'
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - CORE_EX1_625 : Shadowform")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    Hero* opHero = opPlayer->GetHero();
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Shadowform"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Shadowform"));
+
+    game.Process(curPlayer, HeroPowerTask(opHero));
+    CHECK_EQ(opHero->GetHealth(), 29);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetHero()->heroPower->card->name, "Mind Spike");
+
+    game.Process(curPlayer, HeroPowerTask(opHero));
+    CHECK_EQ(opHero->GetHealth(), 27);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curPlayer->GetHero()->heroPower->card->name, "Mind Spike");
+
+    game.Process(curPlayer, HeroPowerTask(opHero));
+    CHECK_EQ(opHero->GetHealth(), 25);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4257,3 +4257,57 @@ TEST_CASE("[Priest : Minion] - CS3_014 : Crimson Clergy")
     CHECK_EQ(curField[0]->GetAttack(), 3);
     CHECK_EQ(curField[1]->GetHealth(), 8);
 }
+
+// ----------------------------------------- SPELL - PRIEST
+// [CS3_027] Focused Will - COST:1
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Silence</b> a minion, then give it +3 Health.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+// RefTag:
+// - SILENCE = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - CS3_027 : Focused Will")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Focused Will", FormatType::STANDARD));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Bloodmage Thalnos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[0]->GetSpellPower(), 1);
+    CHECK_EQ(curField[0]->HasDeathrattle(), true);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(curField[0]->GetSpellPower(), 0);
+    CHECK_EQ(curField[0]->HasDeathrattle(), false);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4194,3 +4194,66 @@ TEST_CASE("[Priest : Minion] - CS3_013 : Shadowed Spirit")
     CHECK_EQ(curField.GetCount(), 0);
     CHECK_EQ(opHero->GetHealth(), 27);
 }
+
+// ---------------------------------------- MINION - PRIEST
+// [CS3_014] Crimson Clergy - COST:1 [ATK:1/HP:3]
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: After a friendly character is healed, gain +1 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - CS3_014 : Crimson Clergy")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Crimson Clergy", FormatType::STANDARD));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+
+    curPlayer->SetUsedMana(0);
+
+    game.Process(curPlayer, HeroPowerTask(curPlayer->GetHero()));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card2));
+    CHECK_EQ(curField[1]->GetHealth(), 6);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, HeroPowerTask(card2));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->GetHealth(), 8);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -3571,3 +3571,76 @@ TEST_CASE("[Priest : Spell] - CORE_CS1_112 : Holy Nova")
     CHECK_EQ(curField[1]->GetHealth(), 7);
     CHECK_EQ(opField.GetCount(), 0);
 }
+
+// ----------------------------------------- SPELL - PRIEST
+// [CORE_CS1_130] Holy Smite - COST:1
+// - Set: CORE, Rarity: Common
+// - Spell School: Holy
+// --------------------------------------------------------
+// Text: Deal 3 damage to a minion.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - CORE_CS1_130 : Holy Smite")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Holy Smite"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Holy Smite"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Holy Smite"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Holy Smite"));
+    const auto card5 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+    const auto card6 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card6));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card6));
+    CHECK_EQ(opField[0]->GetHealth(), 4);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card5));
+    CHECK_EQ(curField.GetCount(), 0);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card4, curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -3968,3 +3968,72 @@ TEST_CASE("[Priest : Minion] - CORE_EX1_335 : Lightspawn")
     CHECK_EQ(curField[0]->GetAttack(), 1);
     CHECK_EQ(curField[0]->GetHealth(), 1);
 }
+
+// ----------------------------------------- SPELL - PRIEST
+// [CORE_EX1_622] Shadow Word: Death - COST:2
+// - Set: CORE, Rarity: Common
+// - Spell School: Shadow
+// --------------------------------------------------------
+// Text: Destroy a minion with 5 or more Attack.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// - REQ_TARGET_MIN_ATTACK = 5
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - CORE_EX1_622 : Shadow Word: Death")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Shadow Word: Death"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(opField.GetCount(), 1);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card1, opPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 10);
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 8);
+    CHECK_EQ(opField.GetCount(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4037,3 +4037,58 @@ TEST_CASE("[Priest : Spell] - CORE_EX1_622 : Shadow Word: Death")
     CHECK_EQ(curPlayer->GetRemainingMana(), 8);
     CHECK_EQ(opField.GetCount(), 1);
 }
+
+// ---------------------------------------- MINION - PRIEST
+// [CORE_EX1_623] Temple Enforcer - COST:5 [ATK:5/HP:6]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give a friendly minion +3 Health.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_FRIENDLY_TARGET = 0
+// - REQ_MINION_TARGET = 0
+// - REQ_TARGET_IF_AVAILABLE = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - CORE_EX1_623 : Temple Enforcer")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Temple Enforcer"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 7);
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card1, card2));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 2);
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(curField[1]->GetAttack(), 5);
+    CHECK_EQ(curField[1]->GetHealth(), 6);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -3644,3 +3644,53 @@ TEST_CASE("[Priest : Spell] - CORE_CS1_130 : Holy Smite")
                  PlayCardTask::SpellTarget(card4, curPlayer->GetHero()));
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
 }
+
+// ---------------------------------------- MINION - PRIEST
+// [CORE_EX1_193] Psychic Conjurer - COST:1 [ATK:1/HP:1]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Copy a card in your opponent's deck
+//       and add it to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - CORE_EX1_193 : Psychic Conjurer")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.skipMulligan = true;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 5; ++i)
+    {
+        config.player2Deck[i] = Cards::FindCardByName("Magma Rager");
+    }
+    config.player2Deck[5] = Cards::FindCardByName("Wolfrider");
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Psychic Conjurer"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ((curHand[0]->card->name == "Magma Rager" ||
+              curHand[0]->card->name == "Wolfrider"),
+             true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -3921,3 +3921,50 @@ TEST_CASE("[Priest : Minion] - CORE_EX1_198 : Natalie Seline")
     CHECK_EQ(opField[0]->GetAttack(), 8);
     CHECK_EQ(opField[0]->GetHealth(), 11);
 }
+
+// ---------------------------------------- MINION - PRIEST
+// [CORE_EX1_335] Lightspawn - COST:3 [ATK:0/HP:4]
+// - Race: Elemental, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: This minion's Attack is always equal to its Health.
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - CORE_EX1_335 : Lightspawn")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Lightspawn"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    game.Process(opPlayer, AttackTask(card2, card1));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4311,3 +4311,57 @@ TEST_CASE("[Priest : Spell] - CS3_027 : Focused Will")
     CHECK_EQ(curField[0]->GetSpellPower(), 0);
     CHECK_EQ(curField[0]->HasDeathrattle(), false);
 }
+
+// ----------------------------------------- SPELL - PRIEST
+// [CS3_028] Thrive in the Shadows - COST:2
+// - Set: CORE, Rarity: Rare
+// - Spell School: Shadow
+// --------------------------------------------------------
+// Text: <b>Discover</b> a spell from your deck.
+// --------------------------------------------------------
+// GameTag:
+// - DISCOVER = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - CS3_028 : Thrive in the Shadows")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Bloodfen Raptor");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Fireball");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Pyroblast");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Thrive in the Shadows", FormatType::STANDARD));
+
+    CHECK_EQ(curPlayer->GetDeckZone()->GetCount(), 26);
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK(curPlayer->choice != nullptr);
+    CHECK_EQ(curPlayer->choice->choices.size(), 2u);
+
+    TestUtils::ChooseNthChoice(game, 1);
+    CHECK_EQ(curPlayer->GetDeckZone()->GetCount(), 25);
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -3694,3 +3694,51 @@ TEST_CASE("[Priest : Minion] - CORE_EX1_193 : Psychic Conjurer")
               curHand[0]->card->name == "Wolfrider"),
              true);
 }
+
+// ----------------------------------------- SPELL - PRIEST
+// [CORE_EX1_194] Power Infusion - COST:4
+// - Set: CORE, Rarity: Common
+// - Spell School: Holy
+// --------------------------------------------------------
+// Text: Give a minion +2/+6.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - CORE_EX1_194 : Power Infusion")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Power Infusion"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetAttack(), 6);
+    CHECK_EQ(curField[0]->GetHealth(), 7);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curField[0]->GetAttack(), 8);
+    CHECK_EQ(curField[0]->GetHealth(), 13);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -3863,3 +3863,61 @@ TEST_CASE("[Priest : Spell] - CORE_EX1_197 : Shadow Word: Ruin")
     CHECK_EQ(opField[0]->GetAttack(), 1);
     CHECK_EQ(opField[1]->GetAttack(), 1);
 }
+
+// ---------------------------------------- MINION - PRIEST
+// [CORE_EX1_198] Natalie Seline - COST:8 [ATK:8/HP:1]
+// - Set: CORE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Destroy a minion and gain its Health.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINION_TARGET = 0
+// - REQ_TARGET_IF_AVAILABLE = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - CORE_EX1_198 : Natalie Seline")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Natalie Seline"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetHealth(), 12);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField[0]->GetHealth(), 11);
+
+    game.Process(opPlayer, PlayCardTask::MinionTarget(card2, card1));
+    CHECK_EQ(curField.GetCount(), 0);
+    CHECK_EQ(opField[0]->GetAttack(), 8);
+    CHECK_EQ(opField[0]->GetHealth(), 11);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -1797,7 +1797,7 @@ TEST_CASE("[Hunter : Minion] - CS3_015 : Selective Breeder")
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     CHECK(curPlayer->choice != nullptr);
-    CHECK_EQ(curPlayer->choice->choices.size(), 3u);
+    CHECK_EQ(curPlayer->choice->choices.size(), 2u);
 
     TestUtils::ChooseNthChoice(game, 1);
     CHECK_EQ(curDeck.GetCount(), 26);

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4143,3 +4143,54 @@ TEST_CASE("[Priest : Spell] - CORE_EX1_625 : Shadowform")
     game.Process(curPlayer, HeroPowerTask(opHero));
     CHECK_EQ(opHero->GetHealth(), 25);
 }
+
+// ---------------------------------------- MINION - PRIEST
+// [CS3_013] Shadowed Spirit - COST:3 [ATK:4/HP:3]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Deal 3 damage to the enemy hero.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - CS3_013 : Shadowed Spirit")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    Hero* opHero = opPlayer->GetHero();
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Shadowed Spirit", FormatType::STANDARD));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(opHero->GetHealth(), 30);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField.GetCount(), 0);
+    CHECK_EQ(opHero->GetHealth(), 27);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TgtCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TgtCardsGenTests.cpp
@@ -247,3 +247,50 @@ TEST_CASE("[Paladin : Minion] - AT_075 : Warhorse Trainer")
     CHECK_EQ(curField[0]->GetAttack(), 3);
     CHECK_EQ(curField[1]->GetAttack(), 1);
 }
+
+// ----------------------------------------- SPELL - PRIEST
+// [AT_055] Flash Heal - COST:1
+// - Set: Tgt, Rarity: Common
+// --------------------------------------------------------
+// Text: Restore 5 Health.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - AT_055 : Flash Heal")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto curHero = curPlayer->GetHero();
+    auto opHero = opPlayer->GetHero();
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flash Heal"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flash Heal"));
+
+    CHECK_EQ(curHero->GetHealth(), 20);
+    CHECK_EQ(opHero->GetHealth(), 20);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, curHero));
+    CHECK_EQ(curHero->GetHealth(), 25);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, opHero));
+    CHECK_EQ(opHero->GetHealth(), 25);
+}


### PR DESCRIPTION
This revision includes:
- Implement 16 CORE cards
  - Flash Heal (CORE_AT_055)
  - Holy Nova (CORE_CS1_112)
  - Holy Smite (CORE_CS1_130)
  - Psychic Conjurer (CORE_EX1_193)
  - Power Infusion (CORE_EX1_194)
  - Kul Tiran Chaplain (CORE_EX1_195)
  - Shadow Word: Ruin (CORE_EX1_197)
  - Natalie Seline (CORE_EX1_198)
  - Lightspawn (CORE_EX1_335)
  - Shadow Word: Death (CORE_EX1_622)
  - Temple Enforcer (CORE_EX1_623)
  - Shadowform (CORE_EX1_625)
  - Shadowed Spirit (CS3_013)
  - Crimson Clergy (CS3_014)
  - Focused Will (CS3_027)
  - Thrive in the Shadows (CS3_028)
- Implement 1 TGT card
  - Flash Heal (AT_055)
- Add enum value 'SPELL_FROM_DECK' and code to process it
- Correct code that Discover effects not present duplicate options