### PR TITLE
Implement 15 CORE cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -49,13 +49,13 @@ CORE | CORE_CS2_042 | Fire Elemental |
 CORE | CORE_CS2_045 | Rockbiter Weapon |  
 CORE | CORE_CS2_062 | Hellfire |  
 CORE | CORE_CS2_064 | Dread Infernal |  
-CORE | CORE_CS2_072 | Backstab |  
-CORE | CORE_CS2_073 | Cold Blood |  
-CORE | CORE_CS2_074 | Deadly Poison |  
-CORE | CORE_CS2_075 | Sinister Strike |  
-CORE | CORE_CS2_076 | Assassinate |  
-CORE | CORE_CS2_077 | Sprint |  
-CORE | CORE_CS2_080 | Assassin's Blade |  
+CORE | CORE_CS2_072 | Backstab | O
+CORE | CORE_CS2_073 | Cold Blood | O
+CORE | CORE_CS2_074 | Deadly Poison | O
+CORE | CORE_CS2_075 | Sinister Strike | O
+CORE | CORE_CS2_076 | Assassinate | O
+CORE | CORE_CS2_077 | Sprint | O
+CORE | CORE_CS2_080 | Assassin's Blade | O
 CORE | CORE_CS2_088 | Guardian of Kings | O
 CORE | CORE_CS2_089 | Holy Light | O
 CORE | CORE_CS2_092 | Blessing of Kings | O
@@ -98,9 +98,9 @@ CORE | CORE_EX1_096 | Loot Hoarder |
 CORE | CORE_EX1_103 | Coldlight Seer |  
 CORE | CORE_EX1_110 | Cairne Bloodhoof |  
 CORE | CORE_EX1_130 | Noble Sacrifice | O
-CORE | CORE_EX1_134 | SI:7 Agent |  
-CORE | CORE_EX1_144 | Shadowstep |  
-CORE | CORE_EX1_145 | Preparation |  
+CORE | CORE_EX1_134 | SI:7 Agent | O
+CORE | CORE_EX1_144 | Shadowstep | O
+CORE | CORE_EX1_145 | Preparation | O
 CORE | CORE_EX1_158 | Soul of the Forest | O
 CORE | CORE_EX1_160 | Power of the Wild | O
 CORE | CORE_EX1_162 | Dire Wolf Alpha |  
@@ -149,7 +149,7 @@ CORE | CORE_EX1_411 | Gorehowl |
 CORE | CORE_EX1_414 | Grommash Hellscream |  
 CORE | CORE_EX1_506 | Murloc Tidehunter |  
 CORE | CORE_EX1_509 | Murloc Tidecaller |  
-CORE | CORE_EX1_522 | Patient Assassin |  
+CORE | CORE_EX1_522 | Patient Assassin | O
 CORE | CORE_EX1_531 | Scavenging Hyena | O
 CORE | CORE_EX1_534 | Savannah Highmane | O
 CORE | CORE_EX1_543 | King Krush | O
@@ -186,14 +186,14 @@ CORE | CORE_ICC_026 | Grim Necromancer |
 CORE | CORE_ICC_038 | Righteous Protector | O
 CORE | CORE_ICC_055 | Drain Soul |  
 CORE | CORE_ICC_419 | Bearshark | O
-CORE | CORE_ICC_809 | Plague Scientist |  
+CORE | CORE_ICC_809 | Plague Scientist | O
 CORE | CORE_KAR_009 | Babbling Book | O
 CORE | CORE_KAR_036 | Arcane Anomaly |  
 CORE | CORE_KAR_065 | Menagerie Warden | O
-CORE | CORE_KAR_069 | Swashburglar |  
+CORE | CORE_KAR_069 | Swashburglar | O
 CORE | CORE_KAR_300 | Enchanted Raven | O
 CORE | CORE_LOE_003 | Ethereal Conjurer | O
-CORE | CORE_LOE_012 | Tomb Pillager |  
+CORE | CORE_LOE_012 | Tomb Pillager | O
 CORE | CORE_LOEA10_3 | Murloc Tinyfin |  
 CORE | CORE_LOOT_124 | Lone Champion |  
 CORE | CORE_LOOT_125 | Stoneskin Basilisk |  
@@ -203,7 +203,7 @@ CORE | CORE_NEW1_018 | Bloodsail Raider |
 CORE | CORE_NEW1_026 | Violet Teacher |  
 CORE | CORE_NEW1_027 | Southsea Captain |  
 CORE | CORE_OG_047 | Feral Rage | O
-CORE | CORE_OG_070 | Bladed Cultist |  
+CORE | CORE_OG_070 | Bladed Cultist | O
 CORE | CORE_OG_241 | Possessed Villager |  
 CORE | CORE_OG_273 | Stand Against Darkness | O
 CORE | CORE_TRL_111 | Headhunter's Hatchet | O
