### PR TITLE
Implement 5 THE_BARRENS cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -820,9 +820,9 @@ THE_BARRENS | BAR_841 | Bulk Up | O
 THE_BARRENS | BAR_842 | Conditioning (Rank 1) | O
 THE_BARRENS | BAR_843 | Warsong Envoy | O
 THE_BARRENS | BAR_844 | Outrider's Axe | O
-THE_BARRENS | BAR_845 | Rancor |  
-THE_BARRENS | BAR_846 | Mor'shan Elite |  
-THE_BARRENS | BAR_847 | Rokara |  
+THE_BARRENS | BAR_845 | Rancor | O
+THE_BARRENS | BAR_846 | Mor'shan Elite | O
+THE_BARRENS | BAR_847 | Rokara | O
 THE_BARRENS | BAR_848 | Lilypad Lurker | O
 THE_BARRENS | BAR_854 | Kindling Elemental |  
 THE_BARRENS | BAR_860 | Firemancer Flurgl | O
@@ -865,8 +865,8 @@ THE_BARRENS | WC_021 | Unstable Shadow Blast |
 THE_BARRENS | WC_022 | Final Gasp |  
 THE_BARRENS | WC_023 | Stealer of Souls |  
 THE_BARRENS | WC_024 | Man-at-Arms | O
-THE_BARRENS | WC_025 | Whetstone Hatchet |  
-THE_BARRENS | WC_026 | Kresh, Lord of Turtling |  
+THE_BARRENS | WC_025 | Whetstone Hatchet | O
+THE_BARRENS | WC_026 | Kresh, Lord of Turtling | O
 THE_BARRENS | WC_027 | Devouring Ectoplasm |  
 THE_BARRENS | WC_028 | Meeting Stone |  
 THE_BARRENS | WC_029 | Selfless Sidekick |  
@@ -885,7 +885,7 @@ THE_BARRENS | WC_803 | Cleric of An'she | O
 THE_BARRENS | WC_805 | Frostweave Dungeoneer | O
 THE_BARRENS | WC_806 | Floecaster | O
 
-- Progress: 48% (82 of 170 Cards)
+- Progress: 51% (87 of 170 Cards)
 
 ## United in Stormwind
 

--- a/Includes/Rosetta/PlayMode/Managers/TriggerManager.hpp
+++ b/Includes/Rosetta/PlayMode/Managers/TriggerManager.hpp
@@ -81,6 +81,10 @@ class TriggerManager
     //! \param sender An entity that is the source of trigger.
     void OnAttackTrigger(Entity* sender);
 
+    //! Callback for trigger when an attack action is ended.
+    //! \param sender An entity that is the source of trigger.
+    void OnAfterAttackTrigger(Entity* sender);
+
     //! Callback for trigger when entity is summoned.
     //! \param sender An entity that is the source of trigger.
     void OnSummonTrigger(Entity* sender);
@@ -140,6 +144,7 @@ class TriggerManager
     TriggerEvent giveHealTrigger;
     TriggerEvent takeHealTrigger;
     TriggerEvent attackTrigger;
