### PR TITLE
Implement 6 THE_BARRENS cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -724,9 +724,9 @@ THE_BARRENS | BAR_027 | Darkspear Berserker |
 THE_BARRENS | BAR_030 | Pack Kodo |  
 THE_BARRENS | BAR_031 | Sunscale Raptor |  
 THE_BARRENS | BAR_032 | Piercing Shot |  
-THE_BARRENS | BAR_033 | Prospector's Caravan |  
-THE_BARRENS | BAR_034 | Tame Beast (Rank 1) |  
-THE_BARRENS | BAR_035 | Kolkar Pack Runner |  
+THE_BARRENS | BAR_033 | Prospector's Caravan | O
+THE_BARRENS | BAR_034 | Tame Beast (Rank 1) | O
+THE_BARRENS | BAR_035 | Kolkar Pack Runner | O
 THE_BARRENS | BAR_037 | Warsong Wrangler |  
 THE_BARRENS | BAR_038 | Tavish Stormpike |  
 THE_BARRENS | BAR_040 | South Coast Chieftain |  
@@ -813,7 +813,7 @@ THE_BARRENS | BAR_745 | Hecklefang Hyena |
 THE_BARRENS | BAR_748 | Varden Dawngrasp |  
 THE_BARRENS | BAR_750 | Earth Revenant |  
 THE_BARRENS | BAR_751 | Spawnpool Forager |  
-THE_BARRENS | BAR_801 | Wound Prey |  
+THE_BARRENS | BAR_801 | Wound Prey | O
 THE_BARRENS | BAR_812 | Oasis Ally |  
 THE_BARRENS | BAR_840 | Whirling Combatant |  
 THE_BARRENS | BAR_841 | Bulk Up |  
@@ -854,7 +854,7 @@ THE_BARRENS | WC_004 | Fangbound Druid | O
 THE_BARRENS | WC_005 | Primal Dungeoneer |  
 THE_BARRENS | WC_006 | Lady Anacondra | O
 THE_BARRENS | WC_007 | Serpentbloom |  
-THE_BARRENS | WC_008 | Sin'dorei Scentfinder |  
+THE_BARRENS | WC_008 | Sin'dorei Scentfinder | O
 THE_BARRENS | WC_013 | Devout Dungeoneer |  
 THE_BARRENS | WC_014 | Against All Odds |  
 THE_BARRENS | WC_015 | Water Moccasin |  
@@ -876,7 +876,7 @@ THE_BARRENS | WC_033 | Judgment of Justice |
 THE_BARRENS | WC_034 | Party Up! |  
 THE_BARRENS | WC_035 | Archdruid Naralex |  
 THE_BARRENS | WC_036 | Deviate Dreadfang | O
-THE_BARRENS | WC_037 | Venomstrike Bow |  
+THE_BARRENS | WC_037 | Venomstrike Bow | O
 THE_BARRENS | WC_040 | Taintheart Tormenter |  
 THE_BARRENS | WC_041 | Shattering Blast |  
 THE_BARRENS | WC_042 | Wailing Vapor |  
@@ -885,7 +885,7 @@ THE_BARRENS | WC_803 | Cleric of An'she |
 THE_BARRENS | WC_805 | Frostweave Dungeoneer |  
 THE_BARRENS | WC_806 | Floecaster |  
 
