### PR TITLE
Implement 7 THE_BARRENS cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -780,8 +780,8 @@ THE_BARRENS | BAR_325 | Razorboar | O
 THE_BARRENS | BAR_326 | Razorfen Beastmaster | O
 THE_BARRENS | BAR_327 | Vile Call | O
 THE_BARRENS | BAR_328 | Vengeful Spirit | O
-THE_BARRENS | BAR_329 | Death Speaker Blackthorn |  
-THE_BARRENS | BAR_330 | Tuskpiercer |  
+THE_BARRENS | BAR_329 | Death Speaker Blackthorn | O
+THE_BARRENS | BAR_330 | Tuskpiercer | O
 THE_BARRENS | BAR_333 | Kurtrus Ashfallen |  
 THE_BARRENS | BAR_334 | Overlord Saurfang | O
 THE_BARRENS | BAR_430 | Horde Operative |  
@@ -803,7 +803,7 @@ THE_BARRENS | BAR_549 | Mark of the Spikeshell | O
 THE_BARRENS | BAR_550 | Galloping Savior | O
 THE_BARRENS | BAR_551 | Barak Kodobane |  
 THE_BARRENS | BAR_552 | Scabbs Cutterbutter |  
-THE_BARRENS | BAR_705 | Sigil of Silence |  
+THE_BARRENS | BAR_705 | Sigil of Silence | O
 THE_BARRENS | BAR_720 | Guff Runetotem | O
 THE_BARRENS | BAR_721 | Mankrik |  
 THE_BARRENS | BAR_735 | Xyrella | O
@@ -836,7 +836,7 @@ THE_BARRENS | BAR_880 | Conviction (Rank 1) | O
 THE_BARRENS | BAR_881 | Invigorating Sermon | O
 THE_BARRENS | BAR_888 | Rimetongue | O
 THE_BARRENS | BAR_890 | Crossroads Gossiper |  
-THE_BARRENS | BAR_891 | Fury (Rank 1) |  
+THE_BARRENS | BAR_891 | Fury (Rank 1) | O
 THE_BARRENS | BAR_896 | Stonemaul Anchorman | O
 THE_BARRENS | BAR_902 | Cariel Roame | O
 THE_BARRENS | BAR_910 | Grimoire of Sacrifice | O
@@ -849,7 +849,7 @@ THE_BARRENS | BAR_916 | Blood Shard Bristleback | O
 THE_BARRENS | BAR_917 | Barrens Scavenger | O
 THE_BARRENS | BAR_918 | Tamsin Roame |  
 THE_BARRENS | BAR_919 | Neeru Fireblade |  
-THE_BARRENS | WC_003 | Sigil of Summoning |  
+THE_BARRENS | WC_003 | Sigil of Summoning | O
 THE_BARRENS | WC_004 | Fangbound Druid | O
 THE_BARRENS | WC_005 | Primal Dungeoneer | O
 THE_BARRENS | WC_006 | Lady Anacondra | O
@@ -877,15 +877,15 @@ THE_BARRENS | WC_034 | Party Up! |
 THE_BARRENS | WC_035 | Archdruid Naralex |  
 THE_BARRENS | WC_036 | Deviate Dreadfang | O
 THE_BARRENS | WC_037 | Venomstrike Bow | O
-THE_BARRENS | WC_040 | Taintheart Tormenter |  
+THE_BARRENS | WC_040 | Taintheart Tormenter | O
 THE_BARRENS | WC_041 | Shattering Blast | O
 THE_BARRENS | WC_042 | Wailing Vapor | O
-THE_BARRENS | WC_701 | Felrattler |  
+THE_BARRENS | WC_701 | Felrattler | O
 THE_BARRENS | WC_803 | Cleric of An'she | O
 THE_BARRENS | WC_805 | Frostweave Dungeoneer | O
 THE_BARRENS | WC_806 | Floecaster | O
 
-- Progress: 54% (92 of 170 Cards)
+- Progress: 58% (99 of 170 Cards)
 
 ## United in Stormwind
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 60% Ashes of Outland (81 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
-  * 54% Forged in the Barrens (92 of 170 cards)
+  * 58% Forged in the Barrens (99 of 170 cards)
   * 1% United in Stormwind (2 of 170 card)
 
 ### Wild Format

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3193,6 +3193,15 @@ void TheBarrensCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::DECK));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::HasDeathrattle()),
+        std::make_shared<SelfCondition>(
+            SelfCondition::IsCost(5, RelaSign::LEQ)) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 3));
+    power.AddPowerTask(std::make_shared<SummonStackTask>(true));
+    cards.emplace("BAR_329", CardDef(power));
 
     // ----------------------------------- WEAPON - DEMONHUNTER
     // [BAR_330] Tuskpiercer - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3278,6 +3278,12 @@ void TheBarrensCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
