### PR TITLE
Implement 16 CORE cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -61,8 +61,8 @@ CORE | CORE_CS2_089 | Holy Light | O
 CORE | CORE_CS2_092 | Blessing of Kings | O
 CORE | CORE_CS2_093 | Consecration | O
 CORE | CORE_CS2_097 | Truesilver Champion | O
-CORE | CORE_CS2_106 | Fiery War Axe |  
-CORE | CORE_CS2_108 | Execute |  
+CORE | CORE_CS2_106 | Fiery War Axe | O
+CORE | CORE_CS2_108 | Execute | O
 CORE | CORE_CS2_117 | Earthen Ring Farseer |  
 CORE | CORE_CS2_120 | River Crocolisk |  
 CORE | CORE_CS2_122 | Raid Leader |  
@@ -91,7 +91,7 @@ CORE | CORE_EX1_049 | Youthful Brewmaster |
 CORE | CORE_EX1_059 | Crazed Alchemist |  
 CORE | CORE_EX1_066 | Acidic Swamp Ooze |  
 CORE | CORE_EX1_082 | Mad Bomber |  
-CORE | CORE_EX1_084 | Warsong Commander |  
+CORE | CORE_EX1_084 | Warsong Commander | O
 CORE | CORE_EX1_093 | Defender of Argus |  
 CORE | CORE_EX1_095 | Gadgetzan Auctioneer |  
 CORE | CORE_EX1_096 | Loot Hoarder |  
@@ -139,14 +139,14 @@ CORE | CORE_EX1_335 | Lightspawn | O
 CORE | CORE_EX1_362 | Argent Protector | O
 CORE | CORE_EX1_382 | Aldor Peacekeeper | O
 CORE | CORE_EX1_383 | Tirion Fordring | O
-CORE | CORE_EX1_391 | Slam |  
+CORE | CORE_EX1_391 | Slam | O
 CORE | CORE_EX1_399 | Gurubashi Berserker |  
-CORE | CORE_EX1_400 | Whirlwind |  
-CORE | CORE_EX1_402 | Armorsmith |  
-CORE | CORE_EX1_407 | Brawl |  
-CORE | CORE_EX1_410 | Shield Slam |  
-CORE | CORE_EX1_411 | Gorehowl |  
-CORE | CORE_EX1_414 | Grommash Hellscream |  
+CORE | CORE_EX1_400 | Whirlwind | O
+CORE | CORE_EX1_402 | Armorsmith | O
+CORE | CORE_EX1_407 | Brawl | O
+CORE | CORE_EX1_410 | Shield Slam | O
+CORE | CORE_EX1_411 | Gorehowl | O
+CORE | CORE_EX1_414 | Grommash Hellscream | O
 CORE | CORE_EX1_506 | Murloc Tidehunter |  
 CORE | CORE_EX1_509 | Murloc Tidecaller |  
 CORE | CORE_EX1_522 | Patient Assassin | O
@@ -159,8 +159,8 @@ CORE | CORE_EX1_567 | Doomhammer | O
 CORE | CORE_EX1_571 | Force of Nature | O
 CORE | CORE_EX1_573 | Cenarius | O
 CORE | CORE_EX1_575 | Mana Tide Totem | O
-CORE | CORE_EX1_603 | Cruel Taskmaster |  
-CORE | CORE_EX1_604 | Frothing Berserker |  
+CORE | CORE_EX1_603 | Cruel Taskmaster | O
+CORE | CORE_EX1_604 | Frothing Berserker | O
 CORE | CORE_EX1_610 | Explosive Trap | O
 CORE | CORE_EX1_611 | Freezing Trap | O
 CORE | CORE_EX1_617 | Deadly Shot | O
@@ -177,7 +177,7 @@ CORE | CORE_GIL_801 | Snap Freeze | O
 CORE | CORE_GIL_828 | Dire Frenzy | O
 CORE | CORE_GVG_013 | Cogmaster |  
 CORE | CORE_GVG_044 | Spider Tank |  
-CORE | CORE_GVG_053 | Shieldmaiden |  
+CORE | CORE_GVG_053 | Shieldmaiden | O
 CORE | CORE_GVG_076 | Explosive Sheep |  
 CORE | CORE_GVG_085 | Annoy-o-Tron |  
 CORE | CORE_GVG_109 | Mini-Mage |  
@@ -219,8 +219,8 @@ CORE | CS3_002 | Ritual of Doom | O
 CORE | CS3_003 | Felsoul Jailer | O
 CORE | CS3_005 | Vanessa VanCleef |  
 CORE | CS3_007 | Novice Zapper | O
-CORE | CS3_008 | Bloodsail Deckhand |  
-CORE | CS3_009 | War Cache |  
+CORE | CS3_008 | Bloodsail Deckhand | O
+CORE | CS3_009 | War Cache | O
 CORE | CS3_012 | Nordrassil Druid | O
 CORE | CS3_013 | Shadowed Spirit | O
 CORE | CS3_014 | Crimson Clergy | O
@@ -236,7 +236,7 @@ CORE | CS3_025 | Overlord Runthak |
 CORE | CS3_027 | Focused Will | O
 CORE | CS3_028 | Thrive in the Shadows | O
 CORE | CS3_029 | Pursuit of Justice |  
-CORE | CS3_030 | Warsong Outrider |  
+CORE | CS3_030 | Warsong Outrider | O
 CORE | CS3_031 | Alexstrasza the Life-Binder |  
 CORE | CS3_032 | Onyxia the Broodmother |  
 CORE | CS3_033 | Ysera the Dreamer |  
@@ -246,7 +246,7 @@ CORE | CS3_036 | Deathwing the Destroyer |
 CORE | CS3_037 | Emerald Skytalon |  
 CORE | CS3_038 | Redgill Razorjaw |  
 
-- Progress: 52% (124 of 235 Cards)
+- Progress: 59% (140 of 235 Cards)
 
 ## Ashes of Outland
 
@@ -848,5 +848,40 @@ THE_BARRENS | BAR_916 | Blood Shard Bristleback |
 THE_BARRENS | BAR_917 | Barrens Scavenger |  
 THE_BARRENS | BAR_918 | Tamsin Roame |  
 THE_BARRENS | BAR_919 | Neeru Fireblade |  
+THE_BARRENS | WC_003 | Sigil of Summoning |  
+THE_BARRENS | WC_004 | Fangbound Druid |  
+THE_BARRENS | WC_005 | Primal Dungeoneer |  
+THE_BARRENS | WC_006 | Lady Anacondra |  
+THE_BARRENS | WC_007 | Serpentbloom |  
+THE_BARRENS | WC_008 | Sin'dorei Scentfinder |  
+THE_BARRENS | WC_013 | Devout Dungeoneer |  
+THE_BARRENS | WC_014 | Against All Odds |  
+THE_BARRENS | WC_015 | Water Moccasin |  
+THE_BARRENS | WC_016 | Shroud of Concealment |  
+THE_BARRENS | WC_017 | Savory Deviate Delight |  
+THE_BARRENS | WC_020 | Perpetual Flame |  
+THE_BARRENS | WC_021 | Unstable Shadow Blast |  
+THE_BARRENS | WC_022 | Final Gasp |  
+THE_BARRENS | WC_023 | Stealer of Souls |  
+THE_BARRENS | WC_024 | Man-at-Arms |  
+THE_BARRENS | WC_025 | Whetstone Hatchet |  
+THE_BARRENS | WC_026 | Kresh, Lord of Turtling |  
+THE_BARRENS | WC_027 | Devouring Ectoplasm |  
+THE_BARRENS | WC_028 | Meeting Stone |  
+THE_BARRENS | WC_029 | Selfless Sidekick |  
+THE_BARRENS | WC_030 | Mutanus the Devourer |  
+THE_BARRENS | WC_032 | Seedcloud Buckler |  
+THE_BARRENS | WC_033 | Judgment of Justice |  
+THE_BARRENS | WC_034 | Party Up! |  
+THE_BARRENS | WC_035 | Archdruid Naralex |  
+THE_BARRENS | WC_036 | Deviate Dreadfang |  
+THE_BARRENS | WC_037 | Venomstrike Bow |  
+THE_BARRENS | WC_040 | Taintheart Tormenter |  
+THE_BARRENS | WC_041 | Shattering Blast |  
+THE_BARRENS | WC_042 | Wailing Vapor |  
+THE_BARRENS | WC_701 | Felrattler |  
+THE_BARRENS | WC_803 | Cleric of An'she |  
+THE_BARRENS | WC_805 | Frostweave Dungeoneer |  
+THE_BARRENS | WC_806 | Floecaster |  
 