@@ -246,7 +246,7 @@ CORE | CS3_036 | Deathwing the Destroyer |
 CORE | CS3_037 | Emerald Skytalon |  
 CORE | CS3_038 | Redgill Razorjaw |  
 
-- Progress: 32% (77 of 235 Cards)
+- Progress: 39% (92 of 235 Cards)
 
 ## Ashes of Outland
 

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -713,7 +713,7 @@ LOE | LOE_007 | Curse of Rafaam |
 LOE | LOE_009 | Obsidian Destroyer |  
 LOE | LOE_010 | Pit Snake |  
 LOE | LOE_011 | Reno Jackson |  
-LOE | LOE_012 | Tomb Pillager |  
+LOE | LOE_012 | Tomb Pillager | O
 LOE | LOE_016 | Rumbling Elemental |  
 LOE | LOE_017 | Keeper of Uldaman |  
 LOE | LOE_018 | Tunnel Trogg |  
@@ -752,7 +752,7 @@ LOE | LOE_118 | Cursed Blade |
 LOE | LOE_119 | Animated Armor |  
 LOE | LOEA10_3 | Murloc Tinyfin |  
 
-- Progress: 2% (1 of 45 Cards)
+- Progress: 4% (2 of 45 Cards)
 
 ## Whispers of the Old Gods
 
@@ -774,7 +774,7 @@ OG | OG_047 | Feral Rage | O
 OG | OG_048 | Mark of Y'Shaarj |  
 OG | OG_051 | Forbidden Ancient |  
 OG | OG_061 | On the Hunt |  
-OG | OG_070 | Bladed Cultist |  
+OG | OG_070 | Bladed Cultist | O
 OG | OG_072 | Journey Below |  
 OG | OG_073 | Thistle Tea |  
 OG | OG_080 | Xaril, Poisoned Mind |  
@@ -893,7 +893,7 @@ OG | OG_338 | Nat, the Darkfisher |
 OG | OG_339 | Skeram Cultist |  
 OG | OG_340 | Soggoth the Slitherer |  
 
-- Progress: 1% (2 of 134 Cards)
+- Progress: 2% (3 of 134 Cards)
 
 ## One Night in Karazhan
 
@@ -923,7 +923,7 @@ KARA | KAR_061 | The Curator |
 KARA | KAR_062 | Netherspite Historian |  
 KARA | KAR_063 | Spirit Claws |  
 KARA | KAR_065 | Menagerie Warden | O
-KARA | KAR_069 | Swashburglar |  
+KARA | KAR_069 | Swashburglar | O
 KARA | KAR_070 | Ethereal Peddler |  
 KARA | KAR_073 | Maelstrom Portal |  
 KARA | KAR_075 | Moonglade Portal |  
@@ -945,7 +945,7 @@ KARA | KAR_710 | Arcanosmith |
 KARA | KAR_711 | Arcane Giant |  
 KARA | KAR_712 | Violet Illusionist |  
 
-- Progress: 6% (3 of 45 Cards)
+- Progress: 8% (4 of 45 Cards)
 
 ## Journey to Un'Goro
 
@@ -1189,7 +1189,7 @@ ICECROWN | ICC_801 | Howling Commander |
 ICECROWN | ICC_802 | Spirit Lash |  
 ICECROWN | ICC_807 | Strongshell Scavenger |  
 ICECROWN | ICC_808 | Crypt Lord |  
-ICECROWN | ICC_809 | Plague Scientist |  
+ICECROWN | ICC_809 | Plague Scientist | O
 ICECROWN | ICC_810 | Deathaxe Punisher |  
 ICECROWN | ICC_811 | Lilian Voss |  
 ICECROWN | ICC_812 | Meat Wagon |  
@@ -1229,7 +1229,7 @@ ICECROWN | ICC_911 | Keening Banshee |
 ICECROWN | ICC_912 | Corpsetaker |  
 ICECROWN | ICC_913 | Tainted Zealot |  
 
-- Progress: 1% (2 of 135 Cards)
+- Progress: 2% (3 of 135 Cards)
 
 ## The Witchwood
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 32% Core Set (77 of 235 cards)
+  * 39% Core Set (92 of 235 cards)
   * 59% Ashes of Outland (80 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
@@ -51,12 +51,12 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 0% Goblins vs Gnomes (0 of 123 Cards)
   * 3% Blackrock Mountain (1 of 31 Cards)
   * 3% The Grand Tournament (5 of 132 Cards)
-  * 2% The League of Explorers (1 of 45 Cards)
-  * 1% Whispers of the Old Gods (2 of 134 Cards)
-  * 6% One Night in Karazhan (3 of 45 Cards)
+  * 4% The League of Explorers (2 of 45 Cards)
+  * 2% Whispers of the Old Gods (3 of 134 Cards)
+  * 8% One Night in Karazhan (4 of 45 Cards)
   * 0% Mean Streets of Gadgetzan (0 of 132 Cards)
   * 0% Journey to Un'Goro (1 of 135 Cards)
-  * 1% Knights of the Frozen Throne (2 of 135 Cards)
+  * 2% Knights of the Frozen Throne (3 of 135 Cards)
   * 0% Kobolds & Catacombs (0 of 135 Cards)
   * 1% The Witchwood (2 of 129 Cards)
   * 1% The Boomsday Project (2 of 136 Cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1541,12 +1541,27 @@ void CoreCardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)
 
 void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------ SPELL - ROGUE
     // [CORE_CS2_072] Backstab - COST:0
     // - Set: CORE, Rarity: Common
     // --------------------------------------------------------
     // Text: Deal 2 damage to an undamaged minion.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_UNDAMAGED_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 2, true));
+    cards.emplace(
+        "CORE_CS2_072",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_UNDAMAGED_TARGET, 0 } }));
 
     // ------------------------------------------ SPELL - ROGUE
     // [CORE_CS2_073] Cold Blood - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1594,6 +1594,15 @@ void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Give your weapon +2 Attack.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_WEAPON_EQUIPPED = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("CS2_074e", EntityType::WEAPON));
