### PR TITLE
Implement 5 VANILLA cards

### DIFF
--- a/Documents/CardList - Classic.md
+++ b/Documents/CardList - Classic.md
@@ -14,11 +14,11 @@ VANILLA | VAN_CS1_129 | Inner Fire |
 VANILLA | VAN_CS1_130 | Holy Smite |  
 VANILLA | VAN_CS2_003 | Mind Vision |  
 VANILLA | VAN_CS2_004 | Power Word: Shield |  
-VANILLA | VAN_CS2_005 | Claw |  
-VANILLA | VAN_CS2_007 | Healing Touch |  
-VANILLA | VAN_CS2_008 | Moonfire |  
-VANILLA | VAN_CS2_009 | Mark of the Wild |  
-VANILLA | VAN_CS2_011 | Savage Roar |  
+VANILLA | VAN_CS2_005 | Claw | O
+VANILLA | VAN_CS2_007 | Healing Touch | O
+VANILLA | VAN_CS2_008 | Moonfire | O
+VANILLA | VAN_CS2_009 | Mark of the Wild | O
+VANILLA | VAN_CS2_011 | Savage Roar | O
 VANILLA | VAN_CS2_012 | Swipe |  
 VANILLA | VAN_CS2_013 | Wild Growth |  
 VANILLA | VAN_CS2_022 | Polymorph |  
@@ -389,4 +389,4 @@ VANILLA | VAN_PRO_001 | Elite Tauren Chieftain |
 VANILLA | VAN_tt_004 | Flesheating Ghoul |  
 VANILLA | VAN_tt_010 | Spellbender |  
 
-- Progress: 0% (0 of 382 Cards)
+- Progress: 1% (5 of 382 Cards)

--- a/Includes/Rosetta/PlayMode/Cards/Card.hpp
+++ b/Includes/Rosetta/PlayMode/Cards/Card.hpp
@@ -114,6 +114,10 @@ class Card
     //! \return true if this card is in WILD set, and false otherwise.
     bool IsWildSet() const;
 
+    //! Finds out if this card is in CLASSIC set.
+    //! \return true if this card is in CLASSIC set, and false otherwise.
+    bool IsClassicSet() const;
+
     //! Returns the number of cards that can be inserted into the deck.
     //! \return The number of cards that can be inserted into the deck.
     std::size_t GetMaxAllowedInDeck() const;

--- a/Includes/Rosetta/PlayMode/Cards/Cards.hpp
+++ b/Includes/Rosetta/PlayMode/Cards/Cards.hpp
@@ -184,6 +184,7 @@ class Cards
     static std::array<std::vector<Card*>, NUM_PLAYER_CLASS> m_wildCards;
     static std::vector<Card*> m_allStandardCards;
     static std::vector<Card*> m_allWildCards;
+    static std::vector<Card*> m_allClassicCards;
     static std::vector<Card*> m_lackeys;
 };
 }  // namespace RosettaStone::PlayMode

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Classic Format
 
-  * 0% Vanilla Set (0 of 382 Cards)
+  * 1% Vanilla Set (5 of 382 Cards)
 
 ## Implementation List
 

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -10,6 +10,8 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 
 namespace RosettaStone::PlayMode
 {
+using PlayReqs = std::map<PlayReq, int>;
+
 void VanillaCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
     // Do nothing
@@ -194,6 +196,14 @@ void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Restore 8 Health.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<HealTask>(EntityType::TARGET, 8));
+    cards.emplace(
+        "VAN_CS2_007",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_CS2_008] Moonfire - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -211,6 +211,15 @@ void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 1 damage.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 1, true));
+    cards.emplace(
+        "VAN_CS2_008",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_CS2_009] Mark of the Wild - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -4,6 +4,7 @@
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 #include <Rosetta/PlayMode/CardSets/VanillaCardsGen.hpp>
+#include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 
 using namespace RosettaStone::PlayMode::SimpleTasks;
@@ -228,9 +229,20 @@ void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // Text: Give a minion <b>Taunt</b> and +2/+2.<i>
     //       (+2 Attack/+2 Health)</i>
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
+        "VAN_CS2_009e", EntityType::TARGET));
+    cards.emplace(
+        "VAN_CS2_009",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_CS2_011] Savage Roar - COST:3
@@ -454,12 +466,17 @@ void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 
 void VanillaCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------ ENCHANTMENT - DRUID
     // [VAN_CS2_009e] Mark of the Wild - COST:0
     // - Set: VANILLA
     // --------------------------------------------------------
     // Text: +2/+2 and <b>Taunt</b>.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("VAN_CS2_009e"));
