### PR TITLE
Implement 16 CORE cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -12,7 +12,7 @@ Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
 CORE | CORE_AT_003 | Fallen Hero | O
 CORE | CORE_AT_008 | Coldarra Drake | O
-CORE | CORE_AT_021 | Tiny Knight of Evil |  
+CORE | CORE_AT_021 | Tiny Knight of Evil | O
 CORE | CORE_AT_047 | Draenei Totemcarver | O
 CORE | CORE_AT_055 | Flash Heal | O
 CORE | CORE_AT_061 | Lock and Load | O
@@ -47,8 +47,8 @@ CORE | CORE_CS2_033 | Water Elemental | O
 CORE | CORE_CS2_039 | Windfury | O
 CORE | CORE_CS2_042 | Fire Elemental | O
 CORE | CORE_CS2_045 | Rockbiter Weapon | O
-CORE | CORE_CS2_062 | Hellfire |  
-CORE | CORE_CS2_064 | Dread Infernal |  
+CORE | CORE_CS2_062 | Hellfire | O
+CORE | CORE_CS2_064 | Dread Infernal | O
 CORE | CORE_CS2_072 | Backstab | O
 CORE | CORE_CS2_073 | Cold Blood | O
 CORE | CORE_CS2_074 | Deadly Poison | O
@@ -129,12 +129,12 @@ CORE | CORE_EX1_275 | Cone of Cold | O
 CORE | CORE_EX1_287 | Counterspell | O
 CORE | CORE_EX1_289 | Ice Barrier | O
 CORE | CORE_EX1_294 | Mirror Entity | O
-CORE | CORE_EX1_302 | Mortal Coil |  
-CORE | CORE_EX1_304 | Void Terror |  
-CORE | CORE_EX1_309 | Siphon Soul |  
-CORE | CORE_EX1_312 | Twisting Nether |  
-CORE | CORE_EX1_319 | Flame Imp |  
-CORE | CORE_EX1_323 | Lord Jaraxxus |  
+CORE | CORE_EX1_302 | Mortal Coil | O
+CORE | CORE_EX1_304 | Void Terror | O
+CORE | CORE_EX1_309 | Siphon Soul | O
+CORE | CORE_EX1_312 | Twisting Nether | O
+CORE | CORE_EX1_319 | Flame Imp | O
+CORE | CORE_EX1_323 | Lord Jaraxxus | O
 CORE | CORE_EX1_335 | Lightspawn | O
 CORE | CORE_EX1_362 | Argent Protector | O
 CORE | CORE_EX1_382 | Aldor Peacekeeper | O
@@ -172,7 +172,7 @@ CORE | CORE_FP1_007 | Nerubian Egg |
 CORE | CORE_FP1_011 | Webspinner | O
 CORE | CORE_FP1_020 | Avenge | O
 CORE | CORE_FP1_031 | Baron Rivendare |  
-CORE | CORE_GIL_191 | Fiendish Circle |  
+CORE | CORE_GIL_191 | Fiendish Circle | O
 CORE | CORE_GIL_801 | Snap Freeze | O
 CORE | CORE_GIL_828 | Dire Frenzy | O
 CORE | CORE_GVG_013 | Cogmaster |  
@@ -184,7 +184,7 @@ CORE | CORE_GVG_109 | Mini-Mage |
 CORE | CORE_GVG_121 | Clockwork Giant |  
 CORE | CORE_ICC_026 | Grim Necromancer |  
 CORE | CORE_ICC_038 | Righteous Protector | O
-CORE | CORE_ICC_055 | Drain Soul |  
+CORE | CORE_ICC_055 | Drain Soul | O
 CORE | CORE_ICC_419 | Bearshark | O
 CORE | CORE_ICC_809 | Plague Scientist | O
 CORE | CORE_KAR_009 | Babbling Book | O
@@ -204,7 +204,7 @@ CORE | CORE_NEW1_026 | Violet Teacher |
 CORE | CORE_NEW1_027 | Southsea Captain |  
 CORE | CORE_OG_047 | Feral Rage | O
 CORE | CORE_OG_070 | Bladed Cultist | O
-CORE | CORE_OG_241 | Possessed Villager |  
+CORE | CORE_OG_241 | Possessed Villager | O
 CORE | CORE_OG_273 | Stand Against Darkness | O
 CORE | CORE_TRL_111 | Headhunter's Hatchet | O
 CORE | CORE_TRL_243 | Pounce | O
@@ -212,11 +212,11 @@ CORE | CORE_tt_004 | Flesheating Ghoul |
 CORE | CORE_UNG_020 | Arcanologist | O
 CORE | CORE_UNG_813 | Stormwatcher |  
 CORE | CORE_UNG_817 | Tidal Surge | O
-CORE | CORE_UNG_833 | Lakkari Felhound |  
+CORE | CORE_UNG_833 | Lakkari Felhound | O
 CORE | CORE_UNG_844 | Humongous Razorleaf |  
 CORE | CS3_001 | Aegwynn, the Guardian |  
-CORE | CS3_002 | Ritual of Doom |  
-CORE | CS3_003 | Felsoul Jailer |  
+CORE | CS3_002 | Ritual of Doom | O
+CORE | CS3_003 | Felsoul Jailer | O
 CORE | CS3_005 | Vanessa VanCleef |  
 CORE | CS3_007 | Novice Zapper | O
 CORE | CS3_008 | Bloodsail Deckhand |  
@@ -229,7 +229,7 @@ CORE | CS3_016 | Reckoning |
 CORE | CS3_017 | Gan'arg Glaivesmith |  
 CORE | CS3_019 | Kor'vas Bloodthorn |  
 CORE | CS3_020 | Illidari Inquisitor |  
-CORE | CS3_021 | Enslaved Fel Lord |  
+CORE | CS3_021 | Enslaved Fel Lord | O
 CORE | CS3_022 | Fogsail Freebooter |  
 CORE | CS3_024 | Taelan Fordring |  
 CORE | CS3_025 | Overlord Runthak |  
