### PR TITLE
Implement 5 THE_BARRENS cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -723,7 +723,7 @@ THE_BARRENS | BAR_026 | Death's Head Cultist |
 THE_BARRENS | BAR_027 | Darkspear Berserker |  
 THE_BARRENS | BAR_030 | Pack Kodo |  
 THE_BARRENS | BAR_031 | Sunscale Raptor |  
-THE_BARRENS | BAR_032 | Piercing Shot |  
+THE_BARRENS | BAR_032 | Piercing Shot | O
 THE_BARRENS | BAR_033 | Prospector's Caravan | O
 THE_BARRENS | BAR_034 | Tame Beast (Rank 1) | O
 THE_BARRENS | BAR_035 | Kolkar Pack Runner | O
@@ -810,7 +810,7 @@ THE_BARRENS | BAR_735 | Xyrella |
 THE_BARRENS | BAR_743 | Toad of the Wilds |  
 THE_BARRENS | BAR_744 | Spirit Healer |  
 THE_BARRENS | BAR_745 | Hecklefang Hyena |  
-THE_BARRENS | BAR_748 | Varden Dawngrasp |  
+THE_BARRENS | BAR_748 | Varden Dawngrasp | O
 THE_BARRENS | BAR_750 | Earth Revenant |  
 THE_BARRENS | BAR_751 | Spawnpool Forager |  
 THE_BARRENS | BAR_801 | Wound Prey | O
@@ -853,7 +853,7 @@ THE_BARRENS | WC_003 | Sigil of Summoning |
 THE_BARRENS | WC_004 | Fangbound Druid | O
 THE_BARRENS | WC_005 | Primal Dungeoneer |  
 THE_BARRENS | WC_006 | Lady Anacondra | O
-THE_BARRENS | WC_007 | Serpentbloom |  
+THE_BARRENS | WC_007 | Serpentbloom | O
 THE_BARRENS | WC_008 | Sin'dorei Scentfinder | O
 THE_BARRENS | WC_013 | Devout Dungeoneer |  
 THE_BARRENS | WC_014 | Against All Odds |  
@@ -882,10 +882,10 @@ THE_BARRENS | WC_041 | Shattering Blast | O
 THE_BARRENS | WC_042 | Wailing Vapor |  
 THE_BARRENS | WC_701 | Felrattler |  
 THE_BARRENS | WC_803 | Cleric of An'she |  
-THE_BARRENS | WC_805 | Frostweave Dungeoneer |  
-THE_BARRENS | WC_806 | Floecaster |  
+THE_BARRENS | WC_805 | Frostweave Dungeoneer | O
+THE_BARRENS | WC_806 | Floecaster | O
 
-- Progress: 14% (24 of 170 Cards)
+- Progress: 17% (29 of 170 Cards)
 
 ## United in Stormwind
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 60% Ashes of Outland (81 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
-  * 14% Forged in the Barrens (24 of 170 cards)
+  * 17% Forged in the Barrens (29 of 170 cards)
   * 1% United in Stormwind (2 of 135 card)
 
 ### Wild Format

--- a/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
@@ -1207,14 +1207,8 @@ void DragonsCardsGen::AddMage(std::map<std::string, CardDef>& cards)
             const int targetHealth = realTarget->GetHealth();
             int realDamage = 8 + source->player->GetCurrentSpellPower();
 
-            if (const auto value = source->player->playerAuraEffects.GetValue(
-                    GameTag::SPELLPOWER_DOUBLE);
-                value > 0)
-            {
-                realDamage *= static_cast<int>(std::pow(2.0, value));
-            }
-
-            realTarget->TakeDamage(realSource, realDamage);
+            Generic::TakeDamageToCharacter(realSource, realTarget, realDamage,
+                                           true);
 
             if (realTarget->isDestroyed)
             {

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3,6 +3,7 @@
 // Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
+#include <Rosetta/PlayMode/Actions/Generic.hpp>
 #include <Rosetta/PlayMode/Auras/SwitchingAura.hpp>
 #include <Rosetta/PlayMode/CardSets/TheBarrensCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
@@ -878,6 +879,24 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<CustomTask>(
+        [](Player* player, Entity* source, [[maybe_unused]] Playable* target) {
+            auto minions = player->opponent->GetFieldZone()->GetAll();
+            for (auto& minion : minions)
+            {
+                if (minion->IsFrozen())
+                {
+                    Generic::TakeDamageToCharacter(
+                        dynamic_cast<Playable*>(source), minion, 4, false);
+                }
+                else
+                {
+                    minion->SetGameTag(GameTag::FROZEN, 1);
+                }
+            }
+        }));
+    cards.emplace("BAR_748", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [BAR_812] Oasis Ally - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -613,9 +613,24 @@ void TheBarrensCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Give a friendly Beast <b>Poisonous</b>.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_TARGET_WITH_RACE = 20
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
     // RefTag:
     // - POISONOUS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::TARGET,
+                                                        GameTag::POISONOUS, 1));
+    cards.emplace(
+        "WC_007",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_TARGET_WITH_RACE, 20 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_FRIENDLY_TARGET, 0 } }));
 
     // ---------------------------------------- MINION - HUNTER
     // [WC_008] Sin'dorei Scentfinder - COST:4 [ATK:1/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -952,6 +952,17 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawSpellTask>(1, true));
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::STACK, SelfCondList{ std::make_shared<SelfCondition>(
+                               SelfCondition::IsFrostSpell()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true,
+        TaskList{
+            std::make_shared<SummonTask>("BAR_888t", SummonSide::LEFT),
+            std::make_shared<SummonTask>("BAR_888t", SummonSide::RIGHT) }));
+    cards.emplace("WC_805", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [WC_806] Floecaster - COST:6 [ATK:5/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -9,6 +9,7 @@
 #include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 #include <Rosetta/PlayMode/Triggers/Triggers.hpp>
+#include <Rosetta/PlayMode/Zones/FieldZone.hpp>
 
 using namespace RosettaStone::PlayMode::SimpleTasks;
 
@@ -970,6 +971,22 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Costs (2) less for each <b>Frozen</b> enemy.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<AdaptiveCostEffect>([](Playable* playable) {
+        auto minions = playable->player->opponent->GetFieldZone()->GetAll();
+        int numFrozenEnemies = 0;
+
+        for (auto& minion : minions)
+        {
+            if (minion->IsFrozen())
+            {
+                ++numFrozenEnemies;
+            }
+        }
+
+        return 2 * numFrozenEnemies;
+    }));
+    cards.emplace("WC_806", CardDef(power));
 }
 
 void TheBarrensCardsGen::AddMageNonCollect(

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -1050,6 +1050,63 @@ TEST_CASE("[Hunter : Spell] - BAR_801 : Wound Prey")
     CHECK_EQ(curField[1]->HasRush(), true);
 }
 
