### PR TITLE
Implement 5 THE_BARRENS cards and fix incorrect the logic of some cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -756,7 +756,7 @@ THE_BARRENS | BAR_079 | Kazakus, Golem Shaper |
 THE_BARRENS | BAR_080 | Shadow Hunter Vol'jin |  
 THE_BARRENS | BAR_081 | Southsea Scoundrel |  
 THE_BARRENS | BAR_082 | Barrens Trapper |  
-THE_BARRENS | BAR_305 | Flurry (Rank 1) |  
+THE_BARRENS | BAR_305 | Flurry (Rank 1) | O
 THE_BARRENS | BAR_306 | Sigil of Flame |  
 THE_BARRENS | BAR_307 | Void Flayer |  
 THE_BARRENS | BAR_308 | Power Word: Fortitude |  
@@ -793,7 +793,7 @@ THE_BARRENS | BAR_537 | Razormane Battleguard | O
 THE_BARRENS | BAR_538 | Druid of the Plains | O
 THE_BARRENS | BAR_539 | Celestial Alignment | O
 THE_BARRENS | BAR_540 | Plaguemaw the Rotting | O
-THE_BARRENS | BAR_541 | Runed Orb |  
+THE_BARRENS | BAR_541 | Runed Orb | O
 THE_BARRENS | BAR_542 | Refreshing Spring Water |  
 THE_BARRENS | BAR_544 | Reckless Apprentice |  
 THE_BARRENS | BAR_545 | Arcane Luminary |  
@@ -814,7 +814,7 @@ THE_BARRENS | BAR_748 | Varden Dawngrasp |
 THE_BARRENS | BAR_750 | Earth Revenant |  
 THE_BARRENS | BAR_751 | Spawnpool Forager |  
 THE_BARRENS | BAR_801 | Wound Prey | O
-THE_BARRENS | BAR_812 | Oasis Ally |  
+THE_BARRENS | BAR_812 | Oasis Ally | O
 THE_BARRENS | BAR_840 | Whirling Combatant |  
 THE_BARRENS | BAR_841 | Bulk Up |  
 THE_BARRENS | BAR_842 | Conditioning (Rank 1) |  
@@ -834,7 +834,7 @@ THE_BARRENS | BAR_878 | Veteran Warmedic |
 THE_BARRENS | BAR_879 | Cannonmaster Smythe |  
 THE_BARRENS | BAR_880 | Conviction (Rank 1) |  
 THE_BARRENS | BAR_881 | Invigorating Sermon |  
-THE_BARRENS | BAR_888 | Rimetongue |  
+THE_BARRENS | BAR_888 | Rimetongue | O
 THE_BARRENS | BAR_890 | Crossroads Gossiper |  
 THE_BARRENS | BAR_891 | Fury (Rank 1) |  
 THE_BARRENS | BAR_896 | Stonemaul Anchorman |  
@@ -878,14 +878,14 @@ THE_BARRENS | WC_035 | Archdruid Naralex |
 THE_BARRENS | WC_036 | Deviate Dreadfang | O
 THE_BARRENS | WC_037 | Venomstrike Bow | O
 THE_BARRENS | WC_040 | Taintheart Tormenter |  
-THE_BARRENS | WC_041 | Shattering Blast |  
+THE_BARRENS | WC_041 | Shattering Blast | O
 THE_BARRENS | WC_042 | Wailing Vapor |  
 THE_BARRENS | WC_701 | Felrattler |  
 THE_BARRENS | WC_803 | Cleric of An'she |  
 THE_BARRENS | WC_805 | Frostweave Dungeoneer |  
 THE_BARRENS | WC_806 | Floecaster |  
 
-- Progress: 11% (19 of 170 Cards)
+- Progress: 14% (24 of 170 Cards)
 
 ## United in Stormwind
 

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -211,6 +211,10 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsNatureSpell();
 
+    //! SelfCondition wrapper for checking the entity is frost spell.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsFrostSpell();
+
     //! SelfCondition wrapper for checking the entity is weapon.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsWeapon();

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -383,6 +383,12 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsEventTargetIs(CardType cardType);
 
+    //! SelfCondition wrapper for checking the field of event target
+    //! is not full.
+    //! \param cardType The type of the card to check.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsEventTargetFieldNotFull();
+
     //! SelfCondition wrapper for checking it is a minion
     //! that is targeted by spell.
     //! \return Generated SelfCondition for intended purpose.

--- a/Includes/Rosetta/PlayMode/Triggers/Trigger.hpp
+++ b/Includes/Rosetta/PlayMode/Triggers/Trigger.hpp
@@ -65,7 +65,7 @@ class Trigger
     TriggerSource triggerSource = TriggerSource::NONE;
 
     std::vector<std::shared_ptr<ITask>> tasks;
-    std::shared_ptr<SelfCondition> condition;
+    std::vector<std::shared_ptr<SelfCondition>> conditions;
 
     TriggerEventHandler handler;
 

--- a/Includes/Rosetta/PlayMode/Triggers/Triggers.hpp
+++ b/Includes/Rosetta/PlayMode/Triggers/Triggers.hpp
@@ -12,6 +12,8 @@
 
 namespace RosettaStone::PlayMode
 {
+using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
+
 //!
 //! \brief Triggers class.
 //!
@@ -26,8 +28,8 @@ class Triggers
     {
         Trigger trigger(TriggerType::PREDAMAGE);
         trigger.triggerSource = TriggerSource::SELF;
-        trigger.condition =
-            std::make_shared<SelfCondition>(SelfCondition::IsUndamaged());
+        trigger.conditions = SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsUndamaged()) };
         trigger.tasks = { std::make_shared<SimpleTasks::AddEnchantmentTask>(
             std::move(enchantmentID), EntityType::SOURCE) };
 
