### PR TITLE
Implement new keyword 'Questline'

### DIFF
--- a/Documents/AbilityList.md
+++ b/Documents/AbilityList.md
@@ -45,7 +45,7 @@
 * [ ] Overkill
 * [ ] Passive
 * [x] Quest
-* [ ] Questline
+* [x] Questline
 * [x] Reborn
 * [ ] Recruit
 * [x] Sidequest

--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -997,7 +997,7 @@ STORMWIND | SW_417 | SI:7 Assassin |
 STORMWIND | SW_418 | SI:7 Skulker |  
 STORMWIND | SW_419 | Oracle of Elune |  
 STORMWIND | SW_422 | Sow the Soil |  
-STORMWIND | SW_428 | Lost in the Park |  
+STORMWIND | SW_428 | Lost in the Park | O
 STORMWIND | SW_429 | Best in Shell |  
 STORMWIND | SW_431 | Park Panther |  
 STORMWIND | SW_432 | Kodo Mount |  
@@ -1027,4 +1027,4 @@ STORMWIND | SW_460 | Devouring Swarm |
 STORMWIND | SW_462 | Hot Streak |  
 STORMWIND | SW_463 | Imported Tarantula |  
 
-- Progress: 0% (1 of 135 Cards)
+- Progress: 1% (2 of 135 Cards)

--- a/Includes/Rosetta/Common/Enums/TriggerEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/TriggerEnums.hpp
@@ -26,12 +26,13 @@ enum class TriggerType
                       //!< activated.
     ZONE,  //!< The effect will be triggered when an entity enters any types of
            //!< zone.
-    GIVE_HEAL,     //!< The effect will be triggered when a playable heals a
-                   //!< character.
-    TAKE_HEAL,     //!< The effect will be triggered when a character is healed.
-    ATTACK,        //!< The effect will be triggered when characters attack.
-    AFTER_ATTACK,  //!< The effect will be triggered after an attack action is
-                   //!< ended.
+    GAIN_ATTACK,  //!< The effect will be triggered when an entity gains attack.
+    GIVE_HEAL,    //!< The effect will be triggered when a playable heals a
+                  //!< character.
+    TAKE_HEAL,    //!< The effect will be triggered when a character is healed.
+    ATTACK,       //!< The effect will be triggered when characters attack.
+    AFTER_ATTACK,    //!< The effect will be triggered after an attack action is
+                     //!< ended.
     AFTER_ATTACKED,  //!< The effect will be triggered after a character is
                      //!< attacked.
     SUMMON,  //!< The effect will be triggered whenever a minion is summoned.
@@ -57,7 +58,7 @@ enum class TriggerType
                         //!< shuffled into a deck.
     MANA_CRYSTAL,   //!< The effect will be triggered when a player gains mana
                     //!< crystal.
-    MULTI_TRIGGER,      //!< The effect for multi trigger.
+    MULTI_TRIGGER,  //!< The effect for multi trigger.
 };
 
 //! \brief An enumerator for identifying trigger source.

--- a/Includes/Rosetta/PlayMode/Enchants/Attrs/Atk.hpp
+++ b/Includes/Rosetta/PlayMode/Enchants/Attrs/Atk.hpp
@@ -59,6 +59,12 @@ class Atk : public SelfContainedIntAttr<Atk, Entity>
         if (const auto character = dynamic_cast<Character*>(entity); character)
         {
             SelfContainedIntAttr::Apply(character, effectOp, value);
+
+            if (const auto hero = dynamic_cast<Hero*>(character);
+                hero && effectOp == EffectOperator::ADD)
+            {
+                hero->gainAttackTrigger(hero);
+            }
         }
         else
         {

--- a/Includes/Rosetta/PlayMode/Enchants/Attrs/Atk.hpp
+++ b/Includes/Rosetta/PlayMode/Enchants/Attrs/Atk.hpp
@@ -63,7 +63,15 @@ class Atk : public SelfContainedIntAttr<Atk, Entity>
             if (const auto hero = dynamic_cast<Hero*>(character);
                 hero && effectOp == EffectOperator::ADD)
             {
+                hero->game->taskQueue.StartEvent();
+                auto tempEventData = std::move(hero->game->currentEventData);
+                hero->game->currentEventData =
+                    std::make_unique<EventMetaData>(hero, nullptr, value);
                 hero->gainAttackTrigger(hero);
+                hero->game->ProcessTasks();
+                hero->game->taskQueue.EndEvent();
+                hero->game->currentEventData.reset();
+                hero->game->currentEventData = std::move(tempEventData);
             }
         }
         else

