### PR TITLE
Implement 16 CORE cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -13,7 +13,7 @@ Set | ID | Name | Implemented
 CORE | CORE_AT_003 | Fallen Hero | O
 CORE | CORE_AT_008 | Coldarra Drake | O
 CORE | CORE_AT_021 | Tiny Knight of Evil |  
-CORE | CORE_AT_047 | Draenei Totemcarver |  
+CORE | CORE_AT_047 | Draenei Totemcarver | O
 CORE | CORE_AT_055 | Flash Heal | O
 CORE | CORE_AT_061 | Lock and Load | O
 CORE | CORE_AT_075 | Warhorse Trainer | O
@@ -21,7 +21,7 @@ CORE | CORE_AT_092 | Ice Rager |
 CORE | CORE_BOT_083 | Toxicologist |  
 CORE | CORE_BOT_420 | Landscaping | O
 CORE | CORE_BOT_453 | Shooting Star | O
-CORE | CORE_BOT_533 | Menacing Nimbus |  
+CORE | CORE_BOT_533 | Menacing Nimbus | O
 CORE | CORE_BRM_013 | Quick Shot | O
 CORE | CORE_BT_035 | Chaos Strike |  
 CORE | CORE_BT_036 | Coordinated Strike |  
@@ -44,9 +44,9 @@ CORE | CORE_CS2_023 | Arcane Intellect | O
 CORE | CORE_CS2_029 | Fireball | O
 CORE | CORE_CS2_032 | Flamestrike | O
 CORE | CORE_CS2_033 | Water Elemental | O
-CORE | CORE_CS2_039 | Windfury |  
-CORE | CORE_CS2_042 | Fire Elemental |  
-CORE | CORE_CS2_045 | Rockbiter Weapon |  
+CORE | CORE_CS2_039 | Windfury | O
+CORE | CORE_CS2_042 | Fire Elemental | O
+CORE | CORE_CS2_045 | Rockbiter Weapon | O
 CORE | CORE_CS2_062 | Hellfire |  
 CORE | CORE_CS2_064 | Dread Infernal |  
 CORE | CORE_CS2_072 | Backstab | O
@@ -118,13 +118,13 @@ CORE | CORE_EX1_194 | Power Infusion | O
 CORE | CORE_EX1_195 | Kul Tiran Chaplain | O
 CORE | CORE_EX1_197 | Shadow Word: Ruin | O
 CORE | CORE_EX1_198 | Natalie Seline | O
-CORE | CORE_EX1_238 | Lightning Bolt |  
-CORE | CORE_EX1_246 | Hex |  
-CORE | CORE_EX1_248 | Feral Spirit |  
+CORE | CORE_EX1_238 | Lightning Bolt | O
+CORE | CORE_EX1_246 | Hex | O
+CORE | CORE_EX1_248 | Feral Spirit | O
 CORE | CORE_EX1_249 | Baron Geddon |  
-CORE | CORE_EX1_250 | Earth Elemental |  
-CORE | CORE_EX1_258 | Unbound Elemental |  
-CORE | CORE_EX1_259 | Lightning Storm |  
+CORE | CORE_EX1_250 | Earth Elemental | O
+CORE | CORE_EX1_258 | Unbound Elemental | O
+CORE | CORE_EX1_259 | Lightning Storm | O
 CORE | CORE_EX1_275 | Cone of Cold | O
 CORE | CORE_EX1_287 | Counterspell | O
 CORE | CORE_EX1_289 | Ice Barrier | O
@@ -155,10 +155,10 @@ CORE | CORE_EX1_534 | Savannah Highmane | O
 CORE | CORE_EX1_543 | King Krush | O
 CORE | CORE_EX1_554 | Snake Trap | O
 CORE | CORE_EX1_564 | Faceless Manipulator |  
-CORE | CORE_EX1_567 | Doomhammer |  
+CORE | CORE_EX1_567 | Doomhammer | O
 CORE | CORE_EX1_571 | Force of Nature | O
 CORE | CORE_EX1_573 | Cenarius | O
-CORE | CORE_EX1_575 | Mana Tide Totem |  
+CORE | CORE_EX1_575 | Mana Tide Totem | O
 CORE | CORE_EX1_603 | Cruel Taskmaster |  
 CORE | CORE_EX1_604 | Frothing Berserker |  
 CORE | CORE_EX1_610 | Explosive Trap | O
@@ -198,7 +198,7 @@ CORE | CORE_LOEA10_3 | Murloc Tinyfin |
 CORE | CORE_LOOT_124 | Lone Champion |  
 CORE | CORE_LOOT_125 | Stoneskin Basilisk |  
 CORE | CORE_LOOT_137 | Sleepy Dragon |  
-CORE | CORE_NEW1_010 | Al'Akir the Windlord |  
+CORE | CORE_NEW1_010 | Al'Akir the Windlord | O
 CORE | CORE_NEW1_018 | Bloodsail Raider |  
 CORE | CORE_NEW1_026 | Violet Teacher |  
 CORE | CORE_NEW1_027 | Southsea Captain |  
@@ -211,14 +211,14 @@ CORE | CORE_TRL_243 | Pounce | O
 CORE | CORE_tt_004 | Flesheating Ghoul |  
 CORE | CORE_UNG_020 | Arcanologist | O
 CORE | CORE_UNG_813 | Stormwatcher |  