-- Progress: 0% (0 of 135 Cards)
+- Progress: 0% (0 of 170 Cards)

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -7,6 +7,7 @@
 * [Demon Hunter Initiate](#demon-hunter-initiate)
 * [Hall of Fame](#hall-of-fame)
 * [Curse of Naxxramas](#curse-of-naxxramas)
+* [Goblins vs Gnomes](#goblins-vs-gnomes)
 * [Blackrock Mountain](#blackrock-mountain)
 * [The Grand Tournament](#the-grand-tournament)
 * [The League of Explorers](#the-league-of-explorers)
@@ -524,6 +525,136 @@ NAXX | FP1_030 | Loatheb |
 NAXX | FP1_031 | Baron Rivendare |  
 
 - Progress: 6% (2 of 30 Cards)
+
+## Goblins vs Gnomes
+
+Set | ID | Name | Implemented
+:---: | :---: | :---: | :---:
+GVG | GVG_001 | Flamecannon |  
+GVG | GVG_002 | Snowchugger |  
+GVG | GVG_003 | Unstable Portal |  
+GVG | GVG_004 | Goblin Blastmage |  
+GVG | GVG_005 | Echo of Medivh |  
+GVG | GVG_006 | Mechwarper |  
+GVG | GVG_007 | Flame Leviathan |  
+GVG | GVG_008 | Lightbomb |  
+GVG | GVG_009 | Shadowbomber |  
+GVG | GVG_010 | Velen's Chosen |  
+GVG | GVG_011 | Shrinkmeister |  
+GVG | GVG_012 | Light of the Naaru |  
+GVG | GVG_013 | Cogmaster |  
+GVG | GVG_014 | Vol'jin |  
+GVG | GVG_015 | Darkbomb |  
+GVG | GVG_016 | Fel Reaver |  
+GVG | GVG_017 | Call Pet |  
+GVG | GVG_018 | Queen of Pain |  
+GVG | GVG_019 | Demonheart |  
+GVG | GVG_020 | Fel Cannon |  
+GVG | GVG_021 | Mal'Ganis |  
+GVG | GVG_022 | Tinker's Sharpsword Oil |  
+GVG | GVG_023 | Goblin Auto-Barber |  
+GVG | GVG_024 | Cogmaster's Wrench |  
+GVG | GVG_025 | One-eyed Cheat |  
+GVG | GVG_026 | Feign Death |  
+GVG | GVG_027 | Iron Sensei |  
+GVG | GVG_028 | Trade Prince Gallywix |  
+GVG | GVG_029 | Ancestor's Call |  
+GVG | GVG_030 | Anodized Robo Cub |  
+GVG | GVG_031 | Recycle |  
+GVG | GVG_032 | Grove Tender |  
+GVG | GVG_033 | Tree of Life |  
+GVG | GVG_034 | Mech-Bear-Cat |  
+GVG | GVG_035 | Malorne |  
+GVG | GVG_036 | Powermace |  
+GVG | GVG_037 | Whirling Zap-o-matic |  
+GVG | GVG_038 | Crackle |  
+GVG | GVG_039 | Vitality Totem |  
+GVG | GVG_040 | Siltfin Spiritwalker |  
+GVG | GVG_041 | Dark Wispers |  
+GVG | GVG_042 | Neptulon |  
+GVG | GVG_043 | Glaivezooka |  
+GVG | GVG_044 | Spider Tank |  
+GVG | GVG_045 | Imp-losion |  
+GVG | GVG_046 | King of Beasts |  
+GVG | GVG_047 | Sabotage |  
+GVG | GVG_048 | Metaltooth Leaper |  
+GVG | GVG_049 | Gahz'rilla |  
+GVG | GVG_050 | Bouncing Blade |  
+GVG | GVG_051 | Warbot |  
+GVG | GVG_052 | Crush |  
+GVG | GVG_053 | Shieldmaiden | O
+GVG | GVG_054 | Ogre Warmaul |  
+GVG | GVG_055 | Screwjank Clunker |  
+GVG | GVG_056 | Iron Juggernaut |  
+GVG | GVG_057 | Seal of Light |  
+GVG | GVG_058 | Shielded Minibot |  
+GVG | GVG_059 | Coghammer |  
+GVG | GVG_060 | Quartermaster |  
+GVG | GVG_061 | Muster for Battle |  
+GVG | GVG_062 | Cobalt Guardian |  
+GVG | GVG_063 | Bolvar Fordragon |  
+GVG | GVG_064 | Puddlestomper |  
+GVG | GVG_065 | Ogre Brute |  
+GVG | GVG_066 | Dunemaul Shaman |  
+GVG | GVG_067 | Stonesplinter Trogg |  
+GVG | GVG_068 | Burly Rockjaw Trogg |  
+GVG | GVG_069 | Antique Healbot |  
+GVG | GVG_070 | Salty Dog |  
+GVG | GVG_071 | Lost Tallstrider |  
+GVG | GVG_072 | Shadowboxer |  
+GVG | GVG_073 | Cobra Shot |  
+GVG | GVG_074 | Kezan Mystic |  
+GVG | GVG_075 | Ship's Cannon |  
+GVG | GVG_076 | Explosive Sheep |  
+GVG | GVG_077 | Anima Golem |  
+GVG | GVG_078 | Mechanical Yeti |  
+GVG | GVG_079 | Force-Tank MAX |  
+GVG | GVG_080 | Druid of the Fang |  
+GVG | GVG_081 | Gilblin Stalker |  
+GVG | GVG_082 | Clockwork Gnome |  
+GVG | GVG_083 | Upgraded Repair Bot |  
+GVG | GVG_084 | Flying Machine |  
+GVG | GVG_085 | Annoy-o-Tron |  
+GVG | GVG_086 | Siege Engine |  
+GVG | GVG_087 | Steamwheedle Sniper |  
+GVG | GVG_088 | Ogre Ninja |  
+GVG | GVG_089 | Illuminator |  
+GVG | GVG_090 | Madder Bomber |  
+GVG | GVG_091 | Arcane Nullifier X-21 |  
+GVG | GVG_092 | Gnomish Experimenter |  
+GVG | GVG_093 | Target Dummy |  
+GVG | GVG_094 | Jeeves |  
+GVG | GVG_095 | Goblin Sapper |  
+GVG | GVG_096 | Piloted Shredder |  
+GVG | GVG_097 | Lil' Exorcist |  
+GVG | GVG_098 | Gnomeregan Infantry |  
+GVG | GVG_099 | Bomb Lobber |  
+GVG | GVG_100 | Floating Watcher |  
+GVG | GVG_101 | Scarlet Purifier |  
+GVG | GVG_102 | Tinkertown Technician |  
+GVG | GVG_103 | Micro Machine |  
+GVG | GVG_104 | Hobgoblin |  
+GVG | GVG_105 | Piloted Sky Golem |  
+GVG | GVG_106 | Junkbot |  
+GVG | GVG_107 | Enhance-o Mechano |  
+GVG | GVG_108 | Recombobulator |  
+GVG | GVG_109 | Mini-Mage |  
+GVG | GVG_110 | Dr. Boom |  
+GVG | GVG_111 | Mimiron's Head |  
+GVG | GVG_112 | Mogor the Ogre |  
+GVG | GVG_113 | Foe Reaper 4000 |  
+GVG | GVG_114 | Sneed's Old Shredder |  
+GVG | GVG_115 | Toshley |  
+GVG | GVG_116 | Mekgineer Thermaplugg |  
+GVG | GVG_117 | Gazlowe |  
+GVG | GVG_118 | Troggzor the Earthinator |  
+GVG | GVG_119 | Blingtron 3000 |  
+GVG | GVG_120 | Hemet Nesingwary |  
+GVG | GVG_121 | Clockwork Giant |  
+GVG | GVG_122 | Wee Spellstopper |  
+GVG | GVG_123 | Soot Spewer |  
+
+- Progress: 0% (1 of 123 Cards)
 
 ## Blackrock Mountain
 

--- a/Includes/Rosetta/Common/Enums/TriggerEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/TriggerEnums.hpp
@@ -52,6 +52,7 @@ enum class TriggerType
               //!< hand.
     DEATH,    //!< The effect will be triggered when a minion dies.
     INSPIRE,  //!< The effect will be triggered when a hero uses power.
+    EQUIP_WEAPON,  //! The effect will be triggered when a hero equips a weapon.
     SHUFFLE_INTO_DECK,  //!< The effect will be triggered when a card is
                         //!< shuffled into a deck.
     MULTI_TRIGGER,      //!< The effect for multi trigger.

--- a/Includes/Rosetta/PlayMode/Managers/TriggerManager.hpp
+++ b/Includes/Rosetta/PlayMode/Managers/TriggerManager.hpp
@@ -113,6 +113,10 @@ class TriggerManager
     //! \param sender An entity that is the source of trigger.
     void OnInspireTrigger(Entity* sender);
 
+    //! Callback for trigger when a hero equips a weapon.
+    //! \param sender An entity that is the source of trigger.
+    void OnEquipWeaponTrigger(Entity* sender);
+
     //! Callback for trigger when a card is shuffled into a deck.
     //! \param sender An entity that is the source of trigger.
     void OnShuffleIntoDeckTrigger(Entity* sender);
@@ -140,6 +144,7 @@ class TriggerManager
     TriggerEvent discardTrigger;
     TriggerEvent deathTrigger;
     TriggerEvent inspireTrigger;
+    TriggerEvent equipWeaponTrigger;
     TriggerEvent shuffleIntoDeckTrigger;
 };
 }  // namespace RosettaStone::PlayMode

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 52% Core Set (124 of 235 cards)
+  * 59% Core Set (140 of 235 cards)
   * 59% Ashes of Outland (80 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
-  * 0% Forged in the Barrens (0 of 135 cards)
+  * 0% Forged in the Barrens (0 of 170 cards)
 
 ### Wild Format
 
@@ -48,7 +48,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * **100% Demon Hunter Initiate (20 of 20 Cards)**
   * 71% Hall of Fame (25 of 35 Cards)
   * 6% Curse of Naxxramas (2 of 30 Cards)
-  * 0% Goblins vs Gnomes (0 of 123 Cards)
+  * 0% Goblins vs Gnomes (1 of 123 Cards)
   * 3% Blackrock Mountain (1 of 31 Cards)
   * 5% The Grand Tournament (7 of 132 Cards)
   * 4% The League of Explorers (2 of 45 Cards)

--- a/Sources/Rosetta/PlayMode/Auras/Aura.cpp
+++ b/Sources/Rosetta/PlayMode/Auras/Aura.cpp
@@ -64,6 +64,10 @@ void Aura::Activate(Playable* owner, bool cloning)
             owner->game->triggerManager.inspireTrigger +=
                 instance->m_removeHandler;
             break;
+        case TriggerType::EQUIP_WEAPON:
+            owner->game->triggerManager.equipWeaponTrigger +=
+                instance->m_removeHandler;
+            break;
         default:
             break;
     }
@@ -183,6 +187,9 @@ void Aura::Remove()
             break;
         case TriggerType::INSPIRE:
             m_owner->game->triggerManager.inspireTrigger -= m_removeHandler;
+            break;
+        case TriggerType::EQUIP_WEAPON:
+            m_owner->game->triggerManager.equipWeaponTrigger -= m_removeHandler;
             break;
         default:
             break;

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2440,10 +2440,18 @@ void CoreCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
 
 void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- WEAPON - WARRIOR
     // [CORE_CS2_106] Fiery War Axe - COST:3
     // - Set: CORE, Rarity: Common
     // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 2
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CORE_CS2_106", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [CORE_CS2_108] Execute - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2685,6 +2685,10 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("CS3_008e", EntityType::PLAYER));
+    cards.emplace("CS3_008", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [CS3_009] War Cache - COST:3
@@ -2707,12 +2711,24 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 
 void CoreCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [CS3_008e] To Arrrms! - COST:0
     // - Set: CORE
     // --------------------------------------------------------
     // Text: Your next weapon costs (1) less.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<Aura>(AuraType::HAND,
+                                         EffectList{ Effects::ReduceCost(1) }));
+    {
+        const auto aura = dynamic_cast<Aura*>(power.GetAura());
+        aura->condition =
+            std::make_shared<SelfCondition>(SelfCondition::IsWeapon());
+        aura->removeTrigger = { TriggerType::EQUIP_WEAPON, nullptr };
+    }
+    cards.emplace("CS3_008e", CardDef(power));
 }
 
 void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2499,6 +2499,22 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 2 damage to a minion. If it survives, draw a card.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 2, true));
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::TARGET, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsNotDead()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<DrawTask>(1) }));
+    cards.emplace(
+        "CORE_EX1_391",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [CORE_EX1_400] Whirlwind - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2549,6 +2549,18 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // Text: Destroy all minions except one.
     //       <i>(chosen randomly)</i>
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINIMUM_TOTAL_MINIONS = 2
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<RandomTask>(EntityType::ALL_MINIONS, 1));
+    power.AddPowerTask(std::make_shared<IncludeTask>(
+        EntityType::ALL_MINIONS, std::vector<EntityType>{ EntityType::STACK }));
+    power.AddPowerTask(std::make_shared<DestroyTask>(EntityType::STACK));
+    cards.emplace(
+        "CORE_EX1_407",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_MINIMUM_TOTAL_MINIONS, 2 } }));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [CORE_EX1_410] Shield Slam - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2625,12 +2625,26 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // [CORE_EX1_603] Cruel Taskmaster - COST:2 [ATK:2/HP:2]
     // - Set: CORE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Deal 1 damage to a minion and