--- a/Includes/Rosetta/PlayMode/Models/Hero.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Hero.hpp
@@ -84,6 +84,8 @@ class Hero : public Character
 
     std::vector<Aura*> weaponAuras;
 
+    TriggerEvent gainAttackTrigger;
+
     int fatigue = 0;
     int damageTakenThisTurn = 0;
 };

--- a/Includes/Rosetta/PlayMode/Models/Spell.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Spell.hpp
@@ -68,6 +68,10 @@ class Spell : public Playable
     //! \return Whether spell is sidequest.
     bool IsSidequest() const;
 
+    //! Returns whether spell is questline.
+    //! \return Whether spell is questline.
+    bool IsQuestline() const;
+
     //! Returns whether spell is twinspell.
     //! \return Whether spell is twinspell.
     bool IsTwinspell() const;

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/QuestProgressTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/QuestProgressTask.hpp
@@ -15,8 +15,8 @@ enum class ProgressType
 {
     DEFAULT,     //!< Increases progress count when the trigger is called.
     SPEND_MANA,  //!< Increases progress count when the player spends mana.
-    SPEND_MANA_ON_SPELLS,  //!< Increases progress count when the player spends
-                           //!< mana on spells.
+    SPEND_MANA_ON_SPELLS,   //!< Increases progress count when the player spends
+                            //!< mana on spells.
     PLAY_ELEMENTAL_MINONS,  //!< Increases progress count when the player plays
                             //!< an elemental minion in this turn.
     GAIN_ATTACK,     //!< Increases progress count when the hero gains attack.
@@ -42,18 +42,25 @@ class QuestProgressTask : public ITask
     explicit QuestProgressTask(const std::string& questRewardID,
                                ProgressType progressType);
 
-    //! Constructs task with given \p rewardTasks and \p progressType.
+    //! Constructs task with given \p rewardTasks, \p progressType
+    //! and \p nextQuestID.
     //! \param rewardTasks A list of tasks to run that is a reward of the quest.
     //! \param progressType The type of quest progress.
+    //! \param nextQuestID The card ID that is next quest for
+    //! keyword 'Questline'.
     explicit QuestProgressTask(
         std::vector<std::shared_ptr<ITask>> rewardTasks,
-        ProgressType progressType = ProgressType::DEFAULT);
+        ProgressType progressType = ProgressType::DEFAULT,
+        std::string&& nextQuestID = "");
 
     //! Constructs task with given various parameters.
     //! \param questRewardID The card ID that is a reward of the quest.
     //! \param progressType The type of quest progress.
     //! \param rewardTasks A list of tasks to run that is a reward of the quest.
+    //! \param nextQuestID The card ID that is next quest for
+    //! keyword 'Questline'.
     explicit QuestProgressTask(const std::string& questRewardID,
+                               const std::string& nextQuestID,
                                ProgressType progressType,
                                std::vector<std::shared_ptr<ITask>> rewardTasks);
 
@@ -67,7 +74,8 @@ class QuestProgressTask : public ITask
     //! \return The cloned task.
     std::unique_ptr<ITask> CloneImpl() override;
 
-    Card* m_card = nullptr;
+    Card* m_questRewardCard = nullptr;
+    Card* m_nextQuestCard = nullptr;
     ProgressType m_progressType = ProgressType::DEFAULT;
     std::vector<std::shared_ptr<ITask>> m_tasks;
 };

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/QuestProgressTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/QuestProgressTask.hpp
@@ -19,6 +19,7 @@ enum class ProgressType
                            //!< mana on spells.
     PLAY_ELEMENTAL_MINONS,  //!< Increases progress count when the player plays
                             //!< an elemental minion in this turn.
