### PR TITLE
Implement 7 THE_BARRENS cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -755,7 +755,7 @@ THE_BARRENS | BAR_078 | Blademaster Samuro |
 THE_BARRENS | BAR_079 | Kazakus, Golem Shaper |  
 THE_BARRENS | BAR_080 | Shadow Hunter Vol'jin |  
 THE_BARRENS | BAR_081 | Southsea Scoundrel |  
-THE_BARRENS | BAR_082 | Barrens Trapper |  
+THE_BARRENS | BAR_082 | Barrens Trapper | O
 THE_BARRENS | BAR_305 | Flurry (Rank 1) | O
 THE_BARRENS | BAR_306 | Sigil of Flame | O
 THE_BARRENS | BAR_307 | Void Flayer | O
@@ -805,11 +805,11 @@ THE_BARRENS | BAR_551 | Barak Kodobane |
 THE_BARRENS | BAR_552 | Scabbs Cutterbutter |  
 THE_BARRENS | BAR_705 | Sigil of Silence | O
 THE_BARRENS | BAR_720 | Guff Runetotem | O
-THE_BARRENS | BAR_721 | Mankrik |  
+THE_BARRENS | BAR_721 | Mankrik | O
 THE_BARRENS | BAR_735 | Xyrella | O
-THE_BARRENS | BAR_743 | Toad of the Wilds |  
-THE_BARRENS | BAR_744 | Spirit Healer |  
-THE_BARRENS | BAR_745 | Hecklefang Hyena |  
+THE_BARRENS | BAR_743 | Toad of the Wilds | O
+THE_BARRENS | BAR_744 | Spirit Healer | O
+THE_BARRENS | BAR_745 | Hecklefang Hyena | O
 THE_BARRENS | BAR_748 | Varden Dawngrasp | O
 THE_BARRENS | BAR_750 | Earth Revenant | O
 THE_BARRENS | BAR_751 | Spawnpool Forager | O
@@ -824,7 +824,7 @@ THE_BARRENS | BAR_845 | Rancor | O
 THE_BARRENS | BAR_846 | Mor'shan Elite | O
 THE_BARRENS | BAR_847 | Rokara | O
 THE_BARRENS | BAR_848 | Lilypad Lurker | O
-THE_BARRENS | BAR_854 | Kindling Elemental |  
+THE_BARRENS | BAR_854 | Kindling Elemental | O
 THE_BARRENS | BAR_860 | Firemancer Flurgl | O
 THE_BARRENS | BAR_871 | Soldier's Caravan | O
 THE_BARRENS | BAR_873 | Knight of Anointment | O
@@ -835,7 +835,7 @@ THE_BARRENS | BAR_879 | Cannonmaster Smythe |
 THE_BARRENS | BAR_880 | Conviction (Rank 1) | O
 THE_BARRENS | BAR_881 | Invigorating Sermon | O
 THE_BARRENS | BAR_888 | Rimetongue | O
-THE_BARRENS | BAR_890 | Crossroads Gossiper |  
+THE_BARRENS | BAR_890 | Crossroads Gossiper | O
 THE_BARRENS | BAR_891 | Fury (Rank 1) | O
 THE_BARRENS | BAR_896 | Stonemaul Anchorman | O
 THE_BARRENS | BAR_902 | Cariel Roame | O
@@ -885,7 +885,7 @@ THE_BARRENS | WC_803 | Cleric of An'she | O
 THE_BARRENS | WC_805 | Frostweave Dungeoneer | O
 THE_BARRENS | WC_806 | Floecaster | O
 
-- Progress: 71% (122 of 170 Cards)
+- Progress: 75% (129 of 170 Cards)
 
 ## United in Stormwind
 

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -146,50 +146,50 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsNotRace(Race race);
 
-    //! SelfCondition wrapper for checking there is the entity
+    //! SelfCondition wrapper for checking there is a minion
     //! with \p race in field zone.
     //! \param race The race for checking.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsControllingRace(Race race);
 
-    //! SelfCondition wrapper for checking there is the entity
+    //! SelfCondition wrapper for checking there is a minion
     //! with \p race in opponent's field zone.
     //! \param race The race for checking.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsOpControllingRace(Race race);
 
