### PR TITLE
Implement 16 CORE cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -23,19 +23,19 @@ CORE | CORE_BOT_420 | Landscaping | O
 CORE | CORE_BOT_453 | Shooting Star | O
 CORE | CORE_BOT_533 | Menacing Nimbus | O
 CORE | CORE_BRM_013 | Quick Shot | O
-CORE | CORE_BT_035 | Chaos Strike |  
-CORE | CORE_BT_036 | Coordinated Strike |  
-CORE | CORE_BT_235 | Chaos Nova |  
-CORE | CORE_BT_323 | Sightless Watcher |  
-CORE | CORE_BT_351 | Battlefiend |  
-CORE | CORE_BT_416 | Raging Felscreamer |  
-CORE | CORE_BT_423 | Ashtongue Battlelord |  
-CORE | CORE_BT_427 | Feast of Souls |  
-CORE | CORE_BT_430 | Warglaives of Azzinoth |  
-CORE | CORE_BT_480 | Crimson Sigil Runner |  
-CORE | CORE_BT_491 | Spectral Sight |  
-CORE | CORE_BT_801 | Eye Beam |  
-CORE | CORE_BT_921 | Aldrachi Warblades |  
+CORE | CORE_BT_035 | Chaos Strike | O
+CORE | CORE_BT_036 | Coordinated Strike | O
+CORE | CORE_BT_235 | Chaos Nova | O
+CORE | CORE_BT_323 | Sightless Watcher | O
+CORE | CORE_BT_351 | Battlefiend | O
+CORE | CORE_BT_416 | Raging Felscreamer | O
+CORE | CORE_BT_423 | Ashtongue Battlelord | O
+CORE | CORE_BT_427 | Feast of Souls | O
+CORE | CORE_BT_430 | Warglaives of Azzinoth | O
+CORE | CORE_BT_480 | Crimson Sigil Runner | O
+CORE | CORE_BT_491 | Spectral Sight | O
+CORE | CORE_BT_801 | Eye Beam | O
+CORE | CORE_BT_921 | Aldrachi Warblades | O
 CORE | CORE_CS1_112 | Holy Nova | O
 CORE | CORE_CS1_130 | Holy Smite | O
 CORE | CORE_CS2_009 | Mark of the Wild | O
@@ -226,9 +226,9 @@ CORE | CS3_013 | Shadowed Spirit | O
 CORE | CS3_014 | Crimson Clergy | O
 CORE | CS3_015 | Selective Breeder | O
 CORE | CS3_016 | Reckoning |  
-CORE | CS3_017 | Gan'arg Glaivesmith |  
-CORE | CS3_019 | Kor'vas Bloodthorn |  
-CORE | CS3_020 | Illidari Inquisitor |  
+CORE | CS3_017 | Gan'arg Glaivesmith | O
+CORE | CS3_019 | Kor'vas Bloodthorn | O
+CORE | CS3_020 | Illidari Inquisitor | O
 CORE | CS3_021 | Enslaved Fel Lord | O
 CORE | CS3_022 | Fogsail Freebooter |  
 CORE | CS3_024 | Taelan Fordring |  
@@ -246,7 +246,7 @@ CORE | CS3_036 | Deathwing the Destroyer |
 CORE | CS3_037 | Emerald Skytalon |  
 CORE | CS3_038 | Redgill Razorjaw |  
 
-- Progress: 59% (140 of 235 Cards)
+- Progress: 66% (156 of 235 Cards)
 
 ## Ashes of Outland
 
@@ -346,7 +346,7 @@ BLACK_TEMPLE | BT_334 | Lady Liadrin |
 BLACK_TEMPLE | BT_341 | Skeletal Dragon | O
 BLACK_TEMPLE | BT_423 | Ashtongue Battlelord | O
 BLACK_TEMPLE | BT_429 | Metamorphosis |  
-BLACK_TEMPLE | BT_430 | Warglaives of Azzinoth |  
+BLACK_TEMPLE | BT_430 | Warglaives of Azzinoth | O
 BLACK_TEMPLE | BT_480 | Crimson Sigil Runner | O
 BLACK_TEMPLE | BT_486 | Pit Commander | O
 BLACK_TEMPLE | BT_491 | Spectral Sight | O
