### PR TITLE
Implement 7 THE_BARRENS cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -731,18 +731,18 @@ THE_BARRENS | BAR_037 | Warsong Wrangler |
 THE_BARRENS | BAR_038 | Tavish Stormpike |  
 THE_BARRENS | BAR_040 | South Coast Chieftain | O
 THE_BARRENS | BAR_041 | Nofin Can Stop Us | O
-THE_BARRENS | BAR_042 | Primordial Protector |  
+THE_BARRENS | BAR_042 | Primordial Protector | O
 THE_BARRENS | BAR_043 | Tinyfin's Caravan | O
 THE_BARRENS | BAR_044 | Chain Lightning (Rank 1) |  
 THE_BARRENS | BAR_045 | Arid Stormer | O
 THE_BARRENS | BAR_048 | Bru'kan |  
-THE_BARRENS | BAR_060 | Hog Rancher |  
-THE_BARRENS | BAR_061 | Ratchet Privateer |  
-THE_BARRENS | BAR_062 | Lushwater Murcenary |  
-THE_BARRENS | BAR_063 | Lushwater Scout |  
+THE_BARRENS | BAR_060 | Hog Rancher | O
+THE_BARRENS | BAR_061 | Ratchet Privateer | O
+THE_BARRENS | BAR_062 | Lushwater Murcenary | O
+THE_BARRENS | BAR_063 | Lushwater Scout | O
 THE_BARRENS | BAR_064 | Talented Arcanist |  
-THE_BARRENS | BAR_065 | Venomous Scorpid |  
-THE_BARRENS | BAR_069 | Injured Marauder |  
+THE_BARRENS | BAR_065 | Venomous Scorpid | O
+THE_BARRENS | BAR_069 | Injured Marauder | O
 THE_BARRENS | BAR_070 | Gruntled Patron |  
 THE_BARRENS | BAR_071 | Taurajo Brave |  
 THE_BARRENS | BAR_072 | Burning Blade Acolyte |  
@@ -885,7 +885,7 @@ THE_BARRENS | WC_803 | Cleric of An'she | O
 THE_BARRENS | WC_805 | Frostweave Dungeoneer | O
 THE_BARRENS | WC_806 | Floecaster | O
 
-- Progress: 62% (106 of 170 Cards)
+- Progress: 66% (113 of 170 Cards)
 
 ## United in Stormwind
 

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp
@@ -11,6 +11,13 @@
 
 namespace RosettaStone::PlayMode::SimpleTasks
 {
+//! The type of draw spell task.
+enum class DrawSpellType
+{
+    DEFAULT,       //!< Don't care.
+    HIGHEST_COST,  //!< Highest cost card.
+};
+
 //!
 //! \brief DrawSpellTask class.
 //!
@@ -39,6 +46,7 @@ class DrawSpellTask : public ITask
 
     int m_amount = 0;
     SpellSchool m_spellSchool = SpellSchool::NONE;
+    DrawSpellType m_drawSpellType = DrawSpellType::DEFAULT;
     bool m_addToStack = false;
 };
 }  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp
@@ -46,6 +46,14 @@ class DrawSpellTask : public ITask
     explicit DrawSpellTask(DrawSpellType drawSpellType, int amount,
                            bool addToStack = false);
 
