### PR TITLE
Implement new keyword 'Tradeable'

### DIFF
--- a/Documents/AbilityList.md
+++ b/Documents/AbilityList.md
@@ -51,7 +51,7 @@
 * [x] Sidequest
 * [x] Spellburst
 * [ ] Start of Game
-* [ ] Tradeable
+* [x] Tradeable
 * [x] Twinspell
 
 ## Keyworded Generation Abilities

--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -925,7 +925,7 @@ STORMWIND | SW_049 | Blessed Goods |
 STORMWIND | SW_050 | Maestra of the Masquerade |  
 STORMWIND | SW_052 | Find the Imposter |  
 STORMWIND | SW_054 | Stormwind Guard |  
-STORMWIND | SW_055 | Impatient Shopkeep |  
+STORMWIND | SW_055 | Impatient Shopkeep | O
 STORMWIND | SW_056 | Spice Bread Baker |  
 STORMWIND | SW_057 | Package Runner |  
 STORMWIND | SW_059 | Deeprun Engineer |  
@@ -1027,4 +1027,4 @@ STORMWIND | SW_460 | Devouring Swarm |
 STORMWIND | SW_462 | Hot Streak |  
 STORMWIND | SW_463 | Imported Tarantula |  
 
-- Progress: 0% (0 of 135 Cards)
+- Progress: 0% (1 of 135 Cards)

--- a/Documents/TaskList.md
+++ b/Documents/TaskList.md
@@ -10,6 +10,7 @@
 * EndTurnTask
 * HeroPowerTask
 * PlayCardTask
+* TradeCardTask
 
 ## Basic tasks
 

--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -34,7 +34,7 @@ constexpr std::array<CardSet, 6> STANDARD_CARD_SETS = {
 };
 
 //! Specifies which card sets combine into the WILD set.
-constexpr std::array<CardSet, 27> WILD_CARD_SETS = {
+constexpr std::array<CardSet, 28> WILD_CARD_SETS = {
     CardSet::EXPERT1,                // Classic, 2014
     CardSet::LEGACY,                 // Legacy, 2021
     CardSet::NAXX,                   // Curse of Naxxramas, 2014
@@ -60,6 +60,7 @@ constexpr std::array<CardSet, 27> WILD_CARD_SETS = {
     CardSet::SCHOLOMANCE,            // Scholomance Academy, 2020
     CardSet::DARKMOON_FAIRE,         // Madness at the Darkmoon Faire, 2020
     CardSet::THE_BARRENS,            // Forged in the Barrens, 2021
+    CardSet::STORMWIND,              // United in Stormwind, 2021
 };
 
 //! Specifies which card sets combine into the CLASSIC set.

--- a/Includes/Rosetta/PlayMode/Models/Playable.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Playable.hpp
@@ -125,6 +125,10 @@ class Playable : public Entity
     //! \return The flag that indicates whether it has corrupt.
     bool HasCorrupt() const;
 
+    //! Returns the flag that indicates whether it has tradeable.
+    //! \return The flag that indicates whether it has tradeable.
+    bool HasTradeable() const;
+
     //! Returns the flag that indicates it can activate 'Spellbrust'.
     //! \return The flag that indicates it can activate 'Spellbrust'.
     bool CanActivateSpellburst() const;

--- a/Includes/Rosetta/PlayMode/Tasks/PlayerTasks/EndTurnTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/PlayerTasks/EndTurnTask.hpp
@@ -23,9 +23,8 @@ class EndTurnTask : public ITask
     //! \return The result of task processing.
     TaskStatus Impl(Player* player) override;
 
-    //! Returns Clone Of Object (pure virtual).
-    //! \returns clone of object.
-    //! \this uses for thread safe. not to access same task in multiple threads
+    //! Internal method of Clone().
+    //! \return The cloned task.
     std::unique_ptr<ITask> CloneImpl() override;
 };
 }  // namespace RosettaStone::PlayMode::PlayerTasks

--- a/Includes/Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.hpp
@@ -32,6 +32,10 @@ class TradeCardTask : public ITask
     //! Internal method of Clone().
     //! \return The cloned task.
     std::unique_ptr<ITask> CloneImpl() override;
+
+    //! Returns whether a card can trade.
+    //! \return Whether a card can trade.
+    bool CanTradeCard() const;
 };
 }  // namespace RosettaStone::PlayMode::PlayerTasks
 