-CORE | CORE_UNG_817 | Tidal Surge |  
+CORE | CORE_UNG_817 | Tidal Surge | O
 CORE | CORE_UNG_833 | Lakkari Felhound |  
 CORE | CORE_UNG_844 | Humongous Razorleaf |  
 CORE | CS3_001 | Aegwynn, the Guardian |  
 CORE | CS3_002 | Ritual of Doom |  
 CORE | CS3_003 | Felsoul Jailer |  
 CORE | CS3_005 | Vanessa VanCleef |  
-CORE | CS3_007 | Novice Zapper |  
+CORE | CS3_007 | Novice Zapper | O
 CORE | CS3_008 | Bloodsail Deckhand |  
 CORE | CS3_009 | War Cache |  
 CORE | CS3_012 | Nordrassil Druid | O
@@ -246,7 +246,7 @@ CORE | CS3_036 | Deathwing the Destroyer |
 CORE | CS3_037 | Emerald Skytalon |  
 CORE | CS3_038 | Redgill Razorjaw |  
 
-- Progress: 39% (92 of 235 Cards)
+- Progress: 45% (108 of 235 Cards)
 
 ## Ashes of Outland
 

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -613,7 +613,7 @@ TGT | AT_043 | Astral Communion |
 TGT | AT_044 | Mulch |  
 TGT | AT_045 | Aviana |  
 TGT | AT_046 | Tuskarr Totemic |  
-TGT | AT_047 | Draenei Totemcarver |  
+TGT | AT_047 | Draenei Totemcarver | O
 TGT | AT_048 | Healing Wave |  
 TGT | AT_049 | Thunder Bluff Valiant |  
 TGT | AT_050 | Charged Hammer |  
@@ -700,7 +700,7 @@ TGT | AT_131 | Eydis Darkbane |
 TGT | AT_132 | Justicar Trueheart |  
 TGT | AT_133 | Gadgetzan Jouster |  
 
-- Progress: 3% (5 of 132 Cards)
+- Progress: 4% (6 of 132 Cards)
 
 ## The League of Explorers
 
@@ -1025,7 +1025,7 @@ UNGORO | UNG_812 | Sabretooth Stalker |
 UNGORO | UNG_813 | Stormwatcher |  
 UNGORO | UNG_814 | Giant Wasp |  
 UNGORO | UNG_816 | Servant of Kalimos |  
-UNGORO | UNG_817 | Tidal Surge |  
+UNGORO | UNG_817 | Tidal Surge | O
 UNGORO | UNG_818 | Volatile Elemental |  
 UNGORO | UNG_823 | Envenom Weapon |  
 UNGORO | UNG_829 | Lakkari Sacrifice |  
@@ -1087,7 +1087,7 @@ UNGORO | UNG_961 | Adaptation |
 UNGORO | UNG_962 | Lightfused Stegodon |  
 UNGORO | UNG_963 | Lyra the Sunshard |  
 
-- Progress: 0% (1 of 135 Cards)
+- Progress: 1% (2 of 135 Cards)
 
 ## Knights of the Frozen Throne
 
@@ -1468,7 +1468,7 @@ BOOMSDAY | BOT_523 | Mulchmuncher |
 BOOMSDAY | BOT_529 | Power Word: Replicate |  
 BOOMSDAY | BOT_531 | Celestial Emissary |  
 BOOMSDAY | BOT_532 | Explodinator |  
-BOOMSDAY | BOT_533 | Menacing Nimbus |  
+BOOMSDAY | BOT_533 | Menacing Nimbus | O
 BOOMSDAY | BOT_534 | Bull Dozer |  
 BOOMSDAY | BOT_535 | Microtech Controller |  
 BOOMSDAY | BOT_536 | Omega Agent |  
@@ -1508,7 +1508,7 @@ BOOMSDAY | BOT_912 | Kangor's Endless Army |
 BOOMSDAY | BOT_913 | Demonic Project |  
 BOOMSDAY | BOT_914 | Whizbang the Wonderful |  
 
-- Progress: 1% (2 of 136 Cards)
+- Progress: 2% (3 of 136 Cards)
 
 ## Rastakhan's Rumble
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 39% Core Set (92 of 235 cards)
+  * 45% Core Set (108 of 235 cards)
   * 59% Ashes of Outland (80 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
@@ -50,16 +50,16 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 6% Curse of Naxxramas (2 of 30 Cards)
   * 0% Goblins vs Gnomes (0 of 123 Cards)
   * 3% Blackrock Mountain (1 of 31 Cards)
-  * 3% The Grand Tournament (5 of 132 Cards)
+  * 4% The Grand Tournament (6 of 132 Cards)
   * 4% The League of Explorers (2 of 45 Cards)
   * 2% Whispers of the Old Gods (3 of 134 Cards)
   * 8% One Night in Karazhan (4 of 45 Cards)
   * 0% Mean Streets of Gadgetzan (0 of 132 Cards)
-  * 0% Journey to Un'Goro (1 of 135 Cards)
+  * 1% Journey to Un'Goro (2 of 135 Cards)
   * 2% Knights of the Frozen Throne (3 of 135 Cards)
   * 0% Kobolds & Catacombs (0 of 135 Cards)
   * 1% The Witchwood (2 of 129 Cards)
-  * 1% The Boomsday Project (2 of 136 Cards)
+  * 2% The Boomsday Project (3 of 136 Cards)
   * 1% Rastakhan's Rumble (2 of 135 Cards)
   * **100% Rise of Shadows (136 of 136 cards)**
   * **99% Saviors of Uldum (134 of 135 cards)**

--- a/Sources/Rosetta/PlayMode/CardSets/BoomsdayCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BoomsdayCardsGen.cpp
@@ -1040,6 +1040,8 @@ void BoomsdayCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 
 void BoomsdayCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- SPELL - SHAMAN
     // [BOT_093] Elementary Reaction - COST:2
     // - Set: BOOMSDAY, Rarity: Common
@@ -1139,6 +1141,11 @@ void BoomsdayCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<RandomCardTask>(
+        CardType::MINION, CardClass::INVALID, Race::ELEMENTAL));
+    power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
+    cards.emplace("BOT_533", CardDef(power));
 
     // ---------------------------------------- MINION - SHAMAN
     // [BOT_543] Omega Mind - COST:2 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1811,6 +1811,8 @@ void CoreCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 
 void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- MINION - SHAMAN
     // [CORE_AT_047] Draenei Totemcarver - COST:4 [ATK:4/HP:5]
     // - Set: CORE, Rarity: Rare
