### PR TITLE
Update Hearthstone Patch 20.4

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,16 +21,16 @@ jobs:
             os: macos-10.15
             compiler: xcode
             version: "12.2"
-          # macOS 10.15 + gcc-8
-          #- name: "macOS 10.15 + gcc-8"
-          #  os: macos-10.15
-          #  compiler: gcc
-          #  version: "8"
           # macOS 10.15 + gcc-9
           - name: "macOS 10.15 + gcc-9"
             os: macos-10.15
             compiler: gcc
             version: "9"
+          # macOS 10.15 + gcc-10
+          - name: "macOS 10.15 + gcc-10"
+            os: macos-10.15
+            compiler: gcc
+            version: "10"
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.name }}

--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -67,7 +67,7 @@ constexpr std::array<CardSet, 1> CLASSIC_CARD_SETS = {
 };
 
 //! The number of all cards.
-constexpr int NUM_ALL_CARDS = 12660;
+constexpr int NUM_ALL_CARDS = 12805;
 
 //! The number of player class.
 //! \note Druid, Hunter, Mage, Paladin, Priest, Rogue, Shaman, Warlock, Warrior,

--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -105,7 +105,7 @@ constexpr int MAX_SECERT_SIZE = 5;
 constexpr int NUM_BATTLEGROUNDS_PLAYERS = 8;
 
 //! The number of heroes in Battlegrounds.
-constexpr int NUM_BATTLEGROUNDS_HEROES = 59;
+constexpr int NUM_BATTLEGROUNDS_HEROES = 60;
 
 //! The number of heroes on the selection list in Battlegrounds.
 constexpr int NUM_HEROES_ON_SELECTION_LIST = 4;
@@ -275,8 +275,8 @@ constexpr std::array<int, NUM_TIER3_MINIONS> TIER3_MINIONS = {
 // Virmen Sensei (40641)
 // Demon Pool
 // Bigfernal (66227)
+// Hexruin Marauder (73072)
 // Ring Matron (61884)
-// Siegebreaker (54835)
 // Dragon Pool
 // Cobalt Scalebane (42442)
 // Drakonid Enforcer (61072)
@@ -305,7 +305,7 @@ constexpr std::array<int, NUM_TIER3_MINIONS> TIER3_MINIONS = {
 // Menagerie Jug (63487)
 // Qiraji Harbinger (63619)
 constexpr std::array<int, NUM_TIER4_MINIONS> TIER4_MINIONS = {
-    43358, 1261,  40641, 66227, 61884, 54835, 42442, 61072, 60498,
+    43358, 1261,  40641, 66227, 73072, 61884, 42442, 61072, 60498,
     63630, 64189, 48993, 49169, 48100, 60028, 52277, 61066, 61056,
     70184, 70173, 70188, 45392, 63623, 763,   63487, 63619
 };

--- a/Resources/cards.collectible.json
+++ b/Resources/cards.collectible.json
@@ -10001,7 +10001,7 @@
         "rarity": "COMMON",
         "set": "BLACK_TEMPLE",
         "spellSchool": "HOLY",
-        "text": "Give a minion +2/+2.\nDraw a card.",
+        "text": "Give a minion +2/+1.\nDraw a card.",
         "type": "SPELL"
     },
     {
@@ -15757,6 +15757,9 @@
         "howToEarn": "Unlocked at level 2.",
         "howToEarnGolden": "Unlocked after winning 50 games as Warrior.",
         "id": "CORE_EX1_084",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
         "name": "Warsong Commander",
         "rarity": "COMMON",
         "referencedTags": [
@@ -16446,7 +16449,7 @@
             "OVERLOAD"
         ],
         "set": "CORE",
-        "text": "Whenever you play a card with <b>Overload</b>, gain +1/+1.",
+        "text": "After you play a card with <b>Overload</b>, gain +1/+1.",
         "type": "MINION"
     },
     {
@@ -16866,7 +16869,7 @@
         "name": "Shield Slam",
         "rarity": "EPIC",
         "set": "CORE",
-        "text": "Deal $1 damage to a minion for each Armor you have.",
+        "text": "Deal 1 damage to a minion for each Armor you have.",
         "type": "SPELL"
     },
     {
@@ -29938,6 +29941,9 @@
         "flavor": "The Warsong clan is <i>such drama</i>. It's really not worth it to become a commander.",
         "health": 3,
         "id": "EX1_084",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
         "name": "Warsong Commander",
         "rarity": "FREE",
         "referencedTags": [
@@ -30833,7 +30839,6 @@
         "race": "DEMON",
         "rarity": "RARE",
         "set": "LEGACY",
-        "techLevel": 4,
         "text": "<b>Taunt</b>\nYour other Demons have +1 Attack.",
         "type": "MINION"
     },
@@ -31338,7 +31343,7 @@
             "OVERLOAD"
         ],
         "set": "EXPERT1",
-        "text": "Whenever you play a card with <b>Overload</b>, gain +1/+1.",
+        "text": "After you play a card with <b>Overload</b>, gain +1/+1.",
         "type": "MINION"
     },
     {
@@ -32453,7 +32458,7 @@
         "name": "Shield Slam",
         "rarity": "EPIC",
         "set": "EXPERT1",
-        "text": "Deal $1 damage to a minion for each Armor you have.",
+        "text": "Deal 1 damage to a minion for each Armor you have.",
         "type": "SPELL"
     },
     {
@@ -39916,7 +39921,7 @@
         "dbfId": 71065,
         "health": 30,
         "id": "HERO_04i",
-        "name": "Judgement Uther",
+        "name": "Judgment Uther",
         "rarity": "FREE",
         "set": "HERO_SKINS",
         "type": "HERO"
@@ -40095,6 +40100,17 @@
         "id": "HERO_06g",
         "name": "Storm's Rage Malfurion",
         "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "DRUID",
+        "collectible": true,
+        "dbfId": 71328,
+        "health": 30,
+        "id": "HERO_06i",
+        "name": "Emerald Malfurion",
+        "rarity": "EPIC",
         "set": "HERO_SKINS",
         "type": "HERO"
     },
@@ -51551,7 +51567,7 @@
         "name": "First Day of School",
         "rarity": "COMMON",
         "set": "SCHOLOMANCE",