@@ -388,7 +388,7 @@ BLACK_TEMPLE | BT_781 | Bulwark of Azzinoth |
 BLACK_TEMPLE | BT_850 | Magtheridon |  
 BLACK_TEMPLE | BT_934 | Imprisoned Antaen | O
 
-- Progress: 59% (80 of 135 Cards)
+- Progress: 60% (81 of 135 Cards)
 
 ## Scholomance Academy
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 59% Core Set (140 of 235 cards)
-  * 59% Ashes of Outland (80 of 135 cards)
+  * 66% Core Set (156 of 235 cards)
+  * 60% Ashes of Outland (81 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
   * 0% Forged in the Barrens (0 of 170 cards)

--- a/Sources/Rosetta/PlayMode/CardSets/BasicCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BasicCardsGen.cpp
@@ -2476,6 +2476,9 @@ void BasicCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Summon three 1/1 Illidari with <b>Rush</b>.
     // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(std::make_shared<SummonTask>("BT_036t", 3));
     cards.emplace("BT_036", CardDef(power));

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -2170,7 +2170,8 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // [BT_423] Ashtongue Battlelord - COST:4 [ATK:3/HP:5]
     // - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Taunt</b> <b>Lifesteal</b>
+    // Text: <b>Taunt</b>
+    //       <b>Lifesteal</b>
     // --------------------------------------------------------
     // GameTag:
     // - LIFESTEAL = 1

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -2202,6 +2202,14 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
+        SelfCondition::IsEventTargetIs(CardType::MINION));
+    power.GetTrigger()->tasks = { std::make_shared<SetGameTagTask>(
+        EntityType::HERO, GameTag::EXHAUSTED, 0) };
+    cards.emplace("BT_430", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [BT_480] Crimson Sigil Runner - COST:1 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -2245,7 +2245,8 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // [BT_491] Spectral Sight - COST:2
     // - Set: BLACK_TEMPLE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Draw a card. <b>Outcast:</b> Draw another.
+    // Text: Draw a card.
+    //       <b>Outcast:</b> Draw another.
     // --------------------------------------------------------
     // GameTag:
     // - OUTCAST = 1

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -3,6 +3,7 @@
 // Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
+#include <Rosetta/PlayMode/Actions/Choose.hpp>
 #include <Rosetta/PlayMode/Auras/AdaptiveEffect.hpp>
 #include <Rosetta/PlayMode/Auras/EnrageEffect.hpp>
 #include <Rosetta/PlayMode/CardSets/CoreCardsGen.hpp>
@@ -2797,6 +2798,25 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::DECK, 3));
+    power.AddPowerTask(std::make_shared<FuncNumberTask>([](Playable* playable) {
+        auto playables = playable->game->taskStack.playables;
+
+        std::vector<int> ids;
+        ids.reserve(3);
+
+        for (auto& p : playables)
+        {
+            ids.emplace_back(p->GetGameTag(GameTag::ENTITY_ID));
+        }
+
+        Generic::CreateChoice(playable->player, playable, ChoiceType::GENERAL,
+                              ChoiceAction::SIGHTLESS_WATCHER, ids);
+
+        return 0;
+    }));
+    cards.emplace("CORE_BT_323", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [CORE_BT_351] Battlefiend - COST:1 [ATK:1/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2965,14 +2965,18 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
                                  { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ----------------------------------- WEAPON - DEMONHUNTER
-    // [CORE_BT_921] Aldrachi Warblades - COST:3
+    // [CORE_BT_921] Aldrachi Warblades - COST:3 [ATK:2/HP:0]
     // - Set: CORE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Lifesteal</b>
     // --------------------------------------------------------
     // GameTag:
     // - LIFESTEAL = 1
+    // - DURABILITY = 2
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CORE_BT_921", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [CS3_017] Gan'arg Glaivesmith - COST:3 [ATK:3/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2747,6 +2747,8 @@ void CoreCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)
 
 void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------ SPELL - DEMONHUNTER
     // [CORE_BT_035] Chaos Strike - COST:2
     // - Set: CORE, Rarity: Common
@@ -2754,6 +2756,11 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Give your hero +2 Attack this turn. Draw a card.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("BT_035e", EntityType::HERO));
+    power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cards.emplace("CORE_BT_035", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [CORE_BT_036] Coordinated Strike - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2782,6 +2782,10 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 4 damage to all minions.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ALL_MINIONS, 4, true));
+    cards.emplace("CORE_BT_235", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [CORE_BT_323] Sightless Watcher - COST:2 [ATK:3/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -3028,6 +3028,12 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // - RUSH = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->tasks = { std::make_shared<AttackTask>(
+        EntityType::SOURCE, EntityType::EVENT_TARGET) };
+    cards.emplace("CS3_020", CardDef(power));
 }
 
 void CoreCardsGen::AddDemonHunterNonCollect(

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2859,6 +2859,9 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // - LIFESTEAL = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CORE_BT_423", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [CORE_BT_427] Feast of Souls - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2827,6 +2827,12 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "BT_351e", EntityType::SOURCE) };
+    cards.emplace("CORE_BT_351", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [CORE_BT_416] Raging Felscreamer - COST:4 [ATK:4/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2843,6 +2843,10 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("BT_416e", EntityType::SOURCE));
+    cards.emplace("CORE_BT_416", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [CORE_BT_423] Ashtongue Battlelord - COST:4 [ATK:3/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2771,6 +2771,9 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("BT_036t", 3));
+    cards.emplace("CORE_BT_036", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [CORE_BT_235] Chaos Nova - COST:5

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2893,6 +2893,14 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
+        SelfCondition::IsEventTargetIs(CardType::MINION));
+    power.GetTrigger()->tasks = { std::make_shared<SetGameTagTask>(
+        EntityType::HERO, GameTag::EXHAUSTED, 0) };
+    cards.emplace("CORE_BT_430", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [CORE_BT_480] Crimson Sigil Runner - COST:1 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4,6 +4,7 @@
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 #include <Rosetta/PlayMode/Actions/Choose.hpp>
+#include <Rosetta/PlayMode/Actions/Draw.hpp>
 #include <Rosetta/PlayMode/Auras/AdaptiveEffect.hpp>
 #include <Rosetta/PlayMode/Auras/EnrageEffect.hpp>
 #include <Rosetta/PlayMode/CardSets/CoreCardsGen.hpp>
@@ -2870,6 +2871,18 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Draw a card for each friendly minion that died this turn.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<CustomTask>(
+        [](Player* player, [[maybe_unused]] Entity* source,
+           [[maybe_unused]] Playable* target) {
+            const int num = player->GetNumFriendlyMinionsDiedThisTurn();
+
+            for (int i = 0; i < num; ++i)
+            {
+                Generic::Draw(player, nullptr);
+            }
+        }));
+    cards.emplace("CORE_BT_427", CardDef(power));
 
     // ----------------------------------- WEAPON - DEMONHUNTER
     // [CORE_BT_430] Warglaives of Azzinoth - COST:5

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2911,6 +2911,9 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - OUTCAST = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddOutcastTask(std::make_shared<DrawTask>(1));
+    cards.emplace("CORE_BT_480", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [CORE_BT_491] Spectral Sight - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2942,6 +2942,27 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // - LIFESTEAL = 1
     // - OUTCAST = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
+    power.AddAura(std::make_shared<AdaptiveCostEffect>([](Playable* playable) {
+        if (playable->GetZonePosition() == 0 ||
+            playable->GetZonePosition() ==
+                playable->player->GetHandZone()->GetCount() - 1)
+        {
+            return playable->GetGameTag(GameTag::COST) - 1;
+        }
+
+        return 0;
+    }));
+    cards.emplace(
+        "CORE_BT_801",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ----------------------------------- WEAPON - DEMONHUNTER
     // [CORE_BT_921] Aldrachi Warblades - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2987,6 +2987,10 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - OUTCAST = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddOutcastTask(
+        std::make_shared<AddEnchantmentTask>("CS3_017e", EntityType::HERO));
+    cards.emplace("CS3_017", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [CS3_019] Kor'vas Bloodthorn - COST:2 [ATK:2/HP:2]
@@ -3022,6 +3026,8 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 void CoreCardsGen::AddDemonHunterNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [CS3_017e] Felfist - COST:0
     // - Set: CORE
@@ -3031,6 +3037,9 @@ void CoreCardsGen::AddDemonHunterNonCollect(
     // GameTag:
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("CS3_017e"));
+    cards.emplace("CS3_017e", CardDef(power));
 }
 
 void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -3009,6 +3009,13 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - OUTCAST = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_PLAY_CARD));
+    power.GetTrigger()->condition =
+        std::make_shared<SelfCondition>(SelfCondition::IsOutcastCard());
+    power.GetTrigger()->tasks = { std::make_shared<ReturnHandTask>(
+        EntityType::SOURCE) };
+    cards.emplace("CS3_019", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [CS3_020] Illidari Inquisitor - COST:8 [ATK:8/HP:8]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2925,6 +2925,10 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - OUTCAST = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawTask>(1));
+    power.AddOutcastTask(std::make_shared<DrawTask>(1));
+    cards.emplace("CORE_BT_491", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [CORE_BT_801] Eye Beam - COST:3

--- a/Tests/UnitTests/PlayMode/CardSets/BasicCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BasicCardsGenTests.cpp
@@ -5409,6 +5409,9 @@ TEST_CASE("[Demon Hunter : Spell] - BT_035 : Chaos Strike")
 // --------------------------------------------------------
 // Text: Summon three 1/1 Illidari with <b>Rush</b>.
 // --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
 TEST_CASE("[Demon Hunter : Spell] - BT_036 : Coordinated Strike")
 {
     GameConfig config;

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -3166,6 +3166,70 @@ TEST_CASE("[Demon Hunter : Minion] - BT_423 : Ashtongue Battlelord")
     // Do nothing
 }
 
+// ----------------------------------- WEAPON - DEMONHUNTER
+// [BT_430] Warglaives of Azzinoth - COST:5
+// - Set: BLACK_TEMPLE, Rarity: Epic
+// --------------------------------------------------------
+// Text: After attacking a minion, your hero may attack again.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Weapon] - BT_430 : Warglaives of Azzinoth")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Warglaives of Azzinoth"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    CHECK_EQ(curPlayer->GetHero()->HasWeapon(), true);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetAttack(), 3);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(curPlayer->GetHero(), card2));
+    CHECK_EQ(curPlayer->GetHero()->CanAttack(), true);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 2);
+    CHECK_EQ(opField.GetCount(), 1);
+
+    game.Process(curPlayer,
+                 AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->CanAttack(), false);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 1);
+}
+
 // ----------------------------------- MINION - DEMONHUNTER
 // [BT_480] Crimson Sigil Runner - COST:1 [ATK:1/HP:1]
 // - Set: BLACK_TEMPLE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -3332,7 +3332,8 @@ TEST_CASE("[Demon Hunter : Spell] - BT_486 : Pit Commander")
 // [BT_491] Spectral Sight - COST:2
 // - Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------