+    power.GetTrigger()->tasks = { std::make_shared<SummonTask>(
+        "WC_003t", 2, SummonSide::SPELL) };
+    power.GetTrigger()->removeAfterTriggered = true;
+    cards.emplace("WC_003", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [WC_040] Taintheart Tormenter - COST:8 [ATK:8/HP:8]
@@ -3397,6 +3403,9 @@ void TheBarrensCardsGen::AddDemonHunterNonCollect(
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("WC_003t", CardDef(power));
 }
 
 void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3296,6 +3296,14 @@ void TheBarrensCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // - AURA = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<Aura>(AuraType::ENEMY_HAND, "WC_040e"));
+    {
+        const auto aura = dynamic_cast<Aura*>(power.GetAura());
+        aura->condition =
+            std::make_shared<SelfCondition>(SelfCondition::IsSpell());
+    }
+    cards.emplace("WC_040", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [WC_701] Felrattler - COST:3 [ATK:3/HP:2]
@@ -4574,6 +4582,9 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: Costs (2) more.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(std::make_shared<Enchant>(Effects::AddCost(2)));
+    cards.emplace("WC_040e", CardDef(power));
 }
 
 void TheBarrensCardsGen::AddAll(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3260,6 +3260,12 @@ void TheBarrensCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // Text: Give your hero +2 Attack this turn.
     //       <i>(Upgrades when you have 5 Mana.)</i>
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("BAR_891e", EntityType::HERO));
+    power.AddTrigger(
+        std::make_shared<Trigger>(Triggers::RankSpellTrigger(5, "BAR_891t")));
+    cards.emplace("BAR_891", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [WC_003] Sigil of Summoning - COST:2
@@ -3325,6 +3331,9 @@ void TheBarrensCardsGen::AddDemonHunterNonCollect(
     // GameTag:
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("BAR_891e"));
+    cards.emplace("BAR_891e", CardDef(power));
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [BAR_891e2] Fury - COST:0
@@ -3335,6 +3344,9 @@ void TheBarrensCardsGen::AddDemonHunterNonCollect(
     // GameTag:
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("BAR_891e2"));
+    cards.emplace("BAR_891e2", CardDef(power));
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [BAR_891e3] Fury - COST:0
@@ -3345,6 +3357,9 @@ void TheBarrensCardsGen::AddDemonHunterNonCollect(
     // GameTag:
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("BAR_891e3"));
+    cards.emplace("BAR_891e3", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [BAR_891t] Fury (Rank 2) - COST:1
@@ -3354,6 +3369,12 @@ void TheBarrensCardsGen::AddDemonHunterNonCollect(
     // Text: Give your hero +3 Attack this turn.
     //       <i>(Upgrades when you have 10 Mana.)</i>
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("BAR_891e2", EntityType::HERO));
+    power.AddTrigger(
+        std::make_shared<Trigger>(Triggers::RankSpellTrigger(10, "BAR_891t2")));
+    cards.emplace("BAR_891t", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [BAR_891t2] Fury (Rank 3) - COST:1
@@ -3362,6 +3383,10 @@ void TheBarrensCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
     // Text: Give your hero +4 Attack this turn.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("BAR_891e3", EntityType::HERO));
+    cards.emplace("BAR_891t2", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [WC_003t] Wailing Demon - COST:2 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3245,6 +3245,12 @@ void TheBarrensCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SILENCE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
+    power.GetTrigger()->tasks = { std::make_shared<SilenceTask>(
+        EntityType::ENEMY_MINIONS) };
+    power.GetTrigger()->removeAfterTriggered = true;
+    cards.emplace("BAR_705", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [BAR_891] Fury (Rank 1) - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3316,6 +3316,10 @@ void TheBarrensCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // - DEATHRATTLE = 1
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 1));
+    cards.emplace("WC_701", CardDef(power));
 }
 
 void TheBarrensCardsGen::AddDemonHunterNonCollect(

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3212,6 +3212,10 @@ void TheBarrensCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(std::make_shared<DrawMinionTask>(
+        DrawMinionType::DEATHRATTLE, 1, false));
+    cards.emplace("BAR_330", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [BAR_333] Kurtrus Ashfallen - COST:4 [ATK:3/HP:4]

--- a/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
@@ -122,6 +122,7 @@ void CardLoader::Load(std::vector<Card*>& cards)
         // NOTE: Healing Totem (AT_132_SHAMANa), Searing Totem (AT_132_SHAMANb),
         //       Stoneclaw Totem (AT_132_SHAMANc), Wrath of Air Totem
         //       (AT_132_SHAMANd) doesn't have Race::TOTEM
+        // NOTE: Wailing Demon (WC_003t) doesn't have GameTag::TAUNT
         if (dbfID == 56091)
         {
             gameTags.emplace(GameTag::DEATHRATTLE, 1);
@@ -134,6 +135,10 @@ void CardLoader::Load(std::vector<Card*>& cards)
                  dbfID == 16225)
         {
             cardRace = static_cast<int>(Race::TOTEM);
+        }
+        else if (dbfID == 63500)
+        {
+            gameTags.emplace(GameTag::TAUNT, 1);
         }
 
         Card* card = new Card();

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -5903,3 +5903,68 @@ TEST_CASE("[Demon Hunter : Spell] - BAR_891 : Fury (Rank 1)")
     game.Process(curPlayer, PlayCardTask::Spell(card3));
     CHECK_EQ(curHero.GetAttack(), 4);
 }
+
+// ------------------------------------ SPELL - DEMONHUNTER
+// [WC_003] Sigil of Summoning - COST:2
+// - Set: THE_BARRENS, Rarity: Rare
+// - Spell School: Shadow
+// --------------------------------------------------------
+// Text: At the start of your next turn,
+//       summon two 2/2 Demons with <b>Taunt</b>.
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Spell] - WC_003 : Sigil of Summoning")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Sigil of Summoning"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Wailing Demon");
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+    CHECK_EQ(curField[1]->card->name, "Wailing Demon");
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+    CHECK_EQ(curField[1]->HasTaunt(), true);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 2);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -5711,3 +5711,56 @@ TEST_CASE("[Demon Hunter : Minion] - BAR_329 : Death Speaker Blackthorn")
     CHECK_EQ(curField[3]->HasDeathrattle(), true);
     CHECK_LE(curField[3]->GetCost(), 5);
 }
+
+// ----------------------------------- WEAPON - DEMONHUNTER
+// [BAR_330] Tuskpiercer - COST:1
+// - Set: THE_BARRENS, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Draw a <b>Deathrattle</b> minion.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Weapon] - BAR_330 : Tuskpiercer")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Savannah Highmane");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Malygos");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Wisp");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Tuskpiercer"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Tuskpiercer"));
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetAttack(), 1);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card2));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[4])->HasDeathrattle(), true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -5651,3 +5651,63 @@ TEST_CASE("[Demon Hunter : Minion] - BAR_328 : Vengeful Spirit")
     CHECK_EQ(dynamic_cast<Minion*>(curHand[4])->HasDeathrattle(), true);
     CHECK_EQ(dynamic_cast<Minion*>(curHand[5])->HasDeathrattle(), true);
 }