@@ -41,8 +43,8 @@ class Triggers
     {
         Trigger trigger(TriggerType::MANA_CRYSTAL);
         trigger.triggerActivation = TriggerActivation::HAND;
-        trigger.condition = std::make_shared<SelfCondition>(
-            SelfCondition::HasAtLeastManaCrystal(mana));
+        trigger.conditions = SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::HasAtLeastManaCrystal(mana)) };
         trigger.tasks = { std::make_shared<SimpleTasks::ChangeEntityTask>(
             std::move(upgradedCardID)) };
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 60% Ashes of Outland (81 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
-  * 11% Forged in the Barrens (19 of 170 cards)
+  * 14% Forged in the Barrens (24 of 170 cards)
   * 0% United in Stormwind (0 of 135 card)
 
 ### Wild Format

--- a/Sources/Rosetta/PlayMode/CardSets/BasicCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BasicCardsGen.cpp
@@ -700,8 +700,9 @@ void BasicCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::SUMMON));
     power.GetTrigger()->triggerSource = TriggerSource::MINIONS_EXCEPT_SELF;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::BEAST));
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::BEAST))
+    };
     power.GetTrigger()->tasks = { std::make_shared<DrawTask>(1) };
     cards.emplace("CS2_237", CardDef(power));
 

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -542,8 +542,9 @@ void BlackTempleCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_CAST));
     power.GetTrigger()->triggerSource = TriggerSource::ENEMY_SPELLS;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsOpFieldNotFull());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsOpFieldNotFull())
+    };
     power.GetTrigger()->tasks = ComplexTask::ActivateSecret(
         TaskList{ std::make_shared<RandomMinionTask>(
                       TagValues{ { GameTag::COST, 4, RelaSign::EQ } }),
@@ -1189,8 +1190,9 @@ void BlackTempleCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::ATTACK));
     power.GetTrigger()->triggerSource = TriggerSource::ENEMY;
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsProposedDefender(CardType::MINION));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsProposedDefender(CardType::MINION)) };
     power.GetTrigger()->tasks = ComplexTask::ActivateSecret(TaskList{
         std::make_shared<TransformMinionTask>(EntityType::EVENT_TARGET, 3) });
     cards.emplace("BT_042", CardDef(power));
@@ -2205,8 +2207,9 @@ void BlackTempleCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
     power.GetTrigger()->triggerSource = TriggerSource::HERO;
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsEventTargetIs(CardType::MINION));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsEventTargetIs(CardType::MINION)) };
     power.GetTrigger()->tasks = { std::make_shared<SetGameTagTask>(
         EntityType::HERO, GameTag::EXHAUSTED, 0) };
     cards.emplace("BT_430", CardDef(power));

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -419,8 +419,9 @@ void CoreCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::DEATH));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::BEAST));
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::BEAST))
+    };
     power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
         "EX1_531e", EntityType::SOURCE) };
     cards.emplace("CORE_EX1_531", CardDef(power));
@@ -466,8 +467,9 @@ void CoreCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::ATTACK));
     power.GetTrigger()->triggerSource = TriggerSource::ENEMY;
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsProposedDefender(CardType::MINION));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsProposedDefender(CardType::MINION)) };
     power.GetTrigger()->tasks = ComplexTask::ActivateSecret(
         TaskList{ std::make_shared<SummonTask>("EX1_554t", 3) });
     cards.emplace("CORE_EX1_554", CardDef(power));
@@ -486,8 +488,9 @@ void CoreCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::ATTACK));
     power.GetTrigger()->triggerSource = TriggerSource::ENEMY;
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsProposedDefender(CardType::HERO));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsProposedDefender(CardType::HERO)) };
     power.GetTrigger()->tasks = ComplexTask::ActivateSecret(
         TaskList{ std::make_shared<DamageTask>(EntityType::ENEMIES, 2, true) });
     cards.emplace("CORE_EX1_610", CardDef(power));
@@ -801,8 +804,9 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::ATTACK));
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsProposedDefender(CardType::HERO));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsProposedDefender(CardType::HERO)) };
     power.GetTrigger()->tasks =
         ComplexTask::ActivateSecret(TaskList{ std::make_shared<ArmorTask>(8) });
     cards.emplace("CORE_EX1_289", CardDef(power));
@@ -1157,8 +1161,9 @@ void CoreCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::DEATH));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsFieldCount(2, RelaSign::GEQ));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsFieldCount(2, RelaSign::GEQ)) };
     power.GetTrigger()->tasks = { ComplexTask::ActivateSecret(
         TaskList{ std::make_shared<RandomTask>(EntityType::MINIONS, 1),
                   std::make_shared<AddEnchantmentTask>("FP1_020e",
@@ -2009,8 +2014,9 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::PLAY_CARD));
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsOverloadCard());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsOverloadCard())
+    };
     power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
         "EX1_258e", EntityType::SOURCE) };
     cards.emplace("CORE_EX1_258", CardDef(power));
@@ -2606,8 +2612,9 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TARGET));
     power.GetTrigger()->triggerSource = TriggerSource::HERO;
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsProposedDefender(CardType::MINION));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsProposedDefender(CardType::MINION)) };
     power.GetTrigger()->fastExecution = true;
     power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
         "EX1_411e", EntityType::SOURCE) };
@@ -2902,8 +2909,9 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
     power.GetTrigger()->triggerSource = TriggerSource::HERO;
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsEventTargetIs(CardType::MINION));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsEventTargetIs(CardType::MINION)) };
     power.GetTrigger()->tasks = { std::make_shared<SetGameTagTask>(
         EntityType::HERO, GameTag::EXHAUSTED, 0) };
     cards.emplace("CORE_BT_430", CardDef(power));
@@ -3017,8 +3025,9 @@ void CoreCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_PLAY_CARD));
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsOutcastCard());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsOutcastCard())
+    };
     power.GetTrigger()->tasks = { std::make_shared<ReturnHandTask>(
         EntityType::SOURCE) };
     cards.emplace("CS3_019", CardDef(power));