-// Text: Draw a card. <b>Outcast:</b> Draw another.
+// Text: Draw a card.
+//       <b>Outcast:</b> Draw another.
 // --------------------------------------------------------
 // GameTag:
 // - OUTCAST = 1

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -3154,7 +3154,8 @@ TEST_CASE("[Demon Hunter : Minion] - BT_321 : Netherwalker")
 // [BT_423] Ashtongue Battlelord - COST:4 [ATK:3/HP:5]
 // - Set: BLACK_TEMPLE, Rarity: Common
 // --------------------------------------------------------
-// Text: <b>Taunt</b> <b>Lifesteal</b>
+// Text: <b>Taunt</b>
+//       <b>Lifesteal</b>
 // --------------------------------------------------------
 // GameTag:
 // - LIFESTEAL = 1

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7707,3 +7707,49 @@ TEST_CASE("[Warrior : Minion] - CS3_030 : Warsong Outrider")
 {
     // Do nothing
 }
+
+// ------------------------------------ SPELL - DEMONHUNTER
+// [CORE_BT_035] Chaos Strike - COST:2
+// - Set: CORE, Rarity: Common
+// - Spell School: Fel
+// --------------------------------------------------------
+// Text: Give your hero +2 Attack this turn. Draw a card.
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Spell] - CORE_BT_035 : Chaos Strike")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Chaos Strike"));
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 3);
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7875,3 +7875,72 @@ TEST_CASE("[Demon Hunter : Spell] - CORE_BT_235 : Chaos Nova")
     CHECK_EQ(curField[0]->GetHealth(), 2);
     CHECK_EQ(opField.GetCount(), 0);
 }