-        "text": "Add 3 random 1-Cost minions to your hand.",
+        "text": "Add 2 random 1-Cost minions to your hand.",
         "type": "SPELL"
     },
     {
@@ -66392,7 +66408,7 @@
         "name": "Shield Slam",
         "rarity": "EPIC",
         "set": "VANILLA",
-        "text": "Deal $1 damage to a minion for each Armor you have.",
+        "text": "Deal 1 damage to a minion for each Armor you have.",
         "type": "SPELL"
     },
     {
@@ -68319,6 +68335,672 @@
         "type": "SPELL"
     },
     {
+        "artist": "Dave Allsop",
+        "cardClass": "DEMONHUNTER",
+        "collectible": true,
+        "cost": 2,
+        "dbfId": 63264,
+        "flavor": "Look, summoning ain’t exactly a science. Sometimes it takes a turn.",
+        "id": "WC_003",
+        "name": "Sigil of Summoning",
+        "rarity": "RARE",
+        "referencedTags": [
+            "TAUNT"
+        ],
+        "set": "THE_BARRENS",
+        "spellSchool": "SHADOW",
+        "text": "At the start of your next turn, summon two 2/2 Demons with <b>Taunt</b>.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Andrew Hou",
+        "attack": 4,
+        "cardClass": "DRUID",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 63329,
+        "flavor": "Bound by the law of the fang, these druid floss their teeth twice a day.",
+        "health": 3,
+        "id": "WC_004",
+        "mechanics": [
+            "DEATHRATTLE",
+            "TAUNT"
+        ],
+        "name": "Fangbound Druid",
+        "rarity": "COMMON",
+        "set": "THE_BARRENS",
+        "text": "<b>Taunt</b>\n<b>Deathrattle:</b> Reduce the Cost of a Beast in your hand by (2).",
+        "type": "MINION"
+    },
+    {
+        "artist": "Konstantin Turovec",
+        "attack": 2,
+        "cardClass": "SHAMAN",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 63331,
+        "flavor": "They wanted a Mature Dungeoneer. Instead they got this.",
+        "health": 3,
+        "id": "WC_005",
+        "mechanics": [
+            "BATTLECRY"
+        ],
+        "name": "Primal Dungeoneer",
+        "rarity": "RARE",
+        "set": "THE_BARRENS",
+        "text": "[x]<b>Battlecry:</b> Draw a spell.\nIf it's a Nature spell, also\ndraw an Elemental.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Steven Prescott",
+        "attack": 3,
+        "cardClass": "DRUID",
+        "collectible": true,
+        "cost": 6,
+        "dbfId": 63332,
+        "elite": true,
+        "flavor": "Do you think she got her name before or after she turned into a snake?",
+        "health": 7,
+        "id": "WC_006",
+        "mechanics": [
+            "AURA"
+        ],
+        "name": "Lady Anacondra",
+        "rarity": "LEGENDARY",
+        "set": "THE_BARRENS",
+        "text": "Your Nature spells\ncost (2) less.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Eva Widermann",
+        "cardClass": "HUNTER",
+        "collectible": true,
+        "cost": 0,
+        "dbfId": 63334,
+        "flavor": "\"Awww, it's so cute!\" —Famous last words",
+        "id": "WC_007",
+        "name": "Serpentbloom",
+        "rarity": "COMMON",
+        "referencedTags": [
+            "POISONOUS"
+        ],
+        "set": "THE_BARRENS",
+        "text": "Give a friendly\nBeast <b>Poisonous</b>.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Matt Dixon",
+        "attack": 1,
+        "cardClass": "HUNTER",
+        "collectible": true,
+        "cost": 4,
+        "dbfId": 63335,
+        "flavor": "Loves candles. Hates deodorant.",
+        "health": 6,
+        "id": "WC_008",
+        "mechanics": [
+            "FRENZY"
+        ],
+        "name": "Sin'dorei Scentfinder",
+        "rarity": "COMMON",
+        "referencedTags": [
+            "RUSH"
+        ],
+        "set": "THE_BARRENS",
+        "text": "<b>Frenzy:</b> Summon four 1/1 Hyenas with <b>Rush</b>.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Konstantin Turovec",
+        "attack": 2,
+        "cardClass": "PRIEST",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 63346,
+        "flavor": "\"Please do smaller pulls, this is my first time healing.\"",
+        "health": 3,
+        "id": "WC_013",
+        "mechanics": [
+            "BATTLECRY"
+        ],
+        "name": "Devout Dungeoneer",
+        "rarity": "RARE",
+        "set": "THE_BARRENS",
+        "text": "[x]<b>Battlecry:</b> Draw a spell.\nIf it's a Holy spell,\nreduce its Cost by (2).",
+        "type": "MINION"
+    },
+    {
+        "artist": "Zoltan Boros",
+        "cardClass": "PRIEST",
+        "collectible": true,
+        "cost": 5,
+        "dbfId": 63347,
+        "flavor": "Time to EVEN out the playing field.",
+        "id": "WC_014",
+        "name": "Against All Odds",
+        "rarity": "EPIC",
+        "set": "THE_BARRENS",
+        "spellSchool": "HOLY",
+        "text": "Destroy ALL\nodd-Attack minions.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Daren Bader",
+        "attack": 2,
+        "cardClass": "ROGUE",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 63357,
+        "flavor": "You need to be specific when you're ordering waterproof shoewear.",
+        "health": 5,
+        "id": "WC_015",
+        "mechanics": [
+            "STEALTH"
+        ],
+        "name": "Water Moccasin",
+        "race": "BEAST",
+        "rarity": "COMMON",
+        "referencedTags": [
+            "POISONOUS"
+        ],
+        "set": "THE_BARRENS",
+        "text": "[x]<b>Stealth</b>\nHas <b>Poisonous</b> while you\n have no other minions.",
+        "type": "MINION"
+    },
+    {
+        "artist": "L. Lullabi & K. Turovec",
+        "cardClass": "ROGUE",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 63358,
+        "flavor": "This page left intentionally blank.",
+        "id": "WC_016",
+        "name": "Shroud of Concealment",
+        "rarity": "RARE",
+        "referencedTags": [
+            "STEALTH"
+        ],
+        "set": "THE_BARRENS",
+        "spellSchool": "SHADOW",
+        "text": "Draw 2 minions. Any played this turn gain <b>Stealth</b> for 1 turn.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Grace Liu",
+        "cardClass": "ROGUE",
+        "collectible": true,
+        "cost": 1,
+        "dbfId": 63359,
+        "flavor": "\"Savory\" is a creative way to put it.",
+        "id": "WC_017",
+        "name": "Savory Deviate Delight",
+        "rarity": "RARE",
+        "referencedTags": [
+            "STEALTH"
+        ],
+        "set": "THE_BARRENS",
+        "text": "[x]Transform a minion in\nboth players' hands into a\nPirate or <b>Stealth</b> minion.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Hideaki Takamura",
+        "cardClass": "SHAMAN",
+        "collectible": true,
+        "cost": 1,
+        "dbfId": 63098,
+        "flavor": "Flame is perpetual.*\n *<i>Perpetual only applies to current turn.</i>",
+        "id": "WC_020",
+        "mechanics": [
+            "OVERLOAD"
+        ],
+        "name": "Perpetual Flame",
+        "overload": 1,
+        "rarity": "RARE",
+        "set": "THE_BARRENS",
+        "spellSchool": "FIRE",
+        "text": "Deal $3 damage to a random enemy minion. If it dies, recast this. <b>Overload:</b> (1)",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Arthur Gimaldinov",
+        "cardClass": "WARLOCK",
+        "collectible": true,
+        "cost": 2,
+        "dbfId": 63368,
+        "flavor": "\"Unstable\" usually means \"awesome!\"",
+        "id": "WC_021",
+        "mechanics": [
+            "ImmuneToSpellpower"
+        ],
+        "name": "Unstable Shadow Blast",
+        "rarity": "COMMON",
+        "set": "THE_BARRENS",
+        "spellSchool": "SHADOW",
+        "text": "[x]Deal $6 damage to a\nminion. Excess damage\nhits your hero.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Vladimir Kafanov",
+        "cardClass": "WARLOCK",
+        "collectible": true,
+        "cost": 1,
+        "dbfId": 63369,
+        "flavor": "And with a raspy whisper, he uttered his final words, \"rez plz.\"",
+        "id": "WC_022",
+        "name": "Final Gasp",
+        "rarity": "COMMON",
+        "set": "THE_BARRENS",
+        "spellSchool": "SHADOW",
+        "text": "[x]Deal $1 damage to a\nminion. If it dies, summon\na 2/2 Adventurer with a\nrandom bonus effect.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "James Ryman",
+        "attack": 2,
+        "cardClass": "WARLOCK",
+        "collectible": true,
+        "cost": 4,
+        "dbfId": 63370,
+        "flavor": "The tooth fairy gig didn't work out.",
+        "health": 6,
+        "id": "WC_023",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Stealer of Souls",
+        "race": "DEMON",
+        "rarity": "RARE",
+        "set": "THE_BARRENS",
+        "text": "After you draw a card, change its Cost to Health instead of Mana.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Ivan Fomin",
+        "attack": 2,
+        "cardClass": "WARRIOR",
+        "collectible": true,
+        "cost": 2,
+        "dbfId": 63373,
+        "flavor": "Arch nemesis of the Man-at-Legs.",
+        "health": 3,
+        "id": "WC_024",
+        "mechanics": [
+            "BATTLECRY"
+        ],
+        "name": "Man-at-Arms",
+        "rarity": "COMMON",
+        "set": "THE_BARRENS",
+        "text": "<b>Battlecry:</b> If you have a weapon equipped, gain +1/+1.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Luca Zontini",
+        "attack": 1,
+        "cardClass": "WARRIOR",
+        "collectible": true,
+        "cost": 1,
+        "dbfId": 63374,
+        "durability": 4,
+        "flavor": "A bad hatchet can make a good spear better.",
+        "id": "WC_025",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Whetstone Hatchet",
+        "rarity": "RARE",
+        "set": "THE_BARRENS",
+        "text": "After your hero attacks, give a minion in your hand +1 Attack.",
+        "type": "WEAPON"
+    },
+    {
+        "artist": "Daren Bader",
+        "attack": 3,
+        "cardClass": "WARRIOR",
+        "collectible": true,
+        "cost": 6,
+        "dbfId": 63375,
+        "elite": true,
+        "flavor": "Never should have flushed him.",
+        "health": 9,
+        "id": "WC_026",
+        "mechanics": [
+            "DEATHRATTLE",
+            "FRENZY"
+        ],
+        "name": "Kresh, Lord of Turtling",
+        "race": "BEAST",
+        "rarity": "LEGENDARY",
+        "set": "THE_BARRENS",
+        "text": "<b>Frenzy:</b> Gain 8 Armor. <b>Deathrattle:</b> Equip a 2/5 Turtle Spike.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Jakub Kasper",
+        "attack": 3,
+        "cardClass": "NEUTRAL",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 63400,
+        "flavor": "When it's on keto, it only devours tauren.",
+        "health": 2,
+        "id": "WC_027",
+        "mechanics": [
+            "DEATHRATTLE"
+        ],
+        "name": "Devouring Ectoplasm",
+        "rarity": "COMMON",
+        "set": "THE_BARRENS",
+        "text": "[x]<b>Deathrattle:</b> Summon a\n2/2 Adventurer with\n a random bonus effect.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Evgeniy Dlinnov",
+        "attack": 0,
+        "cardClass": "NEUTRAL",
+        "collectible": true,
+        "cost": 1,
+        "dbfId": 63396,
+        "flavor": "\"I'm clicking on it, but nothing's happening.\"",
+        "health": 2,
+        "id": "WC_028",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Meeting Stone",
+        "rarity": "COMMON",
+        "set": "THE_BARRENS",
+        "text": "[x]At the end of your turn,\nadd a 2/2 Adventurer\nwith a random bonus effect\nto your hand.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Vika Yarova",
+        "attack": 6,
+        "cardClass": "NEUTRAL",
+        "collectible": true,
+        "cost": 7,
+        "dbfId": 63397,
+        "flavor": "\"I got a real sense of humility from her when she bashed that quilboar's head in.\"",
+        "health": 6,
+        "id": "WC_029",
+        "mechanics": [
+            "BATTLECRY"
+        ],
+        "name": "Selfless Sidekick",
+        "rarity": "COMMON",
+        "set": "THE_BARRENS",
+        "text": "<b>Battlecry:</b> Equip a random weapon from your deck.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Matt Dixon",
+        "attack": 4,
+        "cardClass": "NEUTRAL",
+        "collectible": true,
+        "cost": 7,
+        "dbfId": 63398,
+        "elite": true,
+        "flavor": "As long as Naralex stays under the blanket, Mutanus can't get him.",
+        "health": 4,
+        "id": "WC_030",
+        "mechanics": [
+            "BATTLECRY"
+        ],
+        "name": "Mutanus the Devourer",
+        "race": "MURLOC",
+        "rarity": "LEGENDARY",
+        "set": "THE_BARRENS",
+        "text": "[x]<b>Battlecry:</b> Eat a minion in\nyour opponent's hand.\nGain its stats.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Konstantin Turovec",
+        "attack": 2,
+        "cardClass": "PALADIN",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 63099,
+        "durability": 3,
+        "flavor": "A shield to some, a frisbee to others (mainly dogs).",
+        "id": "WC_032",
+        "mechanics": [
+            "DEATHRATTLE"
+        ],
+        "name": "Seedcloud Buckler",
+        "rarity": "COMMON",
+        "referencedTags": [
+            "DIVINE_SHIELD"
+        ],
+        "set": "THE_BARRENS",
+        "text": "[x]<b>Deathrattle:</b> Give your\n minions <b>Divine Shield</b>.",
+        "type": "WEAPON"
+    },
+    {
+        "artist": "Ursula Dorada",
+        "cardClass": "PALADIN",
+        "collectible": true,
+        "cost": 1,
+        "dbfId": 62921,
+        "flavor": "Look, we don't need a jury. We've got a paladin right here!",
+        "id": "WC_033",
+        "mechanics": [
+            "SECRET"
+        ],
+        "name": "Judgment of Justice",
+        "rarity": "COMMON",
+        "set": "THE_BARRENS",
+        "spellSchool": "HOLY",
+        "text": "<b>Secret:</b> When an enemy minion attacks, set its Attack and Health to 1.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Yaohua Xu",
+        "cardClass": "PALADIN",
+        "collectible": true,
+        "cost": 7,
+        "dbfId": 63102,
+        "flavor": "Random? But what if we don't get a tank?",
+        "id": "WC_034",
+        "name": "Party Up!",
+        "rarity": "RARE",
+        "set": "THE_BARRENS",
+        "text": "Summon five 2/2 Adventurers with random bonus effects.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Arthur Bozonnet",
+        "attack": 3,
+        "cardClass": "NEUTRAL",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 63432,
+        "elite": true,
+        "flavor": "\"Dormant? I think you mean naptime.\"",
+        "health": 3,
+        "id": "WC_035",
+        "name": "Archdruid Naralex",
+        "rarity": "LEGENDARY",
+        "set": "THE_BARRENS",
+        "text": "[x]<b>Dormant</b> for 2 turns.\nWhile <b>Dormant</b>, add a\nDream card to your hand\n  at the end of your turn.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Mauricio Herrera",
+        "attack": 4,
+        "cardClass": "DRUID",
+        "collectible": true,
+        "cost": 8,
+        "dbfId": 63502,
+        "flavor": "Even with wings, snakes STILL don't have legs.",
+        "health": 9,
+        "id": "WC_036",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Deviate Dreadfang",
+        "race": "BEAST",
+        "rarity": "RARE",
+        "referencedTags": [
+            "RUSH"
+        ],
+        "set": "THE_BARRENS",
+        "text": "After you cast a Nature spell, summon a 4/2 Viper with <b>Rush</b>.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Jason Kang",
+        "attack": 1,
+        "cardClass": "HUNTER",
+        "collectible": true,
+        "cost": 4,
+        "dbfId": 63632,
+        "durability": 2,
+        "flavor": "\"You know you only have to coat the arrowhead in poison and not the entire bow, right?\"",
+        "id": "WC_037",
+        "mechanics": [
+            "POISONOUS"
+        ],
+        "name": "Venomstrike Bow",
+        "rarity": "RARE",
+        "set": "THE_BARRENS",
+        "text": "<b>Poisonous</b>",
+        "type": "WEAPON"
+    },
+    {
+        "artist": "Ian Ameling",
+        "attack": 8,
+        "cardClass": "DEMONHUNTER",
+        "collectible": true,
+        "cost": 8,
+        "dbfId": 63230,
+        "flavor": "Oh boo hoo, did someone's World Tree burn down?",
+        "health": 8,
+        "id": "WC_040",
+        "mechanics": [
+            "AURA",
+            "TAUNT"
+        ],
+        "name": "Taintheart Tormenter",
+        "race": "DEMON",
+        "rarity": "RARE",
+        "set": "THE_BARRENS",
+        "text": "<b>Taunt</b>\nYour opponent's spells cost (2) more.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Arthur Bozonnet",
+        "cardClass": "MAGE",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 63515,
+        "flavor": "Let's be honest, they weren't going to unfreeze anyway.",
+        "id": "WC_041",
+        "name": "Shattering Blast",
+        "rarity": "RARE",
+        "set": "THE_BARRENS",
+        "spellSchool": "FROST",
+        "text": "Destroy all <b>Frozen</b> minions.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Samche Chen",
+        "attack": 1,
+        "cardClass": "SHAMAN",
+        "collectible": true,
+        "cost": 1,
+        "dbfId": 63073,
+        "flavor": "If you have The Vapors, your Humors might be imbalanced.",
+        "health": 3,
+        "id": "WC_042",
+        "mechanics": [
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Wailing Vapor",
+        "race": "ELEMENTAL",
+        "rarity": "COMMON",
+        "set": "THE_BARRENS",
+        "text": "[x]After you play an Elemental,\ngain +1 Attack.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Melvin Chan",
+        "attack": 3,
+        "cardClass": "DEMONHUNTER",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 63407,
+        "flavor": "It only rattles when YOU'RE in danger.",
+        "health": 2,
+        "id": "WC_701",
+        "mechanics": [
+            "DEATHRATTLE",
+            "RUSH"
+        ],
+        "name": "Felrattler",
+        "race": "BEAST",
+        "rarity": "COMMON",
+        "set": "THE_BARRENS",
+        "text": "[x]<b>Rush</b>\n<b>Deathrattle:</b> Deal 1 damage\nto all enemy minions.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Maria Trepalina",
+        "attack": 1,
+        "cardClass": "PRIEST",
+        "collectible": true,
+        "cost": 1,
+        "dbfId": 63464,
+        "flavor": "When it's her turn to cook, she'll always go for a Light sear.",
+        "health": 2,
+        "id": "WC_803",
+        "mechanics": [
+            "BATTLECRY",
+            "DISCOVER"
+        ],
+        "name": "Cleric of An'she",
+        "rarity": "COMMON",
+        "set": "THE_BARRENS",
+        "text": "<b>Battlecry:</b> If you've restored Health this turn, <b>Discover</b> a spell from your deck.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Konstantin Turovec",
+        "attack": 2,
+        "cardClass": "MAGE",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 63058,
+        "flavor": "It's a woven blanket of ice but surprisingly comforting.",
+        "health": 3,
+        "id": "WC_805",
+        "mechanics": [
+            "BATTLECRY"
+        ],
+        "name": "Frostweave Dungeoneer",
+        "rarity": "RARE",
+        "referencedTags": [
+            "FREEZE"
+        ],
+        "set": "THE_BARRENS",
+        "text": "[x]<b>Battlecry:</b> Draw a spell.\nIf it's a Frost spell,\nsummon two 1/1\n   Elementals that <b>Freeze</b>.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Matt Dixon",
+        "attack": 5,
+        "cardClass": "MAGE",
+        "collectible": true,
+        "cost": 6,
+        "dbfId": 63520,
+        "flavor": "His real name is Melvin, but he prefers his friends call him ... <sigh> ...\"Floecaster.\"",
+        "health": 5,
+        "id": "WC_806",
+        "name": "Floecaster",
+        "rarity": "COMMON",
+        "set": "THE_BARRENS",
+        "text": "Costs (2) less for each <b>Frozen</b> enemy.",
+        "type": "MINION"
+    },
+    {
         "artist": "Zoltan Boros",
         "cardClass": "DRUID",
         "collectible": true,
@@ -69515,12 +70197,13 @@
         "dbfId": 61962,
         "flavor": "Plainsrunning will result in disqualification.",
         "id": "YOP_024",
-        "multiClassGroup": "DRUID_SHAMAN",
-        "name": "Guidance",
-        "rarity": "RARE",
-        "referencedTags": [
+        "mechanics": [
             "OVERLOAD"
         ],
+        "multiClassGroup": "DRUID_SHAMAN",
+        "name": "Guidance",
+        "overload": 1,
+        "rarity": "RARE",
         "set": "DARKMOON_FAIRE",
         "text": "Look at two spells. Add one to your hand or <b>Overload:</b> (1) to get both.",
         "type": "SPELL"
@@ -69650,11 +70333,15 @@
         "health": 4,
         "id": "YOP_031",
         "mechanics": [
+            "BATTLECRY",
             "RUSH"
         ],
         "name": "Crabrider",
         "race": "MURLOC",
         "rarity": "COMMON",
+        "referencedTags": [
+            "WINDFURY"
+        ],
         "set": "DARKMOON_FAIRE",
         "text": "[x]<b>Rush</b>\n<b>Battlecry:</b> Gain <b>Windfury</b>\nthis turn only.",
         "type": "MINION"

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -839,7 +839,7 @@ void BlackTempleCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // - Set: BLACK_TEMPLE, Rarity: Common
     // - Spell School: Holy
     // --------------------------------------------------------
-    // Text: Give a minion +2/+2. Draw a card.
+    // Text: Give a minion +2/+1. Draw a card.
     // --------------------------------------------------------
     // PlayReq:
     // - REQ_TARGET_TO_PLAY = 0
@@ -928,7 +928,7 @@ void BlackTempleCardsGen::AddPaladinNonCollect(
     // [BT_292e] Hand of A'dal - COST:0
     // - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: +2/+2.
+    // Text: +2/+1.
     // --------------------------------------------------------
     power.ClearData();
     power.AddEnchant(Enchants::GetEnchantFromText("BT_292e"));

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1993,8 +1993,7 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // [CORE_EX1_258] Unbound Elemental - COST:3 [ATK:3/HP:4]
     // - Race: Elemental, Set: CORE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Whenever you play a card with <b>Overload</b>,
-    //       gain +1/+1.
+    // Text: After you play a card with <b>Overload</b>, gain +1/+1.
     // --------------------------------------------------------
     // GameTag:
     // - TRIGGER_VISUAL = 1

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -3004,8 +3004,7 @@ void Expert1CardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // [EX1_258] Unbound Elemental - COST:3 [ATK:3/HP:4]
     // - Race: Elemental, Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
-    // Text: Whenever you play a card with <b>Overload</b>,
-    //       gain +1/+1.
+    // Text: After you play a card with <b>Overload</b>, gain +1/+1.
     // --------------------------------------------------------
     // RefTag:
     // - OVERLOAD = 1

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -674,11 +674,11 @@ void ScholomanceCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // [SCH_247] First Day of School - COST:1
     // - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Add 3 random 1-Cost minions to your hand.
+    // Text: Add 2 random 1-Cost minions to your hand.
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(std::make_shared<RandomMinionTask>(
-        TagValues{ { GameTag::COST, 1, RelaSign::EQ } }, 3));
+        TagValues{ { GameTag::COST, 1, RelaSign::EQ } }, 2));
     power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
     cards.emplace("SCH_247", CardDef(power));
 

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -135,6 +135,44 @@ void TheBarrensCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [WC_004] Fangbound Druid - COST:3 [ATK:4/HP:3]
+    // - Set: THE_BARRENS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Deathrattle:</b> Reduce the Cost of a Beast
+    //       in your hand by (2).
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [WC_006] Lady Anacondra - COST:6 [ATK:3/HP:7]
+    // - Set: THE_BARRENS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Your Nature spells cost (2) less.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - AURA = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [WC_036] Deviate Dreadfang - COST:8 [ATK:4/HP:9]
+    // - Race: Beast, Set: THE_BARRENS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: After you cast a Nature spell,
+    //       summon a 4/2 Viper with <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
 }
 
 void TheBarrensCardsGen::AddDruidNonCollect(
@@ -211,6 +249,30 @@ void TheBarrensCardsGen::AddDruidNonCollect(
     // - Set: THE_BARRENS
     // --------------------------------------------------------
     // Text: +2/+2.
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [WC_004t] Nightmare Trapped - COST:0
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: Costs (2) less.
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [WC_006e] Natural Empowerment - COST:0
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: Costs (2) less.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [WC_036t1] Deviate Viper - COST:3 [ATK:4/HP:2]
+    // - Race: Beast, Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
     // --------------------------------------------------------
 }
 
@@ -333,6 +395,39 @@ void TheBarrensCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [WC_007] Serpentbloom - COST:0
+    // - Set: THE_BARRENS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Give a friendly Beast <b>Poisonous</b>.
+    // --------------------------------------------------------
+    // RefTag:
+    // - POISONOUS = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [WC_008] Sin'dorei Scentfinder - COST:4 [ATK:1/HP:6]
+    // - Set: THE_BARRENS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Frenzy:</b> Summon four 1/1 Hyenas with <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - FRENZY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- WEAPON - HUNTER
+    // [WC_037] Venomstrike Bow - COST:4
+    // - Set: THE_BARRENS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Poisonous</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - POISONOUS = 1
+    // --------------------------------------------------------
 }
 
 void TheBarrensCardsGen::AddHunterNonCollect(
@@ -411,6 +506,16 @@ void TheBarrensCardsGen::AddHunterNonCollect(
     // - Set: THE_BARRENS
     // --------------------------------------------------------
     // Text: +2/+1.
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - HUNTER
+    // [WC_007e] Serpent's Bite - COST:0
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: <b>Poisonous</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - POISONOUS = 1
     // --------------------------------------------------------
 }
 
@@ -529,6 +634,36 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // RefTag:
     // - FREEZE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [WC_041] Shattering Blast - COST:3
+    // - Set: THE_BARRENS, Rarity: Rare
+    // - Spell School: Frost
+    // --------------------------------------------------------
+    // Text: Destroy all <b>Frozen</b> minions.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [WC_805] Frostweave Dungeoneer - COST:3 [ATK:2/HP:3]
+    // - Set: THE_BARRENS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Draw a spell.
+    //       If it's a Frost spell,
+    //       summon two 1/1 Elementals that <b>Freeze</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - FREEZE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [WC_806] Floecaster - COST:6 [ATK:5/HP:5]
+    // - Set: THE_BARRENS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Costs (2) less for each <b>Frozen</b> enemy.
     // --------------------------------------------------------
 }
 
@@ -731,6 +866,39 @@ void TheBarrensCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // - RUSH = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+
+    // --------------------------------------- WEAPON - PALADIN
+    // [WC_032] Seedcloud Buckler - COST:3
+    // - Set: THE_BARRENS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Give your minions
+    //       <b>Divine Shield</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DIVINE_SHIELD = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [WC_033] Judgment of Justice - COST:1
+    // - Set: THE_BARRENS, Rarity: Common
+    // - Spell School: Holy
+    // --------------------------------------------------------
+    // Text: <b>Secret:</b> When an enemy minion attacks,
+    //       set its Attack and Health to 1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [WC_034] Party Up! - COST:7
+    // - Set: THE_BARRENS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Summon five 2/2 Adventurers with random bonus effects.
+    // --------------------------------------------------------
 }
 
 void TheBarrensCardsGen::AddPaladinNonCollect(
@@ -812,6 +980,13 @@ void TheBarrensCardsGen::AddPaladinNonCollect(
     // - Set: THE_BARRENS
     // --------------------------------------------------------
     // Text: Costs (1) less.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [WC_033e] Judged - COST:0
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: 1/1.
     // --------------------------------------------------------
 }
 
@@ -925,6 +1100,37 @@ void TheBarrensCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - ELITE = 1
     // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [WC_013] Devout Dungeoneer - COST:3 [ATK:2/HP:3]
+    // - Set: THE_BARRENS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Draw a spell.
+    //       If it's a Holy spell, reduce its Cost by (2).
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [WC_014] Against All Odds - COST:5
+    // - Set: THE_BARRENS, Rarity: Epic
+    // - Spell School: Holy
+    // --------------------------------------------------------
+    // Text: Destroy all odd-Attack minions.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [WC_803] Cleric of An'she - COST:1 [ATK:1/HP:2]
+    // - Set: THE_BARRENS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you've restored Health this turn,
+    //       <b>Discover</b> a spell from your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
     // --------------------------------------------------------
 }
 
