### PR TITLE
Implement 5 THE_BARRENS cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -784,12 +784,12 @@ THE_BARRENS | BAR_330 | Tuskpiercer |
 THE_BARRENS | BAR_333 | Kurtrus Ashfallen |  
 THE_BARRENS | BAR_334 | Overlord Saurfang |  
 THE_BARRENS | BAR_430 | Horde Operative |  
-THE_BARRENS | BAR_533 | Thorngrowth Sentries |  
-THE_BARRENS | BAR_534 | Pride's Fury |  
-THE_BARRENS | BAR_535 | Thickhide Kodo |  
+THE_BARRENS | BAR_533 | Thorngrowth Sentries | O
+THE_BARRENS | BAR_534 | Pride's Fury | O
+THE_BARRENS | BAR_535 | Thickhide Kodo | O
 THE_BARRENS | BAR_536 | Living Seed (Rank 1) |  
 THE_BARRENS | BAR_537 | Razormane Battleguard |  
-THE_BARRENS | BAR_538 | Druid of the Plains |  
+THE_BARRENS | BAR_538 | Druid of the Plains | O
 THE_BARRENS | BAR_539 | Celestial Alignment |  
 THE_BARRENS | BAR_540 | Plaguemaw the Rotting |  
 THE_BARRENS | BAR_541 | Runed Orb |  
@@ -803,7 +803,7 @@ THE_BARRENS | BAR_550 | Galloping Savior |
 THE_BARRENS | BAR_551 | Barak Kodobane |  
 THE_BARRENS | BAR_552 | Scabbs Cutterbutter |  
 THE_BARRENS | BAR_705 | Sigil of Silence |  
-THE_BARRENS | BAR_720 | Guff Runetotem |  
+THE_BARRENS | BAR_720 | Guff Runetotem | O
 THE_BARRENS | BAR_721 | Mankrik |  
 THE_BARRENS | BAR_735 | Xyrella |  
 THE_BARRENS | BAR_743 | Toad of the Wilds |  
@@ -884,4 +884,4 @@ THE_BARRENS | WC_803 | Cleric of An'she |
 THE_BARRENS | WC_805 | Frostweave Dungeoneer |  
 THE_BARRENS | WC_806 | Floecaster |  
 
-- Progress: 0% (0 of 170 Cards)
+- Progress: 2% (5 of 170 Cards)

--- a/Includes/Rosetta/Common/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/TaskEnums.hpp
@@ -27,6 +27,7 @@ enum class PowerType
     COMBO,
     OUTCAST,
     SPELLBURST,
+    FRENZY,
     START_OF_COMBAT,
 };
 

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -207,6 +207,10 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsSpell();
 
+    //! SelfCondition wrapper for checking the entity is nature spell.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsNatureSpell();
+
     //! SelfCondition wrapper for checking the entity is weapon.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsWeapon();

--- a/Includes/Rosetta/PlayMode/Enchants/Power.hpp
+++ b/Includes/Rosetta/PlayMode/Enchants/Power.hpp
@@ -69,6 +69,10 @@ class Power
     //! \return A list of spellburst tasks.
     std::vector<std::shared_ptr<ITask>>& GetSpellburstTask();
 
+    //! Returns a list of frenzy tasks.
+    //! \return A list of frenzy tasks.
+    std::vector<std::shared_ptr<ITask>>& GetFrenzyTask();
+
     //! Clears power task and enchant.
     void ClearData();
 
@@ -124,6 +128,10 @@ class Power
     //! \param tasks A list of spellburst task.
     void AddSpellburstTask(TaskList tasks);
 
+    //! Adds frenzy task.
+    //! \param task A pointer to frenzy task.
+    void AddFrenzyTask(std::shared_ptr<ITask> task);
+
  private:
     std::shared_ptr<IAura> m_aura;
     std::shared_ptr<Enchant> m_enchant;
@@ -136,6 +144,7 @@ class Power
     std::vector<std::shared_ptr<ITask>> m_afterChooseTask;
     std::vector<std::shared_ptr<ITask>> m_outcastTask;
     std::vector<std::shared_ptr<ITask>> m_spellburstTask;
+    std::vector<std::shared_ptr<ITask>> m_frenzyTask;
 };
 }  // namespace RosettaStone::PlayMode
 

--- a/Includes/Rosetta/PlayMode/Models/Minion.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Minion.hpp
@@ -90,6 +90,10 @@ class Minion : public Character
     //! \return The flag that indicates whether it has reborn.
     bool HasReborn() const;
 
