### PR TITLE
Implement 7 THE_BARRENS cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -714,13 +714,13 @@ DARKMOON_FAIRE | YOP_035 | Moonfang |
 
 Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
-THE_BARRENS | BAR_020 | Razormane Raider |  
-THE_BARRENS | BAR_021 | Gold Road Grunt |  
-THE_BARRENS | BAR_022 | Peon |  
-THE_BARRENS | BAR_024 | Oasis Thrasher |  
-THE_BARRENS | BAR_025 | Sunwell Initiate |  
-THE_BARRENS | BAR_026 | Death's Head Cultist |  
-THE_BARRENS | BAR_027 | Darkspear Berserker |  
+THE_BARRENS | BAR_020 | Razormane Raider | O
+THE_BARRENS | BAR_021 | Gold Road Grunt | O
+THE_BARRENS | BAR_022 | Peon | O
+THE_BARRENS | BAR_024 | Oasis Thrasher | O
+THE_BARRENS | BAR_025 | Sunwell Initiate | O
+THE_BARRENS | BAR_026 | Death's Head Cultist | O
+THE_BARRENS | BAR_027 | Darkspear Berserker | O
 THE_BARRENS | BAR_030 | Pack Kodo |  
 THE_BARRENS | BAR_031 | Sunscale Raptor |  
 THE_BARRENS | BAR_032 | Piercing Shot | O
@@ -885,7 +885,7 @@ THE_BARRENS | WC_803 | Cleric of An'she | O
 THE_BARRENS | WC_805 | Frostweave Dungeoneer | O
 THE_BARRENS | WC_806 | Floecaster | O
 