@@ -246,7 +246,7 @@ CORE | CS3_036 | Deathwing the Destroyer |
 CORE | CS3_037 | Emerald Skytalon |  
 CORE | CS3_038 | Redgill Razorjaw |  
 
-- Progress: 45% (108 of 235 Cards)
+- Progress: 52% (124 of 235 Cards)
 
 ## Ashes of Outland
 

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -587,7 +587,7 @@ TGT | AT_017 | Twilight Guardian |
 TGT | AT_018 | Confessor Paletress |  
 TGT | AT_019 | Dreadsteed |  
 TGT | AT_020 | Fearsome Doomguard |  
-TGT | AT_021 | Tiny Knight of Evil |  
+TGT | AT_021 | Tiny Knight of Evil | O
 TGT | AT_022 | Fist of Jaraxxus |  
 TGT | AT_023 | Void Crusher |  
 TGT | AT_024 | Demonfuse |  
@@ -700,7 +700,7 @@ TGT | AT_131 | Eydis Darkbane |
 TGT | AT_132 | Justicar Trueheart |  
 TGT | AT_133 | Gadgetzan Jouster |  
 
-- Progress: 4% (6 of 132 Cards)
+- Progress: 5% (7 of 132 Cards)
 
 ## The League of Explorers
 
@@ -839,7 +839,7 @@ OG | OG_223 | Divine Strength |
 OG | OG_229 | Ragnaros, Lightlord |  
 OG | OG_234 | Darkshire Alchemist |  
 OG | OG_239 | DOOM! |  
-OG | OG_241 | Possessed Villager |  
+OG | OG_241 | Possessed Villager | O
 OG | OG_247 | Twisted Worgen |  
 OG | OG_248 | Am'gam Rager |  
 OG | OG_249 | Infested Tauren |  
@@ -893,7 +893,7 @@ OG | OG_338 | Nat, the Darkfisher |
 OG | OG_339 | Skeram Cultist |  
 OG | OG_340 | Soggoth the Slitherer |  
 
-- Progress: 2% (3 of 134 Cards)
+- Progress: 2% (4 of 134 Cards)
 
 ## One Night in Karazhan
 
@@ -1032,7 +1032,7 @@ UNGORO | UNG_829 | Lakkari Sacrifice |
 UNGORO | UNG_830 | Cruel Dinomancer |  
 UNGORO | UNG_831 | Corrupting Mist |  
 UNGORO | UNG_832 | Bloodbloom |  
-UNGORO | UNG_833 | Lakkari Felhound |  
+UNGORO | UNG_833 | Lakkari Felhound | O
 UNGORO | UNG_834 | Feeding Time |  
 UNGORO | UNG_835 | Chittering Tunneler |  
 UNGORO | UNG_836 | Clutchmother Zavas |  
@@ -1087,7 +1087,7 @@ UNGORO | UNG_961 | Adaptation |
 UNGORO | UNG_962 | Lightfused Stegodon |  
 UNGORO | UNG_963 | Lyra the Sunshard |  
 
-- Progress: 1% (2 of 135 Cards)
+- Progress: 2% (3 of 135 Cards)
 
 ## Knights of the Frozen Throne
 
@@ -1114,7 +1114,7 @@ ICECROWN | ICC_050 | Webweave |
 ICECROWN | ICC_051 | Druid of the Swarm |  
 ICECROWN | ICC_052 | Play Dead |  
 ICECROWN | ICC_054 | Spreading Plague |  
-ICECROWN | ICC_055 | Drain Soul |  
+ICECROWN | ICC_055 | Drain Soul | O
 ICECROWN | ICC_056 | Cryostasis |  
 ICECROWN | ICC_058 | Brrrloc |  
 ICECROWN | ICC_062 | Mountainfire Armor |  
@@ -1229,7 +1229,7 @@ ICECROWN | ICC_911 | Keening Banshee |
 ICECROWN | ICC_912 | Corpsetaker |  
 ICECROWN | ICC_913 | Tainted Zealot |  
 
-- Progress: 2% (3 of 135 Cards)
+- Progress: 2% (4 of 135 Cards)
 
 ## The Witchwood
 
@@ -1245,6 +1245,7 @@ GILNEAS | GIL_121 | Darkmire Moonkin |
 GILNEAS | GIL_124 | Mossy Horror |  
 GILNEAS | GIL_125 | Mad Hatter |  
 GILNEAS | GIL_128 | Emeriss |  
+GILNEAS | GIL_130 | Gloom Stag |  
 GILNEAS | GIL_134 | Holy Water |  
 GILNEAS | GIL_142 | Chameleos |  
 GILNEAS | GIL_143 | Vicious Scalehide |  
@@ -1255,7 +1256,7 @@ GILNEAS | GIL_155 | Redband Wasp |
 GILNEAS | GIL_156 | Quartz Elemental |  
 GILNEAS | GIL_188 | Druid of the Scythe |  
 GILNEAS | GIL_190 | Nightscale Matriarch |  
-GILNEAS | GIL_191 | Fiendish Circle |  
+GILNEAS | GIL_191 | Fiendish Circle | O
 GILNEAS | GIL_198 | Azalina Soulthief |  
 GILNEAS | GIL_200 | Duskhaven Hunter |  
 GILNEAS | GIL_201 | Pumpkin Peasant |  
@@ -1276,6 +1277,7 @@ GILNEAS | GIL_526 | Wyrmguard |
 GILNEAS | GIL_527 | Felsoul Inquisitor |  
 GILNEAS | GIL_528 | Swift Messenger |  
 GILNEAS | GIL_529 | Spellshifter |  
+GILNEAS | GIL_530 | Murkspark Eel |  
 GILNEAS | GIL_531 | Witch's Apprentice |  
 GILNEAS | GIL_534 | Hench-Clan Thug |  
 GILNEAS | GIL_537 | Deadly Arsenal |  
@@ -1339,6 +1341,7 @@ GILNEAS | GIL_683 | Marsh Drake |
 GILNEAS | GIL_685 | Paragon of Light |  
 GILNEAS | GIL_687 | WANTED! |  
 GILNEAS | GIL_691 | Archmage Arugal |  