@@ -1820,6 +1822,14 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::MINIONS));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::TOTEM)) }));
+    power.AddPowerTask(std::make_shared<CountTask>(EntityType::STACK));
+    power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
+        "AT_047e", EntityType::SOURCE, true));
+    cards.emplace("CORE_AT_047", CardDef(power));
 
     // ---------------------------------------- MINION - SHAMAN
     // [CORE_BOT_533] Menacing Nimbus - COST:2 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2047,6 +2047,10 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->tasks = { std::make_shared<DrawTask>(1) };
+    cards.emplace("CORE_EX1_575", CardDef(power));
 
     // ---------------------------------------- MINION - SHAMAN
     // [CORE_NEW1_010] Al'Akir the Windlord - COST:8 [ATK:3/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1914,7 +1914,17 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // GameTag:
     // - OVERLOAD = 1
+    // - OVERLOAD_OWED = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
+    cards.emplace(
+        "CORE_EX1_238",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [CORE_EX1_246] Hex - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1988,8 +1988,8 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // [CORE_EX1_258] Unbound Elemental - COST:3 [ATK:3/HP:4]
     // - Race: Elemental, Set: CORE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Whenever you play a card with <b>Overload</b>,
-    //       gain +1/+1.
+    // Text: Whenever you play a card with <b>Overload</b>,
+    //       gain +1/+1.
     // --------------------------------------------------------
     // GameTag:
     // - TRIGGER_VISUAL = 1
@@ -1997,6 +1997,13 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - OVERLOAD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::PLAY_CARD));
+    power.GetTrigger()->condition =
+        std::make_shared<SelfCondition>(SelfCondition::IsOverloadCard());
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "EX1_258e", EntityType::SOURCE) };
+    cards.emplace("CORE_EX1_258", CardDef(power));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [CORE_EX1_259] Lightning Storm - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1853,9 +1853,20 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Give a minion <b>Windfury</b>.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
     // RefTag:
     // - WINDFURY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::TARGET,
+                                                        GameTag::WINDFURY, 1));
+    cards.emplace(
+        "CORE_CS2_039",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ---------------------------------------- MINION - SHAMAN
     // [CORE_CS2_042] Fire Elemental - COST:6 [ATK:6/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2065,6 +2065,9 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // - TAUNT = 1
     // - WINDFURY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CORE_NEW1_010", CardDef(power));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [CORE_UNG_817] Tidal Surge - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2029,9 +2029,14 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // Text: <b>Windfury, Overload:</b> (2)
     // --------------------------------------------------------
     // GameTag:
-    // - OVERLOAD = 1
+    // - DURABILITY = 8
     // - WINDFURY = 1
+    // - OVERLOAD = 2
+    // - OVERLOAD_OWED = 2
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CORE_EX1_567", CardDef(power));
 
     // ---------------------------------------- MINION - SHAMAN
     // [CORE_EX1_575] Mana Tide Totem - COST:3 [ATK:0/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1893,6 +1893,17 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Give a friendly character +3 Attack this turn.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("CS2_045e", EntityType::TARGET));
+    cards.emplace(
+        "CORE_CS2_045",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_FRIENDLY_TARGET, 0 } }));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [CORE_EX1_238] Lightning Bolt - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2010,12 +2010,17 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // - Set: CORE, Rarity: Rare
     // - Spell School: Nature
     // --------------------------------------------------------
-    // Text: Deal 3 damage to all enemy minions.
+    // Text: Deal 3 damage to all enemy minions.
     //       <b>Overload:</b> (2)
     // --------------------------------------------------------
     // GameTag:
-    // - OVERLOAD = 1
+    // - OVERLOAD = 2
+    // - OVERLOAD_OWED = 2
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 3, true));
+    cards.emplace("CORE_EX1_259", CardDef(power));
 
     // ---------------------------------------- WEAPON - SHAMAN
     // [CORE_EX1_567] Doomhammer - COST:5

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1957,10 +1957,16 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // GameTag:
     // - OVERLOAD = 1
+    // - OVERLOAD_OWED = 1
     // --------------------------------------------------------
-    // RefTag:
-    // - TAUNT = 1
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("EX1_tk11", 2));
+    cards.emplace(
+        "CORE_EX1_248",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ---------------------------------------- MINION - SHAMAN
     // [CORE_EX1_250] Earth Elemental - COST:5 [ATK:7/HP:8]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2096,12 +2096,17 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // [CS3_007] Novice Zapper - COST:1 [ATK:3/HP:2]
     // - Set: CORE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Spell Damage +1</b> <b>Overload:</b> (1)
+    // Text: <b>Spell Damage +1</b>
+    //       <b>Overload:</b> (1)
     // --------------------------------------------------------
     // GameTag:
     // - OVERLOAD = 1
+    // - OVERLOAD_OWED = 1
     // - SPELLPOWER = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CS3_007", CardDef(power));
 }
 
 void CoreCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1877,6 +1877,14 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::TARGET, 4));