+
+// ----------------------------------- MINION - DEMONHUNTER
+// [CORE_BT_323] Sightless Watcher - COST:2 [ATK:3/HP:2]
+// - Race: Demon, Faction: Horde, Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Look at 3 cards in your deck.
+//       Choose one to put on top.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - CORE_BT_323 : Sightless Watcher")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 10; ++i)
+    {
+        config.player1Deck[i * 3] = Cards::FindCardByName("Magma Rager");
+        config.player1Deck[i * 3 + 1] = Cards::FindCardByName("Wolfrider");
+        config.player1Deck[i * 3 + 2] = Cards::FindCardByName("Wisp");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& curDeck = *(curPlayer->GetDeckZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Sightless Watcher"));
+
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curDeck.GetCount(), 26);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK(curPlayer->choice != nullptr);
+    CHECK_EQ(curPlayer->choice->choices.size(), 3u);
+
+    auto pickedCardID =
+        game.entityList[curPlayer->choice->choices[0]]->card->id;
+    game.Process(curPlayer,
+                 ChooseTask::Pick(curPlayer, curPlayer->choice->choices[0]));
+
+    CHECK_EQ(curHand.GetCount(), 4);
+    CHECK_EQ(curDeck.GetCount(), 26);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curHand[4]->card->id, pickedCardID);
+    CHECK_EQ(curDeck.GetCount(), 25);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -8194,3 +8194,49 @@ TEST_CASE("[Demon Hunter : Weapon] - CORE_BT_430 : Warglaives of Azzinoth")
     CHECK_EQ(curPlayer->GetHero()->CanAttack(), false);
     CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 1);
 }