+    cards.emplace("VAN_CS2_009e", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_EX1_154a] Solar Wrath - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -248,8 +248,12 @@ void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // [VAN_CS2_011] Savage Roar - COST:3
     // - Set: VANILLA, Rarity: Free
     // --------------------------------------------------------
-    // Text: Give your characters +2 Attack this turn.
+    // Text: Give your characters +2 Attack this turn.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("CS2_011o", EntityType::FRIENDS));
+    cards.emplace("VAN_CS2_011", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_CS2_012] Swipe - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -6,6 +6,8 @@
 #include <Rosetta/PlayMode/CardSets/VanillaCardsGen.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 
+using namespace RosettaStone::PlayMode::SimpleTasks;
+
 namespace RosettaStone::PlayMode
 {
 void VanillaCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
@@ -172,12 +174,19 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
 void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------ SPELL - DRUID
     // [VAN_CS2_005] Claw - COST:1
     // - Set: VANILLA, Rarity: Free
     // --------------------------------------------------------
     // Text: Give your hero +2 Attack this turn. Gain 2 Armor.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ArmorTask>(2));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("CS2_005o", EntityType::HERO));
+    cards.emplace("VAN_CS2_005", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_CS2_007] Healing Touch - COST:3

--- a/Sources/Rosetta/PlayMode/Cards/Card.cpp
+++ b/Sources/Rosetta/PlayMode/Cards/Card.cpp
@@ -360,6 +360,11 @@ bool Card::IsWildSet() const
     return false;
 }
 
+bool Card::IsClassicSet() const
+{
+    return GetCardSet() == CardSet::VANILLA;
+}
+
 std::size_t Card::GetMaxAllowedInDeck() const
 {
     return maxAllowedInDeck;

--- a/Sources/Rosetta/PlayMode/Cards/Cards.cpp
+++ b/Sources/Rosetta/PlayMode/Cards/Cards.cpp
@@ -263,8 +263,23 @@ std::vector<Card*> Cards::FindCardByRace(Race race)
 
 Card* Cards::FindCardByName(const std::string_view& name, FormatType format)
 {
-    auto cards =
-        (format == FormatType::STANDARD) ? m_allStandardCards : m_allWildCards;
+    std::vector<Card*> cards;
+
+    switch (format)
+    {
+        case FormatType::STANDARD:
+            cards = m_allStandardCards;
+            break;
+        case FormatType::WILD:
+            cards = m_allWildCards;
+            break;
+        case FormatType::CLASSIC:
+            cards = m_allClassicCards;
+            break;
+        case FormatType::UNKNOWN:
+            break;
+    }
+
     for (Card* card : cards)
     {
         if (card->name == name && card->IsCollectible())

--- a/Sources/Rosetta/PlayMode/Cards/Cards.cpp
+++ b/Sources/Rosetta/PlayMode/Cards/Cards.cpp
@@ -61,6 +61,11 @@ Cards::Cards()
                 }
                 m_allWildCards.emplace_back(card);
             }
+
+            if (card->IsClassicSet())
+            {
+                m_allClassicCards.emplace_back(card);
+            }
         }
 
         if (card->IsLackey())

--- a/Sources/Rosetta/PlayMode/Cards/Cards.cpp
+++ b/Sources/Rosetta/PlayMode/Cards/Cards.cpp
@@ -42,22 +42,25 @@ Cards::Cards()
                                    ? static_cast<int>(card->GetCardClass()) - 5
                                    : static_cast<int>(card->GetCardClass()) - 2;
 
-        if (card->IsCollectible() && card->IsStandardSet())
+        if (card->IsCollectible())
         {
-            if (card->GetCardClass() != CardClass::NEUTRAL)
+            if (card->IsStandardSet())
             {
-                m_standardCards[cardClass].emplace_back(card);
+                if (card->GetCardClass() != CardClass::NEUTRAL)
+                {
+                    m_standardCards[cardClass].emplace_back(card);
+                }
+                m_allStandardCards.emplace_back(card);
             }
-            m_allStandardCards.emplace_back(card);
-        }
 
-        if (card->IsCollectible() && card->IsWildSet())
-        {
-            if (card->GetCardClass() != CardClass::NEUTRAL)
+            if (card->IsWildSet())
             {
-                m_wildCards[cardClass].emplace_back(card);
+                if (card->GetCardClass() != CardClass::NEUTRAL)
+                {
+                    m_wildCards[cardClass].emplace_back(card);
+                }
+                m_allWildCards.emplace_back(card);
             }
-            m_allWildCards.emplace_back(card);
         }
 
         if (card->IsLackey())