+
+// ----------------------------------- MINION - DEMONHUNTER
+// [BAR_329] Death Speaker Blackthorn - COST:7 [ATK:3/HP:6]
+// - Set: THE_BARRENS, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Summon 3 <b>Deathrattle</b>
+//       minions that cost (5) or less from your deck.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - BAR_329 : Death Speaker Blackthorn")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Savannah Highmane");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Malygos");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Teacher's Pet");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curDeck = *(curPlayer->GetDeckZone());
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Death Speaker Blackthorn"));
+
+    CHECK_EQ(curDeck.GetCount(), 26);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curDeck.GetCount(), 23);
+    CHECK_EQ(curField.GetCount(), 4);
+    CHECK_EQ(curField[1]->HasDeathrattle(), true);
+    CHECK_LE(curField[1]->GetCost(), 5);
+    CHECK_EQ(curField[2]->HasDeathrattle(), true);
+    CHECK_LE(curField[2]->GetCost(), 5);
+    CHECK_EQ(curField[3]->HasDeathrattle(), true);
+    CHECK_LE(curField[3]->GetCost(), 5);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -5827,3 +5827,79 @@ TEST_CASE("[Demon Hunter : Spell] - BAR_705 : Sigil of Silence")
     CHECK_EQ(opField[0]->HasTaunt(), false);
     CHECK_EQ(opField[0]->HasDeathrattle(), false);
 }
+
+// ------------------------------------ SPELL - DEMONHUNTER
+// [BAR_891] Fury (Rank 1) - COST:1
+// - Set: THE_BARRENS, Rarity: Common
+// - Spell School: Fel
+// --------------------------------------------------------
+// Text: Give your hero +2 Attack this turn.
+//       <i>(Upgrades when you have 5 Mana.)</i>
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Spell] - BAR_891 : Fury (Rank 1)")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(4);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(4);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHero = *(curPlayer->GetHero());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fury (Rank 1)"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fury (Rank 1)"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fury (Rank 1)"));
+
+    CHECK_EQ(card1->card->name, "Fury (Rank 1)");
+    CHECK_EQ(card2->card->name, "Fury (Rank 1)");
+    CHECK_EQ(card3->card->name, "Fury (Rank 1)");
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curHero.GetAttack(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card2->card->name, "Fury (Rank 1)");
+    CHECK_EQ(card3->card->name, "Fury (Rank 1)");
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card2->card->name, "Fury (Rank 2)");
+    CHECK_EQ(card3->card->name, "Fury (Rank 2)");
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curHero.GetAttack(), 3);
+
+    curPlayer->SetTotalMana(9);
+    opPlayer->SetTotalMana(9);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card3->card->name, "Fury (Rank 2)");
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card3->card->name, "Fury (Rank 3)");
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(curHero.GetAttack(), 4);
+}


### PR DESCRIPTION
This revision includes:
- Implement 7 THE_BARRENS cards
  - Death Speaker Blackthorn (BAR_329)
  - Tuskpiercer (BAR_330)
  - Sigil of Silence (BAR_705)
  - Fury (Rank 1) (BAR_891)
  - Sigil of Summoning (WC_003)
  - Taintheart Tormenter (WC_040)
  - Felrattler (WC_701)
- Add code to consider card 'Wailing Demon' (WC_003t)
  - Wailing Demon (WC_003t) doesn't have GameTag::TAUNT