+    cards.emplace(
+        "CORE_CS2_042",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } }));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [CORE_CS2_045] Rockbiter Weapon - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1840,6 +1840,11 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<RandomCardTask>(
+        CardType::MINION, CardClass::INVALID, Race::ELEMENTAL));
+    power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
+    cards.emplace("CORE_BOT_533", CardDef(power));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [CORE_CS2_039] Windfury - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1976,9 +1976,13 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     //       <b><b>Overload</b>:</b> (2)
     // --------------------------------------------------------
     // GameTag:
-    // - OVERLOAD = 1
+    // - OVERLOAD = 2
+    // - OVERLOAD_OWED = 2
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CORE_EX1_250", CardDef(power));
 
     // ---------------------------------------- MINION - SHAMAN
     // [CORE_EX1_258] Unbound Elemental - COST:3 [ATK:3/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1933,9 +1933,20 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Transform a minion into a 0/1 Frog with <b>Taunt</b>.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<TransformTask>(EntityType::TARGET, "hexfrog"));
+    cards.emplace(
+        "CORE_EX1_246",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [CORE_EX1_248] Feral Spirit - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2075,11 +2075,22 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // - Spell School: Nature
     // --------------------------------------------------------
     // Text: <b>Lifesteal</b>
-    //       Deal 4 damage to a minion.
+    //       Deal 4 damage to a minion.
     // --------------------------------------------------------
     // GameTag:
     // - LIFESTEAL = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 4, true));
+    cards.emplace(
+        "CORE_UNG_817",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ---------------------------------------- MINION - SHAMAN
     // [CS3_007] Novice Zapper - COST:1 [ATK:3/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -3057,6 +3057,9 @@ void Expert1CardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: At the end of your turn, draw a card.
     // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
     power.GetTrigger()->tasks = { std::make_shared<DrawTask>(1) };

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -3023,7 +3023,8 @@ void Expert1CardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // - Faction: Neutral, Set: Expert1, Rarity: Rare
     // - Spell School: Nature
     // --------------------------------------------------------
-    // Text: Deal 3 damage to all enemy minions. <b>Overload:</b> (2)
+    // Text: Deal 3 damage to all enemy minions.
+    //       <b>Overload:</b> (2)
     // --------------------------------------------------------
     // GameTag:
     // - OVERLOAD = 2

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -3004,7 +3004,8 @@ void Expert1CardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // [EX1_258] Unbound Elemental - COST:3 [ATK:3/HP:4]
     // - Race: Elemental, Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
-    // Text: Whenever you play a card with <b>Overload</b>, gain +1/+1.
+    // Text: Whenever you play a card with <b>Overload</b>,
+    //       gain +1/+1.
     // --------------------------------------------------------
     // RefTag:
     // - OVERLOAD = 1

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -2949,8 +2949,8 @@ void Expert1CardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     //       <b>Overload:</b> (1)
     // --------------------------------------------------------
     // GameTag:
-    // - OVERLOAD = 2
-    // - OVERLOAD_OWED = 2
+    // - OVERLOAD = 1
+    // - OVERLOAD_OWED = 1
     // --------------------------------------------------------
     // PlayReq:
     // - REQ_NUM_MINION_SLOTS = 1

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -2969,8 +2969,8 @@ void Expert1CardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     //       <b><b>Overload</b>:</b> (2)
     // --------------------------------------------------------
     // GameTag:
-    // - OVERLOAD = 3
-    // - OVERLOAD_OWED = 3
+    // - OVERLOAD = 2
+    // - OVERLOAD_OWED = 2
     // - TAUNT = 1
     // --------------------------------------------------------
     power.ClearData();

--- a/Sources/Rosetta/PlayMode/CardSets/TgtCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TgtCardsGen.cpp
@@ -12,6 +12,7 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 namespace RosettaStone::PlayMode
 {
 using PlayReqs = std::map<PlayReq, int>;
+using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
 using EffectList = std::vector<std::shared_ptr<IEffect>>;
 
 void TgtCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
@@ -1029,6 +1030,8 @@ void TgtCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 
 void TgtCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- MINION - SHAMAN
     // [AT_046] Tuskarr Totemic - COST:3 [ATK:3/HP:2]
     // - Set: Tgt, Rarity: Common
@@ -1040,7 +1043,7 @@ void TgtCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [AT_047] Draenei Totemcarver - COST:4 [ATK:4/HP:4]
+    // [AT_047] Draenei Totemcarver - COST:4 [ATK:4/HP:5]
     // - Set: Tgt, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Gain +1/+1 for each friendly Totem.
@@ -1048,6 +1051,14 @@ void TgtCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::MINIONS));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::TOTEM)) }));
+    power.AddPowerTask(std::make_shared<CountTask>(EntityType::STACK));
+    power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
+        "AT_047e", EntityType::SOURCE, true));
+    cards.emplace("AT_047", CardDef(power));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [AT_048] Healing Wave - COST:3
@@ -1139,6 +1150,10 @@ void TgtCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Increased stats.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(
+        std::make_unique<Enchant>(Enchants::AddAttackHealthScriptTag));
+    cards.emplace("AT_047e", CardDef(power));
 
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [AT_049e] Power of the Bluff (*) - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
@@ -7,8 +7,12 @@
 #include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 