+GILNEAS | GIL_692 | Genn Greymane |  
 GILNEAS | GIL_693 | Blood Witch |  
 GILNEAS | GIL_694 | Prince Liam |  
 GILNEAS | GIL_696 | Pick Pocket |  
@@ -1355,17 +1358,20 @@ GILNEAS | GIL_817 | The Glass Knight |
 GILNEAS | GIL_819 | Witch's Cauldron |  
 GILNEAS | GIL_820 | Shudderwock |  
 GILNEAS | GIL_825 | Lord Godfrey |  
+GILNEAS | GIL_826 | Baku the Mooneater |  
 GILNEAS | GIL_827 | Blink Fox |  
 GILNEAS | GIL_828 | Dire Frenzy | O
 GILNEAS | GIL_833 | Forest Guide |  
 GILNEAS | GIL_835 | Squashling |  
 GILNEAS | GIL_836 | Blazing Invocation |  
+GILNEAS | GIL_837 | Glitter Moth |  
+GILNEAS | GIL_838 | Black Cat |  
 GILNEAS | GIL_840 | Lady in White |  
 GILNEAS | GIL_902 | Cutthroat Buccaneer |  
 GILNEAS | GIL_903 | Hidden Wisdom |  
 GILNEAS | GIL_905 | Carrion Drake |  
 
-- Progress: 1% (2 of 129 Cards)
+- Progress: 2% (3 of 135 Cards)
 
 ## The Boomsday Project
 

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DiscardTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DiscardTask.hpp
@@ -16,6 +16,7 @@ enum class DiscardType
     DEFAULT,       //!< Don't care.
     LOWEST_COST,   //!< Lowest cost card.
     HIGHEST_COST,  //!< Highest cost card.
+    ENEMY_MINION,   //!< A random enemy minion.
 };
 
 //!

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 45% Core Set (108 of 235 cards)
+  * 52% Core Set (124 of 235 cards)
   * 59% Ashes of Outland (80 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
@@ -50,15 +50,15 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 6% Curse of Naxxramas (2 of 30 Cards)
   * 0% Goblins vs Gnomes (0 of 123 Cards)
   * 3% Blackrock Mountain (1 of 31 Cards)
-  * 4% The Grand Tournament (6 of 132 Cards)
+  * 5% The Grand Tournament (7 of 132 Cards)
   * 4% The League of Explorers (2 of 45 Cards)
-  * 2% Whispers of the Old Gods (3 of 134 Cards)
+  * 2% Whispers of the Old Gods (4 of 134 Cards)
   * 8% One Night in Karazhan (4 of 45 Cards)
   * 0% Mean Streets of Gadgetzan (0 of 132 Cards)
-  * 1% Journey to Un'Goro (2 of 135 Cards)
-  * 2% Knights of the Frozen Throne (3 of 135 Cards)
+  * 2% Journey to Un'Goro (3 of 135 Cards)
+  * 2% Knights of the Frozen Throne (4 of 135 Cards)
   * 0% Kobolds & Catacombs (0 of 135 Cards)
-  * 1% The Witchwood (2 of 129 Cards)
+  * 2% The Witchwood (3 of 135 Cards)
   * 2% The Boomsday Project (3 of 136 Cards)
   * 1% Rastakhan's Rumble (2 of 135 Cards)
   * **100% Rise of Shadows (136 of 136 cards)**

--- a/Sources/Rosetta/PlayMode/CardSets/BasicCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BasicCardsGen.cpp
@@ -2171,7 +2171,8 @@ void BasicCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Shadow
     // --------------------------------------------------------
-    // Text: Deal 1 damage to a minion. If that kills it, draw a card.
+    // Text: Deal 1 damage to a minion.
+    //       If that kills it, draw a card.
     // --------------------------------------------------------
     // PlayReq:
     // - REQ_TARGET_TO_PLAY = 0

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -9,6 +9,8 @@
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
+#include <Rosetta/PlayMode/Zones/GraveyardZone.hpp>
+#include <Rosetta/PlayMode/Zones/HandZone.hpp>
 
 using namespace RosettaStone::PlayMode::SimpleTasks;
 
@@ -2365,6 +2367,18 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DiscardTask>(1, DiscardType::ENEMY_MINION, true));
+    power.AddDeathrattleTask(std::make_shared<CustomTask>(
+        [](Player* player, Entity* source, [[maybe_unused]] Playable* target) {
+            const int entityID =
+                source->GetGameTag(GameTag::TAG_SCRIPT_DATA_ENT_1);
+            Playable* playable = player->game->entityList[entityID];
+            player->opponent->GetGraveyardZone()->Remove(playable);
+            player->opponent->GetHandZone()->Add(playable);
+        }));
+    cards.emplace("CS3_003", CardDef(power));
 
     // --------------------------------------- MINION - WARLOCK
     // [CS3_021] Enslaved Fel Lord - COST:7 [ATK:4/HP:10]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2303,6 +2303,10 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("OG_241a", SummonSide::DEATHRATTLE));
+    cards.emplace("CORE_OG_241", CardDef(power));
 
     // --------------------------------------- MINION - WARLOCK
     // [CORE_UNG_833] Lakkari Felhound - COST:4 [ATK:3/HP:8]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2319,6 +2319,10 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DiscardTask>(2, DiscardType::LOWEST_COST));