+    //! Returns the flag that indicates whether it has frenzy.
+    //! \return The flag that indicates whether it has frenzy.
+    bool HasFrenzy() const;
+
     //! Returns the flag that indicates whether it is attackable by rush.
     //! \return The flag that indicates whether it is attackable by rush.
     bool IsAttackableByRush() const;

--- a/Includes/Rosetta/PlayMode/Models/Spell.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Spell.hpp
@@ -41,6 +41,10 @@ class Spell : public Playable
     //! Deleted move assignment operator.
     Spell& operator=(Spell&&) noexcept = delete;
 
+    //! Returns the value of spell school.
+    //! \return The value of spell school.
+    SpellSchool GetSpellSchool() const;
+
     //! Gets the value of quest progress.
     //! \return The value of quest progress.
     int GetQuestProgress() const;

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 60% Ashes of Outland (81 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
-  * 0% Forged in the Barrens (0 of 170 cards)
+  * 2% Forged in the Barrens (5 of 170 cards)
 
 ### Wild Format
 

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -162,6 +162,13 @@ void TheBarrensCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_CAST));
+    power.GetTrigger()->condition =
+        std::make_shared<SelfCondition>(SelfCondition::IsNatureSpell());
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "BAR_720e", EntityType::MINIONS_NOSOURCE) };
+    cards.emplace("BAR_720", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [WC_004] Fangbound Druid - COST:3 [ATK:4/HP:3]
@@ -288,6 +295,9 @@ void TheBarrensCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("BAR_720e"));
+    cards.emplace("BAR_720e", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [WC_004t] Nightmare Trapped - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -110,6 +110,10 @@ void TheBarrensCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddFrenzyTask(
+        std::make_shared<TransformTask>(EntityType::SOURCE, "BAR_538t"));
+    cards.emplace("BAR_538", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [BAR_539] Celestial Alignment - COST:7
@@ -260,6 +264,9 @@ void TheBarrensCardsGen::AddDruidNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("BAR_538t", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [BAR_539e] Vortexed - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -4,6 +4,7 @@
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 #include <Rosetta/PlayMode/CardSets/TheBarrensCardsGen.hpp>
+#include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 
 using namespace RosettaStone::PlayMode::SimpleTasks;
@@ -52,6 +53,10 @@ void TheBarrensCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Give your minions +1/+3.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("BAR_534e", EntityType::MINIONS));
+    cards.emplace("BAR_534", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [BAR_535] Thickhide Kodo - COST:4 [ATK:3/HP:5]
@@ -214,6 +219,9 @@ void TheBarrensCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
     // Text: +1/+3.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("BAR_534e"));
+    cards.emplace("BAR_534e", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [BAR_536t] Living Seed (Rank 2) - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -6,8 +6,12 @@
 #include <Rosetta/PlayMode/CardSets/TheBarrensCardsGen.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 
+using namespace RosettaStone::PlayMode::SimpleTasks;
+
 namespace RosettaStone::PlayMode
 {
+using PlayReqs = std::map<PlayReq, int>;
+
 void TheBarrensCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
     // Do nothing
@@ -20,6 +24,8 @@ void TheBarrensCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
 void TheBarrensCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------ SPELL - DRUID
     // [BAR_533] Thorngrowth Sentries - COST:2
     // - Set: THE_BARRENS, Rarity: Common
@@ -27,9 +33,18 @@ void TheBarrensCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Summon two 1/2 Turtles with <b>Taunt</b>.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("BAR_533t", 2, SummonSide::SPELL));
+    cards.emplace(
+        "BAR_533",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ------------------------------------------ SPELL - DRUID
     // [BAR_534] Pride's Fury - COST:4
@@ -178,6 +193,8 @@ void TheBarrensCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 void TheBarrensCardsGen::AddDruidNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- MINION - DRUID
     // [BAR_533t] Thornguard Turtle - COST:1 [ATK:1/HP:2]
     // - Race: Beast, Set: THE_BARRENS
@@ -187,6 +204,9 @@ void TheBarrensCardsGen::AddDruidNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("BAR_533t", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [BAR_534e] Overrun - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -69,6 +69,9 @@ void TheBarrensCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - DEATHRATTLE = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(std::make_shared<ArmorTask>(5));
+    cards.emplace("BAR_535", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [BAR_536] Living Seed (Rank 1) - COST:2

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -400,6 +400,19 @@ SelfCondition SelfCondition::IsSpell()
     });
 }
 
+SelfCondition SelfCondition::IsNatureSpell()
+{
+    return SelfCondition([](Playable* playable) {
+        auto spell = dynamic_cast<Spell*>(playable);
+        if (!spell)
+        {
+            return false;
+        }
+
+        return spell->GetSpellSchool() == SpellSchool::NATURE;
+    });
+}
+
 SelfCondition SelfCondition::IsWeapon()
 {
     return SelfCondition([](Playable* playable) {

--- a/Sources/Rosetta/PlayMode/Enchants/Power.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/Power.cpp
@@ -60,6 +60,11 @@ std::vector<std::shared_ptr<ITask>>& Power::GetSpellburstTask()
     return m_spellburstTask;
 }
 
+std::vector<std::shared_ptr<ITask>>& Power::GetFrenzyTask()
+{
+    return m_frenzyTask;
+}
+
 void Power::ClearData()
 {
     m_aura.reset();
@@ -139,5 +144,10 @@ void Power::AddSpellburstTask(std::shared_ptr<ITask> task)
 void Power::AddSpellburstTask(TaskList tasks)
 {
     m_spellburstTask.insert(m_spellburstTask.end(), tasks.begin(), tasks.end());
+}
+
+void Power::AddFrenzyTask(std::shared_ptr<ITask> task)
+{
+    m_frenzyTask.emplace_back(task);
 }
 }  // namespace RosettaStone::PlayMode

--- a/Sources/Rosetta/PlayMode/Models/Character.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Character.cpp
@@ -255,7 +255,7 @@ int Character::TakeDamage(Playable* source, int damage)
         hero->fatigue = damage;
     }
 
-    if (minion != nullptr && GetGameTag(GameTag::DIVINE_SHIELD) == 1)
+    if (minion && GetGameTag(GameTag::DIVINE_SHIELD) == 1)
     {
         SetGameTag(GameTag::DIVINE_SHIELD, 0);
         return 0;
@@ -300,6 +300,18 @@ int Character::TakeDamage(Playable* source, int damage)
     }
 
     SetDamage(GetDamage() + amount);
+
+    if (minion && !minion->isDestroyed)
+    {
+        // Process frenzy tasks
+        if (minion->HasFrenzy())
+        {
+            minion->ActivateTask(PowerType::FRENZY);
+            minion->SetGameTag(GameTag::FRENZY, 0);
+        }
+
+        player->game->ProcessTasks();
+    }
 
     // Process damage triggers
     takeDamageTrigger(this);

--- a/Sources/Rosetta/PlayMode/Models/Minion.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Minion.cpp
@@ -122,6 +122,11 @@ bool Minion::HasReborn() const
     return static_cast<bool>(GetGameTag(GameTag::REBORN));
 }
 
+bool Minion::HasFrenzy() const
+{
+    return static_cast<bool>(GetGameTag(GameTag::FRENZY));
+}
+
 bool Minion::IsAttackableByRush() const
 {
     return static_cast<bool>(GetGameTag(GameTag::ATTACKABLE_BY_RUSH));

--- a/Sources/Rosetta/PlayMode/Models/Playable.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Playable.cpp
@@ -603,6 +603,9 @@ void Playable::ActivateTask(PowerType type, Character* target, int chooseOne,
         case PowerType::SPELLBURST:
             tasks = card->power.GetSpellburstTask();
             break;
+        case PowerType::FRENZY:
+            tasks = card->power.GetFrenzyTask();
+            break;
         default:
             throw std::invalid_argument(
                 "Playable::ActivateTask() - Invalid power type");

--- a/Sources/Rosetta/PlayMode/Models/Spell.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Spell.cpp
@@ -18,6 +18,11 @@ Spell::Spell(Player* player, Card* card, std::map<GameTag, int> tags, int id)
     // Do nothing
 }
 
+SpellSchool Spell::GetSpellSchool() const
+{
+    return static_cast<SpellSchool>(GetGameTag(GameTag::SPELL_SCHOOL));
+}
+
 int Spell::GetQuestProgress() const
 {
     return GetGameTag(GameTag::QUEST_PROGRESS);

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -221,3 +221,65 @@ TEST_CASE("[Druid : Minion] - BAR_538 : Druid of the Plains")
     CHECK_EQ(curField[0]->HasRush(), false);
     CHECK_EQ(curField[0]->HasTaunt(), true);
 }
+
+// ----------------------------------------- MINION - DRUID
+// [BAR_720] Guff Runetotem - COST:3 [ATK:2/HP:4]
+// - Set: THE_BARRENS, Rarity: Legendary
+// --------------------------------------------------------
+// Text: After you cast a Nature spell,
+//       give another friendly minion +2/+2.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - BAR_720 : Guff Runetotem")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Guff Runetotem"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Innervate"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Holy Light"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card4));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -118,3 +118,51 @@ TEST_CASE("[Druid : Spell] - BAR_534 : Pride's Fury")
     CHECK_EQ(curField[1]->GetAttack(), 2);
     CHECK_EQ(curField[1]->GetHealth(), 4);
 }
+
+// ----------------------------------------- MINION - DRUID
+// [BAR_535] Thickhide Kodo - COST:4 [ATK:3/HP:5]
+// - Race: Beast, Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Deathrattle:</b> Gain 5 Armor.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - BAR_535 : Thickhide Kodo")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Thickhide Kodo"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -166,3 +166,58 @@ TEST_CASE("[Druid : Minion] - BAR_535 : Thickhide Kodo")
     game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
 }
+
+// ----------------------------------------- MINION - DRUID
+// [BAR_538] Druid of the Plains - COST:7 [ATK:7/HP:6]
+// - Race: Beast, Set: THE_BARRENS, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Rush</b>
+//       <b>Frenzy:</b> Transform into a 6/7 Kodo with <b>Taunt</b>.
+// --------------------------------------------------------
+// GameTag:
+// - FRENZY = 1
+// - RUSH = 1
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - BAR_538 : Druid of the Plains")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Druid of the Plains"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 7);
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+    CHECK_EQ(curField[0]->HasRush(), true);
+    CHECK_EQ(curField[0]->HasTaunt(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 6);
+    CHECK_EQ(curField[0]->GetHealth(), 7);
+    CHECK_EQ(curField[0]->HasRush(), false);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -69,3 +69,52 @@ TEST_CASE("[Druid : Spell] - BAR_533 : Thorngrowth Sentries")
     CHECK_EQ(curField[1]->GetHealth(), 2);
     CHECK_EQ(curField[1]->HasTaunt(), true);
 }
+
+// ------------------------------------------ SPELL - DRUID
+// [BAR_534] Pride's Fury - COST:4
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: Give your minions +1/+3.
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - BAR_534 : Pride's Fury")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Pride's Fury"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 4);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -7,8 +7,65 @@
 #include "doctest_proxy.hpp"
 
 #include <Utils/CardSetUtils.hpp>
+#include <Utils/TestUtils.hpp>
 
-TEST_CASE("[TheBarrensCardsGen] - Temp")
+#include <Rosetta/PlayMode/Actions/Draw.hpp>
+#include <Rosetta/PlayMode/Cards/Cards.hpp>
+#include <Rosetta/PlayMode/Zones/DeckZone.hpp>
+#include <Rosetta/PlayMode/Zones/FieldZone.hpp>
+#include <Rosetta/PlayMode/Zones/HandZone.hpp>
+
+using namespace RosettaStone;
+using namespace PlayMode;
+using namespace PlayerTasks;
+using namespace SimpleTasks;
+
+// ------------------------------------------ SPELL - DRUID
+// [BAR_533] Thorngrowth Sentries - COST:2
+// - Set: THE_BARRENS, Rarity: Common
+// - Spell School: Nature
+// --------------------------------------------------------
+// Text: Summon two 1/2 Turtles with <b>Taunt</b>.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - BAR_533 : Thorngrowth Sentries")
 {
-    CHECK(true);
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Thorngrowth Sentries"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Thornguard Turtle");
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+    CHECK_EQ(curField[1]->card->name, "Thornguard Turtle");
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+    CHECK_EQ(curField[1]->HasTaunt(), true);
 }


### PR DESCRIPTION
This revision includes:
- Implement 5 THE_BARRENS cards
  - Thorngrowth Sentries (BAR_533)
  - Pride's Fury (BAR_534)
  - Thickhide Kodo (BAR_535)
  - Druid of the Plains (BAR_538)
  - Guff Runetotem (BAR_720)
- Add enum value 'FRENZY' and related method
  - HasFrenzy(): Returns the flag that indicates whether it has frenzy
- Add some methods
  - GetSpellSchool(): Returns the flag that indicates whether it has frenzy
  - IsNatureSpell(): SelfCondition wrapper for checking the entity is nature spell