-    //       give it +2 Attack.
+    // Text: <b>Battlecry:</b> Deal 1 damage to a minion
+    //       and give it +2 Attack.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_NONSELF_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::TARGET, 1));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("EX1_603e", EntityType::TARGET));
+    cards.emplace(
+        "CORE_EX1_603",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_NONSELF_TARGET, 0 } }));
 
     // --------------------------------------- MINION - WARRIOR
     // [CORE_EX1_604] Frothing Berserker - COST:3 [ATK:2/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2718,6 +2718,9 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CS3_030", CardDef(power));
 }
 
 void CoreCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2536,6 +2536,11 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TAKE_DAMAGE));
+    power.GetTrigger()->triggerSource = TriggerSource::MINIONS;
+    power.GetTrigger()->tasks = { std::make_shared<ArmorTask>(1) };
+    cards.emplace("CORE_EX1_402", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [CORE_EX1_407] Brawl - COST:5

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2671,6 +2671,9 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ArmorTask>(5));
+    cards.emplace("CORE_GVG_053", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [CS3_008] Bloodsail Deckhand - COST:1 [ATK:2/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2571,6 +2571,19 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - AFFECTED_BY_SPELL_POWER = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<GetGameTagTask>(EntityType::HERO, GameTag::ARMOR));
+    power.AddPowerTask(
+        std::make_shared<DamageNumberTask>(EntityType::TARGET, true));
+    cards.emplace(
+        "CORE_EX1_410",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // --------------------------------------- WEAPON - WARRIOR
     // [CORE_EX1_411] Gorehowl - COST:7

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2520,8 +2520,12 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // [CORE_EX1_400] Whirlwind - COST:1
     // - Set: CORE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Deal 1 damage to ALL minions.
+    // Text: Deal 1 damage to all minions.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ALL_MINIONS, 1, true));
+    cards.emplace("CORE_EX1_400", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [CORE_EX1_402] Armorsmith - COST:2 [ATK:1/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2655,6 +2655,12 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TAKE_DAMAGE));
+    power.GetTrigger()->triggerSource = TriggerSource::ALL_MINIONS;
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "EX1_604o", EntityType::SOURCE) };
+    cards.emplace("CORE_EX1_604", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [CORE_GVG_053] Shieldmaiden - COST:5 [ATK:5/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2480,9 +2480,18 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: After you summon another minion, give it <b>Rush</b>.
     // --------------------------------------------------------
-    // RefTag:
-    // - RUSH = 1
+    // GameTag:
+    // - AURA = 1
     // --------------------------------------------------------
+    // RefTag:
+    // - CHARGE = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_SUMMON));
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "EX1_084e", EntityType::TARGET) };
+    cards.emplace("CORE_EX1_084", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [CORE_EX1_391] Slam - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2459,6 +2459,20 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Destroy a damaged enemy minion.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_ENEMY_TARGET = 0
+    // - REQ_DAMAGED_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DestroyTask>(EntityType::TARGET));
+    cards.emplace(
+        "CORE_CS2_108",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_ENEMY_TARGET, 0 },
+                                 { PlayReq::REQ_DAMAGED_TARGET, 0 } }));
 
     // --------------------------------------- MINION - WARRIOR
     // [CORE_EX1_084] Warsong Commander - COST:3 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2697,6 +2697,17 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // Text: Add a random Warrior minion, spell,
     //       and weapon to your hand.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<RandomCardTask>(CardType::MINION, CardClass::WARRIOR));