+    GAIN_ATTACK,     //!< Increases progress count when the hero gains attack.
     RESTORE_HEALTH,  //!< Increases progress count when the hero or friendly
                      //!< minion(s) restores health.
 };

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
   * 14% Forged in the Barrens (24 of 170 cards)
-  * 0% United in Stormwind (1 of 135 card)
+  * 1% United in Stormwind (2 of 135 card)
 
 ### Wild Format
 

--- a/Sources/Rosetta/PlayMode/Actions/CastSpell.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/CastSpell.cpp
@@ -18,7 +18,8 @@ void CastSpell(Player* player, Spell* spell, Character* target, int chooseOne)
 {
     player->game->taskQueue.StartEvent();
 
-    if (spell->IsSecret() || spell->IsQuest() || spell->IsSidequest())
+    if (spell->IsSecret() || spell->IsQuest() || spell->IsSidequest() ||
+        spell->IsQuestline())
     {
         // Process trigger
         if (spell->card->power.GetTrigger())
@@ -103,7 +104,8 @@ void CastRandomSpell(Player* player, Spell* spell, Character* target,
 {
     player->game->taskQueue.StartEvent();
 
-    if (spell->IsSecret() || spell->IsQuest() || spell->IsSidequest())
+    if (spell->IsSecret() || spell->IsQuest() || spell->IsSidequest() ||
+        spell->IsQuestline())
     {
         // Process trigger
         if (spell->card->power.GetTrigger())

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -61,7 +61,8 @@ void StormwindCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::GAIN_ATTACK));
     power.GetTrigger()->triggerSource = TriggerSource::HERO;
     power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
-        TaskList{ std::make_shared<ArmorTask>(5) }, ProgressType::GAIN_ATTACK) };
+        TaskList{ std::make_shared<ArmorTask>(5) }, ProgressType::GAIN_ATTACK,
+        "SW_428t") };
     cards.emplace("SW_428", CardDef(power, 4, 0));
 
     // ------------------------------------------ SPELL - DRUID
@@ -150,6 +151,8 @@ void StormwindCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 void StormwindCardsGen::AddDruidNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------ SPELL - DRUID
     // [SW_422a] New Growth - COST:1
     // - Set: STORMWIND
@@ -188,6 +191,14 @@ void StormwindCardsGen::AddDruidNonCollect(
     // GameTag:
     // - ELITE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::GAIN_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
+        TaskList{ std::make_shared<ArmorTask>(5),
+                  std::make_shared<DrawTask>(1) },
+        ProgressType::GAIN_ATTACK, "SW_428t2") };
+    cards.emplace("SW_428t", CardDef(power, 5, 0));
 
     // ------------------------------------------ SPELL - DRUID
     // [SW_428t2] Feral Friendsy - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -210,6 +210,12 @@ void StormwindCardsGen::AddDruidNonCollect(
     // GameTag:
     // - ELITE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::GAIN_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
+        "SW_428t4", ProgressType::GAIN_ATTACK) };
+    cards.emplace("SW_428t2", CardDef(power, 6, 0));
 
     // ----------------------------------------- MINION - DRUID
     // [SW_428t4] Guff the Tough - COST:5 [ATK:8/HP:8]

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -4,6 +4,7 @@
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 #include <Rosetta/PlayMode/CardSets/StormwindCardsGen.hpp>
+#include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 
 using namespace RosettaStone::PlayMode::SimpleTasks;