-    //! SelfCondition wrapper for checking the secret exists
+    //! SelfCondition wrapper for checking a secret exists
     //! in the owner's secret zone.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsControllingSecret();
 
-    //! SelfCondition wrapper for checking the quest exists
+    //! SelfCondition wrapper for checking a quest exists
     //! in the owner's secret zone.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsControllingQuest();
 
-    //! SelfCondition wrapper for checking there is the entity
-    //! with stealthed minion in field zone.
+    //! SelfCondition wrapper for checking there is a stealthed
+    //! minion in field zone.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsControllingStealthedMinion();
 
-    //! SelfCondition wrapper for checking there is the entity
-    //! with Lackey in field zone.
+    //! SelfCondition wrapper for checking there is a Lackey minion
+    //! in field zone.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsControllingLackey();
 
-    //! SelfCondition wrapper for checking the player has secret card
-    //! in hand zone.
+    //! SelfCondition wrapper for checking the player has
+    //! a secret card in hand zone.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsHoldingSecret();
 
-    //! SelfCondition wrapper for checking the player has entity
+    //! SelfCondition wrapper for checking the player has a minion
     //! with \p race in hand zone.
     //! \param race The race for checking.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsHoldingRace(Race race);
 
-    //! SelfCondition wrapper for checking the player has spell card
+    //! SelfCondition wrapper for checking the player has a spell
     //! with \p spellSchool in hand zone.
     //! \param spellSchool The spell school for checking.
     //! \return Generated SelfCondition for intended purpose.
@@ -425,7 +425,6 @@ class SelfCondition
 
     //! SelfCondition wrapper for checking the field of event target
     //! is not full.
-    //! \param cardType The type of the card to check.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsEventTargetFieldNotFull();
 

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -189,6 +189,12 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsHoldingRace(Race race);
 
+    //! SelfCondition wrapper for checking the player has spell card
+    //! with \p spellSchool in hand zone.
+    //! \param spellSchool The spell school for checking.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsHoldingSpell(SpellSchool spellSchool);
+
     //! SelfCondition wrapper for checking the entity is another class card.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsAnotherClassCard();

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
@@ -104,6 +104,19 @@ class ComplexTask
         };
     }
 
+    //! Returns a list of task for giving buff to a random minion in field.
+    //! \param enchantmentCardID The ID of enchantment card to give buff.
+    static TaskList GiveBuffToRandomMinionInField(
+        std::string_view enchantmentCardID)
+    {
+        return TaskList{
+            std::make_shared<SimpleTasks::IncludeTask>(EntityType::MINIONS),
+            std::make_shared<SimpleTasks::RandomTask>(EntityType::STACK, 1),
+            std::make_shared<SimpleTasks::AddEnchantmentTask>(enchantmentCardID,
+                                                              EntityType::STACK)
+        };
+    }
+
     //! Returns a list of task for activating a secret card.
     //! \param tasks A list of task of secret card.
     static TaskList ActivateSecret(TaskList tasks)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 60% Ashes of Outland (81 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
-  * 71% Forged in the Barrens (122 of 170 cards)
+  * 75% Forged in the Barrens (129 of 170 cards)
   * 1% United in Stormwind (2 of 170 card)
 
 ### Wild Format

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1165,9 +1165,7 @@ void CoreCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
         SelfCondList{ std::make_shared<SelfCondition>(
             SelfCondition::IsFieldCount(2, RelaSign::GEQ)) };
     power.GetTrigger()->tasks = { ComplexTask::ActivateSecret(
-        TaskList{ std::make_shared<RandomTask>(EntityType::MINIONS, 1),
-                  std::make_shared<AddEnchantmentTask>("FP1_020e",
-                                                       EntityType::STACK) }) };
+        ComplexTask::GiveBuffToRandomMinionInField("FP1_020e")) };
     cards.emplace("CORE_FP1_020", CardDef(power));
 
     // --------------------------------------- MINION - PALADIN

--- a/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DarkmoonFaireCardsGen.cpp
@@ -1759,11 +1759,8 @@ void DarkmoonFaireCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
     power.GetTrigger()->triggerSource = TriggerSource::HERO;
