### PR TITLE
Implement 5 THE_BARRENS cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -757,7 +757,7 @@ THE_BARRENS | BAR_080 | Shadow Hunter Vol'jin |
 THE_BARRENS | BAR_081 | Southsea Scoundrel |  
 THE_BARRENS | BAR_082 | Barrens Trapper |  
 THE_BARRENS | BAR_305 | Flurry (Rank 1) | O
-THE_BARRENS | BAR_306 | Sigil of Flame |  
+THE_BARRENS | BAR_306 | Sigil of Flame | O
 THE_BARRENS | BAR_307 | Void Flayer | O
 THE_BARRENS | BAR_308 | Power Word: Fortitude | O
 THE_BARRENS | BAR_309 | Desperate Prayer | O
@@ -776,10 +776,10 @@ THE_BARRENS | BAR_321 | Paralytic Poison | O
 THE_BARRENS | BAR_322 | Swinetusk Shank | O
 THE_BARRENS | BAR_323 | Yoink! |  
 THE_BARRENS | BAR_324 | Apothecary Helbrim | O
-THE_BARRENS | BAR_325 | Razorboar |  
-THE_BARRENS | BAR_326 | Razorfen Beastmaster |  
-THE_BARRENS | BAR_327 | Vile Call |  
-THE_BARRENS | BAR_328 | Vengeful Spirit |  
+THE_BARRENS | BAR_325 | Razorboar | O
+THE_BARRENS | BAR_326 | Razorfen Beastmaster | O
+THE_BARRENS | BAR_327 | Vile Call | O
+THE_BARRENS | BAR_328 | Vengeful Spirit | O
 THE_BARRENS | BAR_329 | Death Speaker Blackthorn |  
 THE_BARRENS | BAR_330 | Tuskpiercer |  
 THE_BARRENS | BAR_333 | Kurtrus Ashfallen |  
@@ -885,7 +885,7 @@ THE_BARRENS | WC_803 | Cleric of An'she | O
 THE_BARRENS | WC_805 | Frostweave Dungeoneer | O
 THE_BARRENS | WC_806 | Floecaster | O
 
-- Progress: 51% (87 of 170 Cards)
+- Progress: 54% (92 of 170 Cards)
 
 ## United in Stormwind
 

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.hpp
@@ -16,6 +16,7 @@ enum class DrawMinionType
     DEFAULT,       //!< Don't care.
     LOWEST_COST,   //!< Lowest cost card.
     HIGHEST_COST,  //!< Highest cost card.