--- a/Includes/Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.hpp
@@ -18,6 +18,11 @@ namespace RosettaStone::PlayMode::PlayerTasks
 //!
 class TradeCardTask : public ITask
 {
+ public:
+    //! Constructs task with given \p source.
+    //! \param source A pointer to card to trade.
+    explicit TradeCardTask(Entity* source);
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.hpp
@@ -1,0 +1,33 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_PLAYMODE_TRADE_CARD_TASK_HPP
+#define ROSETTASTONE_PLAYMODE_TRADE_CARD_TASK_HPP
+
+#include <Rosetta/PlayMode/Tasks/ITask.hpp>
+
+namespace RosettaStone::PlayMode::PlayerTasks
+{
+//!
+//! \brief TradeCardTask class.
+//!
+//! This class represents the task for trading a card that has an ability
+//! "Tradeable".
+//!
+class TradeCardTask : public ITask
+{
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player* player) override;
+
+    //! Internal method of Clone().
+    //! \return The cloned task.
+    std::unique_ptr<ITask> CloneImpl() override;
+};
+}  // namespace RosettaStone::PlayMode::PlayerTasks
+
+#endif  // ROSETTASTONE_PLAYMODE_TRADE_CARD_TASK_HPP

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -166,6 +166,7 @@
 #include <Rosetta/PlayMode/Tasks/PlayerTasks/EndTurnTask.hpp>
 #include <Rosetta/PlayMode/Tasks/PlayerTasks/HeroPowerTask.hpp>
 #include <Rosetta/PlayMode/Tasks/PlayerTasks/PlayCardTask.hpp>
+#include <Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ActivateCapturedDeathrattleTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ActivateDeathrattleTask.hpp>

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
   * 14% Forged in the Barrens (24 of 170 cards)
-  * 0% United in Stormwind (0 of 135 card)
+  * 0% United in Stormwind (1 of 135 card)
 
 ### Wild Format
 

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -2084,6 +2084,8 @@ void StormwindCardsGen::AddDemonHunterNonCollect(
 
 void StormwindCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - NEUTRAL
     // [SW_006] Stubborn Suspect - COST:4 [ATK:3/HP:3]
     // - Set: STORMWIND, Rarity: Common
@@ -2147,6 +2149,9 @@ void StormwindCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - TRADEABLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("SW_055", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SW_056] Spice Bread Baker - COST:4 [ATK:3/HP:2]

--- a/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
@@ -31,6 +31,7 @@ void CardLoader::Load(std::vector<Card*>& cards)
     std::regex spellburstRegex("([<b>]*<b>Spellburst[</b>]*:</b>)");
     std::regex dormantRegex("<b>Dormant</b>");
     std::regex dormantTurnRegex("for ([[:digit:]]) turns");
+    std::regex tradeableRegex("<b>Tradeable[.]*</b>");
     std::smatch values;
 
     for (auto& cardData : j)
@@ -189,6 +190,10 @@ void CardLoader::Load(std::vector<Card*>& cards)
                 card->gameTags[GameTag::TAG_SCRIPT_DATA_NUM_1] =
                     std::stoi(values[1].str());
             }
+        }
+        if (std::regex_search(text, values, tradeableRegex))
+        {
+            card->gameTags[GameTag::TRADEABLE] = 1;
         }
 
         // NOTE: Runic Carvings (SCH_612) has GameTag::OVERLOAD

--- a/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
@@ -116,9 +116,6 @@ void CardLoader::Load(std::vector<Card*>& cards)
         }
 
         // NOTE: Skyvateer (YOD_016) doesn't have GameTag::DEATHRATTLE
-        // NOTE: Insatiable Felhound (DMF_247) doesn't have GameTag::TAUNT
-        // NOTE: Insatiable Felhound (DMF_247t) doesn't have GameTag::TAUNT
-        //       and GameTag::LIFESTEAL
         // NOTE: Carousel Gryphon (DMF_064) doesn't have GameTag::DIVINE_SHIELD
         // NOTE: Healing Totem (AT_132_SHAMANa), Searing Totem (AT_132_SHAMANb),
         //       Stoneclaw Totem (AT_132_SHAMANc), Wrath of Air Totem