+    TriggerEvent afterAttackTrigger;
     TriggerEvent summonTrigger;
     TriggerEvent afterSummonTrigger;
     TriggerEvent dealDamageTrigger;

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 60% Ashes of Outland (81 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
-  * 48% Forged in the Barrens (82 of 170 cards)
+  * 51% Forged in the Barrens (87 of 170 cards)
   * 1% United in Stormwind (2 of 135 card)
 
 ### Wild Format

--- a/Sources/Rosetta/PlayMode/Actions/Attack.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Attack.cpp
@@ -150,6 +150,7 @@ void Attack(Player* player, Character* source, Character* target,
     // Process after attack trigger
     player->game->taskQueue.StartEvent();
     source->afterAttackTrigger(source);
+    player->game->triggerManager.OnAfterAttackTrigger(source);
     player->game->ProcessTasks();
     player->game->taskQueue.EndEvent();
 

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -2902,6 +2902,14 @@ void TheBarrensCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::HERO, SelfCondList{ std::make_shared<SelfCondition>(
+                              SelfCondition::IsAttackThisTurn()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<CopyTask>(EntityType::SOURCE,
+                                                   ZoneType::PLAY) }));
+    cards.emplace("BAR_846", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [BAR_847] Rokara - COST:3 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -2859,6 +2859,37 @@ void TheBarrensCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // Text: Deal 2 damage to all minions.
     //       Gain 2 Armor for each destroyed.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ALL_MINIONS, 2, true));
+    power.AddPowerTask(std::make_shared<CustomTask>(
+        [](Player* player, Entity* source, Playable* target) {
+            int count = 0;
+
+            player->GetFieldZone()->ForEach([&](Playable* minion) {
+                if (minion->isDestroyed)
+                {
+                    ++count;
+                }
+            });
+
+            player->opponent->GetFieldZone()->ForEach([&](Playable* minion) {
+                if (minion->isDestroyed)
+                {
+                    ++count;
+                }
+            });
+
+            const auto& armorTask = std::make_shared<ArmorTask>(2 * count);
+            armorTask->SetPlayer(player);
+            armorTask->SetSource(source);
+            armorTask->SetTarget(target);
+
+            armorTask->Run();
+
+            return TaskStatus::COMPLETE;
+        }));
+    cards.emplace("BAR_845", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [BAR_846] Mor'shan Elite - COST:5 [ATK:4/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -2997,6 +2997,10 @@ void TheBarrensCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // - DEATHRATTLE = 1
     // - FRENZY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddFrenzyTask(std::make_shared<ArmorTask>(8));
+    power.AddDeathrattleTask(std::make_shared<WeaponTask>("WC_026t"));
+    cards.emplace("WC_026", CardDef(power));
 }
 
 void TheBarrensCardsGen::AddWarriorNonCollect(
@@ -3073,6 +3077,9 @@ void TheBarrensCardsGen::AddWarriorNonCollect(
     // [WC_026t] Turtle Spike - COST:4
     // - Set: THE_BARRENS
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("WC_026t", CardDef(power));
 }
 
 void TheBarrensCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -2978,6 +2978,12 @@ void TheBarrensCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->tasks = { ComplexTask::GiveBuffToRandomMinionInHand(
+        "WC_025e") };
+    cards.emplace("WC_025", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [WC_026] Kresh, Lord of Turtling - COST:6 [ATK:3/HP:9]
@@ -3059,6 +3065,9 @@ void TheBarrensCardsGen::AddWarriorNonCollect(
     // --------------------------------------------------------
     // Text: +1 Attack
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("WC_025e"));
+    cards.emplace("WC_025e", CardDef(power));
 
     // --------------------------------------- WEAPON - WARRIOR
     // [WC_026t] Turtle Spike - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -2924,6 +2924,15 @@ void TheBarrensCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // - RUSH = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::MINIONS;
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsNotDead())
+    };
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "BAR_847e", EntityType::EVENT_SOURCE) };
+    cards.emplace("BAR_847", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [BAR_896] Stonemaul Anchorman - COST:5 [ATK:4/HP:6]
@@ -4290,6 +4299,9 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("BAR_847e"));
+    cards.emplace("BAR_847e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [BAR_854e] Kindle - COST:0

--- a/Sources/Rosetta/PlayMode/Managers/TriggerManager.cpp
+++ b/Sources/Rosetta/PlayMode/Managers/TriggerManager.cpp
@@ -83,6 +83,11 @@ void TriggerManager::OnAttackTrigger(Entity* sender)
     attackTrigger(sender);
 }
 
+void TriggerManager::OnAfterAttackTrigger(Entity* sender)
+{
+    afterAttackTrigger(sender);
+}
+
 void TriggerManager::OnSummonTrigger(Entity* sender)
 {
     summonTrigger(sender);

--- a/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
+++ b/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
@@ -160,6 +160,12 @@ std::shared_ptr<Trigger> Trigger::Activate(Playable* source,
                     minion->afterAttackTrigger += instance->handler;
                     break;
                 }
+                case TriggerSource::MINIONS:
+                {
+                    game->triggerManager.afterAttackTrigger +=
+                        instance->handler;
+                    break;
+                }
                 case TriggerSource::ENCHANTMENT_TARGET:
                 {
                     const auto enchantment = dynamic_cast<Enchantment*>(source);
@@ -327,6 +333,11 @@ void Trigger::Remove() const
                 {
                     auto minion = dynamic_cast<Minion*>(m_owner);
                     minion->afterAttackTrigger -= handler;
+                    break;
+                }
+                case TriggerSource::MINIONS:
+                {
+                    game->triggerManager.afterAttackTrigger -= handler;
                     break;
                 }
                 case TriggerSource::ENCHANTMENT_TARGET:
@@ -681,7 +692,7 @@ void Trigger::Validate(Entity* source)
         const bool res = (playable != nullptr) ? condition->Evaluate(playable)
                                                : condition->Evaluate(m_owner);
 
-        if (conditionLogic == MultiCondLogic::AND && !res) 
+        if (conditionLogic == MultiCondLogic::AND && !res)
         {
             return;
         }

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -4974,6 +4974,70 @@ TEST_CASE("[Warrior : Weapon] - BAR_844 : Outrider's Axe")
     CHECK_EQ(opField.GetCount(), 1);
 }
 
+// ---------------------------------------- SPELL - WARRIOR
+// [BAR_845] Rancor - COST:4
+// - Set: THE_BARRENS, Rarity: Epic
+// --------------------------------------------------------
+// Text: Deal 2 damage to all minions.
+//       Gain 2 Armor for each destroyed.
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Spell] - BAR_845 : Rancor")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Rancor"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 5);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 4);
+}
+
 // --------------------------------------- MINION - WARRIOR
 // [BAR_896] Stonemaul Anchorman - COST:5 [ATK:4/HP:6]
 // - Race: Pirate, Set: THE_BARRENS, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -5098,6 +5098,80 @@ TEST_CASE("[Warrior : Minion] - BAR_846 : Mor'shan Elite")
 }
 
 // --------------------------------------- MINION - WARRIOR