+    power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
+    power.AddPowerTask(
+        std::make_shared<RandomCardTask>(CardType::SPELL, CardClass::WARRIOR));
+    power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
+    power.AddPowerTask(
+        std::make_shared<RandomCardTask>(CardType::WEAPON, CardClass::WARRIOR));
+    power.AddPowerTask(std::make_shared<AddStackToTask>(EntityType::HAND));
+    cards.emplace("CS3_009", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [CS3_030] Warsong Outrider - COST:4 [ATK:5/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2591,6 +2591,18 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Attacking a minion costs 1 Attack instead of 1 Durability.
     // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TARGET));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
+        SelfCondition::IsProposedDefender(CardType::MINION));
+    power.GetTrigger()->fastExecution = true;
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "EX1_411e", EntityType::SOURCE) };
+    cards.emplace("CORE_EX1_411", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [CORE_EX1_414] Grommash Hellscream - COST:8 [ATK:4/HP:9]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4,6 +4,7 @@
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 #include <Rosetta/PlayMode/Auras/AdaptiveEffect.hpp>
+#include <Rosetta/PlayMode/Auras/EnrageEffect.hpp>
 #include <Rosetta/PlayMode/CardSets/CoreCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Effects.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
@@ -2616,6 +2617,9 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // - CHARGE = 1
     // - ENRAGED = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<EnrageEffect>(AuraType::SELF, "EX1_414e"));
+    cards.emplace("CORE_EX1_414", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [CORE_EX1_603] Cruel Taskmaster - COST:2 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -3729,7 +3729,8 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // [EX1_603] Cruel Taskmaster - COST:2 [ATK:2/HP:2]
     // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Deal 1 damage to a minion and give it +2 Attack.
+    // Text: <b>Battlecry:</b> Deal 1 damage to a minion
+    //       and give it +2 Attack.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -3597,6 +3597,9 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Whenever a friendly minion takes damage, gain 1 Armor.
     // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TAKE_DAMAGE));
     power.GetTrigger()->triggerSource = TriggerSource::MINIONS;

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -3713,11 +3713,12 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // [EX1_414] Grommash Hellscream - COST:8 [ATK:4/HP:9]
     // - Faction: Neutral, Set: Expert1, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Charge</b> Has +6 Attack while damaged.
+    // Text: <b>Charge</b>
+    //       Has +6 Attack while damaged.
     // --------------------------------------------------------
     // GameTag:
-    // - CHARGE = 1
     // - ELITE = 1
+    // - CHARGE = 1
     // - ENRAGED = 1
     // --------------------------------------------------------
     power.ClearData();

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -3610,7 +3610,8 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // [EX1_407] Brawl - COST:5
     // - Faction: Neutral, Set: Expert1, Rarity: Epic
     // --------------------------------------------------------
-    // Text: Destroy all minions except one. <i>(chosen randomly)</i>
+    // Text: Destroy all minions except one.
+    //       <i>(chosen randomly)</i>
     // --------------------------------------------------------
     // PlayReq:
     // - REQ_MINIMUM_TOTAL_MINIONS = 2

--- a/Sources/Rosetta/PlayMode/CardSets/GvgCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/GvgCardsGen.cpp
@@ -20,91 +20,1734 @@ using EffectList = std::vector<std::shared_ptr<IEffect>>;
 
 void GvgCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
+    // Do nothing
 }
 
 void GvgCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 {
+    // Do nothing
 }
 
 void GvgCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------------- MINION - DRUID
+    // [GVG_030] Anodized Robo Cub - COST:2 [ATK:2/HP:2]
+    // - Race: Mechanical, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>.
+    //       <b>Choose One -</b> +1 Attack; or +1 Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - CHOOSE_ONE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [GVG_031] Recycle - COST:6
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Shuffle an enemy minion into your opponent's deck.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_ENEMY_TARGET = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [GVG_032] Grove Tender - COST:3 [ATK:2/HP:4]
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Choose One -</b> Give each player a Mana Crystal;
+    //       or Each player draws a card.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CHOOSE_ONE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [GVG_033] Tree of Life - COST:9
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Restore all characters to full Health.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [GVG_034] Mech-Bear-Cat - COST:6 [ATK:7/HP:6]
+    // - Race: Mechanical, Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Whenever this minion takes damage,
+    //       add a <b>Spare Part</b> card to your hand.
+    // --------------------------------------------------------
+    // Entourage: PART_007, PART_006, PART_005, PART_001,
+    //            PART_003, PART_002, PART_004
+    // --------------------------------------------------------
+    // RefTag:
+    // - SPARE_PART = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [GVG_035] Malorne - COST:7 [ATK:9/HP:7]
+    // - Race: Beast, Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Shuffle this minion into your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DEATHRATTLE = 1
+    // - 542 = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [GVG_041] Dark Wispers - COST:6
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Choose One -</b> Summon 5 Wisps;
+    //       or Give a minion +5/+5 and <b>Taunt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CHOOSE_ONE = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [GVG_080] Druid of the Fang - COST:5 [ATK:4/HP:4]
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you have a Beast,
+    //       transform this minion into a 7/7.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ------------------------------------------ SPELL - DRUID
+    // [GVG_030a] Attack Mode (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +1 Attack.
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [GVG_030ae] Attack Mode (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +1 Attack.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [GVG_030b] Tank Mode (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +1 Health.
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [GVG_030be] Tank Mode (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +1 Health.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [GVG_032a] Gift of Mana (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Give each player a Mana Crystal.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [GVG_032b] Gift of Cards (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Each player draws a card.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [GVG_041a] Dark Wispers (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +5/+5 and <b>Taunt</b>.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [GVG_041b] Dark Wispers (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Summon 5 Wisps.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [GVG_041c] Dark Wispers (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +5/+5 and <b>Taunt</b>.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [GVG_080t] Druid of the Fang (*) - COST:5 [ATK:7/HP:7]
+    // - Race: Beast, Set: Gvg
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------------- SPELL - HUNTER
+    // [GVG_017] Call Pet - COST:2
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Draw a card. If it's a Beast, it costs (4) less.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [GVG_026] Feign Death - COST:2
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Trigger all <b>Deathrattles</b> on your minions.
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- WEAPON - HUNTER
+    // [GVG_043] Glaivezooka - COST:2 [ATK:2/HP:0]
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a random friendly minion
+    //       +1 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 2
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [GVG_046] King of Beasts - COST:5 [ATK:2/HP:6]
+    // - Race: Beast, Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>. <b>Battlecry:</b> Gain +1 Attack
+    //      for each other Beast you have.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [GVG_048] Metaltooth Leaper - COST:3 [ATK:3/HP:3]
+    // - Race: Mechanical, Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give your other Mechs +2 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [GVG_049] Gahz'rilla - COST:7 [ATK:6/HP:9]
+    // - Race: Beast, Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Whenever this minion takes damage, double its Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [GVG_073] Cobra Shot - COST:5
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Deal 3 damage to a minion and the enemy hero.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [GVG_087] Steamwheedle Sniper - COST:2 [ATK:2/HP:3]
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Your Hero Power can target minions.
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------- ENCHANTMENT - HUNTER
+    // [GVG_043e] Glaivezooka (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +1 Attack.
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - HUNTER
+    // [GVG_046e] The King (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Increased Attack.
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - HUNTER
+    // [GVG_048e] Metal Teeth (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +2 Attack.
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - HUNTER
+    // [GVG_049e] Might of Zul'Farrak (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Multiplying Attack.
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    // ------------------------------------------- SPELL - MAGE
+    // [GVG_001] Flamecannon - COST:2
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Deal 4 damage to a random enemy minion
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINIMUM_ENEMY_MINIONS = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [GVG_002] Snowchugger - COST:2 [ATK:2/HP:3]
+    // - Race: Mechanical, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Freeze</b> any character damaged by this minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - FREEZE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [GVG_003] Unstable Portal - COST:2
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Add a random minion to your hand. It costs (3) less.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [GVG_004] Goblin Blastmage - COST:4 [ATK:5/HP:4]
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you have a Mech,
+    //       deal 4 damage randomly split among all enemies.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [GVG_005] Echo of Medivh - COST:4
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Put a copy of each friendly minion into your hand.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [GVG_007] Flame Leviathan - COST:7 [ATK:7/HP:7]
+    // - Race: Mechanical, Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: When you draw this, deal 2 damage to all characters.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - TOPDECK = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [GVG_122] Wee Spellstopper - COST:4 [ATK:2/HP:5]
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Adjacent minions can't be targeted by
+    //       spells or Hero Powers.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AURA = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [GVG_123] Soot Spewer - COST:3 [ATK:3/HP:3]
+    // - Race: Mechanical, Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Spell Damage +1</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPELLPOWER = 1
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // Do nothing
 }
 
 void GvgCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- SPELL - PALADIN
+    // [GVG_057] Seal of Light - COST:2
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Restore 4 Health to your hero and gain
+    //       +2 Attack this turn.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [GVG_058] Shielded Minibot - COST:2 [ATK:2/HP:2]
+    // - Race: Mechanical, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Divine Shield</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - DIVINE_SHIELD = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- WEAPON - PALADIN
+    // [GVG_059] Coghammer - COST:3 [ATK:2/HP:0]
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a random friendly minion
+    //       <b>Divine Shield</b> and <b>Taunt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 3
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // - DIVINE_SHIELD = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [GVG_060] Quartermaster - COST:5 [ATK:2/HP:5]
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give your Silver Hand Recruits +2/+2.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [GVG_061] Muster for Battle - COST:3
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Summon three 1/1 Silver Hand Recruits.
+    //       Equip a 1/4 Weapon.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [GVG_062] Cobalt Guardian - COST:5 [ATK:6/HP:3]
+    // - Race: Mechanical, Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Whenever you summon a Mech, gain <b>Divine Shield</b>.
+    // --------------------------------------------------------
+    // RefTag:
+    // - DIVINE_SHIELD = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [GVG_063] Bolvar Fordragon - COST:5 [ATK:1/HP:7]
+    // - Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Whenever a friendly minion dies while this is in
+    //       your hand, gain +1 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [GVG_101] Scarlet Purifier - COST:3 [ATK:4/HP:3]
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Deal 2 damage to all minions
+    //       with <b>Deathrattle</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [GVG_060e] Well Equipped (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +2/+2.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [GVG_101e] Pure (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Increased Stats.
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------------- SPELL - PRIEST
+    // [GVG_008] Lightbomb - COST:6
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Deal damage to each minion equal to its Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AFFECTED_BY_SPELL_POWER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [GVG_009] Shadowbomber - COST:1 [ATK:2/HP:1]
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Deal 3 damage to each hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [GVG_010] Velen's Chosen - COST:3
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Give a minion +2/+4 and <b>Spell Damage +1</b>.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - SPELLPOWER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [GVG_011] Shrinkmeister - COST:2 [ATK:3/HP:2]
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a minion -2 Attack this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [GVG_012] Light of the Naaru - COST:1
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Restore 3 Health. If the target is still damaged,
+    //       summon a Lightwarden.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [GVG_014] Vol'jin - COST:5 [ATK:6/HP:2]
+    // - Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Swap Health with another minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [GVG_072] Shadowboxer - COST:2 [ATK:2/HP:3]
+    // - Race: Mechanical, Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Whenever a minion is healed,
+    //       deal 1 damage to a random enemy.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [GVG_083] Upgraded Repair Bot - COST:5 [ATK:5/HP:5]
+    // - Race: Mechanical, Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a friendly Mech +4 Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_WITH_RACE = 17
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------- ENCHANTMENT - PRIEST
+    // [GVG_014a] Shadowed (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Health was swapped.
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - PRIEST
+    // [GVG_069a] Repairs! (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +4 Health.
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 {
+    // ------------------------------------------ SPELL - ROGUE
+    // [GVG_022] Tinker's Sharpsword Oil - COST:4
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Give your weapon +3 Attack.
+    //       <b>Combo:</b> Give a random friendly minion +3 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - COMBO = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [GVG_023] Goblin Auto-Barber - COST:2 [ATK:3/HP:2]
+    // - Race: Mechanical, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give your weapon +1 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- WEAPON - ROGUE
+    // [GVG_024] Cogmaster's Wrench - COST:3 [ATK:1/HP:0]
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Has +2 Attack while you have a Mech.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 3
+    // - AURA = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [GVG_025] One-eyed Cheat - COST:2 [ATK:4/HP:1]
+    // - Race: Pirate, Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Whenever you summon a Pirate, gain <b>Stealth</b>.
+    // --------------------------------------------------------
+    // RefTag:
+    // - STEALTH = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [GVG_027] Iron Sensei - COST:3 [ATK:2/HP:2]
+    // - Race: Mechanical, Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: At the end of your turn,
+    //       give another friendly Mech +2/+2.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [GVG_028] Trade Prince Gallywix - COST:6 [ATK:5/HP:8]
+    // - Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Whenever your opponent casts a spell,
+    //       gain a copy of it and give them a Coin.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [GVG_047] Sabotage - COST:4
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Destroy a random enemy minion.
+    //       <b>Combo:</b> And your opponent's weapon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - COMBO = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_ENEMY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [GVG_088] Ogre Ninja - COST:5 [ATK:6/HP:6]
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b>
+    //       50% chance to attack the wrong enemy.
+    // --------------------------------------------------------
+    // GameTag:
+    // - STEALTH = 1
+    // - FORGETFUL = 1
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ------------------------------------ ENCHANTMENT - ROGUE
+    // [GVG_027e] Ironed Out (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Increased stats.
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------------- SPELL - SHAMAN
+    // [GVG_029] Ancestor's Call - COST:4
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Put a random minion from each player's hand
+    //       into the battlefield.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- WEAPON - SHAMAN
+    // [GVG_036] Powermace - COST:3 [ATK:3/HP:0]
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Give a random friendly Mech +2/+2.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 2
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [GVG_037] Whirling Zap-o-matic - COST:2 [ATK:3/HP:2]
+    // - Race: Mechanical, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Windfury</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - WINDFURY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [GVG_038] Crackle - COST:2
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Deal 3-6 damage. <b>Overload:</b> (1)
+    // --------------------------------------------------------
+    // GameTag:
+    // - OVERLOAD = 1
+    // - OVERLOAD_OWED = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [GVG_039] Vitality Totem - COST:2 [ATK:0/HP:3]
+    // - Race: Totem, Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: At the end of your turn,
+    //       restore 4 Health to your hero.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [GVG_040] Siltfin Spiritwalker - COST:4 [ATK:2/HP:5]
+    // - Race: Murloc, Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Whenever another friendly Murloc dies, draw a card.
+    //       <b><b>Overload</b>:</b> (1)
+    // --------------------------------------------------------
+    // GameTag:
+    // - OVERLOAD = 1
+    // - OVERLOAD_OWED = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [GVG_042] Neptulon - COST:7 [ATK:7/HP:7]
+    // - Race: Elemental, Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Add 4 random Murlocs to your hand.
+    //       <b>Overload:</b> (3)
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - OVERLOAD = 3
+    // - BATTLECRY = 1
+    // - OVERLOAD_OWED = 3
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [GVG_066] Dunemaul Shaman - COST:4 [ATK:5/HP:4]
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Windfury, Overload:</b> (1)
+    //       50% chance to attack the wrong enemy.
+    // --------------------------------------------------------
+    // GameTag:
+    // - WINDFURY = 1
+    // - OVERLOAD = 1
+    // - OVERLOAD_OWED = 1
+    // - FORGETFUL = 1
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------- ENCHANTMENT - SHAMAN
+    // [GVG_036e] Powered (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +2/+2.
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- SPELL - WARLOCK
+    // [GVG_015] Darkbomb - COST:2
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Deal 3 damage.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [GVG_018] Queen of Pain - COST:2 [ATK:1/HP:4]
+    // - Race: Demon, Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Lifesteal</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - LIFESTEAL = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [GVG_019] Demonheart - COST:5
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Deal 5 damage to a minion.
+    //       If it's a friendly Demon, give it +5/+5 instead.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [GVG_020] Fel Cannon - COST:4 [ATK:3/HP:5]
+    // - Race: Mechanical, Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: At the end of your turn,
+    //       deal 2 damage to a non-Mech minion.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [GVG_021] Mal'Ganis - COST:9 [ATK:9/HP:7]
+    // - Race: Demon, Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Your other Demons have +2/+2.
+    //       Your hero is <b>Immune</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - AURA = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - IMMUNE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [GVG_045] Imp-losion - COST:4
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Deal 2-4 damage to a minion.
+    //       Summon a 1/1 Imp for each damage dealt.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [GVG_077] Anima Golem - COST:6 [ATK:9/HP:9]
+    // - Race: Mechanical, Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: At the end of each turn,
+    //       destroy this minion if it's your only one.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [GVG_100] Floating Watcher - COST:5 [ATK:4/HP:4]
+    // - Race: Demon, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Whenever your hero takes damage on your turn,
+    //       gain +2/+2.
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------- ENCHANTMENT - WARLOCK
+    // [GVG_019e] Demonheart (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +5/+5.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARLOCK
+    // [GVG_021e] Grasp of Mal'Ganis (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Mal'Ganis is granting +2/+2.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [GVG_045t] Imp (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Demon, Set: Gvg
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARLOCK
+    // [GVG_100e] Brow Furrow (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Increased stats.
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- SPELL - WARRIOR
+    // [GVG_050] Bouncing Blade - COST:3
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Deal 1 damage to a random minion.
+    //       Repeat until a minion dies.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINIMUM_TOTAL_MINIONS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [GVG_051] Warbot - COST:1 [ATK:1/HP:3]
+    // - Race: Mechanical, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Enrage:</b> +1 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ENRAGED = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [GVG_052] Crush - COST:7
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Destroy a minion. If you have a damaged minion,
+    //       this costs (4) less.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [GVG_053] Shieldmaiden - COST:6 [ATK:5/HP:5]
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Gain 5 Armor.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- WEAPON - WARRIOR
+    // [GVG_054] Ogre Warmaul - COST:3 [ATK:4/HP:0]
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: 50% chance to attack the wrong enemy.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 2
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [GVG_055] Screwjank Clunker - COST:4 [ATK:2/HP:5]
+    // - Race: Mechanical, Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a friendly Mech +2/+2.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_TARGET_WITH_RACE = 17
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [GVG_056] Iron Juggernaut - COST:6 [ATK:6/HP:5]
+    // - Race: Mechanical, Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Shuffle a Mine into your opponent's
+    //       deck. When drawn, it explodes for 10 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [GVG_086] Siege Engine - COST:5 [ATK:5/HP:5]
+    // - Race: Mechanical, Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Whenever you gain Armor, give this minion +1 Attack.
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------- ENCHANTMENT - WARRIOR
+    // [GVG_051e] Enraged (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +1 Attack
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARRIOR
+    // [GVG_055e] Screwy Jank (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +2/+2.
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [GVG_056t] Burrowing Mine (*) - COST:6
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: You take 10 damage.
+    //       Draw a card. This explodes when drawn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ImmuneToSpellpower = 1
+    // - TOPDECK = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARRIOR
+    // [GVG_086e] Armor Plated (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Increased Attack.
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 {
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_006] Mechwarper - COST:2 [ATK:2/HP:3]
+    // - Race: Mechanical, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Your Mechs cost (1) less.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AURA = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_013] Cogmaster - COST:1 [ATK:1/HP:2]
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Has +2 Attack while you have a Mech.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AURA = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_016] Fel Reaver - COST:5 [ATK:8/HP:8]
+    // - Race: Mechanical, Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Whenever your opponent plays a card,
+    //       remove the top 3 cards of your deck.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_044] Spider Tank - COST:3 [ATK:3/HP:4]
+    // - Race: Mechanical, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_064] Puddlestomper - COST:2 [ATK:3/HP:2]
+    // - Race: Murloc, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_065] Ogre Brute - COST:3 [ATK:4/HP:4]
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: 50% chance to attack the wrong enemy.
+    // --------------------------------------------------------
+    // GameTag:
+    // - FORGETFUL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_067] Stonesplinter Trogg - COST:2 [ATK:2/HP:3]
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Whenever your opponent casts a spell, gain +1 Attack.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_068] Burly Rockjaw Trogg - COST:4 [ATK:3/HP:5]
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Whenever your opponent casts a spell, gain +2 Attack.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_069] Antique Healbot - COST:5 [ATK:3/HP:3]
+    // - Race: Mechanical, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Restore 8 Health to your hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_070] Salty Dog - COST:5 [ATK:7/HP:4]
+    // - Race: Pirate, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_071] Lost Tallstrider - COST:4 [ATK:5/HP:4]
+    // - Race: Beast, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_074] Kezan Mystic - COST:4 [ATK:4/HP:3]
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Take control of a random enemy
+    //       <b>Secret</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_075] Ship's Cannon - COST:2 [ATK:2/HP:3]
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: After you summon a Pirate,
+    //       deal 2 damage to a random enemy.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_076] Explosive Sheep - COST:2 [ATK:1/HP:1]
+    // - Race: Mechanical, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Deal 2 damage to all minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_078] Mechanical Yeti - COST:4 [ATK:4/HP:5]
+    // - Race: Mechanical, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Give each player a <b>Spare Part.</b>
+    // --------------------------------------------------------
+    // Entourage: PART_007, PART_006, PART_005, PART_001,
+    //            PART_003, PART_002, PART_004
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SPARE_PART = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_079] Force-Tank MAX - COST:8 [ATK:7/HP:7]
+    // - Race: Mechanical, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Divine Shield</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - DIVINE_SHIELD = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_081] Gilblin Stalker - COST:2 [ATK:2/HP:3]
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - STEALTH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_082] Clockwork Gnome - COST:1 [ATK:2/HP:1]
+    // - Race: Mechanical, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Add a <b>Spare Part</b> card
+    //       to your hand.
+    // --------------------------------------------------------
+    // Entourage: PART_007, PART_006, PART_005, PART_001,
+    //            PART_003, PART_002, PART_004
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SPARE_PART = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_084] Flying Machine - COST:3 [ATK:1/HP:4]
+    // - Race: Mechanical, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Windfury</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - WINDFURY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_085] Annoy-o-Tron - COST:2 [ATK:1/HP:2]
+    // - Race: Mechanical, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Divine Shield</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - DIVINE_SHIELD = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_089] Illuminator - COST:3 [ATK:2/HP:4]
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: If you control a <b>Secret</b> at the end of your turn,
+    //       restore 4 Health to your hero.
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_090] Madder Bomber - COST:5 [ATK:5/HP:4]
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Deal 6 damage randomly split
+    //       between all other characters.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_091] Arcane Nullifier X-21 - COST:4 [ATK:2/HP:5]
+    // - Race: Mechanical, Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       Can't be targeted by spells or Hero Powers.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - CANT_BE_TARGETED_BY_SPELLS = 1
+    // - CANT_BE_TARGETED_BY_HERO_POWERS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_092] Gnomish Experimenter - COST:3 [ATK:3/HP:2]
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Draw a card.
+    //       If it's a minion, transform it into a Chicken.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_093] Target Dummy - COST:0 [ATK:0/HP:2]
+    // - Race: Mechanical, Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_094] Jeeves - COST:4 [ATK:1/HP:4]
+    // - Race: Mechanical, Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: At the end of each player's turn,
+    //       that player draws until they have 3 cards.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_095] Goblin Sapper - COST:3 [ATK:2/HP:4]
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Has +4 Attack while your opponent has 6 or
+    //       more cards in hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AURA = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_096] Piloted Shredder - COST:4 [ATK:4/HP:3]
+    // - Race: Mechanical, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon a random 2-Cost minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_097] Lil' Exorcist - COST:3 [ATK:2/HP:3]
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> Gain +1/+1 for each enemy
+    //       <b>Deathrattle</b> minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_098] Gnomeregan Infantry - COST:3 [ATK:1/HP:4]
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Charge</b>
+    //       <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - CHARGE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_099] Bomb Lobber - COST:5 [ATK:3/HP:3]
+    // - Set: Gvg, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Deal 4 damage to a random enemy minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_102] Tinkertown Technician - COST:3 [ATK:3/HP:3]
+    // - Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you have a Mech,
+    //       gain +1/+1 and add a <b>Spare Part</b> to your hand.
+    // --------------------------------------------------------
+    // Entourage: PART_007, PART_006, PART_005, PART_001,
+    //            PART_003, PART_002, PART_004
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SPARE_PART = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_103] Micro Machine - COST:2 [ATK:1/HP:2]
+    // - Race: Mechanical, Set: Gvg, Rarity: Common
+    // --------------------------------------------------------
+    // Text: At the start of each turn, gain +1 Attack.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_104] Hobgoblin - COST:3 [ATK:2/HP:3]
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Whenever you play a 1-Attack minion, give it +2/+2.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_105] Piloted Sky Golem - COST:6 [ATK:6/HP:4]
+    // - Race: Mechanical, Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon a random 4-Cost minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_106] Junkbot - COST:5 [ATK:1/HP:5]
+    // - Race: Mechanical, Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Whenever a friendly Mech dies, gain +2/+2.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_107] Enhance-o Mechano - COST:4 [ATK:3/HP:2]
+    // - Race: Mechanical, Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give your other minions
+    //       <b>Windfury</b>, <b>Taunt</b>, or <b>Divine Shield</b>
+    //       <i>(at random)</i>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - WINDFURY = 1
+    // - TAUNT = 1
+    // - DIVINE_SHIELD = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_108] Recombobulator - COST:2 [ATK:3/HP:2]
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Transform a friendly minion
+    //       into a random minion with the same Cost.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_109] Mini-Mage - COST:4 [ATK:4/HP:1]
+    // - Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b>
+    //       <b>Spell Damage +1</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - STEALTH = 1
+    // - SPELLPOWER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_110] Dr. Boom - COST:7 [ATK:7/HP:7]
+    // - Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon two 1/1 Boom Bots.
+    //       <i>WARNING: Bots may explode.</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_111] Mimiron's Head - COST:5 [ATK:4/HP:5]
+    // - Race: Mechanical, Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: At the start of your turn, if you have at least 3 Mechs,
+    //       destroy them all and form V-07-TR-0N.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_112] Mogor the Ogre - COST:6 [ATK:7/HP:6]
+    // - Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: All minions have a 50% chance to attack the wrong enemy.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_113] Foe Reaper 4000 - COST:8 [ATK:6/HP:9]
+    // - Race: Mechanical, Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Also damages the minions next to whomever it attacks.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_114] Sneed's Old Shredder - COST:8 [ATK:5/HP:7]
+    // - Race: Mechanical, Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon a random
+    //       <b>Legendary</b> minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_115] Toshley - COST:6 [ATK:5/HP:7]
+    // - Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry and Deathrattle:</b>
+    //       Add a <b>Spare Part</b> card to your hand.
+    // --------------------------------------------------------
+    // Entourage: PART_007, PART_006, PART_005, PART_003,
+    //            PART_002, PART_001, PART_004
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DEATHRATTLE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SPARE_PART = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_116] Mekgineer Thermaplugg - COST:9 [ATK:9/HP:7]
+    // - Race: Mechanical, Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Whenever an enemy minion dies, summon a Leper Gnome.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_117] Gazlowe - COST:6 [ATK:3/HP:6]
+    // - Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Whenever you cast a 1-mana spell,
+    //       add a random Mech to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_118] Troggzor the Earthinator - COST:7 [ATK:6/HP:6]
+    // - Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Whenever your opponent casts a spell,
+    //       summon a Burly Rockjaw Trogg.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_119] Blingtron 3000 - COST:5 [ATK:3/HP:4]
+    // - Race: Mechanical, Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Equip a random weapon for each player.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_120] Hemet Nesingwary - COST:5 [ATK:6/HP:3]
+    // - Set: Gvg, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Destroy a Beast.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_WITH_RACE = 20
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_121] Clockwork Giant - COST:12 [ATK:8/HP:8]
+    // - Race: Mechanical, Set: Gvg, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Costs (1) less for each card in your opponent's hand.
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 {
     Power power;
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [GVG_010b] Velen's Chosen (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +2/+4 and <b>Spell Damage +1</b>.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [GVG_011a] Shrink Ray (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: -2 Attack this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [GVG_022a] Tinker's Sharpsword Oil (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +3 Attack.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [GVG_022b] Tinker's Sharpsword Oil (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +3 Attack.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [GVG_023a] Extra Sharp (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +1 Attack.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [GVG_028t] Gallywix's Coin (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Gain 1 Mana Crystal this turn only.
+    //       <i>(Won't trigger Gallywix.)</i>
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [GVG_057a] Seal of Light (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +2 Attack this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [GVG_063a] Retribution (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Increased Attack
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [GVG_067a] Metabolized Magic (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Increased Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AURA = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [GVG_068a] Metabolized Magic (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Increased Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AURA = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [GVG_076a] Pistons (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Increased Attack.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_092t] Chicken (*) - COST:1 [ATK:1/HP:1]
+    // - Race: Beast, Set: Gvg
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [GVG_102e] Might of Tinkertown (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +1/+1.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [GVG_104a] HERE, TAKE BUFF. (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +2/+2.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [GVG_106e] Junked Up (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Increased stats.
+    // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
     // [GVG_110t] Boom Bot (*) - COST:1 [ATK:1/HP:1]
@@ -122,6 +1765,167 @@ void GvgCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
     power.AddDeathrattleTask(
         std::make_shared<DamageNumberTask>(EntityType::STACK));
     cards.emplace("GVG_110t", CardDef(power));
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [GVG_111t] V-07-TR-0N (*) - COST:8 [ATK:4/HP:8]
+    // - Race: Mechanical, Set: Gvg
+    // --------------------------------------------------------
+    // Text: <b>Charge</b>
+    //       <b>Mega-Windfury</b>
+    //       <i>(Can attack four times a turn.)</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - CHARGE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [PART_001] Armor Plating (*) - COST:1
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Give a minion +1 Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPARE_PART = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [PART_001e] Armor Plating (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +1 Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPARE_PART = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [PART_002] Time Rewinder (*) - COST:1
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Return a friendly minion to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPARE_PART = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [PART_003] Rusty Horn (*) - COST:1
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Give a minion <b>Taunt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPARE_PART = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [PART_004] Finicky Cloakfield (*) - COST:1
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Give a friendly minion <b>Stealth</b>
+    //       until your next turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPARE_PART = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - STEALTH = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [PART_004e] Cloaked (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Stealthed until your next turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPARE_PART = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [PART_005] Emergency Coolant (*) - COST:1
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: <b>Freeze</b> a minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - FREEZE = 1
+    // - SPARE_PART = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [PART_006] Reversing Switch (*) - COST:1
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Swap a minion's Attack and Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPARE_PART = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [PART_006a] Switched (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Attack and Health have been swapped by Reversing Switch.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPARE_PART = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [PART_007] Whirling Blades (*) - COST:1
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: Give a minion +1 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPARE_PART = 1
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [PART_007e] Whirling Blades (*) - COST:0
+    // - Set: Gvg
+    // --------------------------------------------------------
+    // Text: +1 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPARE_PART = 1
+    // --------------------------------------------------------
 }
 
 void GvgCardsGen::AddAll(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/GvgCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/GvgCardsGen.cpp
@@ -955,6 +955,8 @@ void GvgCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
 
 void GvgCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- SPELL - WARRIOR
     // [GVG_050] Bouncing Blade - COST:3
     // - Set: Gvg, Rarity: Epic
@@ -997,6 +999,9 @@ void GvgCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ArmorTask>(5));
+    cards.emplace("GVG_053", CardDef(power));
 
     // --------------------------------------- WEAPON - WARRIOR
     // [GVG_054] Ogre Warmaul - COST:3 [ATK:4/HP:0]

--- a/Sources/Rosetta/PlayMode/Managers/TriggerManager.cpp
+++ b/Sources/Rosetta/PlayMode/Managers/TriggerManager.cpp
@@ -123,6 +123,11 @@ void TriggerManager::OnInspireTrigger(Entity* sender)
     inspireTrigger(sender);
 }
 
+void TriggerManager::OnEquipWeaponTrigger(Entity* sender)
+{
+    equipWeaponTrigger(sender);
+}
+
 void TriggerManager::OnShuffleIntoDeckTrigger(Entity* sender)
 {
     shuffleIntoDeckTrigger(sender);

--- a/Sources/Rosetta/PlayMode/Models/Hero.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Hero.cpp
@@ -60,6 +60,8 @@ void Hero::AddWeapon(Weapon& _weapon)
         SetExhausted(false);
     }
 
+    game->triggerManager.OnEquipWeaponTrigger(weapon);
+
     for (int i = static_cast<int>(weaponAuras.size()) - 1; i >= 0; --i)
     {
         weaponAuras[i]->NotifyEntityAdded(weapon);

--- a/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
+++ b/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
@@ -234,6 +234,9 @@ std::shared_ptr<Trigger> Trigger::Activate(Playable* source,
         case TriggerType::INSPIRE:
             game->triggerManager.inspireTrigger += instance->handler;
             break;
+        case TriggerType::EQUIP_WEAPON:
+            game->triggerManager.equipWeaponTrigger += instance->handler;
+            break;
         case TriggerType::SHUFFLE_INTO_DECK:
             game->triggerManager.shuffleIntoDeckTrigger += instance->handler;
             break;
@@ -388,6 +391,9 @@ void Trigger::Remove() const
             break;
         case TriggerType::INSPIRE:
             game->triggerManager.inspireTrigger -= handler;
+            break;
+        case TriggerType::EQUIP_WEAPON:
+            game->triggerManager.equipWeaponTrigger -= handler;
             break;
         case TriggerType::SHUFFLE_INTO_DECK:
             game->triggerManager.shuffleIntoDeckTrigger -= handler;

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7253,3 +7253,66 @@ TEST_CASE("[Warrior : Spell] - CORE_EX1_407 : Brawl")
     CHECK_EQ(curHand.GetCount(), 0);
     CHECK_EQ(curField.GetCount() + opField.GetCount(), 1);
 }
+
+// ---------------------------------------- SPELL - WARRIOR
+// [CORE_EX1_410] Shield Slam - COST:1
+// - Set: CORE, Rarity: Epic
+// --------------------------------------------------------
+// Text: Deal 1 damage to a minion for each Armor you have.
+// --------------------------------------------------------
+// GameTag:
+// - AFFECTED_BY_SPELL_POWER = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINION_TARGET = 0
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Spell] - CORE_EX1_410 : Shield Slam")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetArmor(3);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Shield Slam"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Shield Slam"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Bloodmage Thalnos"));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Ironbark Protector"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opField[0]->GetHealth(), 8);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card4));
+    CHECK_EQ(opField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card4));
+    CHECK_EQ(opField[0]->GetHealth(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7693,3 +7693,17 @@ TEST_CASE("[Warrior : Spell] - CS3_009 : War Cache")
     CHECK(curHand[2]->card->IsCardClass(CardClass::WARRIOR));
     CHECK_EQ(curHand[2]->card->GetCardType(), CardType::WEAPON);
 }
+
+// --------------------------------------- MINION - WARRIOR
+// [CS3_030] Warsong Outrider - COST:4 [ATK:5/HP:4]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Rush</b>
+// --------------------------------------------------------
+// GameTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - CS3_030 : Warsong Outrider")
+{
+    // Do nothing
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7483,3 +7483,69 @@ TEST_CASE("[Warrior : Minion] - CORE_EX1_603 : Cruel Taskmaster")
     CHECK_EQ(curField[1]->GetAttack(), 2);
     CHECK_EQ(curField[1]->GetHealth(), 2);
 }
+
+// --------------------------------------- MINION - WARRIOR
+// [CORE_EX1_604] Frothing Berserker - COST:3 [ATK:2/HP:4]
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: Whenever a minion takes damage, gain +1 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - CORE_EX1_604 : Frothing Berserker")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Frothing Berserker"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Stonetusk Boar"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Stonetusk Boar"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+
+    game.Process(opPlayer, AttackTask(card4, card2));
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+
+    game.Process(opPlayer, AttackTask(card5, card3));
+    CHECK_EQ(curField[0]->GetAttack(), 7);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7134,3 +7134,54 @@ TEST_CASE("[Warrior : Spell] - CORE_EX1_400 : Whirlwind")
     CHECK_EQ(opField.GetCount(), 1);
     CHECK_EQ(opField[0]->GetHealth(), 6);
 }
+
+// --------------------------------------- MINION - WARRIOR
+// [CORE_EX1_402] Armorsmith - COST:2 [ATK:1/HP:4]
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: Whenever a friendly minion takes damage, gain 1 Armor.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - CORE_EX1_402 : Armorsmith")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Armorsmith"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Amani Berserker"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card2));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 1);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 2);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7588,3 +7588,65 @@ TEST_CASE("[Warrior : Minion] - CORE_GVG_053 : Shieldmaiden")
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
 }
+
+// --------------------------------------- MINION - WARRIOR
+// [CS3_008] Bloodsail Deckhand - COST:1 [ATK:2/HP:1]
+// - Race: Pirate, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> The next weapon you play costs
+//       (1) less.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - CS3_008 : Bloodsail Deckhand")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Bloodsail Deckhand", FormatType::STANDARD));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fiery War Axe"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fiery War Axe"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Execute"));
+
+    CHECK_EQ(card2->GetCost(), 3);
+    CHECK_EQ(card3->GetCost(), 3);
+    CHECK_EQ(card4->GetCost(), 9);
+    CHECK_EQ(card5->GetCost(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 9);
+    CHECK_EQ(card2->GetCost(), 2);
+    CHECK_EQ(card3->GetCost(), 2);
+    CHECK_EQ(card4->GetCost(), 9);
+    CHECK_EQ(card5->GetCost(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card2));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 7);
+    CHECK_EQ(card3->GetCost(), 3);
+    CHECK_EQ(card4->GetCost(), 9);
+    CHECK_EQ(card5->GetCost(), 2);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7650,3 +7650,46 @@ TEST_CASE("[Warrior : Minion] - CS3_008 : Bloodsail Deckhand")
     CHECK_EQ(card4->GetCost(), 9);
     CHECK_EQ(card5->GetCost(), 2);
 }
+
+// ---------------------------------------- SPELL - WARRIOR
+// [CS3_009] War Cache - COST:3
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: Add a random Warrior minion, spell,
+//       and weapon to your hand.
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Spell] - CS3_009 : War Cache")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("War Cache", FormatType::STANDARD));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curHand.GetCount(), 3);
+    CHECK(curHand[0]->card->IsCardClass(CardClass::WARRIOR));
+    CHECK_EQ(curHand[0]->card->GetCardType(), CardType::MINION);
+    CHECK(curHand[1]->card->IsCardClass(CardClass::WARRIOR));
+    CHECK_EQ(curHand[1]->card->GetCardType(), CardType::SPELL);
+    CHECK(curHand[2]->card->IsCardClass(CardClass::WARRIOR));
+    CHECK_EQ(curHand[2]->card->GetCardType(), CardType::WEAPON);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6884,3 +6884,15 @@ TEST_CASE("[Warlock : Minion] - CS3_021 : Enslaved Fel Lord")
     CHECK_EQ(opField[2]->HasStealth(), true);
     CHECK_EQ(opField[2]->GetHealth(), 1);
 }
+
+// --------------------------------------- WEAPON - WARRIOR
+// [CORE_CS2_106] Fiery War Axe - COST:3
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// GameTag:
+// - DURABILITY = 2
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Weapon] - CORE_CS2_106 : Fiery War Axe")
+{
+    // Do nothing
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7549,3 +7549,42 @@ TEST_CASE("[Warrior : Minion] - CORE_EX1_604 : Frothing Berserker")
     game.Process(opPlayer, AttackTask(card5, card3));
     CHECK_EQ(curField[0]->GetAttack(), 7);
 }
+
+// --------------------------------------- MINION - WARRIOR
+// [CORE_GVG_053] Shieldmaiden - COST:5 [ATK:5/HP:5]
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Gain 5 Armor.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - CORE_GVG_053 : Shieldmaiden")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Shieldmaiden"));
+
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7066,3 +7066,71 @@ TEST_CASE("[Warrior : Spell] - CORE_EX1_391 : Slam")
     CHECK_EQ(curField.GetCount(), 1);
     CHECK_EQ(opHandCount - 1, opHand.GetCount());
 }