+    cards.emplace("CORE_UNG_833", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [CS3_002] Ritual of Doom - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2192,6 +2192,25 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<IncludeAdjacentTask>(EntityType::SOURCE));
+    power.AddPowerTask(std::make_shared<GetGameTagTask>(EntityType::STACK,
+                                                        GameTag::ATK, 0, 1));
+    power.AddPowerTask(std::make_shared<GetGameTagTask>(EntityType::STACK,
+                                                        GameTag::ATK, 1, 2));
+    power.AddPowerTask(
+        std::make_shared<MathNumberIndexTask>(1, 2, MathOperation::ADD));
+    power.AddPowerTask(std::make_shared<GetGameTagTask>(EntityType::STACK,
+                                                        GameTag::HEALTH, 0, 3));
+    power.AddPowerTask(std::make_shared<GetGameTagTask>(EntityType::STACK,
+                                                        GameTag::HEALTH, 1, 4));
+    power.AddPowerTask(
+        std::make_shared<MathNumberIndexTask>(3, 4, MathOperation::ADD, 1));
+    power.AddPowerTask(std::make_shared<DestroyTask>(EntityType::STACK));
+    power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
+        "EX1_304e", EntityType::SOURCE, true));
+    cards.emplace("CORE_EX1_304", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [CORE_EX1_309] Siphon Soul - COST:5

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2116,6 +2116,8 @@ void CoreCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
 void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - WARLOCK
     // [CORE_AT_021] Tiny Knight of Evil - COST:2 [ATK:3/HP:2]
     // - Race: Demon, Set: CORE, Rarity: Rare
@@ -2125,6 +2127,11 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::DISCARD));
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "AT_021e", EntityType::SOURCE) };
+    cards.emplace("CORE_AT_021", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [CORE_CS2_062] Hellfire - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2390,6 +2390,29 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    power.GetTrigger()->tasks = {
+        std::make_shared<FuncNumberTask>([](Playable* playable) {
+            const auto target = dynamic_cast<Minion*>(
+                playable->game->currentEventData->eventTarget);
+            if (target == nullptr)
+            {
+                return 0;
+            }
+
+            auto& taskStack = playable->game->taskStack;
+            for (auto& minion : target->GetAdjacentMinions())
+            {
+                taskStack.playables.emplace_back(minion);
+            }
+
+            return dynamic_cast<Minion*>(playable)->GetAttack();
+        }),
+        std::make_shared<DamageNumberTask>(EntityType::STACK)
+    };
+    cards.emplace("CS3_021", CardDef(power));
 }
 
 void CoreCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -24,6 +24,8 @@ using EffectList = std::vector<std::shared_ptr<IEffect>>;
 
 void CoreCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- HERO - WARLOCK
     // [CORE_EX1_323] Lord Jaraxxus - COST:9
     // - Set: CORE, Rarity: Legendary
@@ -32,10 +34,11 @@ void CoreCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
-    // --------------------------------------------------------
-    // RefTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<WeaponTask>("EX1_323w"));
+    cards.emplace("CORE_EX1_323", CardDef(power, 0, 1178));
 }
 
 void CoreCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2266,7 +2266,7 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - REQ_NUM_MINION_SLOTS = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<SummonTask>("GIL_191t", 4));