@@ -1066,6 +1272,43 @@ void TheBarrensCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - COMBO = 1
     // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [WC_015] Water Moccasin - COST:3 [ATK:2/HP:5]
+    // - Race: Beast, Set: THE_BARRENS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b>
+    //       Has <b>Poisonous</b> while you have no other minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - STEALTH = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - POISONOUS = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [WC_016] Shroud of Concealment - COST:3
+    // - Set: THE_BARRENS, Rarity: Rare
+    // - Spell School: Shadow
+    // --------------------------------------------------------
+    // Text: Draw 2 minions.
+    //       Any played this turn gain <b>Stealth</b> for 1 turn.
+    // --------------------------------------------------------
+    // RefTag:
+    // - STEALTH = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [WC_017] Savory Deviate Delight - COST:1
+    // - Set: THE_BARRENS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Transform a minion in both players' hands
+    //       into a Pirate or <b>Stealth</b> minion.
+    // --------------------------------------------------------
+    // RefTag:
+    // - STEALTH = 1
+    // --------------------------------------------------------
 }
 
 void TheBarrensCardsGen::AddRogueNonCollect(
@@ -1105,6 +1348,23 @@ void TheBarrensCardsGen::AddRogueNonCollect(
     // --------------------------------------------------------
     // GameTag:
     // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - ROGUE
+    // [WC_016e] Cloaking - COST:0
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: Play this turn to gain <b>Stealth</b> for 1 turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - ROGUE
+    // [WC_016e2] Cloaked - COST:0
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b> for 1 turn.
     // --------------------------------------------------------
 }
 
@@ -1219,6 +1479,39 @@ void TheBarrensCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [WC_005] Primal Dungeoneer - COST:3 [ATK:2/HP:3]
+    // - Set: THE_BARRENS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Draw a spell.
+    //       If it's a Nature spell, also draw an Elemental.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [WC_020] Perpetual Flame - COST:1
+    // - Set: THE_BARRENS, Rarity: Rare
+    // - Spell School: Fire
+    // --------------------------------------------------------
+    // Text: Deal 3 damage to a random enemy minion.
+    //       If it dies, recast this. <b>Overload:</b> (1)
+    // --------------------------------------------------------
+    // GameTag:
+    // - OVERLOAD = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [WC_042] Wailing Vapor - COST:1 [ATK:1/HP:3]
+    // - Race: Elemental, Set: THE_BARRENS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: After you play an Elemental, gain +1 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
 }
 
 void TheBarrensCardsGen::AddShamanNonCollect(
@@ -1265,6 +1558,13 @@ void TheBarrensCardsGen::AddShamanNonCollect(
     // ---------------------------------------- MINION - SHAMAN
     // [BAR_751t] Diremuck Tinyfin - COST:1 [ATK:1/HP:1]
     // - Race: Murloc, Set: THE_BARRENS
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - SHAMAN
+    // [WC_042e] Rising Gas - COST:0
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: +1 Attack.
     // --------------------------------------------------------
 }
 
@@ -1377,6 +1677,38 @@ void TheBarrensCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // RefTag:
     // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [WC_021] Unstable Shadow Blast - COST:2
+    // - Set: THE_BARRENS, Rarity: Common
+    // - Spell School: Shadow
+    // --------------------------------------------------------
+    // Text: Deal 6 damage to a minion.
+    //       Excess damage hits your hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ImmuneToSpellpower = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [WC_022] Final Gasp - COST:1
+    // - Set: THE_BARRENS, Rarity: Common
+    // - Spell School: Shadow
+    // --------------------------------------------------------
+    // Text: Deal 1 damage to a minion. If it dies,
+    //       summon a 2/2 Adventurer with a random bonus effect.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [WC_023] Stealer of Souls - COST:4 [ATK:2/HP:6]
+    // - Race: Demon, Set: THE_BARRENS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: After you draw a card,
+    //       change its Cost to Health instead of Mana.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
 }
 