+
+// ---------------------------------------- SPELL - WARRIOR
+// [CORE_EX1_400] Whirlwind - COST:1
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: Deal 1 damage to all minions.
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Spell] - CORE_EX1_400 : Whirlwind")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Whirlwind"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetHealth(), 7);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opField[0]->GetHealth(), 7);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(opField[1]->GetHealth(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 6);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7429,3 +7429,57 @@ TEST_CASE("[Warrior : Minion] - CORE_EX1_414 : Grommash Hellscream")
     CHECK_EQ(curField[0]->GetAttack(), 4);
     CHECK_EQ(curField[0]->GetHealth(), 9);
 }
+
+// --------------------------------------- MINION - WARRIOR
+// [CORE_EX1_603] Cruel Taskmaster - COST:2 [ATK:2/HP:2]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Deal 1 damage to a minion
+//       and give it +2 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// - REQ_MINION_TARGET = 0
+// - REQ_NONSELF_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - CORE_EX1_603 : Cruel Taskmaster")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Cruel Taskmaster"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Cruel Taskmaster"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7376,3 +7376,56 @@ TEST_CASE("[Warrior : Weapon] - CORE_EX1_411 : Gorehowl")
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 24);
     CHECK_EQ(opPlayer->GetHero()->HasWeapon(), false);
 }
