### PR TITLE
Implement 5 THE_BARRENS cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -783,7 +783,7 @@ THE_BARRENS | BAR_328 | Vengeful Spirit |
 THE_BARRENS | BAR_329 | Death Speaker Blackthorn |  
 THE_BARRENS | BAR_330 | Tuskpiercer |  
 THE_BARRENS | BAR_333 | Kurtrus Ashfallen |  
-THE_BARRENS | BAR_334 | Overlord Saurfang |  
+THE_BARRENS | BAR_334 | Overlord Saurfang | O
 THE_BARRENS | BAR_430 | Horde Operative |  
 THE_BARRENS | BAR_533 | Thorngrowth Sentries | O
 THE_BARRENS | BAR_534 | Pride's Fury | O
@@ -816,10 +816,10 @@ THE_BARRENS | BAR_751 | Spawnpool Forager | O
 THE_BARRENS | BAR_801 | Wound Prey | O
 THE_BARRENS | BAR_812 | Oasis Ally | O
 THE_BARRENS | BAR_840 | Whirling Combatant | O
-THE_BARRENS | BAR_841 | Bulk Up |  
+THE_BARRENS | BAR_841 | Bulk Up | O
 THE_BARRENS | BAR_842 | Conditioning (Rank 1) | O
-THE_BARRENS | BAR_843 | Warsong Envoy |  
-THE_BARRENS | BAR_844 | Outrider's Axe |  
+THE_BARRENS | BAR_843 | Warsong Envoy | O
+THE_BARRENS | BAR_844 | Outrider's Axe | O
 THE_BARRENS | BAR_845 | Rancor |  
 THE_BARRENS | BAR_846 | Mor'shan Elite |  
 THE_BARRENS | BAR_847 | Rokara |  
@@ -864,7 +864,7 @@ THE_BARRENS | WC_020 | Perpetual Flame |
 THE_BARRENS | WC_021 | Unstable Shadow Blast |  
 THE_BARRENS | WC_022 | Final Gasp |  
 THE_BARRENS | WC_023 | Stealer of Souls |  
-THE_BARRENS | WC_024 | Man-at-Arms |  
+THE_BARRENS | WC_024 | Man-at-Arms | O
 THE_BARRENS | WC_025 | Whetstone Hatchet |  
 THE_BARRENS | WC_026 | Kresh, Lord of Turtling |  
 THE_BARRENS | WC_027 | Devouring Ectoplasm |  
@@ -885,7 +885,7 @@ THE_BARRENS | WC_803 | Cleric of An'she | O
 THE_BARRENS | WC_805 | Frostweave Dungeoneer | O
 THE_BARRENS | WC_806 | Floecaster | O
 
-- Progress: 45% (77 of 170 Cards)
+- Progress: 48% (82 of 170 Cards)
 
 ## United in Stormwind
 

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -275,6 +275,10 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition HasReborn();
 
+    //! SelfCondition wrapper for checking the entity has frenzy.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition HasFrenzy();
+
     //! SelfCondition wrapper for checking the player has invoked twice.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition HasInvokedTwice();

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 60% Ashes of Outland (81 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
-  * 45% Forged in the Barrens (77 of 170 cards)
+  * 48% Forged in the Barrens (82 of 170 cards)
   * 1% United in Stormwind (2 of 135 card)
 
 ### Wild Format

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -2911,6 +2911,14 @@ void TheBarrensCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsWeaponEquipped()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<AddEnchantmentTask>(
+                  "WC_024e", EntityType::SOURCE) }));
+    cards.emplace("WC_024", CardDef(power));
 
     // --------------------------------------- WEAPON - WARRIOR
     // [WC_025] Whetstone Hatchet - COST:1
@@ -2993,6 +3001,9 @@ void TheBarrensCardsGen::AddWarriorNonCollect(
     // --------------------------------------------------------
     // Text: +1/+1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("WC_024e"));
+    cards.emplace("WC_024e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [WC_025e] Armed - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -2789,6 +2789,17 @@ void TheBarrensCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::HAND));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsMinion()),
+        std::make_shared<SelfCondition>(SelfCondition::HasTaunt()) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("BAR_841e", EntityType::STACK));
+    power.AddPowerTask(
+        std::make_shared<CopyTask>(EntityType::STACK, ZoneType::HAND));
+    cards.emplace("BAR_841", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [BAR_842] Conditioning (Rank 1) - COST:2
@@ -2921,6 +2932,9 @@ void TheBarrensCardsGen::AddWarriorNonCollect(
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("BAR_841e"));
+    cards.emplace("BAR_841e", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [BAR_842t] Conditioning (Rank 2) - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -2825,6 +2825,14 @@ void TheBarrensCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - FRENZY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddFrenzyTask(std::make_shared<IncludeTask>(EntityType::ALL));
+    power.AddFrenzyTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsDamaged()) }));
+    power.AddFrenzyTask(std::make_shared<CountTask>(EntityType::STACK));
+    power.AddFrenzyTask(std::make_shared<AddEnchantmentTask>(
+        "BAR_896e", EntityType::SOURCE, true));
+    cards.emplace("BAR_843", CardDef(power));
 
     // --------------------------------------- WEAPON - WARRIOR
     // [BAR_844] Outrider's Axe - COST:4