@@ -1547,6 +1879,41 @@ void TheBarrensCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // - FRENZY = 1
     // - RUSH = 1
     // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [WC_024] Man-at-Arms - COST:2 [ATK:2/HP:3]
+    // - Set: THE_BARRENS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you have a weapon equipped,
+    //       gain +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- WEAPON - WARRIOR
+    // [WC_025] Whetstone Hatchet - COST:1
+    // - Set: THE_BARRENS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: After your hero attacks,
+    //       give a minion in your hand +1 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [WC_026] Kresh, Lord of Turtling - COST:6 [ATK:3/HP:9]
+    // - Race: Beast, Set: THE_BARRENS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Frenzy:</b> Gain 8 Armor.
+    //       <b>Deathrattle:</b> Equip a 2/5 Turtle Spike.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DEATHRATTLE = 1
+    // - FRENZY = 1
+    // --------------------------------------------------------
 }
 
 void TheBarrensCardsGen::AddWarriorNonCollect(
@@ -1579,6 +1946,25 @@ void TheBarrensCardsGen::AddWarriorNonCollect(
     // - Set: THE_BARRENS
     // --------------------------------------------------------
     // Text: Increased Attack.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARRIOR
+    // [WC_024e] Armed - COST:0
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: +1/+1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARRIOR
+    // [WC_025e] Armed - COST:0
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: +1 Attack
+    // --------------------------------------------------------
+
+    // --------------------------------------- WEAPON - WARRIOR
+    // [WC_026t] Turtle Spike - COST:4
+    // - Set: THE_BARRENS
     // --------------------------------------------------------
 }
 
@@ -1700,6 +2086,42 @@ void TheBarrensCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // Text: Give your hero +2 Attack this turn.
     //       <i>(Upgrades when you have 5 Mana.)</i>
     // --------------------------------------------------------
+
+    // ------------------------------------ SPELL - DEMONHUNTER
+    // [WC_003] Sigil of Summoning - COST:2
+    // - Set: THE_BARRENS, Rarity: Rare
+    // - Spell School: Shadow
+    // --------------------------------------------------------
+    // Text: At the start of your next turn,
+    //       summon two 2/2 Demons with <b>Taunt</b>.
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------- MINION - DEMONHUNTER
+    // [WC_040] Taintheart Tormenter - COST:8 [ATK:8/HP:8]
+    // - Race: Demon, Set: THE_BARRENS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       Your opponent's spells cost (2) more.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AURA = 1
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------- MINION - DEMONHUNTER
+    // [WC_701] Felrattler - COST:3 [ATK:3/HP:2]
+    // - Race: Beast, Set: THE_BARRENS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>
+    //       <b>Deathrattle:</b> Deal 1 damage to all enemy minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // - RUSH = 1
+    // --------------------------------------------------------
 }
 
 void TheBarrensCardsGen::AddDemonHunterNonCollect(
@@ -1760,6 +2182,16 @@ void TheBarrensCardsGen::AddDemonHunterNonCollect(
     // - Spell School: Fel
     // --------------------------------------------------------
     // Text: Give your hero +4 Attack this turn.
+    // --------------------------------------------------------
+
+    // ----------------------------------- MINION - DEMONHUNTER
+    // [WC_003t] Wailing Demon - COST:2 [ATK:2/HP:2]
+    // - Race: Demon, Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
     // --------------------------------------------------------
 }
 
@@ -2175,6 +2607,62 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // RefTag:
     // - SECRET = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [WC_027] Devouring Ectoplasm - COST:3 [ATK:3/HP:2]
+    // - Set: THE_BARRENS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon a 2/2 Adventurer
+    //       with a random bonus effect.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [WC_028] Meeting Stone - COST:1 [ATK:0/HP:2]
+    // - Set: THE_BARRENS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: At the end of your turn, add a 2/2 Adventurer
+    //       with a random bonus effect to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [WC_029] Selfless Sidekick - COST:7 [ATK:6/HP:6]
+    // - Set: THE_BARRENS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Equip a random weapon from your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [WC_030] Mutanus the Devourer - COST:7 [ATK:4/HP:4]
+    // - Race: Murloc, Set: THE_BARRENS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Eat a minion in your opponent's hand.
+    //       Gain its stats.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [WC_035] Archdruid Naralex - COST:3 [ATK:3/HP:3]
+    // - Set: THE_BARRENS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Dormant</b> for 2 turns.
+    //       While <b>Dormant</b>, add a Dream card to your hand
+    //       at the end of your turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
     // --------------------------------------------------------
 }
 