+
+// --------------------------------------- MINION - WARRIOR
+// [CORE_EX1_414] Grommash Hellscream - COST:8 [ATK:4/HP:9]
+// - Set: CORE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Charge</b>
+//       Has +6 Attack while damaged.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - CHARGE = 1
+// - ENRAGED = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - CORE_EX1_414 : Grommash Hellscream")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Grommash Hellscream"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Circle of Healing"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 9);
+
+    game.Process(curPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 10);
+    CHECK_EQ(curField[0]->GetHealth(), 8);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 9);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7006,3 +7006,63 @@ TEST_CASE("[Warrior : Minion] - CORE_EX1_084 : Warsong Commander")
     game.Process(curPlayer, PlayCardTask::Minion(card3));
     CHECK_EQ(curField[2]->HasRush(), true);
 }
+
+// ---------------------------------------- SPELL - WARRIOR
+// [CORE_EX1_391] Slam - COST:2
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: Deal 2 damage to a minion. If it survives, draw a card.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Spell] - CORE_EX1_391 : Slam")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opHand = *(opPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Magma Rager"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Chillwind Yeti"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Slam"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Slam"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    int opHandCount = opHand.GetCount();
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card2));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(opHandCount, opHand.GetCount());
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(opHandCount - 1, opHand.GetCount());
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6956,3 +6956,53 @@ TEST_CASE("[Warrior : Spell] - CORE_CS2_108 : Execute")
     game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3));
     CHECK_EQ(opField.GetCount(), 0);
 }