@@ -3799,8 +3808,9 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::SUMMON));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::MURLOC));
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::MURLOC))
+    };
     power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
         "EX1_509e", EntityType::SOURCE) };
     cards.emplace("CORE_EX1_509", CardDef(power));

--- a/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
@@ -199,8 +199,9 @@ void DalaranCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_CAST));
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsChooseOneCard());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsChooseOneCard())
+    };
     power.GetTrigger()->tasks = { std::make_shared<CustomTask>(
         [](Player* player, [[maybe_unused]] Entity* source,
            [[maybe_unused]] Playable* target) {
@@ -364,8 +365,9 @@ void DalaranCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TAKE_HEAL));
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsEventSourceFriendly());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsEventSourceFriendly())
+    };
     power.GetTrigger()->tasks = {
         std::make_shared<GetEventNumberTask>(),
         std::make_shared<GetGameTagTask>(EntityType::SOURCE,
@@ -434,8 +436,9 @@ void DalaranCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::PLAY_MINION));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsCost(1));
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsCost(1))
+    };
     power.GetTrigger()->tasks = {
         std::make_shared<IncludeTask>(EntityType::DECK),
         std::make_shared<FilterStackTask>(SelfCondList{
@@ -775,11 +778,12 @@ void DalaranCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_SUMMON));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY_EVENT_SOURCE;
-    power.GetTrigger()->condition =
+    power.GetTrigger()->conditions = SelfCondList{
         std::make_shared<SelfCondition>([=](Playable* playable) -> bool {
             return playable->game->currentEventData->eventSource != playable &&
                    playable->GetGameTag(GameTag::COPIED_BY_KHADGAR) != 1;
-        });
+        })
+    };
     power.GetTrigger()->tasks = { std::make_shared<CustomTask>(
         []([[maybe_unused]] Player* player, [[maybe_unused]] Entity* source,
            Playable* target) {
@@ -1970,8 +1974,9 @@ void DalaranCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_PLAY_MINION));
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::MURLOC));
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::MURLOC))
+    };
     power.GetTrigger()->tasks = {
         std::make_shared<RandomCardTask>(CardType::MINION, CardClass::INVALID,
                                          Race::MURLOC),
@@ -2287,8 +2292,9 @@ void DalaranCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::DEATH));
     power.GetTrigger()->triggerActivation = TriggerActivation::HAND;
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::DEMON));
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::DEMON))
+    };
     power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
         "DAL_561e", EntityType::SOURCE) };
     cards.emplace("DAL_561", CardDef(power));
@@ -2387,8 +2393,9 @@ void DalaranCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::DRAW_CARD));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsMinion());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsMinion())
+    };
     power.GetTrigger()->tasks = {
         std::make_shared<CopyTask>(EntityType::TARGET, ZoneType::PLAY, 1, true),
         std::make_shared<AddEnchantmentTask>("DAL_607e", EntityType::STACK)
@@ -2641,8 +2648,9 @@ void DalaranCardsGen::AddWarriorNonCollect(
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
     power.GetTrigger()->triggerSource = TriggerSource::ENCHANTMENT_TARGET;
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsEventTargetIs(CardType::MINION));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsEventTargetIs(CardType::MINION)) };
     power.GetTrigger()->tasks = {
         std::make_shared<IncludeAdjacentTask>(EntityType::EVENT_TARGET),
         std::make_shared<GetGameTagTask>(EntityType::TARGET, GameTag::ATK),
@@ -3027,8 +3035,9 @@ void DalaranCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TAKE_DAMAGE));
     power.GetTrigger()->triggerSource = TriggerSource::SELF;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsNotDead());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsNotDead())
+    };
     power.GetTrigger()->tasks = { std::make_shared<CopyTask>(EntityType::SOURCE,
                                                              ZoneType::PLAY) };
     cards.emplace("DAL_550", CardDef(power));
@@ -3242,8 +3251,9 @@ void DalaranCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
     power.GetTrigger()->triggerSource = TriggerSource::SELF;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsDefenderDead());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsDefenderDead())
+    };
     power.GetTrigger()->tasks = { std::make_shared<SetGameTagTask>(
                                       EntityType::SOURCE, GameTag::EXHAUSTED,
                                       0),
@@ -3481,8 +3491,9 @@ void DalaranCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_PLAY_MINION));
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsTagValue(GameTag::TAG_LAST_KNOWN_COST_IN_HAND, 1));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(SelfCondition::IsTagValue(
+            GameTag::TAG_LAST_KNOWN_COST_IN_HAND, 1)) };
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
     power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
         "DAL_773e", EntityType::TARGET) };

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -974,8 +974,9 @@ void DarkmoonFaireCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::SUMMON));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsHealth(1, RelaSign::EQ));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsHealth(1, RelaSign::EQ)) };
     power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
         "DMF_237e", EntityType::TARGET) };
     cards.emplace("DMF_237", CardDef(power));

--- a/Sources/Rosetta/PlayMode/CardSets/DemonHunterInitCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DemonHunterInitCardsGen.cpp
@@ -16,6 +16,7 @@ using namespace SimpleTasks;
 namespace RosettaStone::PlayMode
 {
 using PlayReqs = std::map<PlayReq, int>;
+using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
 using EffectList = std::vector<std::shared_ptr<IEffect>>;
 
 void DemonHunterInitCardsGen::AddDemonHunter(
@@ -234,8 +235,9 @@ void DemonHunterInitCardsGen::AddDemonHunter(
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
     power.GetTrigger()->triggerSource = TriggerSource::SELF;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsDefenderDead());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsDefenderDead())
+    };
     power.GetTrigger()->tasks = { std::make_shared<SetGameTagTask>(
         EntityType::SOURCE, GameTag::EXHAUSTED, 0) };
     cards.emplace("BT_487", CardDef(power));