@@ -230,6 +231,11 @@ void StormwindCardsGen::AddDruidNonCollect(
     // - BATTLECRY = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("SW_428t4e", EntityType::HERO));
+    power.AddPowerTask(std::make_shared<ArmorTask>(8));
+    cards.emplace("SW_428t4", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [SW_428t4e] Guff's Buff - COST:0
@@ -240,6 +246,10 @@ void StormwindCardsGen::AddDruidNonCollect(
     // GameTag:
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(
+        std::make_unique<Enchant>(Effects::AttackN(8), false, true));
+    cards.emplace("SW_428t4e", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [SW_429t] Goldshell Turtle - COST:4 [ATK:2/HP:7]

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -4,6 +4,9 @@
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 #include <Rosetta/PlayMode/CardSets/StormwindCardsGen.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
+
+using namespace RosettaStone::PlayMode::SimpleTasks;
 
 namespace RosettaStone::PlayMode
 {
@@ -19,6 +22,8 @@ void StormwindCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
 void StormwindCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- MINION - DRUID
     // [SW_419] Oracle of Elune - COST:3 [ATK:2/HP:4]
     // - Set: STORMWIND, Rarity: Epic
@@ -52,6 +57,12 @@ void StormwindCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - ELITE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::GAIN_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->tasks = { std::make_shared<QuestProgressTask>(
+        TaskList{ std::make_shared<ArmorTask>(5) }, ProgressType::GAIN_ATTACK) };
+    cards.emplace("SW_428", CardDef(power, 4, 0));
 
     // ------------------------------------------ SPELL - DRUID
     // [SW_429] Best in Shell - COST:6

--- a/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
@@ -32,6 +32,7 @@ void CardLoader::Load(std::vector<Card*>& cards)
     std::regex dormantRegex("<b>Dormant</b>");
     std::regex dormantTurnRegex("for ([[:digit:]]) turns");
     std::regex tradeableRegex("<b>Tradeable[.]*</b>");
+    std::regex questlineRegex("<b>Questline:[ ]*</b>");
     std::smatch values;
 
     for (auto& cardData : j)
@@ -194,6 +195,10 @@ void CardLoader::Load(std::vector<Card*>& cards)
         if (std::regex_search(text, values, tradeableRegex))
         {
             card->gameTags[GameTag::TRADEABLE] = 1;
+        }
+        if (std::regex_search(text, values, questlineRegex))
+        {
+            card->gameTags[GameTag::QUESTLINE] = 1;
         }
 
         // NOTE: Runic Carvings (SCH_612) has GameTag::OVERLOAD

--- a/Sources/Rosetta/PlayMode/Models/Spell.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Spell.cpp
@@ -54,6 +54,11 @@ bool Spell::IsSidequest() const
     return GetGameTag(GameTag::SIDEQUEST) == 1;
 }
 
+bool Spell::IsQuestline() const
+{
+    return GetGameTag(GameTag::QUESTLINE) == 1;
+}
+
 bool Spell::IsTwinspell() const
 {
     return GetGameTag(GameTag::TWINSPELL) == 1;

--- a/Sources/Rosetta/PlayMode/Models/Spell.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Spell.cpp
@@ -77,8 +77,9 @@ bool Spell::TargetingRequirements(Card* card, Character* target) const
 
 bool Spell::IsPlayableByPlayer()
 {
-    if ((IsSecret() || IsSidequest()) && (player->GetSecretZone()->IsFull() ||
-                                          player->GetSecretZone()->Exist(this)))
+    if ((IsSecret() || IsQuest() || IsSidequest() || IsQuestline()) &&
+        (player->GetSecretZone()->IsFull() ||
+         player->GetSecretZone()->Exist(this)))
     {
         return false;
     }

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/QuestProgressTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/QuestProgressTask.cpp
@@ -158,6 +158,12 @@ TaskStatus QuestProgressTask::Impl(Player* player)
             {
                 Playable* nextQuest =
                     Entity::GetFromCard(player, m_nextQuestCard);
+
+                // Process trigger
+                if (nextQuest->card->power.GetTrigger())
+                {
+                    nextQuest->card->power.GetTrigger()->Activate(nextQuest);
+                }
                 player->GetSecretZone()->Add(nextQuest);
             }
 

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/QuestProgressTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/QuestProgressTask.cpp
@@ -79,6 +79,7 @@ TaskStatus QuestProgressTask::Impl(Player* player)
             }
             break;
         case ProgressType::RESTORE_HEALTH:
+        case ProgressType::GAIN_ATTACK:
             const int amount = player->game->currentEventData->eventNumber;
             for (int i = 0; i < amount; ++i)
             {

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/QuestProgressTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/QuestProgressTask.cpp
@@ -14,29 +14,34 @@
 namespace RosettaStone::PlayMode::SimpleTasks
 {
 QuestProgressTask::QuestProgressTask(const std::string& questRewardID)
-    : m_card(Cards::FindCardByID(questRewardID))
+    : m_questRewardCard(Cards::FindCardByID(questRewardID))
 {
     // Do nothing
 }
 
 QuestProgressTask::QuestProgressTask(const std::string& questRewardID,
                                      ProgressType progressType)
-    : m_card(Cards::FindCardByID(questRewardID)), m_progressType(progressType)
+    : m_questRewardCard(Cards::FindCardByID(questRewardID)),
+      m_progressType(progressType)
 {
     // Do nothing
 }
 
 QuestProgressTask::QuestProgressTask(
-    std::vector<std::shared_ptr<ITask>> rewardTasks, ProgressType progressType)
-    : m_progressType(progressType), m_tasks(std::move(rewardTasks))
+    std::vector<std::shared_ptr<ITask>> rewardTasks, ProgressType progressType,
+    std::string&& nextQuestID)
+    : m_nextQuestCard(Cards::FindCardByID(nextQuestID)),
+      m_progressType(progressType),
+      m_tasks(std::move(rewardTasks))
 {
     // Do nothing
 }
 
 QuestProgressTask::QuestProgressTask(
-    const std::string& questRewardID, ProgressType progressType,
-    std::vector<std::shared_ptr<ITask>> rewardTasks)
-    : m_card(Cards::FindCardByID(questRewardID)),
+    const std::string& questRewardID, const std::string& nextQuestID,
+    ProgressType progressType, std::vector<std::shared_ptr<ITask>> rewardTasks)
+    : m_questRewardCard(Cards::FindCardByID(questRewardID)),
+      m_nextQuestCard(Cards::FindCardByID(nextQuestID)),
       m_progressType(progressType),
       m_tasks(std::move(rewardTasks))
 {
@@ -90,9 +95,9 @@ TaskStatus QuestProgressTask::Impl(Player* player)
 
     if (spell->GetQuestProgress() >= spell->GetQuestProgressTotal())
     {
-        if (!m_card->id.empty())
+        if (!m_questRewardCard->id.empty())
         {
-            Playable* reward = Entity::GetFromCard(player, m_card);
+            Playable* reward = Entity::GetFromCard(player, m_questRewardCard);
 
             // Reward card is hero power or minion
             if (const auto heroPower = dynamic_cast<HeroPower*>(reward);
@@ -148,6 +153,14 @@ TaskStatus QuestProgressTask::Impl(Player* player)
             player->GetSecretZone()->quest = nullptr;
             player->GetGraveyardZone()->Add(spell);
 
+            // Set next quest for keyword 'Questline'
+            if (!m_nextQuestCard->id.empty())
+            {
+                Playable* nextQuest =
+                    Entity::GetFromCard(player, m_nextQuestCard);
+                player->GetSecretZone()->Add(nextQuest);
+            }
+
             return TaskStatus::COMPLETE;
         }
     }
@@ -157,7 +170,11 @@ TaskStatus QuestProgressTask::Impl(Player* player)
 
 std::unique_ptr<ITask> QuestProgressTask::CloneImpl()
 {
-    const std::string cardID = m_card ? m_card->id : "";
-    return std::make_unique<QuestProgressTask>(cardID, m_progressType, m_tasks);
+    const std::string questRewardCardID =
+        m_questRewardCard ? m_questRewardCard->id : "";
+    const std::string nextQuestCardID =
+        m_nextQuestCard ? m_nextQuestCard->id : "";
+    return std::make_unique<QuestProgressTask>(
+        questRewardCardID, nextQuestCardID, m_progressType, m_tasks);
 }
 }  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
+++ b/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
@@ -128,6 +128,13 @@ std::shared_ptr<Trigger> Trigger::Activate(Playable* source,
         case TriggerType::ZONE:
             game->triggerManager.zoneTrigger += instance->handler;
             break;
+        case TriggerType::GAIN_ATTACK:
+            if (triggerSource == TriggerSource::HERO)
+            {
+                source->player->GetHero()->gainAttackTrigger +=
+                    instance->handler;
+            }
+            break;
         case TriggerType::GIVE_HEAL:
             game->triggerManager.giveHealTrigger += instance->handler;
             break;
@@ -291,6 +298,12 @@ void Trigger::Remove() const
             break;
         case TriggerType::ZONE:
             game->triggerManager.zoneTrigger -= handler;
+            break;
+        case TriggerType::GAIN_ATTACK:
+            if (triggerSource == TriggerSource::HERO)
+            {
+                m_owner->player->GetHero()->gainAttackTrigger -= handler;
+            }
             break;
         case TriggerType::GIVE_HEAL:
             game->triggerManager.giveHealTrigger -= handler;

--- a/Sources/Rosetta/PlayMode/Zones/SecretZone.cpp
+++ b/Sources/Rosetta/PlayMode/Zones/SecretZone.cpp
@@ -23,9 +23,9 @@ void SecretZone::Add(Playable* entity, int zonePos)
 
     if (spell->IsQuest() || spell->IsQuestline())
     {
-        if (quest != nullptr)
+        if (quest)
         {
-            throw std::logic_error("Another quest is already in play");
+            return;
         }
 
         quest = spell;

--- a/Sources/Rosetta/PlayMode/Zones/SecretZone.cpp
+++ b/Sources/Rosetta/PlayMode/Zones/SecretZone.cpp
@@ -21,7 +21,7 @@ void SecretZone::Add(Playable* entity, int zonePos)
 {
     const auto spell = dynamic_cast<Spell*>(entity);
 
-    if (spell->IsQuest())
+    if (spell->IsQuest() || spell->IsQuestline())
     {
         if (quest != nullptr)
         {

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -4,7 +4,70 @@
 // personal capacity and are not conveying any rights to any intellectual
 // property of any third parties.
 
+#include "doctest_proxy.hpp"
+
 #include <Utils/CardSetUtils.hpp>
+#include <Utils/TestUtils.hpp>
+
+#include <Rosetta/PlayMode/Actions/Draw.hpp>
+#include <Rosetta/PlayMode/Cards/Cards.hpp>
+#include <Rosetta/PlayMode/Zones/DeckZone.hpp>
+#include <Rosetta/PlayMode/Zones/FieldZone.hpp>
+#include <Rosetta/PlayMode/Zones/HandZone.hpp>
+#include <Rosetta/PlayMode/Zones/SecretZone.hpp>
+
+using namespace RosettaStone;
+using namespace PlayMode;
+using namespace PlayerTasks;
+using namespace SimpleTasks;
+
+// ------------------------------------------ SPELL - DRUID
+// [SW_428] Lost in the Park - COST:1
+// - Set: STORMWIND, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Questline:</b> Gain 4 Attack with your hero.
+//       <b>Reward:</b> Gain 5 Armor.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - SW_428 : Lost in the Park")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto curSecret = curPlayer->GetSecretZone();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Lost in the Park"));
+
+    auto quest = dynamic_cast<Spell*>(card1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK(curSecret->quest != nullptr);
+    CHECK_EQ(quest->GetQuestProgress(), 0);
+    CHECK_EQ(quest->GetQuestProgressTotal(), 4);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(quest->GetQuestProgress(), 1);
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 1);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 1);
+}
 
 // --------------------------------------- MINION - NEUTRAL
 // [SW_055] Impatient Shopkeep - COST:3 [ATK:3/HP:3]

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -55,18 +55,26 @@ TEST_CASE("[Druid : Spell] - SW_428 : Lost in the Park")
 
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::FindCardByName("Lost in the Park"));
-
-    auto quest = dynamic_cast<Spell*>(card1);
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Feral Rage"));
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
     CHECK(curSecret->quest != nullptr);
-    CHECK_EQ(quest->GetQuestProgress(), 0);
-    CHECK_EQ(quest->GetQuestProgressTotal(), 4);
+    CHECK_EQ(curSecret->quest->GetQuestProgress(), 0);
+    CHECK_EQ(curSecret->quest->GetQuestProgressTotal(), 4);
 
     game.Process(curPlayer, HeroPowerTask());
-    CHECK_EQ(quest->GetQuestProgress(), 1);
+    CHECK_EQ(curSecret->quest->GetQuestProgress(), 1);
     CHECK_EQ(curPlayer->GetHero()->GetAttack(), 1);
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2, 1));
+    CHECK(curSecret->quest != nullptr);
+    CHECK_EQ(curSecret->quest->card->name, "Defend the Squirrels");
+    CHECK_EQ(curSecret->quest->GetQuestProgress(), 0);
+    CHECK_EQ(curSecret->quest->GetQuestProgressTotal(), 5);
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 5);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 6);
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -61,6 +61,10 @@ TEST_CASE("[Druid : Spell] - SW_428 : Lost in the Park")
     const auto card3 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Feral Rage"));
     const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Feral Rage"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Pounce"));
+    const auto card6 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Pounce"));
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
@@ -85,16 +89,40 @@ TEST_CASE("[Druid : Spell] - SW_428 : Lost in the Park")
     CHECK_EQ(curSecret->quest->GetQuestProgress(), 4);
     CHECK_EQ(curPlayer->GetHero()->GetAttack(), 9);
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 6);
-    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand.GetCount(), 7);
 