-- Progress: 58% (99 of 170 Cards)
+- Progress: 62% (106 of 170 Cards)
 
 ## United in Stormwind
 

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/RandomSpellTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/RandomSpellTask.hpp
@@ -13,6 +13,11 @@ namespace RosettaStone::PlayMode::SimpleTasks
 class RandomSpellTask : public ITask
 {
  public:
+    //! Constructs task with given \p cardClass and \p amount.
+    //! \param cardClass The card class to filter.
+    //! \param amount The amount of spell(s) to pick.
+    explicit RandomSpellTask(CardClass cardClass, int amount = 1);
+
     //! Constructs task with given various arguments.
     //! \param cardClass The card class to filter.
     //! \param tag The game tag.

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/RandomSpellTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/RandomSpellTask.hpp
@@ -17,7 +17,7 @@ class RandomSpellTask : public ITask
     //! \param cardClass The card class to filter.
     //! \param tag The game tag.
     //! \param value The value of the game tag to filter.
-    //! \param amount The amount of minions to pick.
+    //! \param amount The amount of spell(s) to pick.
     //! \param relaSign The relation sign to filter.
     //! \param opposite The flag that indicates the card is for the opponent.
     explicit RandomSpellTask(CardClass cardClass, GameTag tag, int value,

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 60% Ashes of Outland (81 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
-  * 58% Forged in the Barrens (99 of 170 cards)
+  * 62% Forged in the Barrens (106 of 170 cards)
   * 1% United in Stormwind (2 of 170 card)
 
 ### Wild Format

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3451,6 +3451,21 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - FRENZY = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddFrenzyTask(std::make_shared<CustomTask>(
+        [](Player* player, [[maybe_unused]] Entity* source,
+           [[maybe_unused]] Playable* target) {
+            int damage = dynamic_cast<Minion*>(source)->GetDamage();
+
+            const auto& armorTask = std::make_shared<ArmorTask>(damage);
+            armorTask->SetPlayer(player);
+            armorTask->SetSource(source);
+            armorTask->SetTarget(target);
+
+            armorTask->Run();
+        }));
+
+    cards.emplace("BAR_021", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_022] Peon - COST:2 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3492,6 +3492,10 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - FRENZY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddFrenzyTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 3));
+    cards.emplace("BAR_024", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_025] Sunwell Initiate - COST:3 [ATK:3/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3422,6 +3422,8 @@ void TheBarrensCardsGen::AddDemonHunterNonCollect(
 
 void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_020] Razormane Raider - COST:5 [ATK:5/HP:6]
     // - Set: THE_BARRENS, Rarity: Common
@@ -3431,6 +3433,12 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - FRENZY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddFrenzyTask(std::make_shared<IncludeTask>(EntityType::ENEMIES));
+    power.AddFrenzyTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddFrenzyTask(
+        std::make_shared<AttackTask>(EntityType::SOURCE, EntityType::STACK));
+    cards.emplace("BAR_020", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_021] Gold Road Grunt - COST:5 [ATK:3/HP:7]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3509,6 +3509,10 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - DIVINE_SHIELD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddFrenzyTask(std::make_shared<SetGameTagTask>(
+        EntityType::SOURCE, GameTag::DIVINE_SHIELD, 1));
+    cards.emplace("BAR_025", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_026] Death's Head Cultist - COST:3 [ATK:2/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3477,6 +3477,11 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - FRENZY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddFrenzyTask(
+        std::make_shared<RandomSpellTask>(CardClass::PLAYER_CLASS, 1));
+    power.AddFrenzyTask(std::make_shared<AddStackToTask>(EntityType::HAND));
+    cards.emplace("BAR_022", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_024] Oasis Thrasher - COST:2 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3538,6 +3538,9 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(std::make_shared<DamageTask>(EntityType::HERO, 5));
+    cards.emplace("BAR_027", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_042] Primordial Protector - COST:8 [ATK:6/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3525,6 +3525,9 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - DEATHRATTLE = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(std::make_shared<HealTask>(EntityType::HERO, 4));
+    cards.emplace("BAR_026", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_027] Darkspear Berserker - COST:4 [ATK:5/HP:7]

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/RandomSpellTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/RandomSpellTask.cpp
@@ -81,14 +81,14 @@ TaskStatus RandomSpellTask::Impl(Player* player)
         return TaskStatus::STOP;
     }
 
-    std::vector<Playable*> randomMinions;
-    randomMinions.reserve(m_amount);
+    std::vector<Playable*> randomSpells;
+    randomSpells.reserve(m_amount);
 
     if (m_amount > 1)
     {
         std::vector<Card*> list = result;
 
-        while (randomMinions.size() < static_cast<std::size_t>(m_amount) &&
+        while (randomSpells.size() < static_cast<std::size_t>(m_amount) &&
                !result.empty())
         {
             const auto idx = Random::get<std::size_t>(0, list.size() - 1);
@@ -97,7 +97,7 @@ TaskStatus RandomSpellTask::Impl(Player* player)
 
             list.erase(list.begin() + idx);
 
-            randomMinions.emplace_back(card);
+            randomSpells.emplace_back(card);
         }
     }
     else
@@ -105,10 +105,10 @@ TaskStatus RandomSpellTask::Impl(Player* player)
         const auto idx = Random::get<std::size_t>(0, result.size() - 1);
         auto card = Entity::GetFromCard(m_opposite ? player->opponent : player,
                                         result.at(idx));
-        randomMinions.emplace_back(card);
+        randomSpells.emplace_back(card);
     }
 
-    player->game->taskStack.playables = randomMinions;
+    player->game->taskStack.playables = randomSpells;
 
     return TaskStatus::COMPLETE;
 }

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/RandomSpellTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/RandomSpellTask.cpp
@@ -33,52 +33,33 @@ RandomSpellTask::RandomSpellTask(CardClass cardClass, GameTag tag, int value,
 
 TaskStatus RandomSpellTask::Impl(Player* player)
 {
-    std::vector<Card*> result;
+    std::vector<Card*> cards, result;
 
     if (m_cardClass == CardClass::INVALID)
     {
-        const auto cards =
-            m_source->game->GetFormatType() == FormatType::STANDARD
-                ? Cards::GetAllStandardCards()
-                : Cards::GetAllWildCards();
-
-        for (const auto& card : cards)
-        {
-            if (Evaluate(card))
-            {
-                result.emplace_back(card);
-            }
-        }
+        cards = m_source->game->GetFormatType() == FormatType::STANDARD
+                    ? Cards::GetAllStandardCards()
+                    : Cards::GetAllWildCards();
     }
     else if (m_cardClass == CardClass::PLAYER_CLASS)
     {
         const auto playerClass = player->GetHero()->card->GetCardClass();
-        const auto cards =
-            m_source->game->GetFormatType() == FormatType::STANDARD
-                ? Cards::GetStandardCards(playerClass)
-                : Cards::GetWildCards(playerClass);
-
-        for (const auto& card : cards)
-        {
-            if (Evaluate(card))
-            {
-                result.emplace_back(card);
-            }
-        }
+        cards = m_source->game->GetFormatType() == FormatType::STANDARD
+                    ? Cards::GetStandardCards(playerClass)
+                    : Cards::GetWildCards(playerClass);
     }
     else
     {
-        const auto cards =
-            m_source->game->GetFormatType() == FormatType::STANDARD
-                ? Cards::GetStandardCards(m_cardClass)
-                : Cards::GetWildCards(m_cardClass);
+        cards = m_source->game->GetFormatType() == FormatType::STANDARD
+                    ? Cards::GetStandardCards(m_cardClass)
+                    : Cards::GetWildCards(m_cardClass);
+    }
 
-        for (const auto& card : cards)
+    for (const auto& card : cards)
+    {
+        if (Evaluate(card))
         {
-            if (Evaluate(card))
-            {
-                result.emplace_back(card);
-            }
+            result.emplace_back(card);
         }
     }
 

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/RandomSpellTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/RandomSpellTask.cpp
@@ -57,6 +57,11 @@ TaskStatus RandomSpellTask::Impl(Player* player)
 
     for (const auto& card : cards)
     {
+        if (card->GetCardType() != CardType::SPELL)
+        {
+            continue;
+        }
+
         if (Evaluate(card))
         {
             result.emplace_back(card);
@@ -108,11 +113,9 @@ std::unique_ptr<ITask> RandomSpellTask::CloneImpl()
 
 bool RandomSpellTask::Evaluate(Card* card) const
 {
-    if (card->GetCardType() == CardType::SPELL &&
-        ((m_relaSign == RelaSign::EQ && card->gameTags[m_gameTag] == m_value) ||
-         (m_relaSign == RelaSign::GEQ &&
-          card->gameTags[m_gameTag] >= m_value) ||
-         (m_relaSign == RelaSign::LEQ && card->gameTags[m_gameTag] <= m_value)))
+    if ((m_relaSign == RelaSign::EQ && card->gameTags[m_gameTag] == m_value) ||
+        (m_relaSign == RelaSign::GEQ && card->gameTags[m_gameTag] >= m_value) ||
+        (m_relaSign == RelaSign::LEQ && card->gameTags[m_gameTag] <= m_value))
     {
         return true;
     }

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/RandomSpellTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/RandomSpellTask.cpp
@@ -13,6 +13,12 @@ using Random = effolkronium::random_static;
 
 namespace RosettaStone::PlayMode::SimpleTasks
 {
+RandomSpellTask::RandomSpellTask(CardClass cardClass, int amount)
+    : m_cardClass(cardClass), m_amount(amount)
+{
+    // Do nothing
+}
+
 RandomSpellTask::RandomSpellTask(CardClass cardClass, GameTag tag, int value,
                                  int amount, RelaSign relaSign, bool opposite)
     : m_cardClass(cardClass),

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/RandomSpellTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/RandomSpellTask.cpp
@@ -62,7 +62,7 @@ TaskStatus RandomSpellTask::Impl(Player* player)
             continue;
         }
 
-        if (Evaluate(card))
+        if (m_gameTag == GameTag::INVALID || Evaluate(card))
         {
             result.emplace_back(card);
         }

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -6327,3 +6327,50 @@ TEST_CASE("[Neutral : Minion] - BAR_025 : Sunwell Initiate")
     game.Process(opPlayer, HeroPowerTask(card1));
     CHECK_EQ(curField[0]->HasDivineShield(), true);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_026] Death's Head Cultist - COST:3 [ATK:2/HP:4]
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Deathrattle:</b> Restore 4 Health to your hero.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_026 : Death's Head Cultist")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Death's Head Cultist"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 24);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -6188,3 +6188,51 @@ TEST_CASE("[Neutral : Minion] - BAR_021 : Gold Road Grunt")
     game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 6);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_022] Peon - COST:2 [ATK:2/HP:3]
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Frenzy:</b> Add a random spell from your class
+//       to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - FRENZY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_022 : Peon")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Peon"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->card->GetCardType(), CardType::SPELL);
+    CHECK_EQ(curHand[4]->card->IsCardClass(CardClass::HUNTER), true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -6374,3 +6374,48 @@ TEST_CASE("[Neutral : Minion] - BAR_026 : Death's Head Cultist")
     game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 24);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_027] Darkspear Berserker - COST:4 [ATK:5/HP:7]
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Deal 5 damage to your hero.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_027 : Darkspear Berserker")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Darkspear Berserker"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Pyroblast"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 25);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -6089,3 +6089,55 @@ TEST_CASE("[Demon Hunter : Minion] - WC_701 : Felrattler")
     CHECK_EQ(curField.GetCount(), 0);
     CHECK_EQ(opField[0]->GetHealth(), 8);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_020] Razormane Raider - COST:5 [ATK:5/HP:6]
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Frenzy:</b> Attack a random enemy.
+// --------------------------------------------------------
+// GameTag:
+// - FRENZY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_020 : Razormane Raider")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Razormane Raider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 25);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 25);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -6236,3 +6236,46 @@ TEST_CASE("[Neutral : Minion] - BAR_022 : Peon")
     CHECK_EQ(curHand[4]->card->GetCardType(), CardType::SPELL);
     CHECK_EQ(curHand[4]->card->IsCardClass(CardClass::HUNTER), true);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_024] Oasis Thrasher - COST:2 [ATK:2/HP:3]