+using namespace RosettaStone::PlayMode::SimpleTasks;
+
 namespace RosettaStone::PlayMode
 {
+using PlayReqs = std::map<PlayReq, int>;
+
 void UngoroCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
     // Do nothing
@@ -1094,6 +1098,8 @@ void UngoroCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 
 void UngoroCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- MINION - SHAMAN
     // [UNG_019] Air Elemental - COST:1 [ATK:2/HP:1]
     // - Race: Elemental, Faction: Horde, Set: Ungoro, Rarity: Common
@@ -1169,14 +1175,25 @@ void UngoroCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // ----------------------------------------- SPELL - SHAMAN
     // [UNG_817] Tidal Surge - COST:3
     // - Faction: Neutral, Set: Ungoro, Rarity: Common
+    // - Spell School: Nature
     // --------------------------------------------------------
-    // Text: Deal 4 damage to a minion.
-    //       Restore 4 Health to your hero.
+    // Text: <b>Lifesteal</b>
+    //       Deal 4 damage to a minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - LIFESTEAL = 1
     // --------------------------------------------------------
     // PlayReq:
     // - REQ_MINION_TARGET = 0
     // - REQ_TARGET_TO_PLAY = 0
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 4, true));
+    cards.emplace(
+        "UNG_817",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ---------------------------------------- MINION - SHAMAN
     // [UNG_938] Hot Spring Guardian - COST:3 [ATK:2/HP:4]

--- a/Tests/UnitTests/PlayMode/CardSets/BoomsdayCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BoomsdayCardsGenTests.cpp
@@ -11,6 +11,7 @@
 #include <Rosetta/PlayMode/Actions/Draw.hpp>
 #include <Rosetta/PlayMode/Cards/Cards.hpp>
 #include <Rosetta/PlayMode/Zones/FieldZone.hpp>
+#include <Rosetta/PlayMode/Zones/HandZone.hpp>
 
 using namespace RosettaStone;
 using namespace PlayMode;
@@ -135,4 +136,44 @@ TEST_CASE("[Mage : Spell] - BOT_453 : Shooting Star")
     game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3));
     CHECK_EQ(opField.GetCount(), 1);
     CHECK_EQ(opField[0]->GetHealth(), 11);
+}
+
+// ---------------------------------------- MINION - SHAMAN
+// [BOT_533] Menacing Nimbus - COST:2 [ATK:2/HP:2]
+// - Race: Elemental, Set: BOOMSDAY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Add a random Elemental to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Minion] - BOT_533 : Menacing Nimbus")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Menacing Nimbus"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->GetCardType(), CardType::MINION);
+    CHECK_EQ(curHand[0]->card->GetRace(), Race::ELEMENTAL);
 }

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5220,3 +5220,67 @@ TEST_CASE("[Shaman : Minion] - CORE_BOT_533 : Menacing Nimbus")
     CHECK_EQ(curHand[0]->card->GetCardType(), CardType::MINION);
     CHECK_EQ(curHand[0]->card->GetRace(), Race::ELEMENTAL);
 }
+
+// ----------------------------------------- SPELL - SHAMAN
+// [CORE_CS2_039] Windfury - COST:2
+// - Set: CORE, Rarity: Common
+// - Spell School: Nature
+// --------------------------------------------------------
+// Text: Give a minion <b>Windfury</b>.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+// RefTag:
+// - WINDFURY = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - CORE_CS2_039 : Windfury")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Windfury"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasWindfury(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(card1, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 24);
+    CHECK_EQ(curField[0]->IsExhausted(), true);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField[0]->HasWindfury(), true);
+    CHECK_EQ(curField[0]->IsExhausted(), false);
+
+    game.Process(curPlayer, AttackTask(card1, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 18);
+    CHECK_EQ(curField[0]->IsExhausted(), true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5885,3 +5885,21 @@ TEST_CASE("[Shaman : Minion] - CORE_EX1_575 : Mana Tide Totem")
 
     CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
 }
+
+// ---------------------------------------- MINION - SHAMAN
+// [CORE_NEW1_010] Al'Akir the Windlord - COST:8 [ATK:3/HP:6]
+// - Race: Elemental, Set: CORE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Charge, Divine Shield, Taunt, Windfury</b>
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - CHARGE = 1
+// - DIVINE_SHIELD = 1
+// - TAUNT = 1
+// - WINDFURY = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Minion] - CORE_NEW1_010 : Al'Akir the Windlord")
+{
+    // Do nothing
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5458,3 +5458,73 @@ TEST_CASE("[Shaman : Spell] - CORE_EX1_238 : Lightning Bolt")
     CHECK_EQ(curPlayer->GetOverloadOwed(), 0);
     CHECK_EQ(curPlayer->GetOverloadLocked(), 1);
 }
+
+// ----------------------------------------- SPELL - SHAMAN
+// [CORE_EX1_246] Hex - COST:4
+// - Set: CORE, Rarity: Common
+// - Spell School: Nature
+// --------------------------------------------------------
+// Text: Transform a minion into a 0/1 Frog with <b>Taunt</b>.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - CORE_EX1_246 : Hex")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Hex"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Hex"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetAttack(), 0);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAUNT), 1);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card4));
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetAttack(), 0);
+    CHECK_EQ(opField[0]->GetHealth(), 1);
+    CHECK_EQ(opField[0]->GetGameTag(GameTag::TAUNT), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5179,3 +5179,44 @@ TEST_CASE("[Shaman : Minion] - CORE_AT_047 : Draenei Totemcarver")
     CHECK_EQ(curField[2]->GetAttack(), 5);
     CHECK_EQ(curField[2]->GetHealth(), 6);
 }