-    game.Process(curPlayer, PlayCardTask::Spell(card4));
+    game.Process(curPlayer, PlayCardTask::Spell(card5));
     CHECK(curSecret->quest != nullptr);
     CHECK_EQ(curSecret->quest->card->name, "Feral Friendsy");
     CHECK_EQ(curSecret->quest->GetQuestProgress(), 0);
     CHECK_EQ(curSecret->quest->GetQuestProgressTotal(), 6);
     CHECK_EQ(curPlayer->GetHero()->GetAttack(), 11);
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 11);
-    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand.GetCount(), 7);
+
+    curPlayer->SetUsedMana(0);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card4, 1));
+    CHECK_EQ(curSecret->quest->GetQuestProgress(), 4);
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 15);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 11);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card6));
+    CHECK(curSecret->quest == nullptr);
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 17);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 11);
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(curHand[5]->card->name, "Guff the Tough");
+
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[5]));
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 25);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 19);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 19);
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -51,12 +51,17 @@ TEST_CASE("[Druid : Spell] - SW_428 : Lost in the Park")
     opPlayer->SetTotalMana(10);
     opPlayer->SetUsedMana(0);
 
+    auto& curHand = *(curPlayer->GetHandZone());
     const auto curSecret = curPlayer->GetSecretZone();
 
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::FindCardByName("Lost in the Park"));
     const auto card2 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Feral Rage"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Feral Rage"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Pounce"));
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
     CHECK(curSecret->quest != nullptr);
