### PR TITLE
Update Hearthstone Patch 21.3

### DIFF
--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -69,7 +69,7 @@ constexpr std::array<CardSet, 1> CLASSIC_CARD_SETS = {
 };
 
 //! The number of all cards.
-constexpr int NUM_ALL_CARDS = 13755;
+constexpr int NUM_ALL_CARDS = 13760;
 
 //! The number of player class.
 //! \note Druid, Hunter, Mage, Paladin, Priest, Rogue, Shaman, Warlock, Warrior,

--- a/Resources/cards.collectible.json
+++ b/Resources/cards.collectible.json
@@ -3315,7 +3315,6 @@
         "health": 5,
         "id": "BAR_081",
         "mechanics": [
-            "BATTLECRY",
             "DISCOVER"
         ],
         "name": "Southsea Scoundrel",
@@ -4130,7 +4129,7 @@
         "artist": "David Kegg",
         "cardClass": "MAGE",
         "collectible": true,
-        "cost": 2,
+        "cost": 1,
         "dbfId": 63062,
         "flavor": "The Barrens were a lush jungle. Then this happened.",
         "id": "BAR_546",
@@ -4143,15 +4142,15 @@
     },
     {
         "artist": "Qinghao Wu",
-        "attack": 10,
+        "attack": 8,
         "cardClass": "MAGE",
         "collectible": true,
         "collectionText": "[x]<b>Battlecry:</b> If you've dealt 10\ndamage with your Hero Power\n this game, deal 10 damage\nto all enemies.",
-        "cost": 10,
+        "cost": 8,
         "dbfId": 63064,
         "elite": true,
         "flavor": "You're not hardcore unless you died hardcore.",
-        "health": 10,
+        "health": 8,
         "id": "BAR_547",
         "mechanics": [
             "BATTLECRY"
@@ -4911,7 +4910,7 @@
         "cost": 5,
         "dbfId": 63701,
         "flavor": "\"Brug will read anything you put on the parchment prompter. Anything.\"",
-        "health": 5,
+        "health": 6,
         "id": "BAR_896",
         "mechanics": [
             "FRENZY",
@@ -20372,7 +20371,7 @@
         "cost": 1,
         "dbfId": 62462,
         "flavor": "Piracy is technically a discount.",
-        "health": 1,
+        "health": 2,
         "howToEarn": "Unlocked at level 1.",
         "howToEarnGolden": "Unlocked after winning 50 games as Warrior.",
         "id": "CS3_008",
@@ -20473,7 +20472,7 @@
         "cost": 2,
         "dbfId": 62698,
         "flavor": "His ethics are top notch. Just look at that smiling kitty!",
-        "health": 1,
+        "health": 3,
         "howToEarn": "Unlocked at level 7.",
         "howToEarnGolden": "Unlocked after winning 100 games as Hunter.",
         "id": "CS3_015",
@@ -39995,6 +39994,17 @@
         "type": "HERO"
     },
     {
+        "cardClass": "PALADIN",
+        "collectible": true,
+        "dbfId": 77249,
+        "health": 30,
+        "id": "HERO_04m",
+        "name": "Ascended Uther",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
         "cardClass": "HUNTER",
         "collectible": true,
         "dbfId": 31,
@@ -40249,6 +40259,17 @@
         "type": "HERO"
     },
     {
+        "cardClass": "DRUID",
+        "collectible": true,
+        "dbfId": 77252,
+        "health": 30,
+        "id": "HERO_06o",
+        "name": "Winter Fury Malfurion",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
         "cardClass": "WARLOCK",
         "collectible": true,
         "dbfId": 893,
@@ -40376,6 +40397,17 @@
         "health": 30,
         "id": "HERO_07l",
         "name": "Tamsin Triumphant",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "WARLOCK",
+        "collectible": true,
+        "dbfId": 77254,
+        "health": 30,
+        "id": "HERO_07m",
+        "name": "House of Rituals Gul'dan",
         "rarity": "FREE",
         "set": "HERO_SKINS",
         "type": "HERO"
@@ -40729,6 +40761,17 @@
         "health": 30,
         "id": "HERO_10h",
         "name": "Skullbearer Illidan",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "DEMONHUNTER",
+        "collectible": true,
+        "dbfId": 77246,
+        "health": 30,
+        "id": "HERO_10k",
+        "name": "Ember Court Illidan",
         "rarity": "FREE",
         "set": "HERO_SKINS",
         "type": "HERO"
@@ -48231,6 +48274,7 @@
         "race": "PIRATE",
         "rarity": "EPIC",
         "set": "EXPERT1",
+        "techLevel": 2,
         "text": "Your other Pirates have +1/+1.",
         "type": "MINION"
     },
@@ -51329,7 +51373,7 @@
         "name": "Mindrender Illucia",
         "rarity": "LEGENDARY",
         "set": "SCHOLOMANCE",
-        "text": "<b>Battlecry:</b> Swap hands and decks with your opponent until your next turn.",
+        "text": "[x]<b>Battlecry:</b> Replace\nyour hand with a copy of\nyour opponent's until\nend of turn.",
         "type": "MINION"
     },
     {
@@ -53766,7 +53810,7 @@
         "attack": 0,
         "cardClass": "WARLOCK",
         "collectible": true,
-        "cost": 3,
+        "cost": 4,
         "dbfId": 63677,
         "durability": 2,
         "flavor": "\"Please, I need these greens to disenchant them.\" —Every Enchanter Ever",
@@ -54107,7 +54151,7 @@
         "attack": 6,
         "cardClass": "DEMONHUNTER",
         "collectible": true,
-        "cost": 7,
+        "cost": 8,
         "dbfId": 64373,
         "flavor": "\"You don't understand… ogres are an untapped market for vengeance and hatred!\"",
         "health": 7,
@@ -55059,7 +55103,7 @@
         "name": "The Demon Seed",
         "rarity": "LEGENDARY",
         "set": "STORMWIND",
-        "text": "[x]<b>Questline:</b> Take 6\ndamage on your turns.\n<b>Reward:</b> <b>Lifesteal</b>. Deal $3\ndamage to the enemy hero.",
+        "text": "[x]<b>Questline:</b> Take 8\ndamage on your turns.\n<b>Reward:</b> <b>Lifesteal</b>. Deal $3\ndamage to the enemy hero.",
         "type": "SPELL"
     },
     {
@@ -55088,7 +55132,7 @@
         "cost": 3,
         "dbfId": 64975,
         "flavor": "\"Just don't stab the ankles! I want his boots!\"",
-        "health": 3,
+        "health": 4,
         "id": "SW_093",
         "name": "Stormwind Freebooter",
         "race": "PIRATE",
@@ -56219,7 +56263,7 @@
         "attack": 0,
         "cardClass": "HUNTER",
         "collectible": true,
-        "cost": 2,
+        "cost": 1,
         "dbfId": 64964,
         "durability": 3,
         "flavor": "Combining taxidermy and tailoring.",
@@ -71348,7 +71392,7 @@
         "artist": "Hideaki Takamura",
         "cardClass": "SHAMAN",
         "collectible": true,
-        "cost": 1,
+        "cost": 2,
         "dbfId": 63098,
         "flavor": "Flame is perpetual.*\n *<i>Perpetual only applies to current turn.</i>",
         "id": "WC_020",

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -614,7 +614,7 @@ void CoreCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     cards.emplace("CORE_TRL_111", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
-    // [CS3_015] Selective Breeder - COST:2 [ATK:1/HP:1]
+    // [CS3_015] Selective Breeder - COST:2 [ATK:1/HP:3]
     // - Set: CORE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> <b>Discover</b> a copy of a Beast
@@ -2691,7 +2691,7 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     cards.emplace("CORE_GVG_053", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
-    // [CS3_008] Bloodsail Deckhand - COST:1 [ATK:2/HP:1]
+    // [CS3_008] Bloodsail Deckhand - COST:1 [ATK:2/HP:2]
     // - Race: Pirate, Set: CORE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> The next weapon you play costs

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -914,8 +914,8 @@ void ScholomanceCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // [SCH_159] Mindrender Illucia - COST:3 [ATK:1/HP:3]
     // - Set: SCHOLOMANCE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Swap hands and decks with your opponent
-    //       until your next turn.
+    // Text: <b>Battlecry:</b> Replace your hand with
+    //       a copy of your opponent¡¯s until end of turn.
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -381,7 +381,7 @@ void StormwindCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- WEAPON - HUNTER
-    // [SW_457] Leatherworking Kit - COST:2
+    // [SW_457] Leatherworking Kit - COST:1
     // - Set: STORMWIND, Rarity: Rare
     // --------------------------------------------------------
     // Text: After three friendly Beasts die,
@@ -1550,7 +1550,7 @@ void StormwindCardsGen::AddShamanNonCollect(
     // [SW_031t2] Tame the Flames - COST:1
     // - Set: STORMWIND, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Questline:</b> Play 2 cards with <b>Overload</b>.
+    // Text: <b>Questline:</b> Play 3 cards with <b>Overload</b>.
     //       <b>Reward:</b> Stormcaller Bru'kan.
     // --------------------------------------------------------
     // GameTag:
@@ -1603,7 +1603,7 @@ void StormwindCardsGen::AddShamanNonCollect(
 void StormwindCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
     // --------------------------------------- WEAPON - WARLOCK
-    // [SW_003] Runed Mithril Rod - COST:3
+    // [SW_003] Runed Mithril Rod - COST:4
     // - Set: STORMWIND, Rarity: Rare
     // --------------------------------------------------------
     // Text: After you draw 4 cards,
@@ -1688,7 +1688,7 @@ void StormwindCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // [SW_091] The Demon Seed - COST:1
     // - Set: STORMWIND, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Questline:</b> Take 6 damage on your turns.
+    // Text: <b>Questline:</b> Take 8 damage on your turns.
     //       <b>Reward:</b> <b>Lifesteal</b>.
     //       Deal 3 damage to the enemy hero.
     // --------------------------------------------------------
@@ -1731,7 +1731,7 @@ void StormwindCardsGen::AddWarlockNonCollect(
     // [SW_091t] Establish the Link - COST:1
     // - Set: STORMWIND, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Questline:</b> Take 7 damage on your turns.
+    // Text: <b>Questline:</b> Take 8 damage on your turns.
     //       <b>Reward:</b> <b>Lifesteal</b>.
     //       Deal 3 damage to the enemy hero.
     // --------------------------------------------------------
@@ -1841,7 +1841,7 @@ void StormwindCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [SW_093] Stormwind Freebooter - COST:3 [ATK:3/HP:3]
+    // [SW_093] Stormwind Freebooter - COST:3 [ATK:3/HP:4]
     // - Race: Pirate, Set: STORMWIND, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Give your hero +2 Attack this turn.
@@ -1940,7 +1940,7 @@ void StormwindCardsGen::AddWarriorNonCollect(
 void StormwindCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 {
     // ----------------------------------- MINION - DEMONHUNTER
-    // [SW_037] Irebound Brute - COST:7 [ATK:6/HP:7]
+    // [SW_037] Irebound Brute - COST:8 [ATK:6/HP:7]
     // - Race: Demon, Set: STORMWIND, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -897,7 +897,7 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------- SPELL - MAGE
-    // [BAR_546] Wildfire - COST:2
+    // [BAR_546] Wildfire - COST:1
     // - Set: THE_BARRENS, Rarity: Epic
     // - Spell School: Fire
     // --------------------------------------------------------
@@ -905,7 +905,7 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [BAR_547] Mordresh Fire Eye - COST:10 [ATK:10/HP:10]
+    // [BAR_547] Mordresh Fire Eye - COST:8 [ATK:8/HP:8]
     // - Set: THE_BARRENS, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> If you've dealt 10 damage with
@@ -2158,7 +2158,7 @@ void TheBarrensCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - SHAMAN
-    // [WC_020] Perpetual Flame - COST:1
+    // [WC_020] Perpetual Flame - COST:2
     // - Set: THE_BARRENS, Rarity: Rare
     // - Spell School: Fire
     // --------------------------------------------------------
@@ -2546,7 +2546,7 @@ void TheBarrensCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - WARRIOR
-    // [BAR_896] Stonemaul Anchorman - COST:5 [ATK:4/HP:5]
+    // [BAR_896] Stonemaul Anchorman - COST:5 [ATK:4/HP:6]
     // - Race: Pirate, Set: THE_BARRENS, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Rush</b>

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -1801,7 +1801,7 @@ TEST_CASE("[Hunter : Weapon] - CORE_TRL_111 : Headhunter's Hatchet")
 }
 
 // ---------------------------------------- MINION - HUNTER
-// [CS3_015] Selective Breeder - COST:2 [ATK:1/HP:1]
+// [CS3_015] Selective Breeder - COST:2 [ATK:1/HP:3]
 // - Set: CORE, Rarity: Rare
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> <b>Discover</b> a copy of a Beast
@@ -7590,7 +7590,7 @@ TEST_CASE("[Warrior : Minion] - CORE_GVG_053 : Shieldmaiden")
 }
 
 // --------------------------------------- MINION - WARRIOR
-// [CS3_008] Bloodsail Deckhand - COST:1 [ATK:2/HP:1]
+// [CS3_008] Bloodsail Deckhand - COST:1 [ATK:2/HP:2]
 // - Race: Pirate, Set: CORE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> The next weapon you play costs


### PR DESCRIPTION
This revision includes:
- Update Hearthstone Patch 21.3 (Resolves #640)
  - Update card data
  - Card update
    - Irebound Brute: Old: [Costs 7] → New: [Costs 8]
    - Mindrender Illucia: Old: Battlecry: Swap hands and decks with your opponent until your next turn. → New: Battlecry: Replace your hand with a copy of your opponent’s until end of turn.
    - Perpetual Flame: Old: [Costs 1] → New: [Costs 2]
    - Tame the Flames (the third portion of the Questline): Old: Play 2 cards with Overload. Reward: Stormcaller Bru’kan. → New: Play 3 cards with Overload. Reward: Stormcaller Bru’kan.
    - The Demon Seed (part 1 of the Questline): Old: Take 6 damage on your turns. Reward: Lifesteal. Deal 3 damage to the enemy hero. → New: Take 8 damage on your turns. Reward: Lifesteal. Deal 3 damage to the enemy hero.
    - Establish the Link (part 2 of the Questline): Old: Take 7 damage on your turns. Reward: Lifesteal. Deal 3 damage to the enemy hero. → New: Take 8 damage on your turns. Reward: Lifesteal. Deal 3 damage to the enemy hero.
    - Additionally, The Demon Seed is now banned in Wild.
    - Runed Mithril Rod: Old: [Costs 3] → New: [Costs 4]
    - Leatherworking Kit: Old: [Costs 2] → New: [Costs 1]
    - Selective Breeder: Old: 1 Attack, 1 Health → New: 1 Attack, 3 Health
    - Wildfire: Old: [Costs 2] → New: [Costs 1]
    - Mordresh Fire Eye: Old: [Costs 10] 10 Attack, 10 Health → New: [Costs 8] 8 Attack, 8 Health
    - Stormwind Freebooter: Old: 3 Attack, 3 Health → New: 3 Attack, 4 Health
    - Stonemaul Anchorman: Old: 4 Attack, 5 Health → New: 4 Attack, 6 Health
    - Bloodsail Deckhand: Old: 2 Attack, 1 Health → New: 2 Attack, 2 Health
  - Battlegrounds update
    - Hero update
      - Shudderwock (Snicker-snack): Old: [Costs 0] → New: [Costs 2]
      - Galewing (Dungar’s Gryphon (Eastern Plaguelands Option)): Old: In 5 turns, upgrade your Tavern Tier. → New: In 5 turns, your next Tavern Tier upgrade costs (5) less.
      - Master Nguyen (Power of the Storm [Passive]): Adjusted the odds of hero power offerings (no text changes).
    - Minion update
      - Defiant Shipwright has been removed from the minion pool.
      - Southsea Captain has been returned to the minion pool.
      - Impatient Doomsayer: Old: [Tavern Tier 3] Avenge (3): Add a random Demon to your hand. → New: [Tavern Tier 4] Avenge (4): Add a random Demon to your hand.
      - Kathra’natir: Old: [Tavern Tier 4] 7 Attack, 5 Health. Your other Demons have +3 Attack. Your Hero is Immune. → New: [Tavern Tier 3] 5 Attack, 4 Health. Your other Demons have +2 Attack. Your Hero is Immune.
      - Leapfrogger: Old: Deathrattle: Give a friendly Beast +2/+2 and this Deathrattle. → New: Give a friendly Beast +1/+1 and this Deathrattle.
      - Monstrous Macaw: Old: After this attacks, trigger a random friendly minion’s Deathrattle. → New: After this attacks, trigger another friendly minion’s Deathrattle.
      - Reanimating Rattler: Old: [Tavern Tier 4] 6 Attack, 2 Health. → New: [Tavern Tier 5] 7 Attack, 3 Health.
      - Whelp Smuggler: Old: 2 Attack, 4 Health. After a friendly Dragon gains Attack, give it +2 Health. → New: 2 Attack, 5 Health. After a friendly Dragon gains Attack, give it +1 Health.
      - Impulsive Trickster: Old: Deathrattle: Give this minion’s maximum Health to a friendly minion. → New: Deathrattle: Give this minion’s maximum Health to another friendly minion.
      - Master of Realities: Old: [Tavern Tier 6]. → New: [Tavern Tier 5].
      - Peggy Brittlebone: Old: 5 Attack, 3 Health. After a card is added to your hand, give another random Pirate +1/+1 → New: 6 Attack, 5 Health. After a card is added to your hand, give another friendly Pirate +1/+1.
      - Goldgrubber: Old: 2 Attack, 2 Health. → New: 4 Attack, 4 Health.
      - Salty Looter: Old: 4 Attack, 4 Health. → New: 4 Attack, 5 Health.
      - Prophet of the Boar: Old: 2 Attack, 3 Health. → New: 3 Attack, 3 Health.
      - Roadboar: Old: 1 Attack, 4 Health. → New: 2 Attack, 4 Health.
      - Bristleback Brute: Old: 3 Attack, 3 Health. → New: 4 Attack, 4 Health.
      - Dynamic Duo: Old: 3 Attack, 4 Health. → New: 4 Attack, 5 Health.
      - Charlga: Old: At the end of your turn, play a Blood Gem on all other friendly minions. → New: At the end of your turn, play a Blood Gem on all friendly minions.