### PR TITLE
Implement 7 THE_BARRENS cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -828,7 +828,7 @@ THE_BARRENS | BAR_854 | Kindling Elemental | O
 THE_BARRENS | BAR_860 | Firemancer Flurgl | O
 THE_BARRENS | BAR_871 | Soldier's Caravan | O
 THE_BARRENS | BAR_873 | Knight of Anointment | O
-THE_BARRENS | BAR_875 | Sword of the Fallen |  
+THE_BARRENS | BAR_875 | Sword of the Fallen | O
 THE_BARRENS | BAR_876 | Northwatch Commander | O
 THE_BARRENS | BAR_878 | Veteran Warmedic | O
 THE_BARRENS | BAR_879 | Cannonmaster Smythe |  
@@ -861,19 +861,19 @@ THE_BARRENS | WC_015 | Water Moccasin |
 THE_BARRENS | WC_016 | Shroud of Concealment |  
 THE_BARRENS | WC_017 | Savory Deviate Delight |  
 THE_BARRENS | WC_020 | Perpetual Flame |  
-THE_BARRENS | WC_021 | Unstable Shadow Blast |  
-THE_BARRENS | WC_022 | Final Gasp |  
+THE_BARRENS | WC_021 | Unstable Shadow Blast | O
+THE_BARRENS | WC_022 | Final Gasp | O
 THE_BARRENS | WC_023 | Stealer of Souls |  
 THE_BARRENS | WC_024 | Man-at-Arms | O
 THE_BARRENS | WC_025 | Whetstone Hatchet | O
 THE_BARRENS | WC_026 | Kresh, Lord of Turtling | O
-THE_BARRENS | WC_027 | Devouring Ectoplasm |  
-THE_BARRENS | WC_028 | Meeting Stone |  
-THE_BARRENS | WC_029 | Selfless Sidekick |  
+THE_BARRENS | WC_027 | Devouring Ectoplasm | O
+THE_BARRENS | WC_028 | Meeting Stone | O
+THE_BARRENS | WC_029 | Selfless Sidekick | O
 THE_BARRENS | WC_030 | Mutanus the Devourer |  
 THE_BARRENS | WC_032 | Seedcloud Buckler | O
 THE_BARRENS | WC_033 | Judgment of Justice | O
-THE_BARRENS | WC_034 | Party Up! |  
+THE_BARRENS | WC_034 | Party Up! | O
 THE_BARRENS | WC_035 | Archdruid Naralex |  
 THE_BARRENS | WC_036 | Deviate Dreadfang | O
 THE_BARRENS | WC_037 | Venomstrike Bow | O
@@ -885,7 +885,7 @@ THE_BARRENS | WC_803 | Cleric of An'she | O
 THE_BARRENS | WC_805 | Frostweave Dungeoneer | O
 THE_BARRENS | WC_806 | Floecaster | O
 
-- Progress: 75% (129 of 170 Cards)
+- Progress: 80% (136 of 170 Cards)
 
 ## United in Stormwind
 

--- a/Documents/TaskList.md
+++ b/Documents/TaskList.md
@@ -25,6 +25,7 @@
 * ArmorTask
 * AttackTask
 * CastRandomSpellTask
+* CastSpellStackTask
 * ChanceTask
 * ChangeAttackingTargetTask
 * ChangeEntityTask
@@ -111,4 +112,5 @@
 * TransformCopyTask
 * TransformMinionTask
 * TransformTask
+* WeaponStackTask
 * WeaponTask

--- a/Includes/Rosetta/PlayMode/Cards/Card.hpp
+++ b/Includes/Rosetta/PlayMode/Cards/Card.hpp
@@ -94,6 +94,10 @@ class Card
     //! \return The flag that indicates whether it is Watch Post.
     bool IsWatchPost() const;
 
+    //! Returns the flag that indicates whether it is Adventurer.
+    //! \return the flag that indicates whether it is Adventurer.
+    bool IsAdventurer() const;
+
     //! Returns the flag that indicates whether it is a card with two Choose One
     //! options involving transform or specific summon effects is played while
     //! controlling Ossirian Tear.

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -526,6 +526,11 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition HasSoulFragmentInDeck();
 