@@ -2967,6 +2975,9 @@ void TheBarrensCardsGen::AddWarriorNonCollect(
     // --------------------------------------------------------
     // Text: Increased Attack.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(std::make_unique<Enchant>(Enchants::AddAttackScriptTag));
+    cards.emplace("BAR_896e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [WC_024e] Armed - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -2843,6 +2843,14 @@ void TheBarrensCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsDefenderDead())
+    };
+    power.GetTrigger()->tasks = { std::make_shared<DrawTask>(1) };
+    cards.emplace("BAR_844", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [BAR_845] Rancor - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -2749,6 +2749,17 @@ void TheBarrensCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - FRENZY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::GRAVEYARD));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsDead()),
+        std::make_shared<SelfCondition>(SelfCondition::HasFrenzy()) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 2));
+    power.AddPowerTask(
+        std::make_shared<CopyTask>(EntityType::STACK, ZoneType::PLAY));
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ALL_MINIONS_NOSOURCE, 1));
+    cards.emplace("BAR_334", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [BAR_840] Whirling Combatant - COST:4 [ATK:3/HP:6]

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -576,6 +576,19 @@ SelfCondition SelfCondition::HasReborn()
     });
 }
 
+SelfCondition SelfCondition::HasFrenzy()
+{
+    return SelfCondition([](Playable* playable) {
+        const auto minion = dynamic_cast<Minion*>(playable);
+        if (!minion)
+        {
+            return false;
+        }
+
+        return minion->HasFrenzy();
+    });
+}
+
 SelfCondition SelfCondition::HasInvokedTwice()
 {
     return SelfCondition(

--- a/Sources/Rosetta/PlayMode/Enchants/Power.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/Power.cpp
@@ -78,6 +78,7 @@ void Power::ClearData()
     m_afterChooseTask.clear();
     m_outcastTask.clear();
     m_spellburstTask.clear();
+    m_frenzyTask.clear();
 }
 
 void Power::AddAura(std::shared_ptr<IAura> aura)

--- a/Sources/Rosetta/PlayMode/Models/Character.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Character.cpp
@@ -310,7 +310,7 @@ int Character::TakeDamage(Playable* source, int damage)
             minion->SetGameTag(GameTag::FRENZY, 0);
         }
 
-        player->game->ProcessTasks();
+        game->ProcessTasks();
     }
 
     // Process damage triggers

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -4786,12 +4786,12 @@ TEST_CASE("[Warrior : Spell] - BAR_842 : Conditioning (Rank 1)")
         curPlayer, Cards::FindCardByName("Conditioning (Rank 1)"));
     const auto card3 = Generic::DrawCard(
         curPlayer, Cards::FindCardByName("Conditioning (Rank 1)"));
-    const auto card4 = Generic::DrawCard(
-        curPlayer, Cards::FindCardByName("Wisp"));
-    const auto card5 = Generic::DrawCard(
-        curPlayer, Cards::FindCardByName("Wolfrider"));
-    const auto card6 = Generic::DrawCard(
-        curPlayer, Cards::FindCardByName("Malygos"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card6 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
 
     const auto minion4 = dynamic_cast<Minion*>(card4);
     const auto minion5 = dynamic_cast<Minion*>(card5);
@@ -4856,6 +4856,54 @@ TEST_CASE("[Warrior : Spell] - BAR_842 : Conditioning (Rank 1)")
     CHECK_EQ(minion5->GetHealth(), 7);
     CHECK_EQ(minion6->GetAttack(), 10);
     CHECK_EQ(minion6->GetHealth(), 18);
+}
+
+// --------------------------------------- MINION - WARRIOR
+// [BAR_843] Warsong Envoy - COST:1 [ATK:1/HP:3]
+// - Set: THE_BARRENS, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Frenzy:</b> Gain +1 Attack
+//       for each damaged character.
+// --------------------------------------------------------
+// GameTag:
+// - FRENZY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - BAR_843 : Warsong Envoy")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Warsong Envoy"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
 }
 
 // --------------------------------------- MINION - WARRIOR

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -4559,6 +4559,82 @@ TEST_CASE("[Warlock : Minion] - BAR_917 : Barrens Scavenger")
 }
 
 // --------------------------------------- MINION - WARRIOR