+
+// ----------------------------------- MINION - DEMONHUNTER
+// [CORE_BT_480] Crimson Sigil Runner - COST:1 [ATK:1/HP:1]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Outcast:</b> Draw a card.
+// --------------------------------------------------------
+// GameTag:
+// - OUTCAST = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - CORE_BT_480 : Crimson Sigil Runner")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Crimson Sigil Runner"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Crimson Sigil Runner"));
+
+    CHECK_EQ(curHand.GetCount(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curHand.GetCount(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7944,3 +7944,58 @@ TEST_CASE("[Demon Hunter : Minion] - CORE_BT_323 : Sightless Watcher")
     CHECK_EQ(curHand[4]->card->id, pickedCardID);
     CHECK_EQ(curDeck.GetCount(), 25);
 }
+
+// ----------------------------------- MINION - DEMONHUNTER
+// [CORE_BT_351] Battlefiend - COST:1 [ATK:1/HP:2]
+// - Race: Demon, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: After your hero attacks, gain +1 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - CORE_BT_351 : Battlefiend")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Battlefiend"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+
+    game.Process(curPlayer, HeroPowerTask());
+    game.Process(curPlayer,
+                 AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, HeroPowerTask());
+    game.Process(curPlayer,
+                 AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -8240,3 +8240,50 @@ TEST_CASE("[Demon Hunter : Minion] - CORE_BT_480 : Crimson Sigil Runner")
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     CHECK_EQ(curHand.GetCount(), 5);
 }
+
+// ------------------------------------ SPELL - DEMONHUNTER
+// [CORE_BT_491] Spectral Sight - COST:2
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: Draw a card.
+//       <b>Outcast:</b> Draw another.
+// --------------------------------------------------------
+// GameTag:
+// - OUTCAST = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Spell] - CORE_BT_491 : Spectral Sight")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Spectral Sight"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Spectral Sight"));
+
+    CHECK_EQ(curHand.GetCount(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curHand.GetCount(), 7);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curHand.GetCount(), 7);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -8059,3 +8059,19 @@ TEST_CASE("[Demon Hunter : Minion] - CORE_BT_416 : Raging Felscreamer")
     CHECK_EQ(card4->GetCost(), 1);
     CHECK_EQ(card5->GetCost(), 5);
 }
+
+// ----------------------------------- MINION - DEMONHUNTER
+// [CORE_BT_423] Ashtongue Battlelord - COST:4 [ATK:3/HP:5]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Lifesteal</b>
+// --------------------------------------------------------
+// GameTag:
+// - LIFESTEAL = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - BT_423 : Ashtongue Battlelord")
+{
+    // Do nothing
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -8071,7 +8071,61 @@ TEST_CASE("[Demon Hunter : Minion] - CORE_BT_416 : Raging Felscreamer")
 // - LIFESTEAL = 1
 // - TAUNT = 1
 // --------------------------------------------------------
-TEST_CASE("[Demon Hunter : Minion] - BT_423 : Ashtongue Battlelord")
+TEST_CASE("[Demon Hunter : Minion] - CORE_BT_423 : Ashtongue Battlelord")
 {
     // Do nothing
+}
+
+// ------------------------------------ SPELL - DEMONHUNTER
+// [CORE_BT_427] Feast of Souls - COST:2
+// - Set: CORE, Rarity: Rare
+// - Spell School: Shadow
+// --------------------------------------------------------
+// Text: Draw a card for each friendly minion that died this turn.
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Spell] - CORE_BT_427 : Feast of Souls")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::DEMONHUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+    auto& opHand = *(opPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Feast of Souls"));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Coordinated Strike"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(opHand.GetCount(), 7);
+
+    game.Process(opPlayer, AttackTask(opField[0], card1));
+    game.Process(opPlayer, AttackTask(opField[0], card1));
+    game.Process(opPlayer, AttackTask(opField[0], card1));
+
+    game.Process(opPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(opHand.GetCount(), 9);
 }

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7999,3 +7999,63 @@ TEST_CASE("[Demon Hunter : Minion] - CORE_BT_351 : Battlefiend")
                  AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
     CHECK_EQ(curField[0]->GetAttack(), 3);
 }
