### PR TITLE
Fix intermittent unit test failure

### DIFF
--- a/Includes/Rosetta/PlayMode/Triggers/Triggers.hpp
+++ b/Includes/Rosetta/PlayMode/Triggers/Triggers.hpp
@@ -34,10 +34,10 @@ class Triggers
         return trigger;
     }
 
-    //! Trigger for upgradable card.
+    //! Trigger for rank spells.
     //! \param mana The amount of mana requires for upgrade.
     //! \param enchantmentID The upgraded card ID.
-    static Trigger UpgradableTrigger(int mana, std::string&& upgradedCardID)
+    static Trigger RankSpellTrigger(int mana, std::string&& upgradedCardID)
     {
         Trigger trigger(TriggerType::MANA_CRYSTAL);
         trigger.triggerActivation = TriggerActivation::HAND;

--- a/Includes/Rosetta/PlayMode/Triggers/Triggers.hpp
+++ b/Includes/Rosetta/PlayMode/Triggers/Triggers.hpp
@@ -44,8 +44,7 @@ class Triggers
         trigger.condition = std::make_shared<SelfCondition>(
             SelfCondition::HasAtLeastManaCrystal(mana));
         trigger.tasks = { std::make_shared<SimpleTasks::ChangeEntityTask>(
-            std::move(upgradedCardID), EntityType::SOURCE) };
-        trigger.fastExecution = true;
+            std::move(upgradedCardID)) };
 
         return trigger;
     }

--- a/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
@@ -63,7 +63,7 @@ void PlayCard(Player* player, Playable* source, Character* target, int fieldPos,
         {
             Card* newCard = Cards::FindCardByDbfID(
                 playable->GetGameTag(GameTag::CORRUPTEDCARD));
-            if (newCard != nullptr)
+            if (newCard != nullptr && !newCard->name.empty())
             {
                 ChangeEntity(player, playable, newCard, true);
             }

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2382,9 +2382,12 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
         [](Player* player, Entity* source, [[maybe_unused]] Playable* target) {
             const int entityID =
                 source->GetGameTag(GameTag::TAG_SCRIPT_DATA_ENT_1);
-            Playable* playable = player->game->entityList[entityID];
-            player->opponent->GetGraveyardZone()->Remove(playable);
-            player->opponent->GetHandZone()->Add(playable);
+            if (entityID > 0)
+            {
+                Playable* playable = player->game->entityList[entityID];
+                player->opponent->GetGraveyardZone()->Remove(playable);
+                player->opponent->GetHandZone()->Add(playable);
+            }
         }));
     cards.emplace("CS3_003", CardDef(power));
 

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -94,7 +94,7 @@ void TheBarrensCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     power.AddPowerTask(
         std::make_shared<AddEnchantmentTask>("BAR_536e", EntityType::STACK));
     power.AddTrigger(
-        std::make_shared<Trigger>(Triggers::UpgradableTrigger(5, "BAR_536t")));
+        std::make_shared<Trigger>(Triggers::RankSpellTrigger(5, "BAR_536t")));
     cards.emplace("BAR_536", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
@@ -339,8 +339,8 @@ void TheBarrensCardsGen::AddDruidNonCollect(
     power.AddPowerTask(std::make_shared<DrawStackTask>(true));
     power.AddPowerTask(
         std::make_shared<AddEnchantmentTask>("BAR_536te", EntityType::STACK));
-    power.AddTrigger(std::make_shared<Trigger>(
-        Triggers::UpgradableTrigger(10, "BAR_536t2")));
+    power.AddTrigger(
+        std::make_shared<Trigger>(Triggers::RankSpellTrigger(10, "BAR_536t2")));
     cards.emplace("BAR_536t", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID

--- a/Sources/Rosetta/PlayMode/Models/Player.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Player.cpp
@@ -180,7 +180,11 @@ void Player::SetTotalMana(int amount)
     SetGameTag(GameTag::RESOURCES, amount);
 
     // Process mana crystal trigger
+    game->taskQueue.StartEvent();
     game->triggerManager.OnManaCrystalTrigger(this);
+    game->ProcessTasks();
+    game->taskQueue.EndEvent();
+    game->ProcessDestroyAndUpdateAura();
 }
 
 int Player::GetUsedMana() const

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.cpp
@@ -38,14 +38,15 @@ TaskStatus DrawMinionTask::Impl(Player* player)
     }
 
     auto deckCards = player->GetDeckZone()->GetAll();
-    if (deckCards.empty())
-    {
-        return TaskStatus::STOP;
-    }
 
     EraseIf(deckCards, [=](Playable* playable) {
         return playable->card->GetCardType() != CardType::MINION;
     });
+
+    if (deckCards.empty())
+    {
+        return TaskStatus::STOP;
+    }
 
     switch (m_drawMinionType)
     {


### PR DESCRIPTION
This revision includes:
- Fix intermittent unit test failure (Resolves #609)
  - Living Seed (Rank 1) (BAR_536)
    - Add code to process task queue and a list of tasks
    - Correct the logic of method 'UpgradableTrigger()'
    - Change method name to 'RankSpellTrigger()'
  - Puzzle Box of Yogg-Saron (ULD_216)
    - Move the position of code to erase non-minion cards
    - Add code to consider the entity ID is empty
  - Bazaar Burglary (ULD_326)
    - Add code to consider the empty card
      - The corrupted card is empty