@@ -407,8 +409,9 @@ void DemonHunterInitCardsGen::AddDemonHunter(
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_PLAY_CARD));
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsLeftOrRightMostCardInHand());
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsLeftOrRightMostCardInHand()) };
     power.GetTrigger()->tasks = { std::make_shared<DamageTask>(
         EntityType::ENEMIES, 1) };
     cards.emplace("BT_937", CardDef(power));

--- a/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
@@ -833,8 +833,9 @@ void DragonsCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::SUMMON));
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::HasRush());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::HasRush())
+    };
     power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
         TaskList{ std::make_shared<SummonTask>("DRG_251t", 1) }) };
     cards.emplace("DRG_251", CardDef(power, 3, 0));
@@ -1346,8 +1347,8 @@ void DragonsCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     auto trigger3 = std::make_shared<Trigger>(TriggerType::PLAY_MINION);
-    trigger3->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::ELEMENTAL));
+    trigger3->conditions = SelfCondList{ std::make_shared<SelfCondition>(
+        SelfCondition::IsRace(Race::ELEMENTAL)) };
     trigger3->tasks = { std::make_shared<QuestProgressTask>(
         TaskList{
             std::make_shared<IncludeTask>(EntityType::DECK),
@@ -1357,8 +1358,8 @@ void DragonsCardsGen::AddMage(std::map<std::string, CardDef>& cards)
             std::make_shared<DrawStackTask>() },
         ProgressType::PLAY_ELEMENTAL_MINONS) };
     auto trigger4 = std::make_shared<Trigger>(TriggerType::TURN_END);
-    trigger4->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsNotPlayElementalMinionThisTurn());
+    trigger4->conditions = SelfCondList{ std::make_shared<SelfCondition>(
+        SelfCondition::IsNotPlayElementalMinionThisTurn()) };
     trigger4->tasks = { std::make_shared<IncludeTask>(EntityType::SOURCE),
                         std::make_shared<FuncPlayableTask>(
                             [=](const std::vector<Playable*>& playables) {
@@ -1777,8 +1778,9 @@ void DragonsCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsMyHeroUndamagedEnemyTurn());
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsMyHeroUndamagedEnemyTurn()) };
     power.GetTrigger()->eitherTurn = true;
     power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
         TaskList{ std::make_shared<SummonTask>("DRG_258t") }) };
@@ -3227,8 +3229,9 @@ void DragonsCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_SUMMON));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::PIRATE));
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::PIRATE))
+    };
     power.GetTrigger()->tasks = {
         std::make_shared<RandomTask>(EntityType::ENEMIES, 1),
         std::make_shared<DamageTask>(EntityType::STACK, 2)
@@ -3452,8 +3455,9 @@ void DragonsCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::PLAY_MINION));
     power.GetTrigger()->triggerActivation = TriggerActivation::HAND;
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::PIRATE));
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::PIRATE))
+    };
     power.GetTrigger()->tasks = {
         std::make_shared<ConditionTask>(
             EntityType::HERO, SelfCondList{ std::make_shared<SelfCondition>(

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -1066,7 +1066,9 @@ void Expert1CardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     power.GetTrigger()->triggerSource = TriggerSource::ENEMY;
     power.GetTrigger()->conditions =
         SelfCondList{ std::make_shared<SelfCondition>(
-            SelfCondition::IsProposedDefender(CardType::MINION)) };
+                          SelfCondition::IsProposedDefender(CardType::MINION)),
+                      std::make_shared<SelfCondition>(
+                          SelfCondition::IsEventTargetFieldNotFull()) };
     power.GetTrigger()->tasks = ComplexTask::ActivateSecret(
         TaskList{ std::make_shared<SummonTask>("EX1_554t", 3) });
     cards.emplace("EX1_554", CardDef(power));

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -868,8 +868,9 @@ void Expert1CardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::DEATH));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::BEAST));
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::BEAST))
+    };
     power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
         "EX1_531e", EntityType::SOURCE) };
     cards.emplace("EX1_531", CardDef(power));
@@ -886,8 +887,9 @@ void Expert1CardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::ATTACK));
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsProposedDefender(CardType::HERO));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsProposedDefender(CardType::HERO)) };
     power.GetTrigger()->tasks = {
         std::make_shared<IncludeTask>(
             EntityType::ALL,
@@ -1062,8 +1064,9 @@ void Expert1CardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::ATTACK));
     power.GetTrigger()->triggerSource = TriggerSource::ENEMY;
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsProposedDefender(CardType::MINION));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsProposedDefender(CardType::MINION)) };
     power.GetTrigger()->tasks = ComplexTask::ActivateSecret(
         TaskList{ std::make_shared<SummonTask>("EX1_554t", 3) });
     cards.emplace("EX1_554", CardDef(power));
@@ -1106,8 +1109,9 @@ void Expert1CardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::ATTACK));
     power.GetTrigger()->triggerSource = TriggerSource::ENEMY;
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsProposedDefender(CardType::HERO));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsProposedDefender(CardType::HERO)) };
     power.GetTrigger()->tasks = ComplexTask::ActivateSecret(
         TaskList{ std::make_shared<DamageTask>(EntityType::ENEMIES, 2, true) });
     cards.emplace("EX1_610", CardDef(power));
@@ -1312,8 +1316,9 @@ void Expert1CardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsControllingSecret());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsControllingSecret())
+    };
     power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
         "EX1_274e", EntityType::SOURCE) };
     cards.emplace("EX1_274", CardDef(power));
@@ -1398,8 +1403,9 @@ void Expert1CardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::ATTACK));
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsProposedDefender(CardType::HERO));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsProposedDefender(CardType::HERO)) };
     power.GetTrigger()->tasks =
         ComplexTask::ActivateSecret(TaskList{ std::make_shared<ArmorTask>(8) });
     cards.emplace("EX1_289", CardDef(power));