+
+// ----------------------------------- MINION - DEMONHUNTER
+// [CORE_BT_416] Raging Felscreamer - COST:4 [ATK:4/HP:4]
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> The next Demon you play costs (2) less.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - CORE_BT_416 : Raging Felscreamer")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Raging Felscreamer"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Satyr Overseer"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Shadowhoof Slayer"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Battlefiend"));
+    const auto card5 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Glaivebound Adept"));
+
+    CHECK_EQ(card2->GetCost(), 3);
+    CHECK_EQ(card3->GetCost(), 1);
+    CHECK_EQ(card4->GetCost(), 1);
+    CHECK_EQ(card5->GetCost(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 6);
+    CHECK_EQ(card2->GetCost(), 1);
+    CHECK_EQ(card3->GetCost(), 0);
+    CHECK_EQ(card4->GetCost(), 0);
+    CHECK_EQ(card5->GetCost(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 6);
+    CHECK_EQ(card2->GetCost(), 3);
+    CHECK_EQ(card4->GetCost(), 1);
+    CHECK_EQ(card5->GetCost(), 5);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7818,3 +7818,60 @@ TEST_CASE("[Demon Hunter : Spell] - CORE_BT_036 : Coordinated Strike")
     CHECK_EQ(curField[0]->GetHealth(), 9);
     CHECK_EQ(opField.GetCount(), 0);
 }
+
+// ------------------------------------ SPELL - DEMONHUNTER
+// [CORE_BT_235] Chaos Nova - COST:5
+// - Set: CORE, Rarity: Common
+// - Spell School: Fel
+// --------------------------------------------------------
+// Text: Deal 4 damage to all minions.
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Spell] - CORE_BT_235 : Chaos Nova")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::DEMONHUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Oasis Snapjaw"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Silverback Patriarch"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Chaos Nova"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Ogre Magi"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+
+    game.Process(opPlayer, PlayCardTask::Spell(card4));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(opField.GetCount(), 0);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -8129,3 +8129,68 @@ TEST_CASE("[Demon Hunter : Spell] - CORE_BT_427 : Feast of Souls")
     game.Process(opPlayer, PlayCardTask::Spell(card2));
     CHECK_EQ(opHand.GetCount(), 9);
 }
