### PR TITLE
Update Hearthstone Patch 20.8.2

### DIFF
--- a/Resources/cards.collectible.json
+++ b/Resources/cards.collectible.json
@@ -9808,7 +9808,7 @@
         "artist": "Konstantin Turovec",
         "cardClass": "PRIEST",
         "collectible": true,
-        "cost": 1,
+        "cost": 2,
         "dbfId": 56595,
         "flavor": "I am rejuvenated, I am renewed, I am my own nightlight!",
         "id": "BT_252",
@@ -9911,7 +9911,7 @@
         ],
         "set": "BLACK_TEMPLE",
         "spellSchool": "HOLY",
-        "text": "Give a minion +2/+3 and <b>Lifesteal</b>.",
+        "text": "Give a minion +1/+2 and <b>Lifesteal</b>.",
         "type": "SPELL"
     },
     {
@@ -51117,6 +51117,7 @@
     {
         "artist": "Matt Dixon",
         "attack": 1,
+        "battlegroundsDarkmoonPrizeTurn": 4,
         "battlegroundsPremiumDbfId": 67493,
         "cardClass": "PALADIN",
         "collectible": true,
@@ -51540,7 +51541,7 @@
         "attack": 1,
         "cardClass": "DRUID",
         "collectible": true,
-        "cost": 1,
+        "cost": 2,
         "dbfId": 59001,
         "flavor": "\"As a Linguistics student I have studied the Gibberlings. I have determined they are speaking Gibberish.\"",
         "health": 1,

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -964,7 +964,7 @@ void BlackTempleCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
 
     // ----------------------------------------- SPELL - PRIEST
-    // [BT_252] Renew - COST:1
+    // [BT_252] Renew - COST:2
     // - Set: BLACK_TEMPLE, Rarity: Common
     // - Spell School: Holy
     // --------------------------------------------------------
@@ -1038,7 +1038,7 @@ void BlackTempleCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // - Set: BLACK_TEMPLE, Rarity: Common
     // - Spell School: Holy
     // --------------------------------------------------------
-    // Text: Give a minion +2/+3 and <b>Lifesteal</b>.
+    // Text: Give a minion +1/+2 and <b>Lifesteal</b>.
     // --------------------------------------------------------
     // RefTag:
     // - LIFESTEAL = 1
@@ -1155,7 +1155,7 @@ void BlackTempleCardsGen::AddPriestNonCollect(
     // [BT_257e] Apotheosis - COST:0
     // - Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: +2/+3 and <b>Lifesteal</b>.
+    // Text: +1/+2 and <b>Lifesteal</b>.
     // --------------------------------------------------------
     power.ClearData();
     power.AddEnchant(Enchants::GetEnchantFromText("BT_257e"));

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -47,7 +47,7 @@ void ScholomanceCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ----------------------------------------- MINION - DRUID
-    // [SCH_242] Gibberling - COST:1 [ATK:1/HP:1]
+    // [SCH_242] Gibberling - COST:2 [ATK:1/HP:1]
     // - Set: SCHOLOMANCE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Spellburst:</b> Summon a Gibberling.

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -1198,7 +1198,7 @@ TEST_CASE("[Paladin : Spell] - BT_024 : Libram of Hope")
 }
 
 // ----------------------------------------- SPELL - PRIEST
-// [BT_252] Renew - COST:1
+// [BT_252] Renew - COST:2
 // - Set: BLACK_TEMPLE, Rarity: Common
 // - Spell School: Holy
 // --------------------------------------------------------
@@ -1359,7 +1359,7 @@ TEST_CASE("[Preist : Minion] - BT_256 : Dragonmaw Overseer")
 // - Set: BLACK_TEMPLE, Rarity: Common
 // - Spell School: Holy
 // --------------------------------------------------------
-// Text: Give a minion +2/+3 and <b>Lifesteal</b>.
+// Text: Give a minion +1/+2 and <b>Lifesteal</b>.
 // --------------------------------------------------------
 // RefTag:
 // - LIFESTEAL = 1
@@ -1402,8 +1402,8 @@ TEST_CASE("[Preist : Spell] - BT_257 : Apotheosis")
 
     game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
     CHECK_EQ(curField[0]->GetGameTag(GameTag::LIFESTEAL), 1);
-    CHECK_EQ(curField[0]->GetAttack(), 4);
-    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
 }
 
 // ---------------------------------------- MINION - PRIEST

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -25,7 +25,7 @@ using namespace PlayerTasks;
 using namespace SimpleTasks;
 
 // ----------------------------------------- MINION - DRUID
-// [SCH_242] Gibberling - COST:1 [ATK:1/HP:1]
+// [SCH_242] Gibberling - COST:2 [ATK:1/HP:1]
 // - Set: SCHOLOMANCE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Spellburst:</b> Summon a Gibberling.


### PR DESCRIPTION
This revision includes:
- Update Hearthstone Patch 20.8.2 (#606)
  - Card update
    - Apotheosis: Old: Give a minion +2/+3 and Lifesteal. → New: Give a minion +1/+2 and Lifesteal.
    - Renew: Old: [Costs 1] → New: [Costs 2]
    - Gibberling: Old: [Costs 1] → New: [Costs 2]