+    cards.emplace(
+        "CORE_CS2_074",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_WEAPON_EQUIPPED, 0 } }));
 
     // ------------------------------------------ SPELL - ROGUE
     // [CORE_CS2_075] Sinister Strike - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1573,6 +1573,19 @@ void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - COMBO = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("CS2_073e", EntityType::TARGET));
+    power.AddComboTask(
+        std::make_shared<AddEnchantmentTask>("CS2_073e2", EntityType::TARGET));
+    cards.emplace(
+        "CORE_CS2_073",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ------------------------------------------ SPELL - ROGUE
     // [CORE_CS2_074] Deadly Poison - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1730,9 +1730,22 @@ void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - COMBO = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_TARGET_FOR_COMBO = 0
+    // --------------------------------------------------------
     // RefTag:
     // - POISONOUS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddComboTask(
+        std::make_shared<AddEnchantmentTask>("ICC_809e", EntityType::TARGET));
+    cards.emplace(
+        "CORE_ICC_809",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_FRIENDLY_TARGET, 0 },
+                                 { PlayReq::REQ_TARGET_FOR_COMBO, 0 } }));
 
     // ----------------------------------------- MINION - ROGUE
     // [CORE_KAR_069] Swashburglar - COST:1 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1701,6 +1701,10 @@ void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: The next spell you cast this turn costs (2) less.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("EX1_145o", EntityType::PLAYER));
+    cards.emplace("CORE_EX1_145", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
     // [CORE_EX1_522] Patient Assassin - COST:2 [ATK:1/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1621,6 +1621,17 @@ void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Destroy an enemy minion.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_ENEMY_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DestroyTask>(EntityType::TARGET));
+    cards.emplace("CORE_CS2_076",
+                  CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                           { PlayReq::REQ_MINION_TARGET, 0 },
+                                           { PlayReq::REQ_ENEMY_TARGET, 0 } }));
 
     // ------------------------------------------ SPELL - ROGUE
     // [CORE_CS2_077] Sprint - COST:6

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1647,6 +1647,12 @@ void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // [CORE_CS2_080] Assassin's Blade - COST:4
     // - Set: CORE, Rarity: Rare
     // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 5
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CORE_CS2_080", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
     // [CORE_EX1_134] SI:7 Agent - COST:3 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1772,6 +1772,10 @@ void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<AddCardTask>(EntityType::HAND, "GAME_005"));
+    cards.emplace("CORE_LOE_012", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
     // [CORE_OG_070] Bladed Cultist - COST:1 [ATK:1/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1608,8 +1608,12 @@ void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // [CORE_CS2_075] Sinister Strike - COST:1
     // - Set: CORE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Deal 3 damage to the enemy hero.
+    // Text: Deal 3 damage to the enemy hero.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 3, true));
+    cards.emplace("CORE_CS2_075", CardDef(power));
 
     // ------------------------------------------ SPELL - ROGUE
     // [CORE_CS2_076] Assassinate - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1751,12 +1751,17 @@ void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // [CORE_KAR_069] Swashburglar - COST:1 [ATK:1/HP:1]
     // - Race: Pirate, Set: CORE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Add a random card from another class
-    //       to your hand.
+    // Text: <b>Battlecry:</b> Add a random card
+    //       from another class to your hand.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<RandomCardTask>(EntityType::ENEMY_HERO));
+    power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
+    cards.emplace("CORE_KAR_069", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
     // [CORE_LOE_012] Tomb Pillager - COST:4 [ATK:5/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1663,6 +1663,14 @@ void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - COMBO = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_FOR_COMBO = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddComboTask(std::make_shared<DamageTask>(EntityType::TARGET, 2));
+    cards.emplace(
+        "CORE_EX1_134",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_FOR_COMBO, 0 } }));
 
     // ------------------------------------------ SPELL - ROGUE
     // [CORE_EX1_144] Shadowstep - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1714,9 +1714,12 @@ void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     //       <b>Poisonous</b>
     // --------------------------------------------------------
     // GameTag:
-    // - POISONOUS = 1
     // - STEALTH = 1
+    // - POISONOUS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CORE_EX1_522", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
     // [CORE_ICC_809] Plague Scientist - COST:3 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1678,8 +1678,22 @@ void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // - Spell School: Shadow
     // --------------------------------------------------------
     // Text: Return a friendly minion to your hand.
-    //       It costs (2) less.
+    //       It costs (2) less.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ReturnHandTask>(EntityType::TARGET));
+    power.AddPowerTask(std::make_shared<AddAuraEffectTask>(
+        Effects::ReduceCost(2), EntityType::TARGET));
+    cards.emplace(
+        "CORE_EX1_144",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_FRIENDLY_TARGET, 0 } }));
 
     // ------------------------------------------ SPELL - ROGUE
     // [CORE_EX1_145] Preparation - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1786,6 +1786,10 @@ void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - COMBO = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddComboTask(
+        std::make_shared<AddEnchantmentTask>("OG_070e", EntityType::SOURCE));
+    cards.emplace("CORE_OG_070", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
     // [CS3_005] Vanessa VanCleef - COST:2 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1639,6 +1639,9 @@ void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Draw 4 cards.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawTask>(4));
+    cards.emplace("CORE_CS2_077", CardDef(power));
 
     // ----------------------------------------- WEAPON - ROGUE
     // [CORE_CS2_080] Assassin's Blade - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -2422,7 +2422,8 @@ void Expert1CardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // [CS2_073] Cold Blood - COST:1
     // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
-    // Text: Give a minion +2 Attack. <b>Combo:</b> +4 Attack instead.
+    // Text: Give a minion +2 Attack.
+    //       <b>Combo:</b> +4 Attack instead.
     // --------------------------------------------------------
     // GameTag:
     // - COMBO = 1

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -2605,7 +2605,8 @@ void Expert1CardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // - Faction: Neutral, Set: Expert1, Rarity: Common
     // - Spell School: Shadow
     // --------------------------------------------------------
-    // Text: Return a friendly minion to your hand. It costs (2) less.
+    // Text: Return a friendly minion to your hand.
+    //       It costs (2) less.
     // --------------------------------------------------------
     // PlayReq:
     // - REQ_TARGET_TO_PLAY = 0

--- a/Sources/Rosetta/PlayMode/CardSets/IcecrownCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/IcecrownCardsGen.cpp
@@ -4,10 +4,15 @@
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 #include <Rosetta/PlayMode/CardSets/IcecrownCardsGen.hpp>
+#include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
+
+using namespace RosettaStone::PlayMode::SimpleTasks;
 
 namespace RosettaStone::PlayMode
 {
+using PlayReqs = std::map<PlayReq, int>;
+
 void IcecrownCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
     // ------------------------------------------ HERO - SHAMAN
@@ -1219,6 +1224,8 @@ void IcecrownCardsGen::AddPriestNonCollect(
 
 void IcecrownCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- MINION - ROGUE
     // [ICC_065] Bone Baron - COST:5 [ATK:5/HP:5]
     // - Set: Icecrown, Rarity: Common
@@ -1296,6 +1303,14 @@ void IcecrownCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - POISONOUS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddComboTask(
+        std::make_shared<AddEnchantmentTask>("ICC_809e", EntityType::TARGET));
+    cards.emplace(
+        "ICC_809",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_FRIENDLY_TARGET, 0 },
+                                 { PlayReq::REQ_TARGET_FOR_COMBO, 0 } }));
 
     // ----------------------------------------- MINION - ROGUE
     // [ICC_811] Lilian Voss - COST:4 [ATK:4/HP:5]
@@ -1341,6 +1356,8 @@ void IcecrownCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 
 void IcecrownCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------ ENCHANTMENT - ROGUE
     // [ICC_018e] Witty Weaponplay (*) - COST:0
     // - Set: Icecrown
@@ -1375,6 +1392,9 @@ void IcecrownCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - POISONOUS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("ICC_809e"));
+    cards.emplace("ICC_809e", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - ROGUE
     // [ICC_827e] Shadow Reflection (*) - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
@@ -274,16 +274,23 @@ void KaraCardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)
 
 void KaraCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- MINION - ROGUE
     // [KAR_069] Swashburglar - COST:1 [ATK:1/HP:1]
     // - Race: Pirate, Faction: Neutral, Set: Kara, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Add a random class card to your hand
-    //       <i>(from your opponent's class).</i>
+    // Text: <b>Battlecry:</b> Add a random card
+    //       from another class to your hand.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<RandomCardTask>(EntityType::ENEMY_HERO));
+    power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
+    cards.emplace("KAR_069", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
     // [KAR_070] Ethereal Peddler - COST:5 [ATK:5/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
@@ -273,6 +273,8 @@ void LoECardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)
 
 void LoECardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- MINION - ROGUE
     // [LOE_010] Pit Snake - COST:1 [ATK:2/HP:1]
     // - Race: Beast, Set: LoE, Rarity: Common