+
+// ----------------------------------- WEAPON - DEMONHUNTER
+// [CORE_BT_430] Warglaives of Azzinoth - COST:5
+// - Set: CORE, Rarity: Epic
+// --------------------------------------------------------
+// Text: After attacking a minion, your hero may attack again.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Weapon] - CORE_BT_430 : Warglaives of Azzinoth")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Warglaives of Azzinoth"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    CHECK_EQ(curPlayer->GetHero()->HasWeapon(), true);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetAttack(), 3);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(curPlayer->GetHero(), card2));
+    CHECK_EQ(curPlayer->GetHero()->CanAttack(), true);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 2);
+    CHECK_EQ(opField.GetCount(), 1);
+
+    game.Process(curPlayer,
+                 AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->CanAttack(), false);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -8287,3 +8287,65 @@ TEST_CASE("[Demon Hunter : Spell] - CORE_BT_491 : Spectral Sight")
     game.Process(curPlayer, PlayCardTask::Spell(card1));
     CHECK_EQ(curHand.GetCount(), 7);
 }
+
+// ------------------------------------ SPELL - DEMONHUNTER
+// [CORE_BT_801] Eye Beam - COST:3
+// - Set: CORE, Rarity: Epic
+// - Spell School: Fel
+// --------------------------------------------------------
+// Text: <b>Lifesteal</b>. Deal 3 damage to a minion.
+//       <b>Outcast:</b> This costs (1).
+// --------------------------------------------------------
+// GameTag:
+// - LIFESTEAL = 1
+// - OUTCAST = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Spell] - CORE_BT_801 : Eye Beam")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::DEMONHUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    opPlayer->GetHero()->SetDamage(15);
+
+    auto opHero = opPlayer->GetHero();
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Eye Beam"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Eye Beam"));
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(opPlayer->GetRemainingMana(), 7);
+    CHECK_EQ(opHero->GetHealth(), 18);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
+    CHECK_EQ(opPlayer->GetRemainingMana(), 6);
+    CHECK_EQ(opHero->GetHealth(), 21);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -8403,3 +8403,52 @@ TEST_CASE("[Demon Hunter : Weapon] - CORE_BT_921 : Aldrachi Warblades")
 
     CHECK_EQ(curPlayer->GetHero()->GetAttack(), 2);
 }
+
+// ----------------------------------- MINION - DEMONHUNTER
+// [CS3_017] Gan'arg Glaivesmith - COST:3 [ATK:3/HP:2]
+// - Race: Demon, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Outcast:</b> Give your hero +3 Attack this turn.
+// --------------------------------------------------------
+// GameTag:
+// - OUTCAST = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - CS3_017 : Gan'arg Glaivesmith")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Gan'arg Glaivesmith", FormatType::STANDARD));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Gan'arg Glaivesmith", FormatType::STANDARD));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+}


### PR DESCRIPTION
This revision includes:
- Implement 16 CORE cards
  - Chaos Strike (CORE_BT_035)
  - Coordinated Strike (CORE_BT_036)
  - Chaos Nova (CORE_BT_235)
  - Sightless Watcher (CORE_BT_323)
  - Battlefiend (CORE_BT_351)
  - Raging Felscreamer (CORE_BT_416)
  - Ashtongue Battlelord (CORE_BT_423)
  - Feast of Souls (CORE_BT_427)
  - Warglaives of Azzinoth (CORE_BT_430)
  - Crimson Sigil Runner (CORE_BT_480)
  - Spectral Sight (CORE_BT_491)
  - Eye Beam (CORE_BT_801)
  - Aldrachi Warblades (CORE_BT_921)
  - Gan'arg Glaivesmith (CS3_017)
  - Kor'vas Bloodthorn (CS3_019)
  - Illidari Inquisitor (CS3_020)
- Implement 1 BLACK_TEMPLE card
  - Warglaives of Azzinoth (BT_430)