+    //! SelfCondition wrapper for checking the secret doesn't exist
+    //! in secret zone.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition NotExistInSecretZone();
+
     //! SelfCondition wrapper for checking the threshold value.
     //! \param relaSign The comparer to check condition.
     //! \return Generated SelfCondition for intended purpose.

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
@@ -75,6 +75,18 @@ class ComplexTask
         };
     }
 
+    //! Returns a list of task for equipping a weapon from your deck.
+    static TaskList EquipWeaponFromDeck()
+    {
+        return TaskList{
+            std::make_shared<SimpleTasks::IncludeTask>(EntityType::DECK),
+            std::make_shared<SimpleTasks::FilterStackTask>(SelfCondList{
+                std::make_shared<SelfCondition>(SelfCondition::IsWeapon()) }),
+            std::make_shared<SimpleTasks::RandomTask>(EntityType::STACK, 1),
+            std::make_shared<SimpleTasks::WeaponStackTask>(true)
+        };
+    }
+
     //! Returns a list of task for destroying random enemy minion(s).
     //! \param num The number of minion(s) to destroy.
     static TaskList DestroyRandomEnemyMinion(int num)

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
@@ -75,6 +75,19 @@ class ComplexTask
         };
     }
 
+    //! Returns a list of task for casting a secret from your deck.
+    static TaskList CastSecretFromDeck()
+    {
+        return TaskList{
+            std::make_shared<SimpleTasks::IncludeTask>(EntityType::DECK),
+            std::make_shared<SimpleTasks::FilterStackTask>(SelfCondList{
+                std::make_shared<SelfCondition>(SelfCondition::IsSecret()),
+                std::make_shared<SelfCondition>(SelfCondition::NotExistInSecretZone()) }),
+            std::make_shared<SimpleTasks::RandomTask>(EntityType::STACK, 1),
+            std::make_shared<SimpleTasks::CastSpellStackTask>(true)
+        };
+    }
+
     //! Returns a list of task for equipping a weapon from your deck.
     static TaskList EquipWeaponFromDeck()
     {

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks.hpp
@@ -105,6 +105,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/TransformCopyTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/TransformMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/TransformTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/WeaponStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/WeaponTask.hpp>
 
 #endif  // ROSETTASTONE_PLAYMODE_SIMPLE_TASKS_HPP

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks.hpp
@@ -18,6 +18,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AttackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/CastRandomSpellTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/CastSpellStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ChanceTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ChangeAttackingTargetTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ChangeEntityTask.hpp>

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/CastSpellStackTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/CastSpellStackTask.hpp
@@ -1,0 +1,40 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_PLAYMODE_CAST_SPELL_STACK_TASK_HPP
+#define ROSETTASTONE_PLAYMODE_CAST_SPELL_STACK_TASK_HPP
+
+#include <Rosetta/PlayMode/Tasks/ITask.hpp>
+
+namespace RosettaStone::PlayMode::SimpleTasks
+{
+//!
+//! \brief CastSpellStackTask class.
+//!
+//! This class represents the task for casting spell from stack.
+//!
+class CastSpellStackTask : public ITask
+{
+ public:
+    //! Constructs task with given \p removeFromZone.
+    //! \param removeFromZone true if entity must be removed before it is
+    //! summoned from the zone.
+    explicit CastSpellStackTask(bool removeFromZone = false);
+
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player* player) override;
+
+    //! Internal method of Clone().
+    //! \return The cloned task.
+    std::unique_ptr<ITask> CloneImpl() override;
+
+    bool m_removeFromZone = false;
+};
+}  // namespace RosettaStone::PlayMode::SimpleTasks
+
+#endif  // ROSETTASTONE_PLAYMODE_CAST_SPELL_STACK_TASK_HPP

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/WeaponStackTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/WeaponStackTask.hpp
@@ -1,0 +1,40 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_PLAYMODE_WEAPON_STACK_TASK_HPP
+#define ROSETTASTONE_PLAYMODE_WEAPON_STACK_TASK_HPP
+
+#include <Rosetta/PlayMode/Tasks/ITask.hpp>
+
+namespace RosettaStone::PlayMode::SimpleTasks
+{
+//!
+//! \brief WeaponStackTask class.
+//!
+//! This class represents the task for equipping weapon from stack.
+//!
+class WeaponStackTask : public ITask
+{
+ public:
+    //! Constructs task with given \p removeFromZone.
+    //! \param removeFromZone true if entity must be removed before it is
+    //! summoned from the zone.
+    explicit WeaponStackTask(bool removeFromZone = false);
+
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player* player) override;
+
+    //! Internal method of Clone().
+    //! \return The cloned task.
+    std::unique_ptr<ITask> CloneImpl() override;
+
+    bool m_removeFromZone = false;
+};
+}  // namespace RosettaStone::PlayMode::SimpleTasks
+
+#endif  // ROSETTASTONE_PLAYMODE_WEAPON_STACK_TASK_HPP

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -267,6 +267,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/TransformCopyTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/TransformMinionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/TransformTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/WeaponStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/WeaponTask.hpp>
 #include <Rosetta/PlayMode/Tasks/TaskQueue.hpp>
 #include <Rosetta/PlayMode/Tasks/TaskStack.hpp>

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -180,6 +180,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ArmorTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/AttackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/CastRandomSpellTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/CastSpellStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ChanceTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ChangeAttackingTargetTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/ChangeEntityTask.hpp>

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 60% Ashes of Outland (81 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
-  * 75% Forged in the Barrens (129 of 170 cards)
+  * 80% Forged in the Barrens (136 of 170 cards)
   * 1% United in Stormwind (2 of 170 card)
 
 ### Wild Format

--- a/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
@@ -852,48 +852,7 @@ void DragonsCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::INSPIRE));
-    power.GetTrigger()->tasks = {
-        std::make_shared<IncludeTask>(EntityType::DECK),
-        std::make_shared<FilterStackTask>(SelfCondList{
-            std::make_shared<SelfCondition>(SelfCondition::IsSecret()) }),
-        std::make_shared<FuncPlayableTask>(
-            [=](const std::vector<Playable*>& playables) {
-                if (playables.empty())
-                {
-                    return std::vector<Playable*>{};
-                }
-
-                auto player = playables[0]->player;
-
-                EraseIf(const_cast<std::vector<Playable*>&>(playables),
-                        [=](Playable* playable) {
-                            return player->GetSecretZone()->Exist(playable);
-                        });
-
-                if (playables.empty())
-                {
-                    return std::vector<Playable*>{};
-                }
-
-                auto pick = *Random::get(playables);
-
-                // Remove it from deck zone
-                player->GetDeckZone()->Remove(pick);
-                if (auto trigger = pick->card->power.GetTrigger(); trigger)
-                {
-                    trigger->Activate(pick);
-                }
-
-                // Add it to secret zone
-                player->GetSecretZone()->Add(pick);
-                if (player == player->game->GetCurrentPlayer())
-                {
-                    pick->SetExhausted(true);
-                }
-
-                return std::vector<Playable*>{};
-            })
-    };
+    power.GetTrigger()->tasks = { ComplexTask::CastSecretFromDeck() };
     cards.emplace("DRG_252", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER

--- a/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
@@ -1160,7 +1160,7 @@ void DragonsCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddPowerTask(std::make_shared<CustomTask>(
         []([[maybe_unused]] Player* player, Entity* source, Playable* target) {
-            if (target == nullptr)
+            if (!target)
             {
                 return;
             }

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -4062,6 +4062,17 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    // Entourage: WC_034t,  WC_034t2, WC_034t3, WC_034t4
+    //            WC_034t5, WC_034t6, WC_034t7, WC_034t8
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(std::make_shared<RandomEntourageTask>());
+    power.AddDeathrattleTask(std::make_shared<SummonStackTask>());
+    cards.emplace(
+        "WC_027",
+        CardDef(power, PlayReqs{}, ChooseCardIDs{},
+                Entourages{ "WC_034t", "WC_034t2", "WC_034t3", "WC_034t4",
+                            "WC_034t5", "WC_034t6", "WC_034t7", "WC_034t8" }));
 
     // --------------------------------------- MINION - NEUTRAL
     // [WC_028] Meeting Stone - COST:1 [ATK:0/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -2661,6 +2661,42 @@ void TheBarrensCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - ImmuneToSpellpower = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<CustomTask>(
+        []([[maybe_unused]] Player* player, Entity* source, Playable* target) {
+            if (!target)
+            {
+                return;
+            }
+
+            const auto realSource = dynamic_cast<Playable*>(source);
+            const auto realTarget = dynamic_cast<Character*>(target);
+
+            const int targetHealth = realTarget->GetHealth();
+            int realDamage = 6 + source->player->GetCurrentSpellPower();
+
+            Generic::TakeDamageToCharacter(realSource, realTarget, realDamage,
+                                           true);
+
+            if (realTarget->isDestroyed)
+            {
+                const int remainDamage = realDamage - targetHealth;
+                if (remainDamage > 0)
+                {
+                    Generic::TakeDamageToCharacter(realSource,
+                                                   player->GetHero(),
+                                                   remainDamage, false);
+                }
+            }
+        }));
+    cards.emplace(
+        "WC_021",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [WC_022] Final Gasp - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -4084,6 +4084,16 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->tasks = { std::make_shared<RandomEntourageTask>(),
+                                  std::make_shared<AddStackToTask>(
+                                      EntityType::HAND) };
+    cards.emplace(
+        "WC_028",
+        CardDef(power, PlayReqs{}, ChooseCardIDs{},
+                Entourages{ "WC_034t", "WC_034t2", "WC_034t3", "WC_034t4",
+                            "WC_034t5", "WC_034t6", "WC_034t7", "WC_034t8" }));
 
     // --------------------------------------- MINION - NEUTRAL
     // [WC_029] Selfless Sidekick - COST:7 [ATK:6/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -2670,6 +2670,30 @@ void TheBarrensCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // Text: Deal 1 damage to a minion. If it dies,
     //       summon a 2/2 Adventurer with a random bonus effect.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // Entourage: WC_034t,  WC_034t2, WC_034t3, WC_034t4
+    //            WC_034t5, WC_034t6, WC_034t7, WC_034t8
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 1, true));
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::TARGET, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsDead()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<RandomEntourageTask>(),
+                        std::make_shared<SummonStackTask>() }));
+    cards.emplace(
+        "WC_022",
+        CardDef(power,
+                PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                          { PlayReq::REQ_MINION_TARGET, 0 } },
+                ChooseCardIDs{},
+                Entourages{ "WC_034t", "WC_034t2", "WC_034t3", "WC_034t4",
+                            "WC_034t5", "WC_034t6", "WC_034t7", "WC_034t8" }));
 
     // --------------------------------------- MINION - WARLOCK
     // [WC_023] Stealer of Souls - COST:4 [ATK:2/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -1249,6 +1249,11 @@ void TheBarrensCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->tasks = { ComplexTask::CastSecretFromDeck() };