@@ -292,6 +294,10 @@ void LoECardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<AddCardTask>(EntityType::HAND, "GAME_005"));
+    cards.emplace("LOE_012", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
     // [LOE_019] Unearthed Raptor - COST:3 [ATK:3/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/OgCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/OgCardsGen.cpp
@@ -707,6 +707,8 @@ void OgCardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)
 
 void OgCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- MINION - ROGUE
     // [OG_070] Bladed Cultist - COST:1 [ATK:1/HP:2]
     // - Set: Og, Rarity: Common
@@ -716,6 +718,10 @@ void OgCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - COMBO = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddComboTask(
+        std::make_shared<AddEnchantmentTask>("OG_070e", EntityType::SOURCE));
+    cards.emplace("OG_070", CardDef(power));
 
     // ------------------------------------------ SPELL - ROGUE
     // [OG_072] Journey Below - COST:1
@@ -821,12 +827,17 @@ void OgCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 
 void OgCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------ ENCHANTMENT - ROGUE
     // [OG_070e] Thirsty Blades (*) - COST:0
     // - Set: Og, Rarity: Common
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("OG_070e"));
+    cards.emplace("OG_070e", CardDef(power));
 
     // ------------------------------------------ SPELL - ROGUE
     // [OG_080b] Kingsblood Toxin (*) - COST:1

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4663,3 +4663,15 @@ TEST_CASE("[Rogue : Spell] - CORE_CS2_077 : Sprint")
     game.Process(curPlayer, PlayCardTask::Spell(card1));
     CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 8);
 }
+
+// ----------------------------------------- WEAPON - ROGUE
+// [CORE_CS2_080] Assassin's Blade - COST:4
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// GameTag:
+// - DURABILITY = 5
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Weapon] - CORE_CS2_080 : Assassin's Blade")
+{
+    // Do nothing
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4365,3 +4365,61 @@ TEST_CASE("[Priest : Spell] - CS3_028 : Thrive in the Shadows")
     CHECK_EQ(curPlayer->GetDeckZone()->GetCount(), 25);
     CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
 }
+
+// ------------------------------------------ SPELL - ROGUE
+// [CORE_CS2_072] Backstab - COST:0
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: Deal 2 damage to an undamaged minion.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// - REQ_UNDAMAGED_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Spell] - CORE_CS2_072 : Backstab")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Backstab"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Backstab"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+    CHECK_EQ(opField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card3));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+    CHECK_EQ(opField[0]->GetHealth(), 5);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4485,3 +4485,55 @@ TEST_CASE("[Rogue : Spell] - CORE_CS2_073 : Cold Blood")
     game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card4));
     CHECK_EQ(curField[1]->GetAttack(), 7);
 }
+
+// ------------------------------------------ SPELL - ROGUE
+// [CORE_CS2_074] Deadly Poison - COST:1
+// - Set: CORE, Rarity: Common
+// - Spell School: Nature
+// --------------------------------------------------------
+// Text: Give your weapon +2 Attack.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_WEAPON_EQUIPPED = 0
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Spell] - CORE_CS2_074 : Deadly Poison")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Deadly Poison"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curPlayer->GetWeapon().GetAttack(), 1);
+    CHECK_EQ(curPlayer->GetWeapon().GetDurability(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetWeapon().GetAttack(), 3);
+    CHECK_EQ(curPlayer->GetWeapon().GetDurability(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetWeapon().GetAttack(), 3);
+    CHECK_EQ(curPlayer->GetWeapon().GetDurability(), 2);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4423,3 +4423,65 @@ TEST_CASE("[Rogue : Spell] - CORE_CS2_072 : Backstab")
     CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
     CHECK_EQ(opField[0]->GetHealth(), 5);
 }
+
+// ------------------------------------------ SPELL - ROGUE
+// [CORE_CS2_073] Cold Blood - COST:2
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: Give a minion +2 Attack.
+//       <b>Combo:</b> +4 Attack instead.
+// --------------------------------------------------------
+// GameTag:
+// - COMBO = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Spell] - CORE_CS2_073 : Cold Blood")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Cold Blood"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Cold Blood"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3));
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card4));
+    CHECK_EQ(curField[1]->GetAttack(), 7);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4890,3 +4890,55 @@ TEST_CASE("[Rogue : Spell] - CORE_EX1_145 : Preparation")
     game.Process(curPlayer, PlayCardTask::Spell(card3));
     CHECK_EQ(card5->GetCost(), 4);
 }