+// [BAR_847] Rokara - COST:3 [ATK:2/HP:3]
+// - Set: THE_BARRENS, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Rush</b>
+//       After a friendly minion attacks and survives,
+//       give it +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - RUSH = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - BAR_847 : Rokara")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Rokara"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Rokara"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Stonemaul Anchorman"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+    CHECK_EQ(curField[1]->GetAttack(), 4);
+    CHECK_EQ(curField[1]->GetHealth(), 6);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(card1, opPlayer->GetHero()));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+
+    game.Process(curPlayer, AttackTask(card3, opPlayer->GetHero()));
+    CHECK_EQ(curField[1]->GetAttack(), 5);
+    CHECK_EQ(curField[1]->GetHealth(), 7);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, AttackTask(card2, card4));
+    CHECK_EQ(curField[2]->GetAttack(), 4);
+    CHECK_EQ(curField[2]->GetHealth(), 4);
+}
+
+// --------------------------------------- MINION - WARRIOR
 // [BAR_896] Stonemaul Anchorman - COST:5 [ATK:4/HP:6]
 // - Race: Pirate, Set: THE_BARRENS, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -5039,6 +5039,65 @@ TEST_CASE("[Warrior : Spell] - BAR_845 : Rancor")
 }
 
 // --------------------------------------- MINION - WARRIOR
+// [BAR_846] Mor'shan Elite - COST:5 [ATK:4/HP:4]
+// - Set: THE_BARRENS, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Taunt</b>. <b>Battlecry:</b> If your hero
+//       attacked this turn, summon a copy of this.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - BAR_846 : Mor'shan Elite")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mor'shan Elite"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mor'shan Elite"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Outrider's Axe"));
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card3));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer,
+                 AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[2]->card->name, "Mor'shan Elite");
+}
+
+// --------------------------------------- MINION - WARRIOR
 // [BAR_896] Stonemaul Anchorman - COST:5 [ATK:4/HP:6]
 // - Race: Pirate, Set: THE_BARRENS, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -5267,3 +5267,46 @@ TEST_CASE("[Warrior : Minion] - WC_024 : Man-at-Arms")
     CHECK_EQ(curField[1]->GetAttack(), 3);
     CHECK_EQ(curField[1]->GetHealth(), 4);
 }
+
+// --------------------------------------- WEAPON - WARRIOR
+// [WC_025] Whetstone Hatchet - COST:1
+// - Set: THE_BARRENS, Rarity: Rare
+// --------------------------------------------------------
+// Text: After your hero attacks,
+//       give a minion in your hand +1 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Weapon] - WC_025 : Whetstone Hatchet")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Whetstone Hatchet"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    game.Process(curPlayer,
+                 AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
+    CHECK_EQ(dynamic_cast<Minion*>(card2)->GetAttack(), 2);
+    CHECK_EQ(dynamic_cast<Minion*>(card2)->GetHealth(), 1);
+}


### PR DESCRIPTION
This revision includes:
- Implement 5 THE_BARRENS cards
  - Rancor (BAR_845)
  - Mor'shan Elite (BAR_846)
  - Rokara (BAR_847)
  - Whetstone Hatchet (WC_025)
  - Kresh, Lord of Turtling (WC_026)
- Add variable 'afterAttackTrigger' and related method
  - OnAfterAttackTrigger(): Callback for trigger when an attack action is ended
  - Add code to consider case 'TriggerSource::MINIONS'
  - Add code to call method 'OnAfterAttackTrigger()'