@@ -126,15 +123,6 @@ void CardLoader::Load(std::vector<Card*>& cards)
         if (dbfID == 56091)
         {
             gameTags.emplace(GameTag::DEATHRATTLE, 1);
-        }
-        else if (dbfID == 61269)
-        {
-            gameTags.emplace(GameTag::TAUNT, 1);
-        }
-        else if (dbfID == 61270)
-        {
-            gameTags.emplace(GameTag::TAUNT, 1);
-            gameTags.emplace(GameTag::LIFESTEAL, 1);
         }
         else if (dbfID == 61581)
         {

--- a/Sources/Rosetta/PlayMode/Models/Playable.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Playable.cpp
@@ -169,6 +169,11 @@ bool Playable::HasCorrupt() const
     return GetGameTag(GameTag::CORRUPT) == 1;
 }
 
+bool Playable::HasTradeable() const
+{
+    return GetGameTag(GameTag::TRADEABLE) == 1;
+}
+
 bool Playable::CanActivateSpellburst() const
 {
     if (!HasSpellburst())

--- a/Sources/Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.cpp
@@ -3,9 +3,11 @@
 // RosettaStone is hearthstone simulator using C++ with reinforcement learning.
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
+#include <Rosetta/PlayMode/Actions/Draw.hpp>
 #include <Rosetta/PlayMode/Models/Player.hpp>
 #include <Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.hpp>
 #include <Rosetta/PlayMode/Zones/DeckZone.hpp>
+#include <Rosetta/PlayMode/Zones/HandZone.hpp>
 
 namespace RosettaStone::PlayMode::PlayerTasks
 {
@@ -16,6 +18,22 @@ TradeCardTask::TradeCardTask(Entity* source) : ITask(source, nullptr)
 
 TaskStatus TradeCardTask::Impl(Player* player)
 {
+    if (!CanTradeCard())
+    {
+        return TaskStatus::STOP;
+    }
+
+    auto tradeCard = dynamic_cast<Playable*>(m_source);
+    if (tradeCard)
+    {
+        Playable* topCard = player->GetDeckZone()->GetTopCard();
+
+        player->GetHandZone()->Remove(tradeCard);
+        player->GetDeckZone()->Add(tradeCard);
+
+        Generic::Draw(player, topCard);
+    }
+
     return TaskStatus::COMPLETE;
 }
 

--- a/Sources/Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.cpp
@@ -1,0 +1,20 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/PlayMode/Models/Player.hpp>
+#include <Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.hpp>
+
+namespace RosettaStone::PlayMode::PlayerTasks
+{
+TaskStatus TradeCardTask::Impl(Player* player)
+{
+    return TaskStatus::COMPLETE;
+}
+
+std::unique_ptr<ITask> TradeCardTask::CloneImpl()
+{
+    return std::make_unique<TradeCardTask>();
+}
+}  // namespace RosettaStone::PlayMode::PlayerTasks

--- a/Sources/Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.cpp
@@ -8,6 +8,11 @@
 
 namespace RosettaStone::PlayMode::PlayerTasks
 {
+TradeCardTask::TradeCardTask(Entity* source) : ITask(source, nullptr)
+{
+    // Do nothing
+}
+
 TaskStatus TradeCardTask::Impl(Player* player)
 {
     return TaskStatus::COMPLETE;
@@ -15,6 +20,6 @@ TaskStatus TradeCardTask::Impl(Player* player)
 
 std::unique_ptr<ITask> TradeCardTask::CloneImpl()
 {
-    return std::make_unique<TradeCardTask>();
+    return std::make_unique<TradeCardTask>(m_source);
 }
 }  // namespace RosettaStone::PlayMode::PlayerTasks

--- a/Sources/Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.cpp
@@ -5,6 +5,7 @@
 
 #include <Rosetta/PlayMode/Models/Player.hpp>
 #include <Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.hpp>
+#include <Rosetta/PlayMode/Zones/DeckZone.hpp>
 
 namespace RosettaStone::PlayMode::PlayerTasks
 {
@@ -21,5 +22,28 @@ TaskStatus TradeCardTask::Impl(Player* player)
 std::unique_ptr<ITask> TradeCardTask::CloneImpl()
 {
     return std::make_unique<TradeCardTask>(m_source);
+}
+
+bool TradeCardTask::CanTradeCard() const
+{
+    if (auto playable = dynamic_cast<Playable*>(m_source);
+        !playable || !playable->HasTradeable())
+    {
+        return false;
+    }
+
+    // The player can also drag it into their deck to spend 1 mana
+    if (m_player->GetRemainingMana() < 1)
+    {
+        return false;
+    }
+
+    // You can't trade a Tradeable card if your deck is empty
+    if (m_player->GetDeckZone()->IsEmpty())
+    {
+        return false;
+    }
+
+    return true;
 }
 }  // namespace RosettaStone::PlayMode::PlayerTasks

--- a/Sources/Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.cpp
@@ -26,6 +26,8 @@ TaskStatus TradeCardTask::Impl(Player* player)
     auto tradeCard = dynamic_cast<Playable*>(m_source);
     if (tradeCard)
     {
+        player->SetUsedMana(player->GetUsedMana() + 1);
+
         Playable* topCard = player->GetDeckZone()->GetTopCard();
 
         player->GetHandZone()->Remove(tradeCard);

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -6,7 +6,20 @@
 
 #include <Utils/CardSetUtils.hpp>
 
-TEST_CASE("[StormwindCardsGen] - Temp")
+// --------------------------------------- MINION - NEUTRAL
+// [SW_055] Impatient Shopkeep - COST:3 [ATK:3/HP:3]
+// - Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Tradeable</b>
+//       <b>Rush</b>
+// --------------------------------------------------------
+// GameTag:
+// - RUSH = 1
+// --------------------------------------------------------
+// RefTag:
+// - TRADEABLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SW_055 : Impatient Shopkeep")
 {
-    CHECK(true);
+    // Do nothing
 }

--- a/Tests/UnitTests/PlayMode/Tasks/PlayerTasks/TradeCardTaskTests.cpp
+++ b/Tests/UnitTests/PlayMode/Tasks/PlayerTasks/TradeCardTaskTests.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#include "doctest_proxy.hpp"
+
+#include <Utils/TestUtils.hpp>
+
+#include <Rosetta/PlayMode/Actions/Draw.hpp>
+#include <Rosetta/PlayMode/Cards/Cards.hpp>
+#include <Rosetta/PlayMode/Games/Game.hpp>
+#include <Rosetta/PlayMode/Games/GameConfig.hpp>
+#include <Rosetta/PlayMode/Tasks/PlayerTasks/EndTurnTask.hpp>
+#include <Rosetta/PlayMode/Tasks/PlayerTasks/TradeCardTask.hpp>
+#include <Rosetta/PlayMode/Zones/HandZone.hpp>
+
+using namespace RosettaStone;
+using namespace PlayMode;
+using namespace PlayerTasks;
+using namespace TestUtils;
+
+TEST_CASE("[TradeCardTask] - Default")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 5; ++i)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Restless Mummy");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Impatient Shopkeep"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    CHECK_EQ(curHand.GetCount(), 6);
+
+    game.Process(curPlayer, TradeCardTask(card2));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 10);
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(curHand[5]->card->name, "Wisp");
+
+    curPlayer->SetUsedMana(10);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 0);
+
+    game.Process(curPlayer, TradeCardTask(card1));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 0);
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(curHand[5]->card->name, "Wisp");
+
+    curPlayer->SetUsedMana(0);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 10);
+
+    game.Process(curPlayer, TradeCardTask(card1));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 9);
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(curHand[5]->card->name, "Restless Mummy");
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, TradeCardTask(curHand[6]));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 10);
+    CHECK_EQ(curHand.GetCount(), 7);
+    CHECK_EQ(curHand[6]->card->name, "Impatient Shopkeep");
+}


### PR DESCRIPTION
This revision includes:
- Implement new keyword 'Tradeable' (Resolves #617)
  - Create class 'TradeCardTask'
    - This class represents the task for trading a card that has an ability "Tradeable"
  - Add methods 'HasTradeable()' and 'CanTradeCard()'
    - HasTradeable(): Returns the flag that indicates whether it has tradeable
    - CanTradeCard(): Returns whether a card can trade
  - Add code to parse the value 'GameTag::TRADEABLE'
  - Add unit test code to check the logic of 'TradeCardTask'
- Implement 1 STORMWIND card
  - Impatient Shopkeep (SW_055)
- Add missing 'CardSet::STORMWIND' to 'WILD_CARD_SETS'
- Delete code to set game tags of cards 'Insatiable Felhound' (DMF_247, DMF_247t)