+    power.AddPowerTask(std::make_shared<SummonTask>("CORE_GIL_191t", 4));
     cards.emplace(
         "CORE_GIL_191",
         CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
@@ -2386,6 +2386,9 @@ void CoreCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
     // [CORE_GIL_191t] Imp - COST:1 [ATK:1/HP:1]
     // - Race: Demon, Set: CORE
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CORE_GIL_191t", CardDef(power));
 
     // --------------------------------------- MINION - WARLOCK
     // [CS3_002t] Demonic Tyrant - COST:5 [ATK:5/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2251,6 +2251,9 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::HERO, 3));
+    cards.emplace("CORE_EX1_319", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [CORE_GIL_191] Fiendish Circle - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2332,6 +2332,27 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // Text: Destroy a friendly minion.
     //       If you had 5 or more, summon a 5/5 Demon.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE,
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsFieldCount(5, RelaSign::GEQ)) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<DestroyTask>(EntityType::TARGET),
+                        std::make_shared<SummonTask>("CS3_002t",
+                                                     SummonSide::TARGET) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        false, TaskList{ std::make_shared<DestroyTask>(EntityType::TARGET) }));
+    cards.emplace(
+        "CS3_002",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_FRIENDLY_TARGET, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // --------------------------------------- MINION - WARLOCK
     // [CS3_003] Felsoul Jailer - COST:5 [ATK:4/HP:6]
@@ -2359,6 +2380,8 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 
 void CoreCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - WARLOCK
     // [CORE_GIL_191t] Imp - COST:1 [ATK:1/HP:1]
     // - Race: Demon, Set: CORE
@@ -2368,6 +2391,9 @@ void CoreCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
     // [CS3_002t] Demonic Tyrant - COST:5 [ATK:5/HP:5]
     // - Race: Demon, Set: CORE
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CS3_002t", CardDef(power));
 }
 
 void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2165,6 +2165,22 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // Text: Deal 1 damage to a minion.
     //       If that kills it, draw a card.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 1, true));
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::TARGET, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsDead()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<DrawTask>(1) }));
+    cards.emplace(
+        "CORE_EX1_302",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // --------------------------------------- MINION - WARLOCK
     // [CORE_EX1_304] Void Terror - COST:3 [ATK:3/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2140,6 +2140,9 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 3 damage to all characters.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::ALL, 3, true));
+    cards.emplace("CORE_CS2_062", CardDef(power));
 
     // --------------------------------------- MINION - WARLOCK
     // [CORE_CS2_064] Dread Infernal - COST:6 [ATK:6/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2238,6 +2238,9 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Destroy all minions.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DestroyTask>(EntityType::ALL_MINIONS));
+    cards.emplace("CORE_EX1_312", CardDef(power));
 
     // --------------------------------------- MINION - WARLOCK
     // [CORE_EX1_319] Flame Imp - COST:1 [ATK:3/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2282,6 +2282,17 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - LIFESTEAL = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
+    cards.emplace(
+        "CORE_ICC_055",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // --------------------------------------- MINION - WARLOCK
     // [CORE_OG_241] Possessed Villager - COST:1 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2153,6 +2153,9 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::ALL, 1));
+    cards.emplace("CORE_CS2_064", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [CORE_EX1_302] Mortal Coil - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2217,8 +2217,19 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - Set: CORE, Rarity: Rare
     // - Spell School: Shadow
     // --------------------------------------------------------
-    // Text: Destroy a minion. Restore #3 Health to your hero.
+    // Text: Destroy a minion. Restore 3 Health to your hero.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DestroyTask>(EntityType::TARGET));
+    power.AddPowerTask(std::make_shared<HealTask>(EntityType::HERO, 3));
+    cards.emplace(
+        "CORE_EX1_309",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [CORE_EX1_312] Twisting Nether - COST:8

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2262,6 +2262,14 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Summon four 1/1 Imps.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("GIL_191t", 4));
+    cards.emplace(
+        "CORE_GIL_191",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [CORE_ICC_055] Drain Soul - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/GilneasCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/GilneasCardsGen.cpp
@@ -1001,12 +1001,22 @@ void GilneasCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
 void GilneasCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- SPELL - WARLOCK
     // [GIL_191] Fiendish Circle - COST:3
     // - Set: Gilneas, Rarity: Common
     // --------------------------------------------------------
     // Text: Summon four 1/1 Imps.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("GIL_191t", 4));
+    cards.emplace(
+        "GIL_191",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // --------------------------------------- MINION - WARLOCK
     // [GIL_508] Duskbat - COST:3 [ATK:2/HP:4]
@@ -1130,10 +1140,15 @@ void GilneasCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 void GilneasCardsGen::AddWarlockNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - WARLOCK
     // [GIL_191t] Imp (*) - COST:1 [ATK:1/HP:1]
     // - Race: Demon, Set: Gilneas
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("GIL_191t", CardDef(power));
 
     // --------------------------------------- MINION - WARLOCK
     // [GIL_508t] Bat (*) - COST:1 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/IcecrownCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/IcecrownCardsGen.cpp
@@ -1562,6 +1562,8 @@ void IcecrownCardsGen::AddShamanNonCollect(
 
 void IcecrownCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- SPELL - WARLOCK
     // [ICC_041] Defile - COST:2
     // - Set: Icecrown, Rarity: Rare
@@ -1573,9 +1575,10 @@ void IcecrownCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // ---------------------------------------- SPELL - WARLOCK
     // [ICC_055] Drain Soul - COST:2
     // - Set: Icecrown, Rarity: Common
+    // - Spell School: Shadow
     // --------------------------------------------------------
     // Text: <b>Lifesteal</b>
-    //       Deal 2 damage to a minion.
+    //       Deal 3 damage to a minion.
     // --------------------------------------------------------
     // GameTag:
     // - LIFESTEAL = 1
@@ -1584,6 +1587,13 @@ void IcecrownCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - REQ_TARGET_TO_PLAY = 0
     // - REQ_MINION_TARGET = 0
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
+    cards.emplace(
+        "ICC_055",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // --------------------------------------- MINION - WARLOCK
     // [ICC_075] Despicable Dreadlord - COST:5 [ATK:4/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/OgCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/OgCardsGen.cpp
@@ -1034,6 +1034,8 @@ void OgCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
 void OgCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - WARLOCK
     // [OG_109] Darkshire Librarian - COST:2 [ATK:3/HP:2]
     // - Set: Og, Rarity: Rare
@@ -1107,6 +1109,10 @@ void OgCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("OG_241a", SummonSide::DEATHRATTLE));
+    cards.emplace("OG_241", CardDef(power));
 
     // --------------------------------------- MINION - WARLOCK
     // [OG_302] Usher of Souls - COST:5 [ATK:5/HP:6]
@@ -1122,6 +1128,8 @@ void OgCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 
 void OgCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------- ENCHANTMENT - WARLOCK
     // [OG_113e] Power of the People (*) - COST:0
     // - Set: Og
@@ -1138,6 +1146,9 @@ void OgCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
     // [OG_241a] Shadowbeast (*) - COST:1 [ATK:1/HP:1]
     // - Set: Og
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("OG_241a", CardDef(power));
 }
 
 void OgCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/TgtCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TgtCardsGen.cpp
@@ -5,6 +5,7 @@
 
 #include <Rosetta/PlayMode/CardSets/TgtCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
+#include <Rosetta/PlayMode/Enchants/OngoingEnchant.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 
 using namespace RosettaStone::PlayMode::SimpleTasks;
@@ -1205,6 +1206,8 @@ void TgtCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
 void TgtCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - WARLOCK
     // [AT_019] Dreadsteed - COST:4 [ATK:1/HP:1]
     // - Race: Demon, Set: Tgt, Rarity: Epic
@@ -1227,6 +1230,14 @@ void TgtCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Whenever you discard a card, gain +1/+1.
     // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::DISCARD));
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "AT_021e", EntityType::SOURCE) };
+    cards.emplace("AT_021", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [AT_022] Fist of Jaraxxus - COST:4
@@ -1297,12 +1308,18 @@ void TgtCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 
 void TgtCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------- ENCHANTMENT - WARLOCK
     // [AT_021e] Felrage (*) - COST:0
     // - Set: Tgt
     // --------------------------------------------------------
     // Text: Increased stats.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(std::make_shared<OngoingEnchant>(
+        std::vector<std::shared_ptr<IEffect>>{ Effects::AttackHealthN(1) }));
+    cards.emplace("AT_021e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - WARLOCK
     // [AT_027e] Master Summoner (*) - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
@@ -1308,6 +1308,8 @@ void UngoroCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
 void UngoroCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - WARLOCK
     // [UNG_047] Ravenous Pterrordax - COST:4 [ATK:4/HP:4]
     // - Race: Beast, Faction: Neutral, Set: Ungoro, Rarity: Common
@@ -1390,13 +1392,16 @@ void UngoroCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - Race: Demon, Faction: Neutral, Set: Ungoro, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
-    //       <b>Battlecry:</b> Discard two random cards.
+    //       <b>Battlecry:</b> Discard your two lowest-Cost cards.
     // --------------------------------------------------------
     // GameTag:
     // - TAUNT = 1
     // - BATTLECRY = 1
-    // - 890 = 2
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DiscardTask>(2, DiscardType::LOWEST_COST));
+    cards.emplace("UNG_833", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [UNG_834] Feeding Time - COST:5

--- a/Tests/UnitTests/PlayMode/CardSets/BasicCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BasicCardsGenTests.cpp
@@ -4710,7 +4710,8 @@ TEST_CASE("[Warlock : Minion] - CS2_065 : Voidwalker")
 // - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Shadow
 // --------------------------------------------------------
-// Text: Deal 1 damage to a minion. If that kills it, draw a card.
+// Text: Deal 1 damage to a minion.
+//       If that kills it, draw a card.
 // --------------------------------------------------------
 // PlayReq:
 // - REQ_TARGET_TO_PLAY = 0

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6204,3 +6204,64 @@ TEST_CASE("[Warlock : Spell] - CORE_EX1_302 : Mortal Coil")
     CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
     CHECK_EQ(opField.GetCount(), 0);
 }
+
+// --------------------------------------- MINION - WARLOCK
+// [CORE_EX1_304] Void Terror - COST:3 [ATK:3/HP:4]
+// - Race: Demon, Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Destroy both adjacent minions
+//       and gain their Attack and Health.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - CORE_EX1_304 : Void Terror")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Void Terror"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Void Terror"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flame Imp"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Blood Imp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[1]->GetAttack(), 0);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask(card1, nullptr, 1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetAttack(), 6);
+    CHECK_EQ(curField[0]->GetHealth(), 7);
+
+    game.Process(curPlayer, PlayCardTask(card2, nullptr, 1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetAttack(), 9);
+    CHECK_EQ(curField[0]->GetHealth(), 11);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6525,3 +6525,52 @@ TEST_CASE("[Warlock : Spell] - CORE_ICC_055 : Drain Soul")
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 23);
     CHECK_EQ(curField[0]->GetHealth(), 2);
 }
+
+// --------------------------------------- MINION - WARLOCK
+// [CORE_OG_241] Possessed Villager - COST:1 [ATK:1/HP:1]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Summon a 1/1 Shadowbeast.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - CORE_OG_241 : Possessed Villager")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Possessed Villager"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->card->name, "Possessed Villager");
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField[0]->card->name, "Shadowbeast");
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6031,3 +6031,68 @@ TEST_CASE("[Warlock : Minion] - CORE_AT_021 : Tiny Knight of Evil")
     CHECK_EQ(curField[0]->GetAttack(), 4);
     CHECK_EQ(curField[0]->GetHealth(), 3);
 }