@@ -1464,8 +1470,9 @@ void Expert1CardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::ATTACK));
     power.GetTrigger()->triggerSource = TriggerSource::ENEMY_MINIONS;
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsProposedDefender(CardType::HERO));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsProposedDefender(CardType::HERO)) };
     power.GetTrigger()->fastExecution = true;
     power.GetTrigger()->tasks = ComplexTask::ActivateSecret(
         TaskList{ std::make_shared<DestroyTask>(EntityType::TARGET) });
@@ -1533,8 +1540,9 @@ void Expert1CardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TARGET));
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsSpellTargetingMinion());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsSpellTargetingMinion())
+    };
     power.GetTrigger()->tasks = {
         std::make_shared<ConditionTask>(
             EntityType::SOURCE,
@@ -3011,8 +3019,9 @@ void Expert1CardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::PLAY_CARD));
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsOverloadCard());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsOverloadCard())
+    };
     power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
         "EX1_258e", EntityType::SOURCE) };
     cards.emplace("EX1_258", CardDef(power));
@@ -3702,8 +3711,9 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TARGET));
     power.GetTrigger()->triggerSource = TriggerSource::HERO;
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsProposedDefender(CardType::MINION));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsProposedDefender(CardType::MINION)) };
     power.GetTrigger()->fastExecution = true;
     power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
         "EX1_411e", EntityType::SOURCE) };
@@ -4261,8 +4271,9 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::HasMinionInHand());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::HasMinionInHand())
+    };
     power.GetTrigger()->tasks = {
         std::make_shared<GetGameTagTask>(EntityType::SOURCE,
                                          GameTag::ZONE_POSITION),
@@ -4665,8 +4676,9 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::CAST_SPELL));
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsSecret());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsSecret())
+    };
     power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
         "EX1_080o", EntityType::SOURCE) };
     cards.emplace("EX1_080", CardDef(power));
@@ -5140,8 +5152,9 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::SUMMON));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::MURLOC));
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::MURLOC))
+    };
     power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
         "EX1_509e", EntityType::SOURCE) };
     cards.emplace("EX1_509", CardDef(power));

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -109,8 +109,9 @@ void NaxxCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::DEATH));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsFieldCount(2, RelaSign::GEQ));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsFieldCount(2, RelaSign::GEQ)) };
     power.GetTrigger()->tasks = { ComplexTask::ActivateSecret(
         TaskList{ std::make_shared<RandomTask>(EntityType::MINIONS, 1),
                   std::make_shared<AddEnchantmentTask>("FP1_020e",

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -1152,12 +1152,13 @@ void ScholomanceCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
     power.GetTrigger()->eitherTurn = true;
-    power.GetTrigger()->condition =
+    power.GetTrigger()->conditions = SelfCondList{
         std::make_shared<SelfCondition>([=](Playable* playable) -> bool {
             const auto opPlayer = playable->game->GetCurrentPlayer();
             return opPlayer != playable->player &&
                    !opPlayer->cardsPlayedThisTurn.empty();
-        });
+        })
+    };
     power.GetTrigger()->tasks =
         ComplexTask::ActivateSecret(TaskList{ std::make_shared<CustomTask>(
             [](Player* player, [[maybe_unused]] Entity* source,

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -770,9 +770,22 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // Text: <b>Freeze</b> a random enemy minion.
     //       <i>(Upgrades when you have 5 Mana.)</i>
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINIMUM_ENEMY_MINIONS = 1
+    // --------------------------------------------------------
     // RefTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<RandomTask>(EntityType::ENEMY_MINIONS, 1));
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::STACK,
+                                                        GameTag::FROZEN, 1));
+    power.AddTrigger(
+        std::make_shared<Trigger>(Triggers::RankSpellTrigger(5, "BAR_305t")));
+    cards.emplace(
+        "BAR_305",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_MINIMUM_ENEMY_MINIONS, 1 } }));
 
     // ------------------------------------------- SPELL - MAGE
     // [BAR_541] Runed Orb - COST:2
@@ -921,6 +934,8 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 void TheBarrensCardsGen::AddMageNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------- ENCHANTMENT - MAGE
     // [BAR_064e] Touch of Arcane - COST:0
     // - Set: THE_BARRENS
@@ -951,9 +966,22 @@ void TheBarrensCardsGen::AddMageNonCollect(
     // Text: <b>Freeze</b> two random enemy minions.
     //       <i>(Upgrades when you have 10 Mana.)</i>
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINIMUM_ENEMY_MINIONS = 1
+    // --------------------------------------------------------
     // RefTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<RandomTask>(EntityType::ENEMY_MINIONS, 2));
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::STACK,
+                                                        GameTag::FROZEN, 1));
+    power.AddTrigger(
+        std::make_shared<Trigger>(Triggers::RankSpellTrigger(10, "BAR_305t2")));
+    cards.emplace(
+        "BAR_305t",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_MINIMUM_ENEMY_MINIONS, 1 } }));
 
     // ------------------------------------------- SPELL - MAGE
     // [BAR_305t2] Flurry (Rank 3) - COST:0
@@ -962,9 +990,20 @@ void TheBarrensCardsGen::AddMageNonCollect(
     // --------------------------------------------------------
     // Text: <b>Freeze</b> three random enemy minions.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINIMUM_ENEMY_MINIONS = 1
+    // --------------------------------------------------------
     // RefTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<RandomTask>(EntityType::ENEMY_MINIONS, 3));
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::STACK,
+                                                        GameTag::FROZEN, 1));
+    cards.emplace(
+        "BAR_305t2",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_MINIMUM_ENEMY_MINIONS, 1 } }));
 
     // ------------------------------------- ENCHANTMENT - MAGE
     // [BAR_545e] Conjured Reduction - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -922,6 +922,12 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Destroy all <b>Frozen</b> minions.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::ALL_MINIONS));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsFrozen()) }));