--- a/Sources/Rosetta/PlayMode/Cards/Cards.cpp
+++ b/Sources/Rosetta/PlayMode/Cards/Cards.cpp
@@ -19,6 +19,7 @@ std::array<std::vector<Card*>, NUM_PLAYER_CLASS> Cards::m_standardCards;
 std::array<std::vector<Card*>, NUM_PLAYER_CLASS> Cards::m_wildCards;
 std::vector<Card*> Cards::m_allStandardCards;
 std::vector<Card*> Cards::m_allWildCards;
+std::vector<Card*> Cards::m_allClassicCards;
 std::vector<Card*> Cards::m_lackeys;
 
 Cards::Cards()

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -250,3 +250,58 @@ TEST_CASE("[Druid : Spell] - VAN_CS2_009 : Mark of the Wild")
     CHECK_EQ(curField[0]->GetAttack(), 5);
     CHECK_EQ(curField[0]->GetHealth(), 3);
 }
+
+// ------------------------------------------ SPELL - DRUID
+// [VAN_CS2_011] Savage Roar - COST:3
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Give your characters +2 Attack this turn.
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - VAN_CS2_011 : Savage Roar")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Savage Roar", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Dalaran Mage", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -1,12 +1,66 @@
-// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+﻿// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 // We are making my contributions/submissions to this project solely in our
 // personal capacity and are not conveying any rights to any intellectual
 // property of any third parties.
 
-#include <Utils/CardSetUtils.hpp>
+#include "doctest_proxy.hpp"
 
-TEST_CASE("[VanillaCardsGen] - Temp")
+#include <Utils/CardSetUtils.hpp>
+#include <Utils/TestUtils.hpp>
+
+#include <Rosetta/PlayMode/Actions/Draw.hpp>
+#include <Rosetta/PlayMode/Cards/Cards.hpp>
+#include <Rosetta/PlayMode/Zones/DeckZone.hpp>
+#include <Rosetta/PlayMode/Zones/FieldZone.hpp>
+#include <Rosetta/PlayMode/Zones/HandZone.hpp>
+
+using namespace RosettaStone;
+using namespace PlayMode;
+using namespace PlayerTasks;
+using namespace SimpleTasks;
+
+// ------------------------------------------ SPELL - DRUID
+// [VAN_CS2_005] Claw - COST:1
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Give your hero +2 Attack this turn. Gain 2 Armor.
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - VAN_CS2_005 : Claw")
 {
-    CHECK(true);
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Claw", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 2);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 2);
+
+    game.Process(curPlayer,
+                 AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 2);
 }

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -196,3 +196,57 @@ TEST_CASE("[Druid : Spell] - VAN_CS2_008 : Moonfire")
                  PlayCardTask::SpellTarget(card4, curPlayer->GetHero()));
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 29);
 }
+
+// ------------------------------------------ SPELL - DRUID
+// [VAN_CS2_009] Mark of the Wild - COST:2
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Give a minion <b>Taunt</b> and +2/+2.<i>
+//       (+2 Attack/+2 Health)</i>
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - VAN_CS2_009 : Mark of the Wild")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Mark of the Wild", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAUNT), 0);
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAUNT), 1);
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -123,3 +123,76 @@ TEST_CASE("[Druid : Spell] - VAN_CS2_007 : Healing Touch")
     game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card3));
     CHECK_EQ(opField[0]->GetHealth(), 7);
 }
+
+// ------------------------------------------ SPELL - DRUID
+// [VAN_CS2_008] Moonfire - COST:0
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Deal 1 damage.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - VAN_CS2_008 : Moonfire")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Moonfire", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Moonfire", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Moonfire", FormatType::CLASSIC));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Moonfire", FormatType::CLASSIC));
+    const auto card5 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Acidic Swamp Ooze", FormatType::CLASSIC));
+    const auto card6 = Generic::DrawCard(
+        opPlayer,
+        Cards::FindCardByName("Acidic Swamp Ooze", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card6));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card6));
+    CHECK_EQ(opField[0]->GetHealth(), 1);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 29);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card5));
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card4, curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 29);
+}


### PR DESCRIPTION
This revision includes:
- Implement 5 VANILLA cards
  - Claw (VAN_CS2_005)
  - Healing Touch (VAN_CS2_007)
  - Moonfire (VAN_CS2_008)
  - Mark of the Wild (VAN_CS2_009)
  - Savage Roar (VAN_CS2_011)
- Refactor code to get cards according to the format type
  - Add member variable 'm_allClassicCards'
  - Change code to emplace standard/wild set cards
  - Add method 'IsClassicSet()': Finds out if this card is in CLASSIC set
  - Add code to emplace classic cards