+    cards.emplace("BAR_875", CardDef(power));
 
     // --------------------------------------- MINION - PALADIN
     // [BAR_876] Northwatch Commander - COST:3 [ATK:3/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -21,6 +21,8 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 namespace RosettaStone::PlayMode
 {
 using PlayReqs = std::map<PlayReq, int>;
+using ChooseCardIDs = std::vector<std::string>;
+using Entourages = std::vector<std::string>;
 using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
 using EffectList = std::vector<std::shared_ptr<IEffect>>;
 
@@ -1415,6 +1417,21 @@ void TheBarrensCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Summon five 2/2 Adventurers with random bonus effects.
     // --------------------------------------------------------
+    // Entourage: WC_034t,  WC_034t2, WC_034t3, WC_034t4
+    //            WC_034t5, WC_034t6, WC_034t7, WC_034t8
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<RandomEntourageTask>(5));
+    power.AddPowerTask(std::make_shared<SummonStackTask>());
+    cards.emplace(
+        "WC_034",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } },
+                ChooseCardIDs{},
+                Entourages{ "WC_034t", "WC_034t2", "WC_034t3", "WC_034t4",
+                            "WC_034t5", "WC_034t6", "WC_034t7", "WC_034t8" }));
 }
 
 void TheBarrensCardsGen::AddPaladinNonCollect(
@@ -4732,6 +4749,9 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - POISONOUS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("WC_034t", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [WC_034t2] Burly Adventurer - COST:2 [ATK:2/HP:2]
@@ -4742,6 +4762,9 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("WC_034t2", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [WC_034t3] Devout Adventurer - COST:2 [ATK:2/HP:2]
@@ -4752,6 +4775,9 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - DIVINE_SHIELD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("WC_034t3", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [WC_034t4] Relentless Adventurer - COST:2 [ATK:2/HP:2]
@@ -4762,6 +4788,9 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - WINDFURY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("WC_034t4", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [WC_034t5] Arcane Adventurer - COST:2 [ATK:2/HP:2]
@@ -4772,6 +4801,9 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - SPELLPOWER = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("WC_034t5", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [WC_034t6] Sneaky Adventurer - COST:2 [ATK:2/HP:2]
@@ -4782,6 +4814,9 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - STEALTH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("WC_034t6", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [WC_034t7] Vital Adventurer - COST:2 [ATK:2/HP:2]
@@ -4792,6 +4827,9 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - LIFESTEAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("WC_034t7", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [WC_034t8] Swift Adventurer - COST:2 [ATK:2/HP:2]
@@ -4802,6 +4840,9 @@ void TheBarrensCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("WC_034t8", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [WC_035e] Dreaming - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -507,7 +507,7 @@ void TheBarrensCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddPowerTask(std::make_shared<CustomTask>(
         []([[maybe_unused]] Player* player, Entity* source, Playable* target) {
-            if (target == nullptr)
+            if (!target)
             {
                 return;
             }

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -4104,6 +4104,9 @@ void TheBarrensCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(ComplexTask::EquipWeaponFromDeck());
+    cards.emplace("WC_029", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [WC_030] Mutanus the Devourer - COST:7 [ATK:4/HP:4]

--- a/Sources/Rosetta/PlayMode/Cards/Card.cpp
+++ b/Sources/Rosetta/PlayMode/Cards/Card.cpp
@@ -322,6 +322,23 @@ bool Card::IsWatchPost() const
     return false;
 }
 
+bool Card::IsAdventurer() const
+{
+    if (id == "WC_034t" ||   // WC_034t: Deadly Adventurer
+        id == "WC_034t2" ||  // WC_034t2: Burly Adventurer
+        id == "WC_034t3" ||  // WC_034t3: Devout Adventurer
+        id == "WC_034t4" ||  // WC_034t4: Relentless Adventurer
+        id == "WC_034t5" ||  // WC_034t5: Arcane Adventurer
+        id == "WC_034t6" ||  // WC_034t6: Sneaky Adventurer
+        id == "WC_034t7" ||  // WC_034t7: Vital Adventurer
+        id == "WC_034t8")    // WC_034t8: Swift Adventurer
+    {
+        return true;
+    }
+
+    return false;
+}
+
 bool Card::IsTransformMinion() const
 {
     // NOTE: Transformed minions list

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -1109,6 +1109,21 @@ SelfCondition SelfCondition::HasSoulFragmentInDeck()
     });
 }
 
+SelfCondition SelfCondition::NotExistInSecretZone()
+{
+    return SelfCondition([](Playable* playable) {
+        for (auto& secretCard : playable->player->GetSecretZone()->GetAll())
+        {
+            if (playable->card->dbfID == secretCard->card->dbfID)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    });
+}
+
 SelfCondition SelfCondition::CheckThreshold(RelaSign relaSign)
 {
     return SelfCondition([relaSign](Playable* playable) {

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/CastSpellStackTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/CastSpellStackTask.cpp
@@ -1,0 +1,39 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/PlayMode/Actions/CastSpell.hpp>
+#include <Rosetta/PlayMode/Games/Game.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/CastSpellStackTask.hpp>
+
+namespace RosettaStone::PlayMode::SimpleTasks
+{
+CastSpellStackTask::CastSpellStackTask(bool removeFromZone)
+    : m_removeFromZone(removeFromZone)
+{
+    // Do nothing
+}
+
+TaskStatus CastSpellStackTask::Impl(Player* player)
+{
+    const auto stack = player->game->taskStack;
+
+    for (auto& playable : stack.playables)
+    {
+        if (m_removeFromZone)
+        {
+            playable->zone->Remove(playable);
+        }
+
+        Generic::CastSpell(player, dynamic_cast<Spell*>(playable), nullptr, -1);
+    }
+
+    return TaskStatus::COMPLETE;
+}
+
+std::unique_ptr<ITask> CastSpellStackTask::CloneImpl()
+{
+    return std::make_unique<CastSpellStackTask>(m_removeFromZone);
+}
+}  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/WeaponStackTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/WeaponStackTask.cpp
@@ -1,0 +1,39 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/PlayMode/Actions/PlayCard.hpp>
+#include <Rosetta/PlayMode/Games/Game.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/WeaponStackTask.hpp>
+
+namespace RosettaStone::PlayMode::SimpleTasks
+{
+WeaponStackTask::WeaponStackTask(bool removeFromZone)
+    : m_removeFromZone(removeFromZone)
+{
+    // Do nothing
+}
+
+TaskStatus WeaponStackTask::Impl(Player* player)
+{
+    const auto stack = player->game->taskStack;
+
+    for (auto& playable : stack.playables)
+    {
+        if (m_removeFromZone)
+        {
+            playable->zone->Remove(playable);
+        }
+
+        Generic::PlayWeapon(player, dynamic_cast<Weapon*>(playable), nullptr);
+    }
+
+    return TaskStatus::COMPLETE;
+}
+
+std::unique_ptr<ITask> WeaponStackTask::CloneImpl()
+{
+    return std::make_unique<WeaponStackTask>(m_removeFromZone);
+}
+}  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/WeaponTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/WeaponTask.cpp
@@ -25,11 +25,6 @@ TaskStatus WeaponTask::Impl(Player* player)
 
     Player* owner = m_isOpponent ? player->opponent : player;
 
-    if (owner->GetHero()->HasWeapon())
-    {
-        owner->GetWeapon().Destroy();
-    }
-
     const auto weapon =
         dynamic_cast<Weapon*>(Entity::GetFromCard(owner, weaponCard));
     Generic::PlayWeapon(owner, weapon, nullptr);

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -4601,6 +4601,62 @@ TEST_CASE("[Warlock : Minion] - BAR_917 : Barrens Scavenger")
 }
 
 // ---------------------------------------- SPELL - WARLOCK
+// [WC_021] Unstable Shadow Blast - COST:2
+// - Set: THE_BARRENS, Rarity: Common
+// - Spell School: Shadow
+// --------------------------------------------------------
+// Text: Deal 6 damage to a minion.
+//       Excess damage hits your hero.
+// --------------------------------------------------------
+// GameTag:
+// - ImmuneToSpellpower = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Spell] - WC_021 : Unstable Shadow Blast")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Unstable Shadow Blast"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Unstable Shadow Blast"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Kobold Geomancer"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card4));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 25);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card5));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 19);
+}
+
+// ---------------------------------------- SPELL - WARLOCK
 // [WC_022] Final Gasp - COST:1
 // - Set: THE_BARRENS, Rarity: Common
 // - Spell School: Shadow

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -2523,6 +2523,52 @@ TEST_CASE("[Paladin : Spell] - WC_033 : Judgment of Justice")
     CHECK_EQ(opField[0]->GetHealth(), 1);
 }
 
+// ---------------------------------------- SPELL - PALADIN
+// [WC_034] Party Up! - COST:7
+// - Set: THE_BARRENS, Rarity: Rare
+// --------------------------------------------------------
+// Text: Summon five 2/2 Adventurers with random bonus effects.
+// --------------------------------------------------------
+// Entourage: WC_034t,  WC_034t2, WC_034t3, WC_034t4
+//            WC_034t5, WC_034t6, WC_034t7, WC_034t8
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Spell] - WC_034 : Party Up!")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Party Up!"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 5);
+    CHECK_EQ(curField[0]->card->IsAdventurer(), true);
+    CHECK_EQ(curField[1]->card->IsAdventurer(), true);
+    CHECK_EQ(curField[2]->card->IsAdventurer(), true);
+    CHECK_EQ(curField[3]->card->IsAdventurer(), true);
+    CHECK_EQ(curField[4]->card->IsAdventurer(), true);
+}
+
 // ---------------------------------------- MINION - PRIEST
 // [BAR_307] Void Flayer - COST:4 [ATK:3/HP:4]
 // - Set: THE_BARRENS, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -7869,3 +7869,48 @@ TEST_CASE("[Neutral : Minion] - WC_027 : Devouring Ectoplasm")
     CHECK_EQ(curField.GetCount(), 1);
     CHECK_EQ(curField[0]->card->IsAdventurer(), true);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [WC_028] Meeting Stone - COST:1 [ATK:0/HP:2]
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: At the end of your turn, add a 2/2 Adventurer
+//       with a random bonus effect to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - WC_028 : Meeting Stone")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Meeting Stone"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->IsAdventurer(), true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -7914,3 +7914,52 @@ TEST_CASE("[Neutral : Minion] - WC_028 : Meeting Stone")
     CHECK_EQ(curHand.GetCount(), 1);
     CHECK_EQ(curHand[0]->card->IsAdventurer(), true);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [WC_029] Selfless Sidekick - COST:7 [ATK:6/HP:6]
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Equip a random weapon from your deck.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - WC_029 : Selfless Sidekick")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Fiery War Axe");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Malygos");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Wisp");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curDeck = *(curPlayer->GetDeckZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Selfless Sidekick"));
+
+    CHECK_EQ(curPlayer->GetHero()->HasWeapon(), false);
+    CHECK_EQ(curDeck.GetCount(), 26);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->HasWeapon(), true);
+    CHECK_EQ(curDeck.GetCount(), 25);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -7818,3 +7818,54 @@ TEST_CASE("[Neutral : Minion] - BAR_890 : Crossroads Gossiper")
     CHECK_EQ(curField[0]->GetAttack(), 6);
     CHECK_EQ(curField[0]->GetHealth(), 5);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [WC_027] Devouring Ectoplasm - COST:3 [ATK:3/HP:2]
+// - Set: THE_BARRENS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Summon a 2/2 Adventurer
+//       with a random bonus effect.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+// Entourage: WC_034t,  WC_034t2, WC_034t3, WC_034t4
+//            WC_034t5, WC_034t6, WC_034t7, WC_034t8
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - WC_027 : Devouring Ectoplasm")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Devouring Ectoplasm"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->card->IsAdventurer(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->IsAdventurer(), true);
+}


### PR DESCRIPTION
This revision includes:
- Implement 7 THE_BARRENS cards
  - Sword of the Fallen (BAR_875)
  - Unstable Shadow Blast (WC_021)
  - Final Gasp (WC_022)
  - Devouring Ectoplasm (WC_027)
  - Meeting Stone (WC_028)
  - Selfless Sidekick (WC_029)
  - Party Up! (WC_034)
- Add 2 task classes
  - WeaponStackTask: This class represents the task for equipping weapon from stack
  - CastSpellStackTask: This class represents the task for casting spell from stack
- Add some functions and methods
  - IsAdventurer(): Returns the flag that indicates whether it is Adventurer
  - SelfCondition wrapper for checking the secret doesn't exist in secret zone
  - NotExistInSecretZone(): EquipWeaponFromDeck(): Returns a list of task for equipping a weapon from your deck
  - CastSecretFromDeck(): Returns a list of task for casting a secret from your deck
- Refactor some codes
  - Delete unnecessary code to destroy weapon
  - Replace code to use function 'CastSecretFromDeck()'