+
+// --------------------------------------- MINION - WARRIOR
+// [CORE_EX1_084] Warsong Commander - COST:3 [ATK:2/HP:3]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: After you summon another minion, give it <b>Rush</b>.
+// --------------------------------------------------------
+// GameTag:
+// - AURA = 1
+// --------------------------------------------------------
+// RefTag:
+// - CHARGE = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - CORE_EX1_084 : Warsong Commander")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Warsong Commander"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bloodfen Raptor"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bloodfen Raptor"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->HasRush(), false);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[2]->HasRush(), true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -7618,7 +7618,8 @@ TEST_CASE("[Warrior : Minion] - EX1_402 : Armorsmith")
 // [EX1_407] Brawl - COST:5
 // - Faction: Neutral, Set: Expert1, Rarity: Epic
 // --------------------------------------------------------
-// Text: Destroy all minions except one. <i>(chosen randomly)</i>
+// Text: Destroy all minions except one.
+//       <i>(chosen randomly)</i>
 // --------------------------------------------------------
 // PlayReq:
 // - REQ_MINIMUM_TOTAL_MINIONS = 2

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -7964,7 +7964,8 @@ TEST_CASE("[Warrior : Minion] - EX1_414 : Grommash Hellscream")
 // [EX1_603] Cruel Taskmaster - COST:2 [ATK:2/HP:2]
 // - Faction: Neutral, Set: Expert1, Rarity: Common
 // --------------------------------------------------------