+    power.AddPowerTask(std::make_shared<DestroyTask>(EntityType::STACK));
+    cards.emplace("WC_041", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [WC_805] Frostweave Dungeoneer - COST:3 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -914,6 +914,15 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::CAST_SPELL));
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsFrostSpell())
+    };
+    power.GetTrigger()->tasks = { std::make_shared<SummonTask>(
+        "BAR_888t", SummonSide::RIGHT) };
+    cards.emplace("BAR_888", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [WC_041] Shattering Blast - COST:3
@@ -1049,6 +1058,9 @@ void TheBarrensCardsGen::AddMageNonCollect(
     // GameTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("BAR_888t", CardDef(power));
 }
 
 void TheBarrensCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -762,6 +762,8 @@ void TheBarrensCardsGen::AddHunterNonCollect(
 
 void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------- SPELL - MAGE
     // [BAR_305] Flurry (Rank 1) - COST:0
     // - Set: THE_BARRENS, Rarity: Rare
@@ -784,6 +786,16 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DISCOVER = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 2, true));
+    power.AddPowerTask(std::make_shared<DiscoverTask>(DiscoverType::SPELL));
+    cards.emplace(
+        "BAR_541",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ------------------------------------------- SPELL - MAGE
     // [BAR_542] Refreshing Spring Water - COST:5

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -178,8 +178,9 @@ void TheBarrensCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::DEATH));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::HasTaunt());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::HasTaunt())
+    };
     power.GetTrigger()->tasks = {
         std::make_shared<SummonCopyTask>(EntityType::TARGET, false, true),
         std::make_shared<SetGameTagTask>(EntityType::STACK, GameTag::TAUNT, 0)
@@ -228,8 +229,9 @@ void TheBarrensCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_CAST));
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsNatureSpell());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsNatureSpell())
+    };
     power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
         "BAR_720e", EntityType::MINIONS_NOSOURCE) };
     cards.emplace("BAR_720", CardDef(power));
@@ -289,8 +291,9 @@ void TheBarrensCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_CAST));
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsNatureSpell());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsNatureSpell())
+    };
     power.GetTrigger()->tasks = { std::make_shared<SummonTask>(
         "WC_036t1", SummonSide::SPELL) };
     cards.emplace("WC_036", CardDef(power));
@@ -889,8 +892,9 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::ATTACK));
     power.GetTrigger()->triggerSource = TriggerSource::ENEMY;
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsProposedDefender(CardType::MINION));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsProposedDefender(CardType::MINION)) };
     power.GetTrigger()->tasks = ComplexTask::ActivateSecret(
         TaskList{ std::make_shared<SummonTask>("CS2_033", SummonSide::SPELL) });
     cards.emplace("BAR_812", CardDef(power));

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -894,7 +894,9 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.GetTrigger()->triggerSource = TriggerSource::ENEMY;
     power.GetTrigger()->conditions =
         SelfCondList{ std::make_shared<SelfCondition>(
-            SelfCondition::IsProposedDefender(CardType::MINION)) };
+                          SelfCondition::IsProposedDefender(CardType::MINION)),
+                      std::make_shared<SelfCondition>(
+                          SelfCondition::IsEventTargetFieldNotFull()) };
     power.GetTrigger()->tasks = ComplexTask::ActivateSecret(
         TaskList{ std::make_shared<SummonTask>("CS2_033", SummonSide::SPELL) });
     cards.emplace("BAR_812", CardDef(power));

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -6,6 +6,7 @@
 #include <Rosetta/PlayMode/Auras/SwitchingAura.hpp>
 #include <Rosetta/PlayMode/CardSets/TheBarrensCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
+#include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 #include <Rosetta/PlayMode/Triggers/Triggers.hpp>
 
@@ -885,6 +886,14 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::ENEMY;
+    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
+        SelfCondition::IsProposedDefender(CardType::MINION));
+    power.GetTrigger()->tasks = ComplexTask::ActivateSecret(
+        TaskList{ std::make_shared<SummonTask>("CS2_033", SummonSide::SPELL) });
+    cards.emplace("BAR_812", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [BAR_888] Rimetongue - COST:3 [ATK:3/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -589,7 +589,6 @@ void TheBarrensCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // PlayReq:
     // - REQ_TARGET_TO_PLAY = 0
-    // - REQ_MINION_TARGET = 0
     // --------------------------------------------------------
     // RefTag:
     // - RUSH = 1
@@ -600,8 +599,7 @@ void TheBarrensCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     power.AddPowerTask(std::make_shared<SummonTask>("BAR_035t", 1));
     cards.emplace(
         "BAR_801",
-        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
-                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ----------------------------------------- SPELL - HUNTER
     // [WC_007] Serpentbloom - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UldumCardsGen.cpp
@@ -220,8 +220,9 @@ void UldumCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsUnspentMana());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsUnspentMana())
+    };
     power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
         "ULD_131p") };
     cards.emplace("ULD_131", CardDef(power, 4, 0));
@@ -235,8 +236,9 @@ void UldumCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsUnspentMana());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsUnspentMana())
+    };
     power.GetTrigger()->tasks = { std::make_shared<DrawTask>(1) };
     cards.emplace("ULD_133", CardDef(power));
 
@@ -536,8 +538,9 @@ void UldumCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::CAST_SPELL));
     power.GetTrigger()->triggerSource = TriggerSource::ENEMY_SPELLS;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsFieldNotEmpty());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsFieldNotEmpty())
+    };
     power.GetTrigger()->tasks = ComplexTask::ActivateSecret(
         TaskList{ std::make_shared<RandomTask>(EntityType::ENEMY_MINIONS, 1),
                   std::make_shared<DestroyTask>(EntityType::STACK) });
@@ -847,8 +850,9 @@ void UldumCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_CAST));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsSecret());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsSecret())
+    };
     power.GetTrigger()->tasks = {
         std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 2),
     };