+    //! Constructs task with given various arguments.
+    //! \param spellSchool The stated school of the spell.
+    //! \param drawSpellType The type of draw spell task.
+    //! \param amount The amount to draw minion card(s).
+    //! \param addToStack A flag to store card to stack.
+    explicit DrawSpellTask(SpellSchool spellSchool, DrawSpellType drawSpellType,
+                           int amount, bool addToStack);
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp
@@ -26,6 +26,11 @@ enum class DrawSpellType
 class DrawSpellTask : public ITask
 {
  public:
+    //! Constructs task with given \p amount and \p addToStack.
+    //! \param amount The amount to draw minion card(s).
+    //! \param addToStack A flag to store card to stack.
+    explicit DrawSpellTask(int amount, bool addToStack = false);
+
     //! Constructs task with given \p spellSchool, \p amount and \p addToStack.
     //! \param spellSchool The stated school of the spell.
     //! \param amount The amount to draw minion card(s).

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp
@@ -26,12 +26,11 @@ enum class DrawSpellType
 class DrawSpellTask : public ITask
 {
  public:
-    //! Constructs task with given \p amount, \p spellSchool and \p addToStack.
-    //! \param amount The amount to draw minion card(s).
+    //! Constructs task with given \p spellSchool, \p amount and \p addToStack.
     //! \param spellSchool The stated school of the spell.
+    //! \param amount The amount to draw minion card(s).
     //! \param addToStack A flag to store card to stack.
-    explicit DrawSpellTask(int amount,
-                           SpellSchool spellSchool = SpellSchool::NONE,
+    explicit DrawSpellTask(SpellSchool spellSchool, int amount,
                            bool addToStack = false);
 
     //! Constructs task with given \p drawSpellType, \p amount and
@@ -40,7 +39,7 @@ class DrawSpellTask : public ITask
     //! \param amount The amount to draw minion card(s).
     //! \param addToStack A flag to store card to stack.
     explicit DrawSpellTask(DrawSpellType drawSpellType, int amount,
-                           bool addToStack);
+                           bool addToStack = false);
 
  private:
     //! Processes task logic internally and returns meta data.
@@ -52,9 +51,9 @@ class DrawSpellTask : public ITask
     //! \return The cloned task.
     std::unique_ptr<ITask> CloneImpl() override;
 
-    int m_amount = 0;
     SpellSchool m_spellSchool = SpellSchool::NONE;
     DrawSpellType m_drawSpellType = DrawSpellType::DEFAULT;
+    int m_amount = 0;
     bool m_addToStack = false;
 };
 }  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.hpp
@@ -34,6 +34,14 @@ class DrawSpellTask : public ITask
                            SpellSchool spellSchool = SpellSchool::NONE,
                            bool addToStack = false);
 
+    //! Constructs task with given \p drawSpellType, \p amount and
+    //! \p addToStack.
+    //! \param drawSpellType The type of draw spell task.
+    //! \param amount The amount to draw minion card(s).
+    //! \param addToStack A flag to store card to stack.
+    explicit DrawSpellTask(DrawSpellType drawSpellType, int amount,
+                           bool addToStack);
+
  private:
     //! Processes task logic internally and returns meta data.
     //! \param player The player to run task.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 60% Ashes of Outland (81 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