+
+// ---------------------------------------- MINION - SHAMAN
+// [CORE_BOT_533] Menacing Nimbus - COST:2 [ATK:2/HP:2]
+// - Race: Elemental, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Add a random Elemental to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Minion] - CORE_BOT_533 : Menacing Nimbus")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Menacing Nimbus"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->GetCardType(), CardType::MINION);
+    CHECK_EQ(curHand[0]->card->GetRace(), Race::ELEMENTAL);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5402,3 +5402,59 @@ TEST_CASE("[Shaman : Spell] - CORE_CS2_045 : Rockbiter Weapon")
     CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
     CHECK_EQ(curField[0]->GetAttack(), 3);
 }
+
+// ----------------------------------------- SPELL - SHAMAN
+// [CORE_EX1_238] Lightning Bolt - COST:1
+// - Set: CORE, Rarity: Common
+// - Spell School: Nature
+// --------------------------------------------------------
+// Text: Deal 3 damage. <b>Overload:</b> (1)
+// --------------------------------------------------------
+// GameTag:
+// - OVERLOAD = 1
+// - OVERLOAD_OWED = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - CORE_EX1_238 : Lightning Bolt")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Lightning Bolt"));
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card1, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 9);
+    CHECK_EQ(curPlayer->GetOverloadOwed(), 1);
+    CHECK_EQ(curPlayer->GetOverloadLocked(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetRemainingMana(), 9);
+    CHECK_EQ(curPlayer->GetOverloadOwed(), 0);
+    CHECK_EQ(curPlayer->GetOverloadLocked(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5130,3 +5130,52 @@ TEST_CASE("[Rogue : Minion] - CORE_OG_070 : Bladed Cultist")
     CHECK_EQ(curField[1]->GetAttack(), 2);
     CHECK_EQ(curField[1]->GetHealth(), 3);
 }
+
+// ---------------------------------------- MINION - SHAMAN
+// [CORE_AT_047] Draenei Totemcarver - COST:4 [ATK:4/HP:5]
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Gain +1/+1 for each friendly Totem.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Minion] - CORE_AT_047 : Draenei Totemcarver")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Draenei Totemcarver"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Draenei Totemcarver"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[2]->GetAttack(), 5);
+    CHECK_EQ(curField[2]->GetHealth(), 6);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5903,3 +5903,55 @@ TEST_CASE("[Shaman : Minion] - CORE_NEW1_010 : Al'Akir the Windlord")
 {
     // Do nothing
 }
+
+// ----------------------------------------- SPELL - SHAMAN
+// [CORE_UNG_817] Tidal Surge - COST:3
+// - Set: CORE, Rarity: Common
+// - Spell School: Nature
+// --------------------------------------------------------
+// Text: <b>Lifesteal</b>
+//       Deal 4 damage to a minion.
+// --------------------------------------------------------
+// GameTag:
+// - LIFESTEAL = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINION_TARGET = 0
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - CORE_UNG_817 : Tidal Surge")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Tidal Surge"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(curField[0]->GetHealth(), 7);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 24);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5343,3 +5343,62 @@ TEST_CASE("[Shaman : Minion] - CORE_CS2_042 : Fire Elemental")
     game.Process(curPlayer, PlayCardTask::MinionTarget(card2, opField[0]));
     CHECK_EQ(opField[0]->GetHealth(), 3);
 }
+
+//----------------------------------------- SPELL - SHAMAN
+// [CORE_CS2_045] Rockbiter Weapon - COST:2
+// - Set: CORE, Rarity: Common
+// - Spell School: Nature
+// --------------------------------------------------------
+// Text: Give a friendly character +3 Attack this turn.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_FRIENDLY_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - CORE_CS2_045 : Rockbiter Weapon")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Rockbiter Weapon"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Rockbiter Weapon"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card1, curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 3);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card3));
+    CHECK_EQ(curField[0]->GetAttack(), 6);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5651,3 +5651,65 @@ TEST_CASE("[Shaman : Minion] - CORE_EX1_250 : Earth Elemental")
     CHECK_EQ(curPlayer->GetOverloadOwed(), 0);
     CHECK_EQ(curPlayer->GetOverloadLocked(), 2);
 }
+
+// ---------------------------------------- MINION - SHAMAN
+// [CORE_EX1_258] Unbound Elemental - COST:3 [ATK:3/HP:4]
+// - Race: Elemental, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: Whenever you play a card with <b>Overload</b>,
+//       gain +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+// RefTag:
+// - OVERLOAD = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Minion] - CORE_EX1_258 : Unbound Elemental")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Unbound Elemental"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Earth Elemental"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Feral Spirit"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5843,3 +5843,45 @@ TEST_CASE("[Shaman : Weapon] - CORE_EX1_567 : Doomhammer")
     CHECK_EQ(curPlayer->GetOverloadOwed(), 0);
     CHECK_EQ(curPlayer->GetOverloadLocked(), 2);
 }
+
+// ---------------------------------------- MINION - SHAMAN
+// [CORE_EX1_575] Mana Tide Totem - COST:3 [ATK:0/HP:3]
+// - Race: Totem, Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: At the end of your turn, draw a card.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Minion] - CORE_EX1_575 : Mana Tide Totem")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mana Tide Totem"));
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5528,3 +5528,67 @@ TEST_CASE("[Shaman : Spell] - CORE_EX1_246 : Hex")
     CHECK_EQ(opField[0]->GetHealth(), 1);
     CHECK_EQ(opField[0]->GetGameTag(GameTag::TAUNT), 1);
 }