@@ -1075,8 +1079,9 @@ void UldumCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_PLAY_MINION));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::HasReborn());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::HasReborn())
+    };
     power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
         "ULD_431p") };
     cards.emplace("ULD_431", CardDef(power, 5, 0));
@@ -1504,8 +1509,9 @@ void UldumCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::PLAY_CARD));
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsComboCard());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsComboCard())
+    };
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
     power.GetTrigger()->tasks = {
         std::make_shared<RandomCardTask>(CardType::INVALID, CardClass::INVALID,
@@ -1625,8 +1631,9 @@ void UldumCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::ADD_CARD));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsAnotherClassCard());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsAnotherClassCard())
+    };
     power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
         "ULD_326p") };
     cards.emplace("ULD_326", CardDef(power, 4, 0));
@@ -1936,8 +1943,9 @@ void UldumCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::PLAY_CARD));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsBattlecryCard());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsBattlecryCard())
+    };
     power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
         "ULD_291p") };
     cards.emplace("ULD_291", CardDef(power, 6, 0));
@@ -2146,8 +2154,9 @@ void UldumCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TAKE_DAMAGE));
     power.GetTrigger()->triggerSource = TriggerSource::HERO;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsMyTurn());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsMyTurn())
+    };
     power.GetTrigger()->tasks =
         TaskList{ std::make_shared<RandomMinionTask>(
                       TagValues{ { GameTag::COST, 3, RelaSign::EQ } }),
@@ -3105,8 +3114,9 @@ void UldumCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_PLAY_CARD));
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsDiscoverCard());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsDiscoverCard())
+    };
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
     power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
         "ULD_309e", EntityType::STACK_NUM0) };
@@ -3151,8 +3161,9 @@ void UldumCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::ControlThisCard(3));
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::ControlThisCard(3))
+    };
     power.GetTrigger()->tasks = {
         std::make_shared<RandomTask>(EntityType::ENEMIES, 1),
         std::make_shared<DamageTask>(EntityType::STACK, 5)

--- a/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
@@ -173,8 +173,9 @@ void YoDCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::DEATH));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition = std::make_shared<SelfCondition>(
-        SelfCondition::IsRace(Race::MECHANICAL));
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::MECHANICAL))
+    };
     power.GetTrigger()->tasks = {
         std::make_shared<RandomMinionTask>(
             TagValues{ { GameTag::CARDRACE, static_cast<int>(Race::MECHANICAL),
@@ -811,8 +812,9 @@ void YoDCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_PLAY_MINION));
     power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->condition =
-        std::make_shared<SelfCondition>(SelfCondition::IsLackey());
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsLackey())
+    };
     power.GetTrigger()->tasks = { std::make_shared<AddLackeyTask>(1) };
     cards.emplace("YOD_035", CardDef(power));
 

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -413,6 +413,19 @@ SelfCondition SelfCondition::IsNatureSpell()
     });
 }
 
+SelfCondition SelfCondition::IsFrostSpell()
+{
+    return SelfCondition([](Playable* playable) {
+        auto spell = dynamic_cast<Spell*>(playable);
+        if (!spell)
+        {
+            return false;
+        }
+
+        return spell->GetSpellSchool() == SpellSchool::FROST;
+    });
+}
+
 SelfCondition SelfCondition::IsWeapon()
 {
     return SelfCondition([](Playable* playable) {

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -779,6 +779,19 @@ SelfCondition SelfCondition::IsEventTargetIs(CardType cardType)
     });
 }
 
+SelfCondition SelfCondition::IsEventTargetFieldNotFull()
+{
+    return SelfCondition([](Playable* playable) {
+        if (const auto eventData = playable->game->currentEventData.get();
+            eventData)
+        {
+            return !eventData->eventTarget->player->GetFieldZone()->IsFull();
+        }
+
+        return false;
+    });
+}
+
 SelfCondition SelfCondition::IsSpellTargetingMinion()
 {
     return SelfCondition([](Playable* playable) {

--- a/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
+++ b/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
@@ -50,7 +50,7 @@ Trigger::Trigger(Trigger& prototype, Entity& owner)
     : triggerActivation(prototype.triggerActivation),
       triggerSource(prototype.triggerSource),
       tasks(prototype.tasks),
-      condition(prototype.condition),
+      conditions(prototype.conditions),
       eitherTurn(prototype.eitherTurn),
       fastExecution(prototype.fastExecution),
       removeAfterTriggered(prototype.removeAfterTriggered),
@@ -661,7 +661,7 @@ void Trigger::Validate(Entity* source)
             break;
     }
 
-    if (condition != nullptr)
+    for (auto& condition : conditions)
     {
         const auto playable = dynamic_cast<Playable*>(source);
         const bool res = (playable != nullptr) ? condition->Evaluate(playable)

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -1642,7 +1642,7 @@ TEST_CASE("[Hunter : Spell] - EX1_554 : Snake Trap")
     config.player1Class = CardClass::HUNTER;
     config.player2Class = CardClass::HUNTER;
     config.startPlayer = PlayerType::PLAYER1;
-    config.doFillDecks = true;
+    config.doFillDecks = false;
     config.autoRun = false;
 
     Game game(config);
@@ -1672,6 +1672,12 @@ TEST_CASE("[Hunter : Spell] - EX1_554 : Snake Trap")
         Generic::DrawCard(opPlayer, Cards::FindCardByName("Chillwind Yeti"));
     const auto card6 =
         Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card7 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card8 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card9 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
     CHECK_EQ(curSecret->GetCount(), 1);
@@ -1708,7 +1714,20 @@ TEST_CASE("[Hunter : Spell] - EX1_554 : Snake Trap")
 
     game.Process(curPlayer, AttackTask(card4, card5));
     CHECK_EQ(curSecret->GetCount(), 1);
+    CHECK_EQ(curField.GetCount(), 4);
     CHECK_EQ(opField.GetCount(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card7));
+    game.Process(curPlayer, PlayCardTask::Minion(card8));
+    game.Process(curPlayer, PlayCardTask::Minion(card9));
+    CHECK_EQ(curField.GetCount(), 7);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, AttackTask(card5, curField[6]));
+    CHECK_EQ(curSecret->GetCount(), 1);
+    CHECK_EQ(curField.GetCount(), 6);
 }
 
 // ----------------------------------------- SPELL - HUNTER

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -1154,6 +1154,118 @@ TEST_CASE("[Hunter : Weapon] - WC_037 : Venomstrike Bow")
 }
 
 // ------------------------------------------- SPELL - MAGE