+// - Race: Beast, Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Frenzy:</b> Deal 3 damage to the enemy Hero.
+// --------------------------------------------------------
+// GameTag:
+// - FRENZY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_024 : Oasis Thrasher")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Oasis Thrasher"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -6141,3 +6141,50 @@ TEST_CASE("[Neutral : Minion] - BAR_020 : Razormane Raider")
     game.Process(opPlayer, HeroPowerTask(card1));
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 25);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_021] Gold Road Grunt - COST:5 [ATK:3/HP:7]
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Frenzy:</b> Gain Armor equal to the damage taken.
+// --------------------------------------------------------
+// GameTag:
+// - FRENZY = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_021 : Gold Road Grunt")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Gold Road Grunt"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 6);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -6279,3 +6279,51 @@ TEST_CASE("[Neutral : Minion] - BAR_024 : Oasis Thrasher")
     game.Process(opPlayer, HeroPowerTask(card1));
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_025] Sunwell Initiate - COST:3 [ATK:3/HP:4]
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Frenzy:</b> Gain <b>Divine Shield</b>.
+// --------------------------------------------------------
+// GameTag:
+// - FRENZY = 1
+// --------------------------------------------------------
+// RefTag:
+// - DIVINE_SHIELD = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_025 : Sunwell Initiate")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Sunwell Initiate"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasDivineShield(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField[0]->HasDivineShield(), true);
+}


### PR DESCRIPTION
This revision includes:
- Implement 7 THE_BARRENS cards
  - Razormane Raider (BAR_020)
  - Gold Road Grunt (BAR_021)
  - Peon (BAR_022)
  - Oasis Thrasher (BAR_024)
  - Sunwell Initiate (BAR_025)
  - Death's Head Cultist (BAR_026)
  - Darkspear Berserker (BAR_027)
- Refactor class 'RandomSpellTask'
  - Rename variable 'randomMinions' to 'randomSpells'
  - Correct minor typo
    - minions -> spell(s)
  - Add constructor with given cardClass and amount
  - Remove redundant code to improve quality
  - Move code to check the card type for performance
  - Add code to consider 'm_gameTag' is 'GameTag::INVALID'