@@ -75,6 +80,21 @@ TEST_CASE("[Druid : Spell] - SW_428 : Lost in the Park")
     CHECK_EQ(curSecret->quest->GetQuestProgressTotal(), 5);
     CHECK_EQ(curPlayer->GetHero()->GetAttack(), 5);
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3, 1));
+    CHECK_EQ(curSecret->quest->GetQuestProgress(), 4);
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 9);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 6);
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card4));
+    CHECK(curSecret->quest != nullptr);
+    CHECK_EQ(curSecret->quest->card->name, "Feral Friendsy");
+    CHECK_EQ(curSecret->quest->GetQuestProgress(), 0);
+    CHECK_EQ(curSecret->quest->GetQuestProgressTotal(), 6);
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 11);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 11);
+    CHECK_EQ(curHand.GetCount(), 5);
 }
 
 // --------------------------------------- MINION - NEUTRAL


### PR DESCRIPTION
This revision includes:
- Implement new keyword 'Questline' (Resolves #618)
  - Add method 'IsQuestline()': Returns whether spell is questline
    - Add code to process the keyword 'Questline'
  - Add code to parse the value 'GameTag::QUESTLINE'
  - Add variable 'm_nextQuestCard' and code to process it in class 'QuestProgressTask'
  - Add code to process trigger for next quest
- Implement 1 STORMWIND card
  - Lost in the Park (SW_428)
    - Add member variable 'gainAttackTrigger'
    - Add enum value 'GAIN_ATTACK' and code to process it
    - Add code to call a trigger when hero gains attack