+// [BAR_305] Flurry (Rank 1) - COST:0
+// - Set: THE_BARRENS, Rarity: Rare
+// - Spell School: Frost
+// --------------------------------------------------------
+// Text: <b>Freeze</b> a random enemy minion.
+//       <i>(Upgrades when you have 5 Mana.)</i>
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINIMUM_ENEMY_MINIONS = 1
+// --------------------------------------------------------
+// RefTag:
+// - FREEZE = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - BAR_305 : Flurry (Rank 1)")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(3);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(3);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flurry (Rank 1)"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flurry (Rank 1)"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flurry (Rank 1)"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card6 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+
+    auto NumFrozenMinions = [&](FieldZone& field) -> int {
+        int count = 0;
+
+        for (auto& minion : field.GetAll())
+        {
+            if (minion->IsFrozen())
+            {
+                ++count;
+            }
+        }
+
+        return count;
+    };
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    game.Process(opPlayer, PlayCardTask::Minion(card6));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card1->card->name, "Flurry (Rank 1)");
+    CHECK_EQ(card2->card->name, "Flurry (Rank 1)");
+    CHECK_EQ(card3->card->name, "Flurry (Rank 1)");
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(NumFrozenMinions(opField), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card2->card->name, "Flurry (Rank 1)");
+    CHECK_EQ(card3->card->name, "Flurry (Rank 1)");
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card2->card->name, "Flurry (Rank 2)");
+    CHECK_EQ(card3->card->name, "Flurry (Rank 2)");
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(NumFrozenMinions(opField), 2);
+
+    curPlayer->SetTotalMana(9);
+    opPlayer->SetTotalMana(9);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card3->card->name, "Flurry (Rank 2)");
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card3->card->name, "Flurry (Rank 3)");
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(NumFrozenMinions(opField), 3);
+}
+
+// ------------------------------------------- SPELL - MAGE
 // [BAR_541] Runed Orb - COST:2
 // - Set: THE_BARRENS, Rarity: Common
 // - Spell School: Arcane

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -1374,3 +1374,62 @@ TEST_CASE("[Mage : Spell] - BAR_812 : Oasis Ally")
     CHECK_EQ(curField[0]->card->name, "Water Elemental");
     CHECK_EQ(opField.GetCount(), 0);
 }
+
+// ------------------------------------------- SPELL - MAGE
+// [WC_041] Shattering Blast - COST:3
+// - Set: THE_BARRENS, Rarity: Rare
+// - Spell School: Frost
+// --------------------------------------------------------
+// Text: Destroy all <b>Frozen</b> minions.
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - WC_041 : Shattering Blast")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Shattering Blast"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Frost Nova"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opField.GetCount(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(opField[0]->IsFrozen(), true);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(opField.GetCount(), 0);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -1153,3 +1153,51 @@ TEST_CASE("[Hunter : Weapon] - WC_037 : Venomstrike Bow")
     game.Process(curPlayer, AttackTask(curPlayer->GetHero(), card2));
     CHECK_EQ(opField.GetCount(), 0);
 }
+
+// ------------------------------------------- SPELL - MAGE
+// [BAR_541] Runed Orb - COST:2
+// - Set: THE_BARRENS, Rarity: Common
+// - Spell School: Arcane
+// --------------------------------------------------------
+// Text: Deal 2 damage. <b>Discover</b> a spell.
+// --------------------------------------------------------
+// GameTag:
+// - DISCOVER = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - BAR_541 : Runed Orb")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Runed Orb"));
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card1, opPlayer->GetHero()));
+    CHECK(curPlayer->choice != nullptr);
+
+    auto cards = TestUtils::GetChoiceCards(game);
+    for (auto& card : cards)
+    {
+        CHECK_EQ(card->GetCardType(), CardType::SPELL);
+        CHECK(card->IsCardClass(CardClass::MAGE));
+    }
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -1006,7 +1006,6 @@ TEST_CASE("[Hunter : Minion] - BAR_035 : Kolkar Pack Runner")
 // --------------------------------------------------------
 // PlayReq:
 // - REQ_TARGET_TO_PLAY = 0
-// - REQ_MINION_TARGET = 0
 // --------------------------------------------------------
 // RefTag:
 // - RUSH = 1


### PR DESCRIPTION
This revision includes:
- Implement 5 THE_BARRENS cards
  - Flurry (Rank 1) (BAR_305)
  - Runed Orb (BAR_541)
  - Oasis Ally (BAR_812)
  - Rimetongue (BAR_888)
  - Shattering Blast (WC_041)
- Fix incorrect the logic of some cards (Resolves #620)
  - Wound Prey (BAR_801)
    - Remove play requirement 'REQ_MINION_TARGET'
  - Snake Trap (EX1_554)
    - Change the type of variable 'condition' to 'std::vector<std::shared_ptr<SelfCondition>>' to add several conditions
    - Add method 'IsEventTargetFieldNotFull()': SelfCondition wrapper for checking the field of event target is not full
    - Add unit test code to check the case when the field is full
- Add method 'IsFrostSpell()': SelfCondition wrapper for checking the entity is frost spell