-    power.GetTrigger()->tasks = {
-        std::make_shared<IncludeTask>(EntityType::MINIONS),
-        std::make_shared<RandomTask>(EntityType::STACK, 1),
-        std::make_shared<AddEnchantmentTask>("DMF_705e", EntityType::STACK)
-    };
+    power.GetTrigger()->tasks =
+        ComplexTask::GiveBuffToRandomMinionInField("DMF_705e");
     cards.emplace("DMF_705", CardDef(power));
 
     // ----------------------------------------- SPELL - SHAMAN

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -113,9 +113,7 @@ void NaxxCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
         SelfCondList{ std::make_shared<SelfCondition>(
             SelfCondition::IsFieldCount(2, RelaSign::GEQ)) };
     power.GetTrigger()->tasks = { ComplexTask::ActivateSecret(
-        TaskList{ std::make_shared<RandomTask>(EntityType::MINIONS, 1),
-                  std::make_shared<AddEnchantmentTask>("FP1_020e",
-                                                       EntityType::STACK) }) };
+        ComplexTask::GiveBuffToRandomMinionInField("FP1_020e")) };
     cards.emplace("FP1_020", CardDef(power));
 }
 

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -4004,6 +4004,12 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::SECRET_REVEALED));
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "BAR_890e", EntityType::SOURCE) };
+    cards.emplace("BAR_890", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [WC_027] Devouring Ectoplasm - COST:3 [ATK:3/HP:2]
@@ -4675,6 +4681,9 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("BAR_890e"));
+    cards.emplace("BAR_890e", CardDef(power));
 
     // ---------------------------------------- SPELL - NEUTRAL
     // [BAR_COIN1] The Coin - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3957,6 +3957,14 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_CAST));
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsHolySpell())
+    };
+    power.GetTrigger()->tasks =
+        ComplexTask::GiveBuffToRandomMinionInField("BAR_744e");
+    cards.emplace("BAR_744", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_745] Hecklefang Hyena - COST:2 [ATK:2/HP:4]
@@ -4593,6 +4601,9 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +2 Health
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("BAR_744e"));
+    cards.emplace("BAR_744e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [BAR_842e] Gains - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3920,6 +3920,10 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::DECK, "BAR_721t"));
+    cards.emplace("BAR_721", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_743] Toad of the Wilds - COST:2 [ATK:2/HP:2]
@@ -4545,11 +4549,24 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - TOPDECK = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTopdeckTask(
+        std::make_shared<SummonTask>("BAR_721t2", SummonSide::SPELL, true));
+    power.AddTopdeckTask(std::make_shared<AttackTask>(
+        EntityType::STACK, EntityType::ENEMY_HERO, true));
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("BAR_721t2", SummonSide::SPELL, true));
+    power.AddPowerTask(std::make_shared<AttackTask>(
+        EntityType::STACK, EntityType::ENEMY_HERO, true));
+    cards.emplace("BAR_721t", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BAR_721t2] Mankrik, Consumed by Hatred - COST:5 [ATK:3/HP:10]
+    // [BAR_721t2] Mankrik, Consumed by Hatred - COST:5 [ATK:3/HP:7]
     // - Set: THE_BARRENS
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("BAR_721t2", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [BAR_743e] Toadin' Wild - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3973,6 +3973,9 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::HERO, 3));
+    cards.emplace("BAR_745", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_854] Kindling Elemental - COST:1 [ATK:1/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -1318,9 +1318,7 @@ void TheBarrensCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // - REQ_NUM_MINION_SLOTS = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::MINIONS, 1));
-    power.AddPowerTask(
-        std::make_shared<AddEnchantmentTask>("BAR_880e", EntityType::STACK));
+    power.AddPowerTask(ComplexTask::GiveBuffToRandomMinionInField("BAR_880e"));
     power.AddTrigger(
         std::make_shared<Trigger>(Triggers::RankSpellTrigger(5, "BAR_880t")));
     cards.emplace(

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3987,6 +3987,10 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("BAR_854e", EntityType::SOURCE));
+    cards.emplace("BAR_854", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_890] Crossroads Gossiper - COST:3 [ATK:4/HP:3]
@@ -4652,6 +4656,18 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: Your next Elemental costs (2) less.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<Aura>(AuraType::HAND,
+                                         EffectList{ Effects::ReduceCost(2) }));
+    {
+        const auto aura = dynamic_cast<Aura*>(power.GetAura());
+        aura->condition = std::make_shared<SelfCondition>(
+            SelfCondition::IsRace(Race::ELEMENTAL));
+        aura->removeTrigger = { TriggerType::PLAY_MINION,
+                                std::make_shared<SelfCondition>(
+                                    SelfCondition::IsRace(Race::ELEMENTAL)) };
+    }
+    cards.emplace("BAR_854e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [BAR_890e] Shameless - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3887,6 +3887,15 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<Aura>(AuraType::HAND,
+                                         EffectList{ Effects::ReduceCost(1) }));
+    {
+        const auto aura = dynamic_cast<Aura*>(power.GetAura());
+        aura->condition =
+            std::make_shared<SelfCondition>(SelfCondition::HasDeathrattle());
+    }
+    cards.emplace("BAR_082", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_430] Horde Operative - COST:3 [ATK:3/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -3937,6 +3937,15 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE,
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsHoldingSpell(SpellSchool::NATURE)) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<AddEnchantmentTask>(
+                  "BAR_743e", EntityType::SOURCE) }));
+    cards.emplace("BAR_743", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [BAR_744] Spirit Healer - COST:4 [ATK:3/HP:6]
@@ -4574,6 +4583,9 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +2 Health.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("BAR_743e"));
+    cards.emplace("BAR_743e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [BAR_744e] Lifted Spirits - COST:0

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -337,9 +337,10 @@ SelfCondition SelfCondition::IsHoldingSecret()
 SelfCondition SelfCondition::IsHoldingRace(Race race)
 {
     return SelfCondition([race](Playable* playable) {
-        for (auto& minion : playable->player->GetHandZone()->GetAll())
+        for (auto& handCard : playable->player->GetHandZone()->GetAll())
         {
-            if (minion->card->GetRace() == race)
+            if (handCard->card->GetCardType() == CardType::MINION &&
+                handCard->card->GetRace() == race)
             {
                 return true;
             }

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -349,6 +349,22 @@ SelfCondition SelfCondition::IsHoldingRace(Race race)
     });
 }
 
+SelfCondition SelfCondition::IsHoldingSpell(SpellSchool spellSchool)
+{
+    return SelfCondition([spellSchool](Playable* playable) {
+        for (auto& handCard : playable->player->GetHandZone()->GetAll())
+        {
+            if (handCard->card->GetCardType() == CardType::SPELL &&
+                handCard->card->GetSpellSchool() == spellSchool)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    });
+}
+
 SelfCondition SelfCondition::IsAnotherClassCard()
 {
     return SelfCondition([](Playable* playable) {

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -7503,3 +7503,53 @@ TEST_CASE("[Neutral : Minion] - BAR_743 : Toad of the Wilds")
     CHECK_EQ(curField[1]->GetAttack(), 2);
     CHECK_EQ(curField[1]->GetHealth(), 2);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_744] Spirit Healer - COST:4 [ATK:3/HP:6]
+// - Set: THE_BARRENS, Rarity: Epic
+// --------------------------------------------------------
+// Text: After you cast a Holy spell,
+//       give a random friendly minion +2 Health.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_744 : Spirit Healer")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Spirit Healer"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Holy Light"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curField[0]->GetHealth(), 8);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
+    CHECK_EQ(curField[0]->GetHealth(), 8);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -7589,3 +7589,63 @@ TEST_CASE("[Neutral : Minion] - BAR_745 : Hecklefang Hyena")
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 27);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_854] Kindling Elemental - COST:1 [ATK:1/HP:2]
+// - Race: Elemental, Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> The next Elemental you play
+//       costs (1) less.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_854 : Kindling Elemental")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Kindling Elemental"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Unbound Elemental"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wailing Vapor"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wailing Vapor"));
+    const auto card5 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Stranglethorn Tiger"));
+
+    CHECK_EQ(card2->GetCost(), 3);
+    CHECK_EQ(card3->GetCost(), 1);
+    CHECK_EQ(card4->GetCost(), 1);
+    CHECK_EQ(card5->GetCost(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 9);
+    CHECK_EQ(card2->GetCost(), 1);
+    CHECK_EQ(card3->GetCost(), 0);
+    CHECK_EQ(card4->GetCost(), 0);
+    CHECK_EQ(card5->GetCost(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 9);
+    CHECK_EQ(card2->GetCost(), 3);
+    CHECK_EQ(card4->GetCost(), 1);
+    CHECK_EQ(card5->GetCost(), 5);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -7649,3 +7649,62 @@ TEST_CASE("[Neutral : Minion] - BAR_854 : Kindling Elemental")
     CHECK_EQ(card4->GetCost(), 1);
     CHECK_EQ(card5->GetCost(), 5);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_890] Crossroads Gossiper - COST:3 [ATK:4/HP:3]
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: After a friendly <b>Secret</b> is revealed, gain +2/+2.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+// RefTag:
+// - SECRET = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_890 : Crossroads Gossiper")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curSecret = *(curPlayer->GetSecretZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Crossroads Gossiper"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Snipe"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Chillwind Yeti"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curSecret.GetCount(), 0);
+    CHECK_EQ(curField[0]->GetAttack(), 6);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -7343,3 +7343,59 @@ TEST_CASE("[Neutral : Minion] - BAR_077 : Kargal Battlescar")
     CHECK_EQ(curField[3]->GetAttack(), 5);
     CHECK_EQ(curField[3]->GetHealth(), 5);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_082] Barrens Trapper - COST:3 [ATK:2/HP:4]
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: Your <b>Deathrattle</b> cards cost (1) less.
+// --------------------------------------------------------
+// GameTag:
+// - AURA = 1
+// --------------------------------------------------------
+// RefTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_082 : Barrens Trapper")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Barrens Trapper"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Far Watch Post"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Loot Hoarder"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    CHECK_EQ(card2->GetCost(), 2);
+    CHECK_EQ(card3->GetCost(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(card2->GetCost(), 2);
+    CHECK_EQ(card3->GetCost(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card1));
+    CHECK_EQ(card2->GetCost(), 2);
+    CHECK_EQ(card3->GetCost(), 2);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -7553,3 +7553,39 @@ TEST_CASE("[Neutral : Minion] - BAR_744 : Spirit Healer")
                  PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
     CHECK_EQ(curField[0]->GetHealth(), 8);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_745] Hecklefang Hyena - COST:2 [ATK:2/HP:4]
+// - Race: Beast, Set: THE_BARRENS, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Deal 3 damage to your hero.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_745 : Hecklefang Hyena")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Hecklefang Hyena"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 27);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -7452,3 +7452,54 @@ TEST_CASE("[Neutral : Minion] - BAR_721 : Mankrik")
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 13);
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 17);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_743] Toad of the Wilds - COST:2 [ATK:2/HP:2]
+// - Race: Beast, Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Battlecry:</b> If you're holding a Nature spell,
+//       gain +2 Health.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_743 : Toad of the Wilds")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Toad of the Wilds"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Toad of the Wilds"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Innervate"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -7399,3 +7399,56 @@ TEST_CASE("[Neutral : Minion] - BAR_082 : Barrens Trapper")
     CHECK_EQ(card2->GetCost(), 2);
     CHECK_EQ(card3->GetCost(), 2);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BAR_721] Mankrik - COST:3 [ATK:3/HP:4]
+// - Set: THE_BARRENS, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Help Mankrik find his wife!
+//       She was last seen somewhere in your deck.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BAR_721 : Mankrik")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curDeck = *(curPlayer->GetDeckZone());
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mankrik"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curDeck.GetCount(), 1);
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curDeck.GetCount(), 0);
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[1]->card->name, "Mankrik, Consumed by Hatred");
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->GetHealth(), 7);
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 13);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 17);
+}


### PR DESCRIPTION
This revision includes:
- Implement 7 THE_BARRENS cards
  - Barrens Trapper (BAR_082)
  - Mankrik (BAR_721)
  - Toad of the Wilds (BAR_743)
  - Spirit Healer (BAR_744)
  - Hecklefang Hyena (BAR_745)
  - Kindling Elemental (BAR_854)
  - Crossroads Gossiper (BAR_890)
- Add some methods
  - IsHoldingSpell(): SelfCondition wrapper for checking the player has spell card with spell school in hand zone
  - GiveBuffToRandomMinionInField(): Returns a list of task for giving buff to a random minion in field
- Refactor the logic of method 'IsHoldingRace()'
- Replace code to use method 'GiveBuffToRandomMinionInField()'