@@ -2706,6 +3194,132 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // - Set: THE_BARRENS
     // --------------------------------------------------------
     // Text: Gain 1 Mana Crystal this turn only.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [WC_013e] Ray of Light - COST:0
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: Costs (2) less.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [WC_023e] Stolen Soul - COST:0
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: Costs Health instead of Mana.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [WC_030e] Devoured - COST:0
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: Increased Stats
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [WC_034t] Deadly Adventurer - COST:2 [ATK:2/HP:2]
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: <b>Poisonous</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - POISONOUS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [WC_034t2] Burly Adventurer - COST:2 [ATK:2/HP:2]
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [WC_034t3] Devout Adventurer - COST:2 [ATK:2/HP:2]
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: <b>Divine Shield</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - DIVINE_SHIELD = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [WC_034t4] Relentless Adventurer - COST:2 [ATK:2/HP:2]
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: <b>Windfury</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - WINDFURY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [WC_034t5] Arcane Adventurer - COST:2 [ATK:2/HP:2]
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: <b>Spell Damage +1</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPELLPOWER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [WC_034t6] Sneaky Adventurer - COST:2 [ATK:2/HP:2]
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - STEALTH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [WC_034t7] Vital Adventurer - COST:2 [ATK:2/HP:2]
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: <b>Lifesteal</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - LIFESTEAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [WC_034t8] Swift Adventurer - COST:2 [ATK:2/HP:2]
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [WC_035e] Dreaming - COST:0
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: <b>Dormant</b>. Awaken in 2 turns.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [WC_035e2] Asleep - COST:0
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // GameTag:
+    // - ENCHANTMENT_INVISIBLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [WC_040e] Tormented - COST:0
+    // - Set: THE_BARRENS
+    // --------------------------------------------------------
+    // Text: Costs (2) more.
     // --------------------------------------------------------
 }
 

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -2095,8 +2095,7 @@ void VanillaCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // [VAN_EX1_258] Unbound Elemental - COST:3 [ATK:3/HP:4]
     // - Set: VANILLA, Rarity: Common
     // --------------------------------------------------------