+// [BAR_334] Overlord Saurfang - COST:7 [ATK:5/HP:4]
+// - Set: THE_BARRENS, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Resurrect 2 friendly <b>Frenzy</b>
+//       minions. Deal 1 damage to all other minions.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - FRENZY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - BAR_334 : Overlord Saurfang")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Overlord Saurfang"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Stonemaul Anchorman"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Stonemaul Anchorman"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+    const auto card6 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(curField.GetCount(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card5, card2));
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card6, card3));
+    game.Process(opPlayer, HeroPowerTask(card4));
+    CHECK_EQ(curField.GetCount(), 0);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curHand.GetCount(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curHand.GetCount(), 7);
+    CHECK_EQ(curField[1]->GetHealth(), 5);
+    CHECK_EQ(curField[2]->GetHealth(), 5);
+}
+
+// --------------------------------------- MINION - WARRIOR
 // [BAR_840] Whirling Combatant - COST:4 [ATK:3/HP:6]
 // - Set: THE_BARRENS, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -4906,6 +4906,74 @@ TEST_CASE("[Warrior : Minion] - BAR_843 : Warsong Envoy")
     CHECK_EQ(curField[0]->GetHealth(), 2);
 }
 
+// --------------------------------------- WEAPON - WARRIOR
+// [BAR_844] Outrider's Axe - COST:4
+// - Set: THE_BARRENS, Rarity: Rare
+// --------------------------------------------------------
+// Text: After your hero attacks and kills a minion, draw a card.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Weapon] - BAR_844 : Outrider's Axe")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Outrider's Axe"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, AttackTask(curPlayer->GetHero(), card2));
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(opField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(curPlayer->GetHero(), card3));
+    CHECK_EQ(curHand.GetCount(), 7);
+    CHECK_EQ(opField.GetCount(), 1);
+}
+
 // --------------------------------------- MINION - WARRIOR
 // [BAR_896] Stonemaul Anchorman - COST:5 [ATK:4/HP:6]
 // - Race: Pirate, Set: THE_BARRENS, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -4703,6 +4703,57 @@ TEST_CASE("[Warrior : Minion] - BAR_840 : Whirling Combatant")
 }
 
 // ---------------------------------------- SPELL - WARRIOR
+// [BAR_841] Bulk Up - COST:2
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: Give a random <b>Taunt</b> minion in your hand +1/+1
+//       and copy it.
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Spell] - BAR_841 : Bulk Up")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bulk Up"));
+    [[maybe_unused]] const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+    [[maybe_unused]] const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Sen'jin Shieldmasta"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 3);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[0])->GetAttack(), 4);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[0])->GetHealth(), 12);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[1])->GetAttack(), 4);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[1])->GetHealth(), 6);
+    CHECK_EQ(curHand[2]->card->name, "Sen'jin Shieldmasta");
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[2])->GetAttack(), 4);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[2])->GetHealth(), 6);
+}
+
+// ---------------------------------------- SPELL - WARRIOR
 // [BAR_842] Conditioning (Rank 1) - COST:2
 // - Set: THE_BARRENS, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -5020,3 +5020,53 @@ TEST_CASE("[Warrior : Minion] - BAR_896 : Stonemaul Anchorman")
     game.Process(opPlayer, HeroPowerTask(card1));
     CHECK_EQ(curHand.GetCount(), 5);
 }
+
+// --------------------------------------- MINION - WARRIOR
+// [WC_024] Man-at-Arms - COST:2 [ATK:2/HP:3]
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you have a weapon equipped,
+//       gain +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - WC_024 : Man-at-Arms")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Man-at-Arms"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Man-at-Arms"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Outrider's Axe"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->GetHealth(), 4);
+}


### PR DESCRIPTION
This revision includes:
- Implement 5 THE_BARRENS cards
  - Overlord Saurfang (BAR_334)
  - Bulk Up (BAR_841)
  - Warsong Envoy (BAR_843)
  - Outrider's Axe (BAR_844)
  - Man-at-Arms (WC_024)
- Add method 'HasFrenzy()': SelfCondition wrapper for checking the entity has frenzy
- Add missing code to clear a list of frenzy tasks
- Refactor unnecessary code
  - Remove 'player->'