+    DEATHRATTLE,   //!< Has Deathrattle.
 };
 
 //!

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 60% Ashes of Outland (81 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
-  * 51% Forged in the Barrens (87 of 170 cards)
+  * 54% Forged in the Barrens (92 of 170 cards)
   * 1% United in Stormwind (2 of 170 card)
 
 ### Wild Format

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3111,6 +3111,16 @@ void TheBarrensCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(std::make_shared<IncludeTask>(EntityType::HAND));
+    power.AddDeathrattleTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::HasDeathrattle()),
+        std::make_shared<SelfCondition>(
+            SelfCondition::IsCost(3, RelaSign::LEQ)) }));
+    power.AddDeathrattleTask(
+        std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddDeathrattleTask(std::make_shared<SummonStackTask>(true));
+    cards.emplace("BAR_325", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [BAR_326] Razorfen Beastmaster - COST:3 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3149,9 +3149,18 @@ void TheBarrensCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Summon two 2/2 Demons with <b>Lifesteal</b>.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
     // RefTag:
     // - LIFESTEAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("BAR_327t", 2, SummonSide::SPELL));
+    cards.emplace(
+        "BAR_327",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [BAR_328] Vengeful Spirit - COST:4 [ATK:4/HP:4]
@@ -3269,6 +3278,8 @@ void TheBarrensCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 void TheBarrensCardsGen::AddDemonHunterNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------- MINION - DEMONHUNTER
     // [BAR_327t] Ravenous Vilefiend - COST:2 [ATK:2/HP:2]
     // - Race: Demon, Set: THE_BARRENS
@@ -3278,6 +3289,9 @@ void TheBarrensCardsGen::AddDemonHunterNonCollect(
     // GameTag:
     // - LIFESTEAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("BAR_327t", CardDef(power));
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [BAR_891e] Fury - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3132,6 +3132,16 @@ void TheBarrensCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(std::make_shared<IncludeTask>(EntityType::HAND));
+    power.AddDeathrattleTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::HasDeathrattle()),
+        std::make_shared<SelfCondition>(
+            SelfCondition::IsCost(4, RelaSign::LEQ)) }));
+    power.AddDeathrattleTask(
+        std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddDeathrattleTask(std::make_shared<SummonStackTask>(true));
+    cards.emplace("BAR_326", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [BAR_327] Vile Call - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3084,6 +3084,8 @@ void TheBarrensCardsGen::AddWarriorNonCollect(
 
 void TheBarrensCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------ SPELL - DEMONHUNTER
     // [BAR_306] Sigil of Flame - COST:2
     // - Set: THE_BARRENS, Rarity: Epic
@@ -3092,6 +3094,12 @@ void TheBarrensCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // Text: At the start of your next turn,
     //       deal 3 damage to all minions.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
+    power.GetTrigger()->tasks = { std::make_shared<DamageTask>(
+        EntityType::ALL_MINIONS, 3, true) };
+    power.GetTrigger()->removeAfterTriggered = true;
+    cards.emplace("BAR_306", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [BAR_325] Razorboar - COST:2 [ATK:3/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3174,6 +3174,10 @@ void TheBarrensCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddOutcastTask(std::make_shared<DrawMinionTask>(
+        DrawMinionType::DEATHRATTLE, 2, false));
+    cards.emplace("BAR_328", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [BAR_329] Death Speaker Blackthorn - COST:7 [ATK:3/HP:6]

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawMinionTask.cpp
@@ -66,6 +66,11 @@ TaskStatus DrawMinionTask::Impl(Player* player)
                           return card1->GetCost() > card2->GetCost();
                       });
             break;
+        case DrawMinionType::DEATHRATTLE:
+            EraseIf(deckCards, [=](Playable* playable) {
+                return !playable->HasDeathrattle();
+            });
+            break;
     }
 
     for (int i = 0; i < m_amount; ++i)

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -5544,3 +5544,53 @@ TEST_CASE("[Demon Hunter : Minion] - BAR_326 : Razorfen Beastmaster")
     CHECK_EQ(curField[0]->card->name, "Razorfen Beastmaster");
     CHECK_EQ(curHand.GetCount(), 5);
 }
+
+// ------------------------------------ SPELL - DEMONHUNTER
+// [BAR_327] Vile Call - COST:3
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: Summon two 2/2 Demons with <b>Lifesteal</b>.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+// RefTag:
+// - LIFESTEAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Spell] - BAR_327 : Vile Call")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Vile Call"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Ravenous Vilefiend");
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->HasLifesteal(), true);
+    CHECK_EQ(curField[1]->card->name, "Ravenous Vilefiend");
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+    CHECK_EQ(curField[1]->HasLifesteal(), true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -5369,3 +5369,68 @@ TEST_CASE("[Warrior : Minion] - WC_026 : Kresh, Lord of Turtling")
     CHECK_EQ(curHero.weapon->GetAttack(), 2);
     CHECK_EQ(curHero.weapon->GetDurability(), 5);
 }
+
+// ------------------------------------ SPELL - DEMONHUNTER
+// [BAR_306] Sigil of Flame - COST:2
+// - Set: THE_BARRENS, Rarity: Epic
+// - Spell School: Fel
+// --------------------------------------------------------
+// Text: At the start of your next turn,
+//       deal 3 damage to all minions.
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Spell] - BAR_306 : Sigil of Flame")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Sigil of Flame"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Kresh, Lord of Turtling"));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Kresh, Lord of Turtling"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetHealth(), 9);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField[0]->GetHealth(), 9);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+    CHECK_EQ(opField[0]->GetHealth(), 6);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+    CHECK_EQ(opField[0]->GetHealth(), 6);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -5594,3 +5594,60 @@ TEST_CASE("[Demon Hunter : Spell] - BAR_327 : Vile Call")
     CHECK_EQ(curField[1]->GetHealth(), 2);
     CHECK_EQ(curField[1]->HasLifesteal(), true);
 }
+
+// ----------------------------------- MINION - DEMONHUNTER
+// [BAR_328] Vengeful Spirit - COST:4 [ATK:4/HP:4]
+// - Set: THE_BARRENS, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Outcast:</b> Draw 2 <b>Deathrattle</b> minions.
+// --------------------------------------------------------
+// GameTag:
+// - OUTCAST = 1
+// --------------------------------------------------------
+// RefTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - BAR_328 : Vengeful Spirit")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Savannah Highmane");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Malygos");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Wisp");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Vengeful Spirit"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Vengeful Spirit"));
+
+    CHECK_EQ(curHand.GetCount(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[4])->HasDeathrattle(), true);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[5])->HasDeathrattle(), true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -5489,3 +5489,58 @@ TEST_CASE("[Demon Hunter : Minion] - BAR_325 : Razorboar")
     CHECK_EQ(curField[0]->card->name, "Razorfen Beastmaster");
     CHECK_EQ(curHand.GetCount(), 5);
 }
+
+// ----------------------------------- MINION - DEMONHUNTER
+// [BAR_326] Razorfen Beastmaster - COST:3 [ATK:3/HP:3]
+// - Set: THE_BARRENS, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Summon a <b>Deathrattle</b>
+//       minion that costs (4) or less from your hand.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - BAR_326 : Razorfen Beastmaster")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Razorfen Beastmaster"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Razorfen Beastmaster"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Plagued Protodrake"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 6);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Razorfen Beastmaster");
+    CHECK_EQ(curHand.GetCount(), 5);
+}


### PR DESCRIPTION
This revision includes:
- Implement 5 THE_BARRENS cards
  - Sigil of Flame (BAR_306)
  - Razorboar (BAR_325)
  - Razorfen Beastmaster (BAR_326)
  - Vile Call (BAR_327)
  - Vengeful Spirit (BAR_328)
- Add enum value 'DrawMinionType::DEATHRATTLE' and code to process it