-    // Text: Whenever you play a card with <b>Overload</b>,
-    //       gain +1/+1.
+    // Text: After you play a card with <b>Overload</b>, gain +1/+1.
     // --------------------------------------------------------
     // GameTag:
     // - TRIGGER_VISUAL = 1

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -1593,7 +1593,7 @@ TEST_CASE("[Priest : Minion] - BT_341 : Skeletal Dragon")
 // - Set: BLACK_TEMPLE, Rarity: Common
 // - Spell School: Holy
 // --------------------------------------------------------
-// Text: Give a minion +2/+2. Draw a card.
+// Text: Give a minion +2/+1. Draw a card.
 // --------------------------------------------------------
 TEST_CASE("[Paladin : SPELL] - BT_292 : Hand of A'dal")
 {
@@ -1630,7 +1630,7 @@ TEST_CASE("[Paladin : SPELL] - BT_292 : Hand of A'dal")
     game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
     CHECK_EQ(curHand.GetCount(), 5);
     CHECK_EQ(curField[0]->GetAttack(), 5);
-    CHECK_EQ(curField[0]->GetHealth(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
 }
 
 // ------------------------------------------ SPELL - ROGUE

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -5710,8 +5710,7 @@ TEST_CASE("[Shaman : Minion] - CORE_EX1_250 : Earth Elemental")
 // [CORE_EX1_258] Unbound Elemental - COST:3 [ATK:3/HP:4]
 // - Race: Elemental, Set: CORE, Rarity: Common
 // --------------------------------------------------------
-// Text: Whenever you play a card with <b>Overload</b>,
-//       gain +1/+1.
+// Text: After you play a card with <b>Overload</b>, gain +1/+1.
 // --------------------------------------------------------
 // GameTag:
 // - TRIGGER_VISUAL = 1

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -6279,8 +6279,7 @@ TEST_CASE("[Shaman : Spell] - EX1_251 : Forked Lightning")
 // [EX1_258] Unbound Elemental - COST:3 [ATK:3/HP:4]
 // - Race: Elemental, Faction: Neutral, Set: Expert1, Rarity: Common
 // --------------------------------------------------------
-// Text: Whenever you play a card with <b>Overload</b>,
-//       gain +1/+1.
+// Text: After you play a card with <b>Overload</b>, gain +1/+1.
 // --------------------------------------------------------
 // RefTag:
 // - OVERLOAD = 1

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -934,7 +934,7 @@ TEST_CASE("[Mage : Minion] - SCH_310 : Lab Partner")
 // [SCH_247] First Day of School - COST:1
 // - Set: SCHOLOMANCE, Rarity: Common
 // --------------------------------------------------------
-// Text: Add 3 random 1-Cost minions to your hand.
+// Text: Add 2 random 1-Cost minions to your hand.
 // --------------------------------------------------------
 TEST_CASE("[Paladin : Spell] - SCH_247 : First Day of School")
 {
@@ -962,13 +962,11 @@ TEST_CASE("[Paladin : Spell] - SCH_247 : First Day of School")
         curPlayer, Cards::FindCardByName("First Day of School"));
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
-    CHECK_EQ(curHand.GetCount(), 3);
+    CHECK_EQ(curHand.GetCount(), 2);
     CHECK_EQ(curHand[0]->card->GetCardType(), CardType::MINION);
     CHECK_EQ(curHand[0]->card->GetCost(), 1);
     CHECK_EQ(curHand[1]->card->GetCardType(), CardType::MINION);
     CHECK_EQ(curHand[1]->card->GetCost(), 1);
-    CHECK_EQ(curHand[2]->card->GetCardType(), CardType::MINION);
-    CHECK_EQ(curHand[2]->card->GetCost(), 1);
 }
 
 // ---------------------------------------- SPELL - PALADIN


### PR DESCRIPTION
This revision includes:
- Update Hearthstone Patch 20.4 (#592)
  - Card update
    - NUM_ALL_CARDS: 12660 -> 12805
    - First Day of School: Old: Add 3 random 1-Cost minions to your hand. → New: Add 2 random 1-Cost minions to your hand.
    - Hand of A’dal: Old: Give a minion +2/+2. Draw a card. → New: Give a minion +2/+1. Draw a card.
    - Unbound Elemental: Old: Whenever you play a card with Overload, gain +1/+1. → New: After you play a card with Overload, gain +1/+1.
  - Battlegrounds update
    - NEW HEROES: Mutanus the Devourer, Guff Runetotem
    - HERO POOL UPDATE: Maiev Shadowsong has been temporarily removed from the Battlegrounds Hero Pool.
    - NEW MINION: Hexruin Marauder
    - MINION POOL UPDATES
      - Quilboar are no longer guaranteed to be in every Battlegrounds match.
      - Siegebreaker has been removed from Battlegrounds.
      - Cap’n Hoggarr’s text has been reworded to say “whenever” instead of “after” (no functional change).