+
+// ----------------------------------------- MINION - ROGUE
+// [CORE_EX1_522] Patient Assassin - COST:2 [ATK:1/HP:2]
+// - Set: CORE, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Stealth</b>
+//       <b>Poisonous</b>
+// --------------------------------------------------------
+// GameTag:
+// - STEALTH = 1
+// - POISONOUS = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - CORE_EX1_522 : Patient Assassin")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Patient Assassin"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Chillwind Yeti"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(card1, card2));
+
+    CHECK(card2->isDestroyed);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5084,3 +5084,49 @@ TEST_CASE("[Rogue : Minion] - CORE_LOE_012 : Tomb Pillager")
     CHECK_EQ(curHand.GetCount(), 1);
     CHECK_EQ(curHand[0]->card->name, "The Coin");
 }
+
+// ----------------------------------------- MINION - ROGUE
+// [CORE_OG_070] Bladed Cultist - COST:1 [ATK:1/HP:2]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Combo:</b> Gain +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - COMBO = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - CORE_OG_070 : Bladed Cultist")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bladed Cultist"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bladed Cultist"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4537,3 +4537,37 @@ TEST_CASE("[Rogue : Spell] - CORE_CS2_074 : Deadly Poison")
     CHECK_EQ(curPlayer->GetWeapon().GetAttack(), 3);
     CHECK_EQ(curPlayer->GetWeapon().GetDurability(), 2);
 }
+
+// ------------------------------------------ SPELL - ROGUE
+// [CORE_CS2_075] Sinister Strike - COST:1
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: Deal 3 damage to the enemy hero.
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Spell] - CORE_CS2_075 : Sinister Strike")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Sinister Strike"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4942,3 +4942,56 @@ TEST_CASE("[Rogue : Minion] - CORE_EX1_522 : Patient Assassin")
 
     CHECK(card2->isDestroyed);
 }
+
+// ----------------------------------------- MINION - ROGUE
+// [CORE_ICC_809] Plague Scientist - COST:3 [ATK:2/HP:3]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Combo:</b> Give a friendly minion <b>Poisonous</b>.
+// --------------------------------------------------------
+// GameTag:
+// - COMBO = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINION_TARGET = 0
+// - REQ_FRIENDLY_TARGET = 0
+// - REQ_TARGET_FOR_COMBO = 0
+// --------------------------------------------------------
+// RefTag:
+// - POISONOUS = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - CORE_ICC_809 : Plague Scientist")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Plague Scientist"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Plague Scientist"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasPoisonous(), false);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card1));
+    CHECK_EQ(curField[0]->HasPoisonous(), true);
+    CHECK_EQ(curField[1]->HasPoisonous(), false);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4628,3 +4628,38 @@ TEST_CASE("[Rogue : Spell] - CORE_CS2_076 : Assassinate")
     CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
     CHECK_EQ(opField.GetCount(), 0);
 }
+
+// ------------------------------------------ SPELL - ROGUE
+// [CORE_CS2_077] Sprint - COST:6
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: Draw 4 cards.
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Spell] - CORE_CS2_077 : Sprint")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Sprint"));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 8);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4675,3 +4675,49 @@ TEST_CASE("[Rogue : Weapon] - CORE_CS2_080 : Assassin's Blade")
 {
     // Do nothing
 }
+
+// ----------------------------------------- MINION - ROGUE
+// [CORE_EX1_134] SI:7 Agent - COST:3 [ATK:3/HP:3]
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Combo:</b> Deal 2 damage.
+// --------------------------------------------------------
+// GameTag:
+// - COMBO = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_FOR_COMBO = 0
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - CORE_EX1_134 : SI:7 Agent")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("SI:7 Agent"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("SI:7 Agent"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4721,3 +4721,108 @@ TEST_CASE("[Rogue : Minion] - CORE_EX1_134 : SI:7 Agent")
                  PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
 }
+
+// ------------------------------------------ SPELL - ROGUE
+// [CORE_EX1_144] Shadowstep - COST:0
+// - Set: CORE, Rarity: Common
+// - Spell School: Shadow
+// --------------------------------------------------------
+// Text: Return a friendly minion to your hand.
+//       It costs (2) less.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// - REQ_FRIENDLY_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Spell] - CORE_EX1_144 : Shadowstep")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Shadowstep"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Shadowstep"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Shadowstep"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Stonetusk Boar"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("SI:7 Agent"));
+    const auto card6 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("SI:7 Agent"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 9);
+    CHECK_EQ(curPlayer->GetFieldZone()->GetCount(), 1);
+    CHECK_EQ(card4->GetCost(), 1);
+
+    game.Process(curPlayer, AttackTask(card4, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 29);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card4));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 9);
+    CHECK_EQ(curPlayer->GetFieldZone()->GetCount(), 0);
+    CHECK_EQ(card4->GetCost(), 0);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(dynamic_cast<Minion*>(card4)->CanAttack(), true);
+
+    game.Process(curPlayer, AttackTask(card4, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+
+    CHECK_EQ(curPlayer->IsComboActive(), true);
+
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card5, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 26);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card5));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 7);
+    CHECK_EQ(curPlayer->GetFieldZone()->GetCount(), 1);
+    CHECK_EQ(card5->GetCost(), 1);
+
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card5, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 24);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->IsComboActive(), false);
+
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card6, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 24);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card6));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+    CHECK_EQ(curPlayer->GetFieldZone()->GetCount(), 2);
+    CHECK_EQ(card6->GetCost(), 1);
+
+    CHECK_EQ(curPlayer->IsComboActive(), true);
+
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card6, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 22);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4995,3 +4995,44 @@ TEST_CASE("[Rogue : Minion] - CORE_ICC_809 : Plague Scientist")
     CHECK_EQ(curField[0]->HasPoisonous(), true);
     CHECK_EQ(curField[1]->HasPoisonous(), false);
 }
