### PR TITLE
Fix intermittent unit test failure of card 'Puzzle Box of Yogg-Saron (ULD_216)'

### DIFF
--- a/Includes/Rosetta/PlayMode/Actions/CastSpell.hpp
+++ b/Includes/Rosetta/PlayMode/Actions/CastSpell.hpp
@@ -11,12 +11,20 @@
 
 namespace RosettaStone::PlayMode::Generic
 {
-//! Casts spell without/to target.
+//! Casts target or non-target spell.
 //! \param player The player to cast spell.
 //! \param spell The spell to cast.
 //! \param target The target of spell.
 //! \param chooseOne The index of chosen card from two cards.
 void CastSpell(Player* player, Spell* spell, Character* target, int chooseOne);
+
+//! Casts random spell with random target such as 'Puzzle Box of Yogg-Saron'.
+//! \param player The player to cast spell.
+//! \param spell The spell to cast.
+//! \param target The target of spell.
+//! \param chooseOne The index of chosen card from two cards.
+void CastRandomSpell(Player* player, Spell* spell, Character* target,
+                     int chooseOne);
 }  // namespace RosettaStone::PlayMode::Generic
 
 #endif  // ROSETTASTONE_PLAYMODE_CAST_SPELL_HPP

--- a/Sources/Rosetta/PlayMode/Actions/CastSpell.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/CastSpell.cpp
@@ -97,4 +97,47 @@ void CastSpell(Player* player, Spell* spell, Character* target, int chooseOne)
 
     player->game->taskQueue.EndEvent();
 }
+
+void CastRandomSpell(Player* player, Spell* spell, Character* target,
+                     int chooseOne)
+{
+    player->game->taskQueue.StartEvent();
+
+    if (spell->IsSecret() || spell->IsQuest() || spell->IsSidequest())
+    {
+        // Process trigger
+        if (spell->card->power.GetTrigger())
+        {
+            spell->card->power.GetTrigger()->Activate(spell);
+        }
+
+        player->GetSecretZone()->Add(spell);
+        spell->SetExhausted(true);
+    }
+    else
+    {
+        // Process power task
+        spell->ActivateTask(PowerType::POWER, target, chooseOne);
+
+        if (spell->IsTwinspell())
+        {
+            const auto twinspell = Entity::GetFromCard(
+                player, Cards::FindCardByID(spell->card->id + "ts"));
+            AddCardToHand(player, twinspell);
+        }
+
+        // Check card has overload
+        if (spell->HasOverload())
+        {
+            const int amount = spell->GetOverload();
+            player->SetOverloadOwed(player->GetOverloadOwed() + amount);
+        }
+
+        player->game->ProcessTasks();
+
+        player->GetGraveyardZone()->Add(spell);
+    }
+
+    player->game->taskQueue.EndEvent();
+}
 }  // namespace RosettaStone::PlayMode::Generic

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/CastRandomSpellTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/CastRandomSpellTask.cpp
@@ -63,7 +63,7 @@ TaskStatus CastRandomSpellTask::Impl(Player* player)
     player->choice = nullptr;
 
     player->game->taskQueue.StartEvent();
-    Generic::CastSpell(player, spellToCast, randTarget, randChooseOne);
+    Generic::CastRandomSpell(player, spellToCast, randTarget, randChooseOne);
     player->game->ProcessDestroyAndUpdateAura();
     player->game->taskQueue.EndEvent();
 


### PR DESCRIPTION
This revision includes:
- Fix intermittent unit test failure (Resolves #613)
  - Puzzle Box of Yogg-Saron (ULD_216)
    - Add function 'CastRandomSpell()': Casts random spell with random target such as 'Puzzle Box of Yogg-Saron'
    - Change code to call function 'CastRandomSpell()'