-// Text: <b>Battlecry:</b> Deal 1 damage to a minion and give it +2 Attack.
+// Text: <b>Battlecry:</b> Deal 1 damage to a minion
+//       and give it +2 Attack.
 // --------------------------------------------------------
 // GameTag:
 // - BATTLECRY = 1

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -7570,6 +7570,9 @@ TEST_CASE("[Warrior : Minion] - EX1_398 : Arathi Weaponsmith")
 // --------------------------------------------------------
 // Text: Whenever a friendly minion takes damage, gain 1 Armor.
 // --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
 TEST_CASE("[Warrior : Minion] - EX1_402 : Armorsmith")
 {
     GameConfig config;

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -7912,11 +7912,12 @@ TEST_CASE("[Warrior : Weapon] - EX1_411 : Gorehowl")
 // [EX1_414] Grommash Hellscream - COST:8 [ATK:4/HP:9]
 // - Faction: Neutral, Set: Expert1, Rarity: Legendary
 // --------------------------------------------------------
-// Text: <b>Charge</b> Has +6 Attack while damaged.
+// Text: <b>Charge</b>
+//       Has +6 Attack while damaged.
 // --------------------------------------------------------
 // GameTag:
-// - CHARGE = 1
 // - ELITE = 1
+// - CHARGE = 1
 // - ENRAGED = 1
 // --------------------------------------------------------
 TEST_CASE("[Warrior : Minion] - EX1_414 : Grommash Hellscream")

--- a/Tests/UnitTests/PlayMode/CardSets/GvgCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/GvgCardsGenTests.cpp
@@ -8,7 +8,48 @@
 
 #include <Utils/CardSetUtils.hpp>
 
-TEST_CASE("[GvgCardsGen] - Temp")
+#include <Rosetta/PlayMode/Actions/Draw.hpp>
+#include <Rosetta/PlayMode/Cards/Cards.hpp>
+
+using namespace RosettaStone;
+using namespace PlayMode;
+using namespace PlayerTasks;
+using namespace SimpleTasks;
+
+// --------------------------------------- MINION - WARRIOR
+// [GVG_053] Shieldmaiden - COST:6 [ATK:5/HP:5]
+// - Set: Gvg, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Gain 5 Armor.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - GVG_053 : Shieldmaiden")
 {
-    CHECK(true);
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Shieldmaiden"));
+
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
 }

--- a/Tests/UnitTests/PlayMode/CardSets/GvgCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/GvgCardsGenTests.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#include "doctest_proxy.hpp"
+
+#include <Utils/CardSetUtils.hpp>
+
+TEST_CASE("[GvgCardsGen] - Temp")
+{
+    CHECK(true);
+}


### PR DESCRIPTION
This revision includes:
- Implement 16 CORE cards
  - Fiery War Axe (CORE_CS2_106)
  - Execute (CORE_CS2_108)
  - Warsong Commander (CORE_EX1_084)
  - Slam (CORE_EX1_391)
  - Whirlwind (CORE_EX1_400)
  - Armorsmith (CORE_EX1_402)
  - Brawl (CORE_EX1_407)
  - Shield Slam (CORE_EX1_410)
  - Gorehowl (CORE_EX1_411)
  - Grommash Hellscream (CORE_EX1_414)
  - Cruel Taskmaster (CORE_EX1_603)
  - Frothing Berserker (CORE_EX1_604)
  - Shieldmaiden (CORE_GVG_053)
  - Bloodsail Deckhand (CS3_008)
  - War Cache (CS3_009)
  - Warsong Outrider (CS3_030)
- Implement 1 GVG card
  - Shieldmaiden (GVG_053)
- Add comments for 'GVG' cards
- Create unit test file for 'GVG' cards
- Add enum value 'EQUIP_WEAPON' and code to process it
- Add variable 'equipWeaponTrigger' and related method
  - 'OnEquipWeaponTrigger()': Callback for trigger when a hero equips a weapon