+
+// ----------------------------------------- MINION - ROGUE
+// [CORE_KAR_069] Swashburglar - COST:1 [ATK:1/HP:1]
+// - Race: Pirate, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Add a random card
+//       from another class to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - CORE_KAR_069 : Swashburglar")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Swashburglar"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK(curHand[0]->card->IsCardClass(CardClass::HUNTER));
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4826,3 +4826,67 @@ TEST_CASE("[Rogue : Spell] - CORE_EX1_144 : Shadowstep")
                  PlayCardTask::MinionTarget(card6, opPlayer->GetHero()));
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 22);
 }
+
+// ------------------------------------------ SPELL - ROGUE
+// [CORE_EX1_145] Preparation - COST:0
+// - Set: CORE, Rarity: Epic
+// --------------------------------------------------------
+// Text: The next spell you cast this turn costs (2) less.
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Spell] - CORE_EX1_145 : Preparation")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Preparation"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Preparation"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Preparation"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Eviscerate"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Vanish"));
+
+    CHECK_EQ(card1->GetCost(), 0);
+    CHECK_EQ(card2->GetCost(), 0);
+    CHECK_EQ(card3->GetCost(), 0);
+    CHECK_EQ(card4->GetCost(), 2);
+    CHECK_EQ(card5->GetCost(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(card2->GetCost(), 0);
+    CHECK_EQ(card3->GetCost(), 0);
+    CHECK_EQ(card4->GetCost(), 0);
+    CHECK_EQ(card5->GetCost(), 4);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(card3->GetCost(), 0);
+    CHECK_EQ(card4->GetCost(), 0);
+    CHECK_EQ(card5->GetCost(), 4);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card4, opPlayer->GetHero()));
+    CHECK_EQ(card3->GetCost(), 0);
+    CHECK_EQ(card5->GetCost(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(card5->GetCost(), 4);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5036,3 +5036,51 @@ TEST_CASE("[Rogue : Minion] - CORE_KAR_069 : Swashburglar")
     CHECK_EQ(curHand.GetCount(), 1);
     CHECK(curHand[0]->card->IsCardClass(CardClass::HUNTER));
 }
+
+// ----------------------------------------- MINION - ROGUE
+// [CORE_LOE_012] Tomb Pillager - COST:4 [ATK:5/HP:4]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Add a Coin to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - CORE_LOE_012 : Tomb Pillager")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Tomb Pillager"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->name, "The Coin");
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4571,3 +4571,60 @@ TEST_CASE("[Rogue : Spell] - CORE_CS2_075 : Sinister Strike")
     game.Process(curPlayer, PlayCardTask::Spell(card1));
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
 }
+
+// ------------------------------------------ SPELL - ROGUE
+// [CORE_CS2_076] Assassinate - COST:4
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: Destroy an enemy minion.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// - REQ_ENEMY_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Spell] - CORE_CS2_076 : Assassinate")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Assassinate"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(opField.GetCount(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card1, opPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+    CHECK_EQ(opField.GetCount(), 0);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -5320,7 +5320,8 @@ TEST_CASE("[Rogue : Spell] - EX1_137 : Headcrack")
 // - Faction: Neutral, Set: Expert1, Rarity: Common
 // - Spell School: Shadow
 // --------------------------------------------------------
-// Text: Return a friendly minion to your hand. It costs (2) less.
+// Text: Return a friendly minion to your hand.
+//       It costs (2) less.
 // --------------------------------------------------------
 // PlayReq:
 // - REQ_TARGET_TO_PLAY = 0

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -4835,7 +4835,8 @@ TEST_CASE("[Priest : Spell] - EX1_626 : Mass Dispel")
 // [CS2_073] Cold Blood - COST:1
 // - Faction: Neutral, Set: Expert1, Rarity: Common
 // --------------------------------------------------------
-// Text: Give a minion +2 Attack. <b>Combo:</b> +4 Attack instead.
+// Text: Give a minion +2 Attack.
+//       <b>Combo:</b> +4 Attack instead.
 // --------------------------------------------------------
 // GameTag:
 // - COMBO = 1

--- a/Tests/UnitTests/PlayMode/CardSets/IcecrownCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/IcecrownCardsGenTests.cpp
@@ -8,6 +8,15 @@
 
 #include <Utils/CardSetUtils.hpp>
 