-  * 62% Forged in the Barrens (106 of 170 cards)
+  * 66% Forged in the Barrens (113 of 170 cards)
   * 1% United in Stormwind (2 of 170 card)
 
 ### Wild Format

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -2139,7 +2139,7 @@ void TheBarrensCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(std::make_shared<ConditionTask>(
-        EntityType::SOURCE,
+        EntityType::MINIONS_NOSOURCE,
         SelfCondList{ std::make_shared<SelfCondition>(
             SelfCondition::IsControllingRace(Race::MURLOC)) }));
     power.AddPowerTask(std::make_shared<FlagTask>(

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -1028,8 +1028,7 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - FREEZE = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(
-        std::make_shared<DrawSpellTask>(1, SpellSchool::NONE, true));
+    power.AddPowerTask(std::make_shared<DrawSpellTask>(1, true));
     power.AddPowerTask(std::make_shared<ConditionTask>(
         EntityType::STACK, SelfCondList{ std::make_shared<SelfCondition>(
                                SelfCondition::IsFrostSpell()) }));
@@ -1221,7 +1220,7 @@ void TheBarrensCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<DrawSpellTask>(1, SpellSchool::HOLY));
+    power.AddPowerTask(std::make_shared<DrawSpellTask>(SpellSchool::HOLY, 1));
     cards.emplace("BAR_873", CardDef(power));
 
     // --------------------------------------- WEAPON - PALADIN
@@ -1742,8 +1741,7 @@ void TheBarrensCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(
-        std::make_shared<DrawSpellTask>(1, SpellSchool::NONE, true));
+    power.AddPowerTask(std::make_shared<DrawSpellTask>(1, true));
     power.AddPowerTask(std::make_shared<ConditionTask>(
         EntityType::STACK, SelfCondList{ std::make_shared<SelfCondition>(
                                SelfCondition::IsHolySpell()) }));
@@ -2334,8 +2332,7 @@ void TheBarrensCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(
-        std::make_shared<DrawSpellTask>(1, SpellSchool::NONE, true));
+    power.AddPowerTask(std::make_shared<DrawSpellTask>(1, true));
     power.AddPowerTask(std::make_shared<ConditionTask>(
         EntityType::STACK, SelfCondList{ std::make_shared<SelfCondition>(
                                SelfCondition::IsNatureSpell()) }));

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3549,6 +3549,14 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DrawSpellTask>(DrawSpellType::HIGHEST_COST, 1, true));
+    power.AddPowerTask(
+        std::make_shared<GetGameTagTask>(EntityType::STACK, GameTag::COST));
+    power.AddPowerTask(std::make_shared<RandomMinionNumberTask>(GameTag::COST));
+    power.AddPowerTask(std::make_shared<SummonTask>());
+    cards.emplace("BAR_042", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_060] Hog Rancher - COST:3 [ATK:3/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3657,6 +3657,9 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - DISCOVER = 1
     // - POISONOUS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DiscoverTask>(DiscoverType::SPELL));
+    cards.emplace("BAR_065", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_069] Injured Marauder - COST:4 [ATK:5/HP:10]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3598,6 +3598,15 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::MINIONS_NOSOURCE,
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsControllingRace(Race::MURLOC)) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<AddEnchantmentTask>(
+                  "BAR_062e", EntityType::SOURCE) }));
+    cards.emplace("BAR_062", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_063] Lushwater Scout - COST:2 [ATK:1/HP:3]
@@ -4010,6 +4019,9 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("BAR_062e"));
+    cards.emplace("BAR_062e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [BAR_063e] Emboldened - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3621,6 +3621,15 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_SUMMON));
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::MURLOC))
+    };
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "BAR_063e", EntityType::TARGET) };
+    cards.emplace("BAR_063", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_064] Talented Arcanist - COST:2 [ATK:1/HP:3]
@@ -4029,6 +4038,9 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +1 Attack and <b>Rush</b>.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("BAR_063e"));
+    cards.emplace("BAR_063e", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_072t] Demonspawn - COST:6 [ATK:5/HP:8]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3584,6 +3584,10 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("BAR_061e", EntityType::WEAPON));
+    cards.emplace("BAR_061", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_062] Lushwater Murcenary - COST:2 [ATK:3/HP:2]
@@ -3996,6 +4000,9 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +1 Attack.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("BAR_061e"));
+    cards.emplace("BAR_061e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [BAR_062e] Bolstered - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3570,6 +3570,10 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("BAR_060t", 1, SummonSide::RIGHT));
+    cards.emplace("BAR_060", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_061] Ratchet Privateer - COST:3 [ATK:4/HP:3]
@@ -3982,6 +3986,9 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("BAR_060t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [BAR_061e] Privateering - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3669,6 +3669,9 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::SOURCE, 6));
+    cards.emplace("BAR_069", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_070] Gruntled Patron - COST:4 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.cpp
@@ -22,6 +22,13 @@ DrawSpellTask::DrawSpellTask(int amount, SpellSchool spellSchool,
     // Do nothing
 }
 
+DrawSpellTask::DrawSpellTask(DrawSpellType drawSpellType, int amount,
+                             bool addToStack)
+    : m_amount(amount), m_drawSpellType(drawSpellType), m_addToStack(addToStack)
+{
+    // Do nothing
+}
+
 TaskStatus DrawSpellTask::Impl(Player* player)
 {
     if (m_addToStack)

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.cpp
@@ -16,16 +16,16 @@ using Random = effolkronium::random_static;
 
 namespace RosettaStone::PlayMode::SimpleTasks
 {
-DrawSpellTask::DrawSpellTask(int amount, SpellSchool spellSchool,
+DrawSpellTask::DrawSpellTask(SpellSchool spellSchool, int amount,
                              bool addToStack)
-    : m_amount(amount), m_spellSchool(spellSchool), m_addToStack(addToStack)
+    : m_spellSchool(spellSchool), m_amount(amount), m_addToStack(addToStack)
 {
     // Do nothing
 }
 
 DrawSpellTask::DrawSpellTask(DrawSpellType drawSpellType, int amount,
                              bool addToStack)
-    : m_amount(amount), m_drawSpellType(drawSpellType), m_addToStack(addToStack)
+    : m_drawSpellType(drawSpellType), m_amount(amount), m_addToStack(addToStack)
 {
     // Do nothing
 }
@@ -84,7 +84,7 @@ TaskStatus DrawSpellTask::Impl(Player* player)
 
 std::unique_ptr<ITask> DrawSpellTask::CloneImpl()
 {
-    return std::make_unique<DrawSpellTask>(m_amount, m_spellSchool,
+    return std::make_unique<DrawSpellTask>(m_spellSchool, m_amount,
                                            m_addToStack);
 }
 }  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.cpp
@@ -16,6 +16,12 @@ using Random = effolkronium::random_static;
 
 namespace RosettaStone::PlayMode::SimpleTasks
 {
+DrawSpellTask::DrawSpellTask(int amount, bool addToStack)
+    : m_amount(amount), m_addToStack(addToStack)
+{
+    // Do nothing
+}
+
 DrawSpellTask::DrawSpellTask(SpellSchool spellSchool, int amount,
                              bool addToStack)
     : m_spellSchool(spellSchool), m_amount(amount), m_addToStack(addToStack)

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawSpellTask.cpp
@@ -36,6 +36,17 @@ DrawSpellTask::DrawSpellTask(DrawSpellType drawSpellType, int amount,
     // Do nothing
 }
 
+DrawSpellTask::DrawSpellTask(SpellSchool spellSchool,
+                             DrawSpellType drawSpellType, int amount,
+                             bool addToStack)
+    : m_spellSchool(spellSchool),
+      m_drawSpellType(drawSpellType),
+      m_amount(amount),
+      m_addToStack(addToStack)
+{
+    // Do nothing
+}
+
 TaskStatus DrawSpellTask::Impl(Player* player)
 {
     if (m_addToStack)
@@ -90,7 +101,7 @@ TaskStatus DrawSpellTask::Impl(Player* player)
 
 std::unique_ptr<ITask> DrawSpellTask::CloneImpl()
 {
-    return std::make_unique<DrawSpellTask>(m_spellSchool, m_amount,
-                                           m_addToStack);
+    return std::make_unique<DrawSpellTask>(m_spellSchool, m_drawSpellType,
+                                           m_amount, m_addToStack);
 }
 }  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -6656,6 +6656,52 @@ TEST_CASE("[Neutral : Minion] - BAR_063 : Lushwater Scout")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [BAR_065] Venomous Scorpid - COST:3 [ATK:1/HP:3]
+// - Race: Beast, Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Poisonous</b>
+//       <b>Battlecry:</b> <b>Discover</b> a spell.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - DISCOVER = 1
+// - POISONOUS = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_065 : Venomous Scorpid")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Venomous Scorpid"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK(curPlayer->choice != nullptr);
+
+    auto cards = TestUtils::GetChoiceCards(game);
+    for (auto& card : cards)
+    {
+        CHECK_EQ(card->GetCardType(), CardType::SPELL);
+        CHECK(card->IsCardClass(CardClass::HUNTER));
+    }
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [BAR_069] Injured Marauder - COST:4 [ATK:5/HP:10]
 // - Set: THE_BARRENS, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -6515,3 +6515,48 @@ TEST_CASE("[Neutral : Minion] - BAR_060 : Hog Rancher")
     CHECK_EQ(curField[1]->GetHealth(), 1);
     CHECK_EQ(curField[1]->HasRush(), true);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_061] Ratchet Privateer - COST:3 [ATK:4/HP:3]
+// - Race: Pirate, Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give your weapon +1 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_061 : Ratchet Privateer")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Ratchet Privateer"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Ratchet Privateer"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 2);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -6419,3 +6419,53 @@ TEST_CASE("[Neutral : Minion] - BAR_027 : Darkspear Berserker")
     game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 25);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_042] Primordial Protector - COST:8 [ATK:6/HP:6]
+// - Race: Elemental, Set: THE_BARRENS, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Draw your highest Cost spell.
+//       Summon a random minion with the same Cost.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_042 : Primordial Protector")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Pyroblast");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Fireball");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Wisp");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Primordial Protector"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->card->name, "Pyroblast");
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[1]->card->GetCost(), 10);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -6606,3 +6606,51 @@ TEST_CASE("[Neutral : Minion] - BAR_062 : Lushwater Murcenary")
     CHECK_EQ(curField[1]->GetAttack(), 4);
     CHECK_EQ(curField[1]->GetHealth(), 3);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_063] Lushwater Scout - COST:2 [ATK:1/HP:3]
+// - Race: Murloc, Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: After you summon a Murloc,
+//       give it +1 Attack and <b>Rush</b>.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_063 : Lushwater Scout")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Lushwater Scout"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Murloc Tinyfin"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->HasRush(), true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -6654,3 +6654,45 @@ TEST_CASE("[Neutral : Minion] - BAR_063 : Lushwater Scout")
     CHECK_EQ(curField[1]->GetHealth(), 1);
     CHECK_EQ(curField[1]->HasRush(), true);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_069] Injured Marauder - COST:4 [ATK:5/HP:10]
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Battlecry:</b> Deal 6 damage to this minion.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_069 : Injured Marauder")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Injured Marauder"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -6469,3 +6469,49 @@ TEST_CASE("[Neutral : Minion] - BAR_042 : Primordial Protector")
     CHECK_EQ(curField.GetCount(), 2);
     CHECK_EQ(curField[1]->card->GetCost(), 10);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_060] Hog Rancher - COST:3 [ATK:3/HP:2]
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Summon a 2/1 Hog with <b>Rush</b>.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_060 : Hog Rancher")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Hog Rancher"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[1]->card->name, "Hog");
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->HasRush(), true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -6560,3 +6560,49 @@ TEST_CASE("[Neutral : Minion] - BAR_061 : Ratchet Privateer")
     game.Process(curPlayer, PlayCardTask::Minion(card2));
     CHECK_EQ(curPlayer->GetHero()->GetAttack(), 2);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_062] Lushwater Murcenary - COST:2 [ATK:3/HP:2]
+// - Race: Murloc, Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you control a Murloc, gain +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_062 : Lushwater Murcenary")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Lushwater Murcenary"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Lushwater Murcenary"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 4);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+}


### PR DESCRIPTION
This revision includes:
- Implement 7 THE_BARRENS cards
  - Primordial Protector (BAR_042)
  - Hog Rancher (BAR_060)
  - Ratchet Privateer (BAR_061)
  - Lushwater Murcenary (BAR_062)
  - Lushwater Scout (BAR_063)
  - Venomous Scorpid (BAR_065)
  - Injured Marauder (BAR_069)
- Correct the logic of the card 'South Coast Chieftain' (BAR_040)
- Refactor class 'DrawSpellTask'
  - Add enum 'DrawSpellType' and variable 'm_drawSpellType' 
  - Add constructor that takes 'drawSpellType'
  - Add constructor that takes 'amount' and 'addToStack'
  - Add constructor that takes all arguments
  - Cleanup the logic of method 'Impl()'
  - Change code to get spell cards according to spell type