+
+// ---------------------------------------- SPELL - WARLOCK
+// [CORE_CS2_062] Hellfire - COST:4
+// - Set: CORE, Rarity: Common
+// - Spell School: Fire
+// --------------------------------------------------------
+// Text: Deal 3 damage to all characters.
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Spell] - CORE_CS2_062 : Hellfire")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Hellfire"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 27);
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 4);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6096,3 +6096,52 @@ TEST_CASE("[Warlock : Spell] - CORE_CS2_062 : Hellfire")
     CHECK_EQ(opField.GetCount(), 1);
     CHECK_EQ(opField[0]->GetHealth(), 4);
 }
+
+// --------------------------------------- MINION - WARLOCK
+// [CORE_CS2_064] Dread Infernal - COST:6 [ATK:6/HP:6]
+// - Race: Demon, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Deal 1 damage to all other characters.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - CORE_CS2_064 : Dread Infernal")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Dread Infernal"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetHealth(), 7);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 29);
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 29);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6145,3 +6145,62 @@ TEST_CASE("[Warlock : Minion] - CORE_CS2_064 : Dread Infernal")
     CHECK_EQ(curField[0]->GetHealth(), 6);
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 29);
 }
+
+// ---------------------------------------- SPELL - WARLOCK
+// [CORE_EX1_302] Mortal Coil - COST:1
+// - Set: CORE, Rarity: Common
+// - Spell School: Shadow
+// --------------------------------------------------------
+// Text: Deal 1 damage to a minion.
+//       If that kills it, draw a card.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Spell] - CORE_EX1_302 : Mortal Coil")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mortal Coil"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mortal Coil"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+    CHECK_EQ(opField[0]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card3));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+    CHECK_EQ(opField.GetCount(), 0);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6422,3 +6422,54 @@ TEST_CASE("[Warlock : Minion] - CORE_EX1_319 : Flame Imp")
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 27);
 }
+
+// ---------------------------------------- SPELL - WARLOCK
+// [CORE_GIL_191] Fiendish Circle - COST:3
+// - Set: CORE, Rarity: Common
+// - Spell School: Fel
+// --------------------------------------------------------
+// Text: Summon four 1/1 Imps.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Spell] - CORE_GIL_191 : Fiendish Circle")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fiendish Circle"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fiendish Circle"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 4);
+    CHECK_EQ(curField[0]->card->name, "Imp");
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curField.GetCount(), 7);
+    CHECK_EQ(curField[6]->card->name, "Imp");
+    CHECK_EQ(curField[6]->GetAttack(), 1);
+    CHECK_EQ(curField[6]->GetHealth(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6265,3 +6265,52 @@ TEST_CASE("[Warlock : Minion] - CORE_EX1_304 : Void Terror")
     CHECK_EQ(curField[0]->GetAttack(), 9);
     CHECK_EQ(curField[0]->GetHealth(), 11);
 }
+
+// ---------------------------------------- SPELL - WARLOCK
+// [CORE_EX1_309] Siphon Soul - COST:5
+// - Set: CORE, Rarity: Rare
+// - Spell School: Shadow
+// --------------------------------------------------------
+// Text: Destroy a minion. Restore 3 Health to your hero.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Spell] - CORE_EX1_309 : Siphon Soul")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(8);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Siphon Soul"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Voidwalker"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 22);
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 25);
+    CHECK_EQ(curField.GetCount(), 0);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6385,3 +6385,40 @@ TEST_CASE("[Warlock : Spell] - CORE_EX1_312 : Twisting Nether")
     CHECK_EQ(opPlayer->GetHandZone()->GetCount(), 6);
     CHECK_EQ(opField.GetCount(), 0);
 }
