### PR TITLE
Update Hearthstone Patch 21.0.3

### DIFF
--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -69,7 +69,7 @@ constexpr std::array<CardSet, 1> CLASSIC_CARD_SETS = {
 };
 
 //! The number of all cards.
-constexpr int NUM_ALL_CARDS = 13540;
+constexpr int NUM_ALL_CARDS = 13541;
 
 //! The number of player class.
 //! \note Druid, Hunter, Mage, Paladin, Priest, Rogue, Shaman, Warlock, Warrior,

--- a/Resources/cards.collectible.json
+++ b/Resources/cards.collectible.json
@@ -2737,13 +2737,13 @@
     },
     {
         "artist": "Matt Dixon",
-        "attack": 2,
+        "attack": 3,
         "cardClass": "HUNTER",
         "collectible": true,
-        "cost": 2,
+        "cost": 3,
         "dbfId": 63007,
         "flavor": "Is he running or galloping?",
-        "health": 3,
+        "health": 4,
         "id": "BAR_035",
         "mechanics": [
             "TRIGGER_VISUAL"
@@ -4818,7 +4818,7 @@
         "artist": "Ursula Dorada",
         "cardClass": "PALADIN",
         "collectible": true,
-        "cost": 1,
+        "cost": 2,
         "dbfId": 62947,
         "flavor": "It was the strength of Cariel's faith that emboldened the defenders of Northwatch that day. Although the strength of her giant hammer didn’t exactly hurt either.",
         "id": "BAR_880",
@@ -8380,7 +8380,7 @@
         "artist": "David Kegg",
         "cardClass": "MAGE",
         "collectible": true,
-        "cost": 2,
+        "cost": 3,
         "dbfId": 56385,
         "flavor": "\"Gettin' them discounts in bulk amounts, spells can come, and spells can go, castin' costs drop with my sweet, sweet flow.\"",
         "id": "BT_002",
@@ -10116,13 +10116,13 @@
     },
     {
         "artist": "Nicola Saviori",
-        "attack": 2,
+        "attack": 3,
         "cardClass": "WARLOCK",
         "collectible": true,
-        "cost": 2,
+        "cost": 3,
         "dbfId": 56523,
         "flavor": "He's got a dark glare, but he sees crystal clear!",
-        "health": 3,
+        "health": 4,
         "id": "BT_307",
         "mechanics": [
             "TRIGGER_VISUAL"
@@ -25222,14 +25222,14 @@
     },
     {
         "artist": "James Ryman",
-        "attack": 2,
+        "attack": 4,
         "cardClass": "DEMONHUNTER",
         "collectible": true,
-        "cost": 4,
+        "cost": 6,
         "dbfId": 61136,
         "elite": true,
         "flavor": "Well, that just sounds like damage with extra steps.",
-        "health": 6,
+        "health": 8,
         "id": "DMF_230",
         "name": "Il'gynoth",
         "rarity": "LEGENDARY",
@@ -51135,7 +51135,7 @@
             "WARLOCK"
         ],
         "collectible": true,
-        "cost": 8,
+        "cost": 9,
         "dbfId": 59585,
         "flavor": "\"A BIG mistake.\"",
         "health": 8,
@@ -54028,7 +54028,7 @@
         "cost": 4,
         "dbfId": 64320,
         "flavor": "If he stops being useful, just turn him into a kitchen countertop.",
-        "health": 5,
+        "health": 4,
         "id": "SW_032",
         "mechanics": [
             "BATTLECRY"
@@ -54494,7 +54494,7 @@
         "name": "Florist",
         "rarity": "COMMON",
         "set": "STORMWIND",
-        "text": "[x]At then end of your turn,\nreduce the cost of a Nature\nspell in your hand by (1).",
+        "text": "[x]At the end of your turn,\nreduce the cost of a Nature\n spell in your hand by (1).",
         "type": "MINION"
     },
     {
@@ -54542,7 +54542,7 @@
         "attack": 5,
         "cardClass": "NEUTRAL",
         "collectible": true,
-        "cost": 5,
+        "cost": 6,
         "dbfId": 64711,
         "flavor": "Farm! No wait… Mine! No wait… 3 to Smith—they're taking Farm. Get there now!",
         "health": 5,
@@ -56075,7 +56075,7 @@
         "name": "Psyfiend",
         "rarity": "RARE",
         "set": "STORMWIND",
-        "text": "After you cast a Shadow spell, deal 2 damage to each Hero.",
+        "text": "After you cast a Shadow spell, deal 2 damage to each hero.",
         "type": "MINION"
     },
     {

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -514,7 +514,7 @@ void BlackTempleCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     Power power;
 
     // ------------------------------------------- SPELL - MAGE
-    // [BT_002] Incanter's Flow - COST:2
+    // [BT_002] Incanter's Flow - COST:3
     // - Set: BLACK_TEMPLE, Rarity: Common
     // - Spell School: Arcane
     // --------------------------------------------------------
@@ -1789,7 +1789,7 @@ void BlackTempleCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARLOCK
-    // [BT_307] Darkglare - COST:2 [ATK:2/HP:3]
+    // [BT_307] Darkglare - COST:3 [ATK:3/HP:4]
     // - Race: Demon, Set: BLACK_TEMPLE, Rarity: Epic
     // --------------------------------------------------------
     // Text: After your hero takes damage, refresh a Mana Crystals.

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -2580,7 +2580,7 @@ void DarkmoonFaireCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [DMF_230] Il'gynoth - COST:4 [ATK:2/HP:6]
+    // [DMF_230] Il'gynoth - COST:6 [ATK:4/HP:8]
     // - Set: DARKMOON_FAIRE, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Lifesteal</b>

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -903,7 +903,7 @@ void ScholomanceCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     cards.emplace("SCH_137", CardDef(power));
 
     // ---------------------------------------- MINION - PRIEST
-    // [SCH_140] Flesh Giant - COST:8 [ATK:8/HP:8]
+    // [SCH_140] Flesh Giant - COST:9 [ATK:8/HP:8]
     // - Set: SCHOLOMANCE, Rarity: Epic
     // --------------------------------------------------------
     // Text: Costs (1) less for each time your hero's Health changed

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -1432,7 +1432,7 @@ void StormwindCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [SW_032] Granite Forgeborn - COST:4 [ATK:4/HP:5]
+    // [SW_032] Granite Forgeborn - COST:4 [ATK:4/HP:4]
     // - Race: Elemental, Set: STORMWIND, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Reduce the cost of Elementals
@@ -2256,7 +2256,7 @@ void StormwindCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [SW_063] Battleground Battlemaster - COST:5 [ATK:5/HP:5]
+    // [SW_063] Battleground Battlemaster - COST:6 [ATK:5/HP:5]
     // - Set: STORMWIND, Rarity: Common
     // --------------------------------------------------------
     // Text: Adjacent minions have <b>Windfury</b>.

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -569,7 +569,7 @@ void TheBarrensCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     cards.emplace("BAR_034", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
-    // [BAR_035] Kolkar Pack Runner - COST:2 [ATK:2/HP:3]
+    // [BAR_035] Kolkar Pack Runner - COST:3 [ATK:3/HP:4]
     // - Set: THE_BARRENS, Rarity: Epic
     // --------------------------------------------------------
     // Text: After you cast a spell,
@@ -1256,7 +1256,7 @@ void TheBarrensCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [BAR_880] Conviction (Rank 1) - COST:1
+    // [BAR_880] Conviction (Rank 1) - COST:2
     // - Set: THE_BARRENS, Rarity: Epic
     // - Spell School: Holy
     // --------------------------------------------------------
@@ -1373,7 +1373,7 @@ void TheBarrensCardsGen::AddPaladinNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [BAR_880t] Conviction (Rank 2) - COST:1
+    // [BAR_880t] Conviction (Rank 2) - COST:2
     // - Set: THE_BARRENS, Rarity: Epic
     // - Spell School: Holy
     // --------------------------------------------------------
@@ -1382,7 +1382,7 @@ void TheBarrensCardsGen::AddPaladinNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [BAR_880t2] Conviction (Rank 3) - COST:1
+    // [BAR_880t2] Conviction (Rank 3) - COST:2
     // - Set: THE_BARRENS, Rarity: Epic
     // - Spell School: Holy
     // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BlackTempleCardsGenTests.cpp
@@ -590,7 +590,7 @@ TEST_CASE("[Hunter : Spell] - BT_213 : Scavenger's Ingenuity")
 }
 
 // ------------------------------------------- SPELL - MAGE
-// [BT_002] Incanter's Flow - COST:2
+// [BT_002] Incanter's Flow - COST:3
 // - Set: BLACK_TEMPLE, Rarity: Common
 // - Spell School: Arcane
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -1001,7 +1001,7 @@ TEST_CASE("[Hunter : Spell] - BAR_034 : Tame Beast (Rank 1)")
 }
 
 // ---------------------------------------- MINION - HUNTER
-// [BAR_035] Kolkar Pack Runner - COST:2 [ATK:2/HP:3]
+// [BAR_035] Kolkar Pack Runner - COST:3 [ATK:3/HP:4]
 // - Set: THE_BARRENS, Rarity: Epic
 // --------------------------------------------------------
 // Text: After you cast a spell,


### PR DESCRIPTION
This revision includes:
- Update Hearthstone Patch 21.0.3 (Resolves #626)
  - Standard Updates
    - NUM_ALL_CARDS: 13540 -> 13541
    - Incanter’s Flow: Old: [Costs 2] → New: [Costs 3]
    - Il’gynoth: Old: [Costs 4] 2 Attack, 6 Health → New: [Costs 6] 4 Attack, 8 Health
    - Darkglare: Old: [Costs 2] 2 Attack, 3 Health → New: [Costs 3] 3 Attack, 4 Health
    - Battleground Battlemaster: Old: [Costs 5] → New: [Costs 6]
    - Kolkar Pack Runner: Old: [Costs 2] 2 Attack, 3 Health → New: [Costs 3] 3 Attack, 4 Health
    - Granite Forgeborn: Old: 4 Attack, 5 Health → New: 4 Attack, 4 Health
    - Conviction (Rank 1), Conviction (Rank 2), Conviction (Rank 3): Old: [Costs 1] → New: [Costs 2]
    - Flesh Giant: Old: [Costs 8] → New: [Costs 9]
  - Battlegrounds Update
    - Shudderwock: Old: Burbling [Costs 1] Your next Battlecry this turn triggers twice. → New: Snicker-snack [Costs 0] Add a 1/1 Shudderling to your hand that repeats all Battlecries you’ve played. (Twice per game).
    - Dancin’ Deryl: Old: [Passive] After you sell a minion, randomly give a minion in Bob’s Tavern +1/+1 twice. → New: [Passive] After you sell a minion, randomly give a minion in Bob’s Tavern +1/+1 three times.
    - Fungalmancer Flurgl: Old: [Passive] After you sell a Murloc, add a random Murloc to Bob’s Tavern. → New: [Passive] After you sell a minion, add a random Murloc to Bob’s Tavern.
    - Maiev Shadowsong: Old: [Costs 1] Make a minion in Bob’s Tavern Dormant. After 3 turns, get it with +1/+1. → New: [Costs 1] Make a minion in Bob’s Tavern Dormant. After 3 turns, get it with +2/+2.
    - Malygos: Old: [Costs 0] Replace a minion with a random one of the same Tavern Tier. → New: [Costs 0] Replace a minion with a random one of the same Tavern Tier. (Twice per turn).