+
+// ----------------------------------------- SPELL - SHAMAN
+// [CORE_EX1_248] Feral Spirit - COST:3
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: Summon two 2/3 Spirit Wolves with <b>Taunt</b>.
+//       <b>Overload:</b> (1)
+// --------------------------------------------------------
+// GameTag:
+// - OVERLOAD = 1
+// - OVERLOAD_OWED = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - CORE_EX1_248 : Feral Spirit")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Feral Spirit"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+    CHECK_EQ(curField[1]->HasTaunt(), true);
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+
+    CHECK_EQ(curPlayer->GetRemainingMana(), 7);
+    CHECK_EQ(curPlayer->GetOverloadOwed(), 1);
+    CHECK_EQ(curPlayer->GetOverloadLocked(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetRemainingMana(), 9);
+    CHECK_EQ(curPlayer->GetOverloadOwed(), 0);
+    CHECK_EQ(curPlayer->GetOverloadLocked(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5713,3 +5713,81 @@ TEST_CASE("[Shaman : Minion] - CORE_EX1_258 : Unbound Elemental")
     CHECK_EQ(curField[0]->GetAttack(), 5);
     CHECK_EQ(curField[0]->GetHealth(), 6);
 }
+
+// ----------------------------------------- SPELL - SHAMAN
+// [CORE_EX1_259] Lightning Storm - COST:3
+// - Set: CORE, Rarity: Rare
+// - Spell School: Nature
+// --------------------------------------------------------
+// Text: Deal 3 damage to all enemy minions.
+//       <b>Overload:</b> (2)
+// --------------------------------------------------------
+// GameTag:
+// - OVERLOAD = 2
+// - OVERLOAD_OWED = 2
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - CORE_EX1_259 : Lightning Storm")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Lightning Storm"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(opField[0]->GetHealth(), 7);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField[1]->GetHealth(), 7);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(opField[0]->GetHealth(), 4);
+    CHECK_EQ(opField[1]->GetHealth(), 4);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 7);
+    CHECK_EQ(curPlayer->GetOverloadOwed(), 2);
+    CHECK_EQ(curPlayer->GetOverloadLocked(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetRemainingMana(), 8);
+    CHECK_EQ(curPlayer->GetOverloadOwed(), 0);
+    CHECK_EQ(curPlayer->GetOverloadLocked(), 2);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5592,3 +5592,62 @@ TEST_CASE("[Shaman : Spell] - CORE_EX1_248 : Feral Spirit")
     CHECK_EQ(curPlayer->GetOverloadOwed(), 0);
     CHECK_EQ(curPlayer->GetOverloadLocked(), 1);
 }
+
+//----------------------------------------- MINION - SHAMAN
+// [CORE_EX1_250] Earth Elemental - COST:5 [ATK:7/HP:8]
+// - Race: Elemental, Set: CORE, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b><b>Overload</b>:</b> (2)
+// --------------------------------------------------------
+// GameTag:
+// - OVERLOAD = 2
+// - OVERLOAD_OWED = 2
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Minion] - CORE_EX1_250 : Earth Elemental")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Earth Elemental"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+    CHECK_EQ(curField[0]->GetAttack(), 7);
+    CHECK_EQ(curField[0]->GetHealth(), 8);
+
+    CHECK_EQ(curPlayer->GetRemainingMana(), 5);
+    CHECK_EQ(curPlayer->GetOverloadOwed(), 2);
+    CHECK_EQ(curPlayer->GetOverloadLocked(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetRemainingMana(), 8);
+    CHECK_EQ(curPlayer->GetOverloadOwed(), 0);
+    CHECK_EQ(curPlayer->GetOverloadLocked(), 2);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5791,3 +5791,55 @@ TEST_CASE("[Shaman : Spell] - CORE_EX1_259 : Lightning Storm")
     CHECK_EQ(curPlayer->GetOverloadOwed(), 0);
     CHECK_EQ(curPlayer->GetOverloadLocked(), 2);
 }
+
+// ---------------------------------------- WEAPON - SHAMAN
+// [CORE_EX1_567] Doomhammer - COST:5
+// - Set: CORE, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Windfury, Overload:</b> (2)
+// --------------------------------------------------------
+// GameTag:
+// - DURABILITY = 8
+// - WINDFURY = 1
+// - OVERLOAD = 2
+// - OVERLOAD_OWED = 2
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Weapon] - CORE_EX1_567 : Doomhammer")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Doomhammer"));
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    CHECK_EQ(curPlayer->GetWeapon().GetAttack(), 2);
+    CHECK_EQ(curPlayer->GetWeapon().GetDurability(), 8);
+    CHECK_EQ(curPlayer->GetWeapon().GetGameTag(GameTag::WINDFURY), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetRemainingMana(), 8);
+    CHECK_EQ(curPlayer->GetOverloadOwed(), 0);
+    CHECK_EQ(curPlayer->GetOverloadLocked(), 2);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5955,3 +5955,20 @@ TEST_CASE("[Shaman : Spell] - CORE_UNG_817 : Tidal Surge")
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 24);
     CHECK_EQ(curField[0]->GetHealth(), 3);
 }
+
+// ---------------------------------------- MINION - SHAMAN
+// [CS3_007] Novice Zapper - COST:1 [ATK:3/HP:2]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Spell Damage +1</b>
+//       <b>Overload:</b> (1)
+// --------------------------------------------------------
+// GameTag:
+// - OVERLOAD = 1
+// - OVERLOAD_OWED = 1
+// - SPELLPOWER = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Minion] - CS3_007 : Novice Zapper")
+{
+    // Do nothing
+}

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -6145,8 +6145,8 @@ TEST_CASE("[Shaman : Spell] - EX1_248 : Feral Spirit")
 //       <b><b>Overload</b>:</b> (2)
 // --------------------------------------------------------
 // GameTag:
-// - OVERLOAD = 3
-// - OVERLOAD_OWED = 3
+// - OVERLOAD = 2
+// - OVERLOAD_OWED = 2
 // - TAUNT = 1
 // --------------------------------------------------------
 TEST_CASE("[Shaman : Minion] - EX1_250 : Earth Elemental")

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -6279,7 +6279,8 @@ TEST_CASE("[Shaman : Spell] - EX1_251 : Forked Lightning")
 // [EX1_258] Unbound Elemental - COST:3 [ATK:3/HP:4]
 // - Race: Elemental, Faction: Neutral, Set: Expert1, Rarity: Common
 // --------------------------------------------------------
-// Text: Whenever you play a card with <b>Overload</b>, gain +1/+1.
+// Text: Whenever you play a card with <b>Overload</b>,
+//       gain +1/+1.
 // --------------------------------------------------------
 // RefTag:
 // - OVERLOAD = 1

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -6467,6 +6467,9 @@ TEST_CASE("[Shaman : Weapon] - EX1_567 : Doomhammer")
 // --------------------------------------------------------
 // Text: At the end of your turn, draw a card.
 // --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
 TEST_CASE("[Shaman : Minion] - EX1_575 : Mana Tide Totem")
 {
     GameConfig config;

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -6338,7 +6338,8 @@ TEST_CASE("[Shaman : Minion] - EX1_258 : Unbound Elemental")
 // - Faction: Neutral, Set: Expert1, Rarity: Rare
 // - Spell School: Nature
 // --------------------------------------------------------
-// Text: Deal 3 damage to all enemy minions. <b>Overload:</b> (2)
+// Text: Deal 3 damage to all enemy minions.
+//       <b>Overload:</b> (2)
 // --------------------------------------------------------
 // GameTag:
 // - OVERLOAD = 2

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -6082,8 +6082,8 @@ TEST_CASE("[Shaman : Weapon] - EX1_247 : Stormforged Axe")
 //       <b>Overload:</b> (1)
 // --------------------------------------------------------
 // GameTag:
-// - OVERLOAD = 2
-// - OVERLOAD_OWED = 2
+// - OVERLOAD = 1
+// - OVERLOAD_OWED = 1
 // --------------------------------------------------------
 // PlayReq:
 // - REQ_NUM_MINION_SLOTS = 1

--- a/Tests/UnitTests/PlayMode/CardSets/TgtCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TgtCardsGenTests.cpp
@@ -294,3 +294,51 @@ TEST_CASE("[Priest : Spell] - AT_055 : Flash Heal")
     game.Process(curPlayer, PlayCardTask::SpellTarget(card2, opHero));
     CHECK_EQ(opHero->GetHealth(), 25);
 }
+
+// ---------------------------------------- MINION - SHAMAN
+// [AT_047] Draenei Totemcarver - COST:4 [ATK:4/HP:5]
+// - Set: Tgt, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Gain +1/+1 for each friendly Totem.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Minion] - AT_047 : Draenei Totemcarver")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Draenei Totemcarver"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Draenei Totemcarver"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[2]->GetAttack(), 5);
+    CHECK_EQ(curField[2]->GetHealth(), 6);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
@@ -10,6 +10,7 @@
 
 #include <Rosetta/PlayMode/Actions/Draw.hpp>
 #include <Rosetta/PlayMode/Cards/Cards.hpp>
+#include <Rosetta/PlayMode/Zones/FieldZone.hpp>
 #include <Rosetta/PlayMode/Zones/HandZone.hpp>
 
 using namespace RosettaStone;
@@ -64,4 +65,55 @@ TEST_CASE("[Mage : Minion] - UNG_020 : Arcanologist")
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     CHECK_EQ(curHand.GetCount(), 5);
     CHECK_EQ(curHand[4]->card->IsSecret(), true);
+}
+
+// ----------------------------------------- SPELL - SHAMAN
+// [UNG_817] Tidal Surge - COST:3
+// - Faction: Neutral, Set: Ungoro, Rarity: Common
+// - Spell School: Nature
+// --------------------------------------------------------
+// Text: <b>Lifesteal</b>
+//       Deal 4 damage to a minion.
+// --------------------------------------------------------
+// GameTag:
+// - LIFESTEAL = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINION_TARGET = 0
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - UNG_817 : Tidal Surge")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Tidal Surge"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(curField[0]->GetHealth(), 7);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 24);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
 }


### PR DESCRIPTION
This revision includes:
- Implement 16 CORE cards
  - Draenei Totemcarver (CORE_AT_047)
  - Menacing Nimbus (CORE_BOT_533)
  - Windfury (CORE_CS2_039)
  - Fire Elemental (CORE_CS2_042)
  - Rockbiter Weapon (CORE_CS2_045)
  - Lightning Bolt (CORE_EX1_238)
  - Hex (CORE_EX1_246)
  - Feral Spirit (CORE_EX1_248)
  - Earth Elemental (CORE_EX1_250)
  - Unbound Elemental (CORE_EX1_258)
  - Lightning Storm (CORE_EX1_259)
  - Doomhammer (CORE_EX1_567)
  - Mana Tide Totem (CORE_EX1_575)
  - Al'Akir the Windlord (CORE_NEW1_010)
  - Tidal Surge (CORE_UNG_817)
  - Novice Zapper (CS3_007)
- Implement 1 TGT card
  - Draenei Totemcarver (AT_047)
- Implement 1 UNGORO card
  - Tidal Surge (UNG_817)
- Implement 1 BOOMSDAY card
  - Menacing Nimbus (BOT_533)