+
+// --------------------------------------- MINION - WARLOCK
+// [CORE_EX1_319] Flame Imp - COST:1 [ATK:3/HP:2]
+// - Race: Demon, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Deal 3 damage to your hero.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - CORE_EX1_319 : Flame Imp")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flame Imp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 27);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6627,3 +6627,78 @@ TEST_CASE("[Warlock : Minion] - CORE_UNG_833 : Lakkari Felhound")
     CHECK_EQ(curHand[0]->card->name, "Pyroblast");
     CHECK_EQ(curHand[1]->card->name, "Malygos");
 }
+
+// ---------------------------------------- SPELL - WARLOCK
+// [CS3_002] Ritual of Doom - COST:0
+// - Set: CORE, Rarity: Rare
+// - Spell School: Shadow
+// --------------------------------------------------------
+// Text: Destroy a friendly minion.
+//       If you had 5 or more, summon a 5/5 Demon.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_FRIENDLY_TARGET = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - CS3_002 : Ritual of Doom")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Ritual of Doom", FormatType::STANDARD));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Ritual of Doom", FormatType::STANDARD));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card6 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card7 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card8 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+    game.Process(curPlayer, PlayCardTask::Minion(card6));
+    CHECK_EQ(curField.GetCount(), 4);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3));
+    CHECK_EQ(curField.GetCount(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card7));
+    game.Process(curPlayer, PlayCardTask::Minion(card8));
+    CHECK_EQ(curField.GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card4));
+    CHECK_EQ(curField.GetCount(), 5);
+    CHECK_EQ(curField[0]->card->name, "Demonic Tyrant");
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6473,3 +6473,55 @@ TEST_CASE("[Warlock : Spell] - CORE_GIL_191 : Fiendish Circle")
     CHECK_EQ(curField[6]->GetAttack(), 1);
     CHECK_EQ(curField[6]->GetHealth(), 1);
 }
+
+// ---------------------------------------- SPELL - WARLOCK
+// [CORE_ICC_055] Drain Soul - COST:2
+// - Set: CORE, Rarity: Common
+// - Spell School: Shadow
+// --------------------------------------------------------
+// Text: <b>Lifesteal</b>
+//       Deal 3 damage to a minion.
+// --------------------------------------------------------
+// GameTag:
+// - LIFESTEAL = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Spell] - CORE_ICC_055 : Drain Soul")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Drain Soul"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Sen'jin Shieldmasta"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 23);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -21,6 +21,60 @@ using namespace PlayMode;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ----------------------------------------- HERO - WARLOCK
+// [CORE_EX1_323] Lord Jaraxxus - COST:9
+// - Set: CORE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Equip a 3/8 Blood Fury.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Hero] - CORE_EX1_323 : Lord Jaraxxus")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByID("EX1_323"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetAttack(), 3);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 8);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetAttack(), 6);
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [CORE_BOT_420] Landscaping - COST:3
 // - Set: CORE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6314,3 +6314,74 @@ TEST_CASE("[Warlock : Spell] - CORE_EX1_309 : Siphon Soul")
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 25);
     CHECK_EQ(curField.GetCount(), 0);
 }
+
+// ---------------------------------------- SPELL - WARLOCK
+// [CORE_EX1_312] Twisting Nether - COST:8
+// - Set: CORE, Rarity: Epic
+// - Spell School: Shadow
+// --------------------------------------------------------
+// Text: Destroy all minions.
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Spell] - CORE_EX1_312 : Twisting Nether")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Twisting Nether"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Voidwalker"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opPlayer->GetHandZone()->GetCount(), 7);
+    CHECK_EQ(opField.GetCount(), 1);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(opPlayer->GetHandZone()->GetCount(), 6);
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+    CHECK_EQ(curField.GetCount(), 0);
+    CHECK_EQ(opPlayer->GetHandZone()->GetCount(), 6);
+    CHECK_EQ(opField.GetCount(), 0);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6574,3 +6574,56 @@ TEST_CASE("[Warlock : Minion] - CORE_OG_241 : Possessed Villager")
     CHECK_EQ(curField[0]->GetAttack(), 1);
     CHECK_EQ(curField[0]->GetHealth(), 1);
 }
+
+// --------------------------------------- MINION - WARLOCK
+// [CORE_UNG_833] Lakkari Felhound - COST:4 [ATK:3/HP:8]
+// - Race: Demon, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Battlecry:</b> Discard your two lowest-Cost cards.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - CORE_UNG_833 : Lakkari Felhound")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Lakkari Felhound"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Pyroblast"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Blizzard"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 2);
+    CHECK_EQ(curHand[0]->card->name, "Pyroblast");
+    CHECK_EQ(curHand[1]->card->name, "Malygos");
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5972,3 +5972,62 @@ TEST_CASE("[Shaman : Minion] - CS3_007 : Novice Zapper")
 {
     // Do nothing
 }
+
+//--------------------------------------- MINION - WARLOCK
+// [CORE_AT_021] Tiny Knight of Evil - COST:2 [ATK:3/HP:2]
+// - Race: Demon, Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: Whenever you discard a card, gain +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - CORE_AT_021 : Tiny Knight of Evil")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Tiny Knight of Evil"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Soulfire"));
+    [[maybe_unused]] const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Soulfire"));
+    [[maybe_unused]] const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Soulfire"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(curHand[0], opPlayer->GetHero()));
+    CHECK_EQ(curHand.GetCount(), 0);
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6760,3 +6760,74 @@ TEST_CASE("[Warlock : Minion] - CS3_003 : Felsoul Jailer")
     CHECK_EQ(opHand.GetCount(), 2);
     CHECK_EQ(opHand[1]->card->name, "Malygos");
 }