-- Progress: 7% (13 of 170 Cards)
+- Progress: 11% (19 of 170 Cards)
 
 ## United in Stormwind
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 60% Ashes of Outland (81 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
-  * 7% Forged in the Barrens (13 of 170 cards)
+  * 11% Forged in the Barrens (19 of 170 cards)
   * 0% United in Stormwind (0 of 135 card)
 
 ### Wild Format

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -614,6 +614,9 @@ void TheBarrensCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - POISONOUS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("WC_037", CardDef(power));
 }
 
 void TheBarrensCardsGen::AddHunterNonCollect(

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -539,6 +539,12 @@ void TheBarrensCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::CAST_SPELL));
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    power.GetTrigger()->tasks = { std::make_shared<SummonTask>(
+        "BAR_035t", SummonSide::RIGHT) };
+    cards.emplace("BAR_035", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
     // [BAR_037] Warsong Wrangler - COST:4 [ATK:3/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -510,6 +510,12 @@ void TheBarrensCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("BAR_034t3", SummonSide::SPELL));
+    power.AddTrigger(
+        std::make_shared<Trigger>(Triggers::RankSpellTrigger(5, "BAR_034t")));
+    cards.emplace("BAR_034", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
     // [BAR_035] Kolkar Pack Runner - COST:2 [ATK:2/HP:3]
@@ -645,6 +651,12 @@ void TheBarrensCardsGen::AddHunterNonCollect(
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("BAR_034t4", SummonSide::SPELL));
+    power.AddTrigger(
+        std::make_shared<Trigger>(Triggers::RankSpellTrigger(10, "BAR_034t2")));
+    cards.emplace("BAR_034t", CardDef(power));
 
     // ----------------------------------------- SPELL - HUNTER
     // [BAR_034t2] Tame Beast (Rank 3) - COST:2
@@ -655,6 +667,10 @@ void TheBarrensCardsGen::AddHunterNonCollect(
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("BAR_034t5", SummonSide::SPELL));
+    cards.emplace("BAR_034t2", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
     // [BAR_034t3] Tamed Crab - COST:2 [ATK:2/HP:2]
@@ -665,6 +681,9 @@ void TheBarrensCardsGen::AddHunterNonCollect(
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("BAR_034t3", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
     // [BAR_034t4] Tamed Scorpid - COST:4 [ATK:4/HP:4]
@@ -675,6 +694,9 @@ void TheBarrensCardsGen::AddHunterNonCollect(
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("BAR_034t4", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
     // [BAR_034t5] Tamed Thunder Lizard - COST:6 [ATK:6/HP:6]
@@ -685,6 +707,9 @@ void TheBarrensCardsGen::AddHunterNonCollect(
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("BAR_034t5", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
     // [BAR_035t] Swift Hyena - COST:1 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -499,6 +499,15 @@ void TheBarrensCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
+    power.GetTrigger()->tasks = {
+        std::make_shared<IncludeTask>(EntityType::HAND),
+        std::make_shared<FilterStackTask>(SelfCondList{
+            std::make_shared<SelfCondition>(SelfCondition::IsMinion()) }),
+        std::make_shared<AddEnchantmentTask>("BAR_033e", EntityType::STACK)
+    };
+    cards.emplace("BAR_033", CardDef(power));
 
     // ----------------------------------------- SPELL - HUNTER
     // [BAR_034] Tame Beast (Rank 1) - COST:2
@@ -640,6 +649,9 @@ void TheBarrensCardsGen::AddHunterNonCollect(
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("BAR_033e"));
+    cards.emplace("BAR_033e", CardDef(power));
 
     // ----------------------------------------- SPELL - HUNTER
     // [BAR_034t] Tame Beast (Rank 2) - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -193,12 +193,12 @@ void TheBarrensCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // Text: Give a minion +2/+2.
     //       If it has <b>Taunt</b>, add a copy of it to your hand.
     // --------------------------------------------------------
-    // RefTag:
-    // - TAUNT = 1
-    // --------------------------------------------------------
     // PlayReq:
     // - REQ_TARGET_TO_PLAY = 0
     // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(
@@ -450,6 +450,8 @@ void TheBarrensCardsGen::AddDruidNonCollect(
 
 void TheBarrensCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- MINION - HUNTER
     // [BAR_030] Pack Kodo - COST:3 [ATK:3/HP:3]
     // - Race: Beast, Set: THE_BARRENS, Rarity: Common
@@ -564,9 +566,21 @@ void TheBarrensCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 1 damage. Summon a 1/1 Hyena with <b>Rush</b>.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 1, true));
+    power.AddPowerTask(std::make_shared<SummonTask>("BAR_035t", 1));
+    cards.emplace(
+        "BAR_801",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ----------------------------------------- SPELL - HUNTER
     // [WC_007] Serpentbloom - COST:0
@@ -605,6 +619,8 @@ void TheBarrensCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 void TheBarrensCardsGen::AddHunterNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [BAR_033e] Prospector's Findings - COST:0
     // - Set: THE_BARRENS
@@ -672,6 +688,9 @@ void TheBarrensCardsGen::AddHunterNonCollect(
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("BAR_035t", CardDef(power));
 
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [BAR_037e] Centaur Call - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -604,6 +604,10 @@ void TheBarrensCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddFrenzyTask(
+        std::make_shared<SummonTask>("BAR_035t", 4, SummonSide::SPELL));
+    cards.emplace("WC_008", CardDef(power));
 
     // ---------------------------------------- WEAPON - HUNTER
     // [WC_037] Venomstrike Bow - COST:4

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.cpp
@@ -61,7 +61,6 @@ TaskStatus DrawMinionTask::Impl(Player* player)
                       });
             break;
         case DrawMinionType::HIGHEST_COST:
-
             std::sort(deckCards.begin(), deckCards.end(),
                       [](const Playable* card1, const Playable* card2) {
                           return card1->GetCost() > card2->GetCost();

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -944,6 +944,60 @@ TEST_CASE("[Hunter : Spell] - BAR_034 : Tame Beast (Rank 1)")
     CHECK_EQ(curField[2]->HasRush(), true);
 }
 
+// ---------------------------------------- MINION - HUNTER
+// [BAR_035] Kolkar Pack Runner - COST:2 [ATK:2/HP:3]
+// - Set: THE_BARRENS, Rarity: Epic
+// --------------------------------------------------------
+// Text: After you cast a spell,
+//       summon a 1/1 Hyena with <b>Rush</b>.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - BAR_035 : Kolkar Pack Runner")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Kolkar Pack Runner"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Holy Light"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[1]->card->name, "Swift Hyena");
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->HasRush(), true);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [BAR_801] Wound Prey - COST:1
 // - Set: THE_BARRENS, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -847,6 +847,57 @@ TEST_CASE("[Hunter : Spell] - BAR_801 : Wound Prey")
     CHECK_EQ(curField[1]->HasRush(), true);
 }
 
+// ---------------------------------------- MINION - HUNTER
+// [WC_008] Sin'dorei Scentfinder - COST:4 [ATK:1/HP:6]
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Frenzy:</b> Summon four 1/1 Hyenas with <b>Rush</b>.
+// --------------------------------------------------------
+// GameTag:
+// - FRENZY = 1
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - WC_008 : Sin'dorei Scentfinder")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Sin'dorei Scentfinder"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField.GetCount(), 5);
+    CHECK_EQ(curField[1]->card->name, "Swift Hyena");
+    CHECK_EQ(curField[2]->card->name, "Swift Hyena");
+    CHECK_EQ(curField[3]->card->name, "Swift Hyena");
+    CHECK_EQ(curField[4]->card->name, "Swift Hyena");
+}
+
 // ---------------------------------------- WEAPON - HUNTER
 // [WC_037] Venomstrike Bow - COST:4
 // - Set: THE_BARRENS, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -794,3 +794,55 @@ TEST_CASE("[Druid : Minion] - WC_036 : Deviate Dreadfang")
     CHECK_EQ(curField[1]->GetHealth(), 2);
     CHECK_EQ(curField[1]->HasRush(), true);
 }
+
+// ----------------------------------------- SPELL - HUNTER
+// [BAR_801] Wound Prey - COST:1
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: Deal 1 damage. Summon a 1/1 Hyena with <b>Rush</b>.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Spell] - BAR_801 : Wound Prey")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wound Prey"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+    CHECK_EQ(curField[1]->card->name, "Swift Hyena");
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->HasRush(), true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -795,6 +795,64 @@ TEST_CASE("[Druid : Minion] - WC_036 : Deviate Dreadfang")
     CHECK_EQ(curField[1]->HasRush(), true);
 }
 
+// ---------------------------------------- MINION - HUNTER
+// [BAR_033] Prospector's Caravan - COST:2 [ATK:1/HP:3]
+// - Set: THE_BARRENS, Rarity: Rare
+// --------------------------------------------------------
+// Text: At the start of your turn,
+//       give all minions in your hand +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - BAR_033 : Prospector's Caravan")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Prospector's Caravan"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Prospector's Caravan"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(dynamic_cast<Minion*>(card3)->GetAttack(), 1);
+    CHECK_EQ(dynamic_cast<Minion*>(card3)->GetHealth(), 1);
+    CHECK_EQ(dynamic_cast<Minion*>(card4)->GetAttack(), 4);
+    CHECK_EQ(dynamic_cast<Minion*>(card4)->GetHealth(), 12);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(dynamic_cast<Minion*>(card3)->GetAttack(), 3);
+    CHECK_EQ(dynamic_cast<Minion*>(card3)->GetHealth(), 3);
+    CHECK_EQ(dynamic_cast<Minion*>(card4)->GetAttack(), 6);
+    CHECK_EQ(dynamic_cast<Minion*>(card4)->GetHealth(), 14);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [BAR_034] Tame Beast (Rank 1) - COST:2
 // - Set: THE_BARRENS, Rarity: Rare
@@ -808,7 +866,7 @@ TEST_CASE("[Druid : Minion] - WC_036 : Deviate Dreadfang")
 TEST_CASE("[Hunter : Spell] - BAR_034 : Tame Beast (Rank 1)")
 {
     GameConfig config;
-    config.player1Class = CardClass::DRUID;
+    config.player1Class = CardClass::HUNTER;
     config.player2Class = CardClass::MAGE;
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = false;

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -796,6 +796,97 @@ TEST_CASE("[Druid : Minion] - WC_036 : Deviate Dreadfang")
 }
 
 // ----------------------------------------- SPELL - HUNTER
+// [BAR_034] Tame Beast (Rank 1) - COST:2
+// - Set: THE_BARRENS, Rarity: Rare
+// --------------------------------------------------------
+// Text: Summon a 2/2 Beast with <b>Rush</b>.
+//       <i>(Upgrades when you have 5 Mana.)</i>
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Spell] - BAR_034 : Tame Beast (Rank 1)")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(4);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(4);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Tame Beast (Rank 1)"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Tame Beast (Rank 1)"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Tame Beast (Rank 1)"));
+
+    CHECK_EQ(curField.GetCount(), 0);
+    CHECK_EQ(card1->card->name, "Tame Beast (Rank 1)");
+    CHECK_EQ(card2->card->name, "Tame Beast (Rank 1)");
+    CHECK_EQ(card3->card->name, "Tame Beast (Rank 1)");
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Tamed Crab");
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->HasRush(), true);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card2->card->name, "Tame Beast (Rank 1)");
+    CHECK_EQ(card3->card->name, "Tame Beast (Rank 1)");
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card2->card->name, "Tame Beast (Rank 2)");
+    CHECK_EQ(card3->card->name, "Tame Beast (Rank 2)");
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[1]->card->name, "Tamed Scorpid");
+    CHECK_EQ(curField[1]->GetAttack(), 4);
+    CHECK_EQ(curField[1]->GetHealth(), 4);
+    CHECK_EQ(curField[1]->HasRush(), true);
+
+    curPlayer->SetTotalMana(9);
+    opPlayer->SetTotalMana(9);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card3->card->name, "Tame Beast (Rank 2)");
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card3->card->name, "Tame Beast (Rank 3)");
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[2]->card->name, "Tamed Thunder Lizard");
+    CHECK_EQ(curField[2]->GetAttack(), 6);
+    CHECK_EQ(curField[2]->GetHealth(), 6);
+    CHECK_EQ(curField[2]->HasRush(), true);
+}
+
+// ----------------------------------------- SPELL - HUNTER
 // [BAR_801] Wound Prey - COST:1
 // - Set: THE_BARRENS, Rarity: Common
 // --------------------------------------------------------


### PR DESCRIPTION
This revision includes:
- Implement 6 THE_BARRENS cards
  - Prospector's Caravan (BAR_033)
  - Tame Beast (Rank 1) (BAR_034)
  - Kolkar Pack Runner (BAR_035)
  - Wound Prey (BAR_801)
  - Sin'dorei Scentfinder (WC_008)
  - Venomstrike Bow (WC_037)