+// ----------------------------------------- SPELL - HUNTER
+// [WC_007] Serpentbloom - COST:0
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: Give a friendly Beast <b>Poisonous</b>.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_TARGET_WITH_RACE = 20
+// - REQ_MINION_TARGET = 0
+// - REQ_FRIENDLY_TARGET = 0
+// --------------------------------------------------------
+// RefTag:
+// - POISONOUS = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Spell] - WC_007 : Serpentbloom")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Serpentbloom"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Enchanted Raven"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->HasPoisonous(), false);
+    CHECK_EQ(curField[1]->HasPoisonous(), false);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curField[0]->HasPoisonous(), false);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3));
+    CHECK_EQ(curField[1]->HasPoisonous(), true);
+}
+
 // ---------------------------------------- MINION - HUNTER
 // [WC_008] Sin'dorei Scentfinder - COST:4 [ATK:1/HP:6]
 // - Set: THE_BARRENS, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -1588,7 +1588,7 @@ TEST_CASE("[Mage : Minion] - WC_805 : Frostweave Dungeoneer")
     config.player1Class = CardClass::MAGE;
     config.player2Class = CardClass::WARRIOR;
     config.startPlayer = PlayerType::PLAYER1;
-    config.doFillDecks = true;
+    config.doFillDecks = false;
     config.autoRun = false;
 
     for (int i = 0; i < 30; i += 3)

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -1502,3 +1502,61 @@ TEST_CASE("[Mage : Spell] - WC_041 : Shattering Blast")
     CHECK_EQ(curField.GetCount(), 1);
     CHECK_EQ(opField.GetCount(), 0);
 }
+
+// ------------------------------------------ MINION - MAGE
+// [WC_805] Frostweave Dungeoneer - COST:3 [ATK:2/HP:3]
+// - Set: THE_BARRENS, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Draw a spell.
+//       If it's a Frost spell,
+//       summon two 1/1 Elementals that <b>Freeze</b>.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - FREEZE = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - WC_805 : Frostweave Dungeoneer")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Ice Barrier");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Malygos");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Wisp");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Frostweave Dungeoneer"));
+
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->card->name, "Ice Barrier");
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[0]->card->name, "Frosted Elemental");
+    CHECK_EQ(curField[1]->card->name, "Frostweave Dungeoneer");
+    CHECK_EQ(curField[2]->card->name, "Frosted Elemental");
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -1560,3 +1560,72 @@ TEST_CASE("[Mage : Minion] - WC_805 : Frostweave Dungeoneer")
     CHECK_EQ(curField[1]->card->name, "Frostweave Dungeoneer");
     CHECK_EQ(curField[2]->card->name, "Frosted Elemental");
 }
+
+// ------------------------------------------ MINION - MAGE
+// [WC_806] Floecaster - COST:6 [ATK:5/HP:5]
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: Costs (2) less for each <b>Frozen</b> enemy.
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - WC_806 : Floecaster")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Floecaster"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flurry (Rank 1)"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flurry (Rank 1)"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card6 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+
+    CHECK_EQ(card1->GetCost(), 6);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card1->GetCost(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(card1->GetCost(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card6));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card1->GetCost(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(card1->GetCost(), 0);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -796,6 +796,61 @@ TEST_CASE("[Druid : Minion] - WC_036 : Deviate Dreadfang")
     CHECK_EQ(curField[1]->HasRush(), true);
 }
 
+// ----------------------------------------- SPELL - HUNTER
+// [BAR_032] Piercing Shot - COST:4
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: Deal 6 damage to a minion.
+//       Excess damage hits the enemy hero.
+// --------------------------------------------------------
+// GameTag:
+// - ImmuneToSpellpower = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Spell] - BAR_032 : Piercing Shot")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Piercing Shot"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Piercing Shot"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Kobold Geomancer"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card4));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 25);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card5));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 19);
+}
+
 // ---------------------------------------- MINION - HUNTER
 // [BAR_033] Prospector's Caravan - COST:2 [ATK:1/HP:3]
 // - Set: THE_BARRENS, Rarity: Rare


### PR DESCRIPTION
This revision includes:
- Implement 5 THE_BARRENS cards
  - Piercing Shot (BAR_032)
  - Varden Dawngrasp (BAR_748)
  - Serpentbloom (WC_007)
  - Frostweave Dungeoneer (WC_805)
  - Floecaster (WC_806)
- Refactor code to take damage with generic function