+
+// --------------------------------------- MINION - WARLOCK
+// [CS3_021] Enslaved Fel Lord - COST:7 [ATK:4/HP:10]
+// - Race: Demon, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>. Also damages the minions next to
+//       whomever this attacks.
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - CS3_021 : Enslaved Fel Lord")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Enslaved Fel Lord", FormatType::STANDARD));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Chillwind Yeti"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Argent Squire"));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Stranglethorn Tiger"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 10);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opField.GetCount(), 3);
+    CHECK_EQ(opField[1]->HasDivineShield(), true);
+    CHECK_EQ(opField[2]->HasStealth(), true);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(card1, card3));
+    CHECK_EQ(curField[0]->GetHealth(), 9);
+    CHECK_EQ(opField.GetCount(), 3);
+    CHECK_EQ(opField[0]->GetHealth(), 1);
+    CHECK_EQ(opField[1]->HasDivineShield(), false);
+    CHECK_EQ(opField[1]->GetHealth(), 1);
+    CHECK_EQ(opField[2]->HasStealth(), true);
+    CHECK_EQ(opField[2]->GetHealth(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/GilneasCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/GilneasCardsGenTests.cpp
@@ -150,3 +150,52 @@ TEST_CASE("[Mage : Spell] - GIL_801 : Snap Freeze")
     game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card3));
     CHECK_EQ(opField.GetCount(), 0);
 }
+
+// ---------------------------------------- SPELL - WARLOCK
+// [GIL_191] Fiendish Circle - COST:3
+// - Set: Gilneas, Rarity: Common
+// --------------------------------------------------------
+// Text: Summon four 1/1 Imps.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Spell] - GIL_191 : Fiendish Circle")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fiendish Circle"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fiendish Circle"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 4);
+    CHECK_EQ(curField[0]->card->name, "Imp");
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curField.GetCount(), 7);
+    CHECK_EQ(curField[6]->card->name, "Imp");
+    CHECK_EQ(curField[6]->GetAttack(), 1);
+    CHECK_EQ(curField[6]->GetHealth(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/IcecrownCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/IcecrownCardsGenTests.cpp
@@ -99,3 +99,54 @@ TEST_CASE("[Rogue : Minion] - ICC_809 : Plague Scientist")
     CHECK_EQ(curField[0]->HasPoisonous(), true);
     CHECK_EQ(curField[1]->HasPoisonous(), false);
 }
+
+// ---------------------------------------- SPELL - WARLOCK
+// [ICC_055] Drain Soul - COST:2
+// - Set: Icecrown, Rarity: Common
+// - Spell School: Shadow
+// --------------------------------------------------------
+// Text: <b>Lifesteal</b>
+//       Deal 3 damage to a minion.
+// --------------------------------------------------------
+// GameTag:
+// - LIFESTEAL = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Spell] - ICC_055 : Drain Soul")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Drain Soul"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Sen'jin Shieldmasta"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 23);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/OgCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/OgCardsGenTests.cpp
@@ -158,3 +158,51 @@ TEST_CASE("[Rogue : Minion] - OG_070 : Bladed Cultist")
     CHECK_EQ(curField[1]->GetAttack(), 2);
     CHECK_EQ(curField[1]->GetHealth(), 3);
 }
+
+// --------------------------------------- MINION - WARLOCK
+// [OG_241] Possessed Villager - COST:1 [ATK:1/HP:1]
+// - Set: Og, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Summon a 1/1 Shadowbeast.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - OG_241 : Possessed Villager")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Possessed Villager"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->card->name, "Possessed Villager");
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField[0]->card->name, "Shadowbeast");
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TgtCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TgtCardsGenTests.cpp
@@ -342,3 +342,61 @@ TEST_CASE("[Shaman : Minion] - AT_047 : Draenei Totemcarver")
     CHECK_EQ(curField[2]->GetAttack(), 5);
     CHECK_EQ(curField[2]->GetHealth(), 6);
 }
+
+// --------------------------------------- MINION - WARLOCK
+// [AT_021] Tiny Knight of Evil - COST:2 [ATK:3/HP:2]
+// - Race: Demon, Set: Tgt, Rarity: Rare
+// --------------------------------------------------------
+// Text: Whenever you discard a card, gain +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - AT_021 : Tiny Knight of Evil")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Tiny Knight of Evil"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Soulfire"));
+    [[maybe_unused]] const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Soulfire"));
+    [[maybe_unused]] const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Soulfire"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(curHand[0], opPlayer->GetHero()));
+    CHECK_EQ(curHand.GetCount(), 0);
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
@@ -117,3 +117,55 @@ TEST_CASE("[Shaman : Spell] - UNG_817 : Tidal Surge")
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 24);
     CHECK_EQ(curField[0]->GetHealth(), 3);
 }
+
+// --------------------------------------- MINION - WARLOCK
+// [UNG_833] Lakkari Felhound - COST:4 [ATK:3/HP:8]
+// - Race: Demon, Faction: Neutral, Set: Ungoro, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Battlecry:</b> Discard your two lowest-Cost cards.
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - UNG_833 : Lakkari Felhound")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Lakkari Felhound"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Pyroblast"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Blizzard"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 2);
+    CHECK_EQ(curHand[0]->card->name, "Pyroblast");
+    CHECK_EQ(curHand[1]->card->name, "Malygos");
+}


### PR DESCRIPTION
This revision includes:
- Implement 16 CORE cards
  - Tiny Knight of Evil (CORE_AT_021)
  - Hellfire (CORE_CS2_062)
  - Dread Infernal (CORE_CS2_064)
  - Mortal Coil (CORE_EX1_302)
  - Void Terror (CORE_EX1_304)
  - Siphon Soul (CORE_EX1_309)
  - Twisting Nether CORE_EX1_312)
  - Flame Imp (CORE_EX1_319)
  - Lord Jaraxxus (CORE_EX1_323)
  - Fiendish Circle (CORE_GIL_191)
  - Drain Soul (CORE_ICC_055)
  - Possessed Villager (CORE_OG_241)
  - Lakkari Felhound (CORE_UNG_833)
  - Ritual of Doom (CS3_002)
  - Felsoul Jailer (CS3_003)
  - Enslaved Fel Lord (CS3_021)
- Implement 1 TGT card
  - Tiny Knight of Evil (AT_021)
- Implement 1 OG card
  - Possessed Villager (OG_241)
- Implement 1 UNGORO card
  - Lakkari Felhound (UNG_833)
- Implement 1 ICECROWN card
  - Drain Soul (ICC_055)
- Implement 1 GILNEAS card
  - Fiendish Circle (GIL_191)