+#include <Rosetta/PlayMode/Actions/Draw.hpp>
+#include <Rosetta/PlayMode/Cards/Cards.hpp>
+#include <Rosetta/PlayMode/Zones/FieldZone.hpp>
+
+using namespace RosettaStone;
+using namespace PlayMode;
+using namespace PlayerTasks;
+using namespace SimpleTasks;
+
 // ---------------------------------------- MINION - HUNTER
 // [ICC_419] Bearshark - COST:3 [ATK:4/HP:3]
 // - Race: Beast, Set: Icecrown, Rarity: Common
@@ -37,4 +46,56 @@ TEST_CASE("[Hunter : Minion] - ICC_419 : Bearshark")
 TEST_CASE("[Paladin : Minion] - ICC_038 : Righteous Protector")
 {
     // Do nothing
+}
+
+// ----------------------------------------- MINION - ROGUE
+// [ICC_809] Plague Scientist - COST:3 [ATK:2/HP:3]
+// - Set: Icecrown, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Combo:</b> Give a friendly minion <b>Poisonous</b>.
+// --------------------------------------------------------
+// GameTag:
+// - COMBO = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINION_TARGET = 0
+// - REQ_FRIENDLY_TARGET = 0
+// - REQ_TARGET_FOR_COMBO = 0
+// --------------------------------------------------------
+// RefTag:
+// - POISONOUS = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - ICC_809 : Plague Scientist")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Plague Scientist"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Plague Scientist"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasPoisonous(), false);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card1));
+    CHECK_EQ(curField[0]->HasPoisonous(), true);
+    CHECK_EQ(curField[1]->HasPoisonous(), false);
 }

--- a/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
@@ -129,3 +129,43 @@ TEST_CASE("[Mage : Minion] - KAR_009 : Babbling Book")
     CHECK_EQ(curHand[0]->card->GetCardType(), CardType::SPELL);
     CHECK(curHand[0]->card->IsCardClass(CardClass::MAGE));
 }
+
+// ----------------------------------------- MINION - ROGUE
+// [KAR_069] Swashburglar - COST:1 [ATK:1/HP:1]
+// - Race: Pirate, Faction: Neutral, Set: Kara, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Add a random card
+//       from another class to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - KAR_069 : Swashburglar")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Swashburglar"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK(curHand[0]->card->IsCardClass(CardClass::HUNTER));
+}

--- a/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
@@ -68,3 +68,50 @@ TEST_CASE("[Mage : Minion] - LOE_003 : Ethereal Conjurer")
     TestUtils::ChooseNthChoice(game, 1);
     CHECK_EQ(curHand.GetCount(), 1);
 }
+
+// ----------------------------------------- MINION - ROGUE
+// [LOE_012] Tomb Pillager - COST:4 [ATK:5/HP:4]
+// - Set: LoE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Add a Coin to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - LOE_012 : Tomb Pillager")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Tomb Pillager"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->name, "The Coin");
+}

--- a/Tests/UnitTests/PlayMode/CardSets/OgCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/OgCardsGenTests.cpp
@@ -113,3 +113,48 @@ TEST_CASE("[Paladin : Spell] - OG_273 : Stand Against Darkness")
     CHECK_EQ(curField[5]->card->name, "Silver Hand Recruit");
     CHECK_EQ(curField[6]->card->name, "Silver Hand Recruit");
 }
+
+// ----------------------------------------- MINION - ROGUE
+// [OG_070] Bladed Cultist - COST:1 [ATK:1/HP:2]
+// - Set: Og, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Combo:</b> Gain +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - COMBO = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - OG_070 : Bladed Cultist")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bladed Cultist"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bladed Cultist"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey=RosettaStone
-sonar.projectName=Hearthstone simulator using C++ with some reinforcement learning
+sonar.projectName=RosettaStone
 sonar.projectVersion=0.4
 
 # =====================================================


### PR DESCRIPTION
This revision includes:
- Implement 15 CORE cards
  - Backstab (CORE_CS2_072)
  - Cold Blood (CORE_CS2_073)
  - Deadly Poison (CORE_CS2_074)
  - Sinister Strike (CORE_CS2_075)
  - Assassinate (CORE_CS2_076)
  - Sprint (CORE_CS2_077)
  - Assassin's Blade (CORE_CS2_080)
  - SI:7 Agent (CORE_EX1_134)
  - Shadowstep (CORE_EX1_144)
  - Preparation (CORE_EX1_145)
  - Patient Assassin (CORE_EX1_522)
  - Plague Scientist (CORE_ICC_809)
  - Swashburglar (CORE_KAR_069)
  - Tomb Pillager (CORE_LOE_012)
  - Bladed Cultist (CORE_OG_070)
- Implement 1 ICECROWN card
  - Plague Scientist (ICC_809)
- Implement 1 KARA card
  - Swashburglar (KAR_069)
- Implement 1 LOE card
  - Tomb Pillager (LOE_012)
- Implement 1 OG card
  - Bladed Cultist (OG_070)