### PR TITLE
Implement hero powers for Classic mode

### DIFF
--- a/Documents/CardList - Classic.md
+++ b/Documents/CardList - Classic.md
@@ -250,7 +250,7 @@ VANILLA | VAN_EX1_316 | Power Overwhelming |
 VANILLA | VAN_EX1_317 | Sense Demons |  
 VANILLA | VAN_EX1_319 | Flame Imp |  
 VANILLA | VAN_EX1_320 | Bane of Doom |  
-VANILLA | VAN_EX1_323 | Lord Jaraxxus |  
+VANILLA | VAN_EX1_323 | Lord Jaraxxus | O
 VANILLA | VAN_EX1_332 | Silence |  
 VANILLA | VAN_EX1_334 | Shadow Madness |  
 VANILLA | VAN_EX1_335 | Lightspawn |  
@@ -389,4 +389,4 @@ VANILLA | VAN_PRO_001 | Elite Tauren Chieftain |
 VANILLA | VAN_tt_004 | Flesheating Ghoul |  
 VANILLA | VAN_tt_010 | Spellbender |  
 
-- Progress: 1% (5 of 382 Cards)
+- Progress: 1% (6 of 382 Cards)

--- a/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
@@ -16,6 +16,7 @@ enum class DiscoverType
     DECK,
     SPELL_FROM_DECK,
     BASIC_TOTEM,
+    BASIC_TOTEM_CLASSIC,
     CHOOSE_ONE,
     FOUR_COST_CARD,
     SIX_COST_MINION_SUMMON,

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Classic Format
 
-  * 1% Vanilla Set (5 of 382 Cards)
+  * 1% Vanilla Set (6 of 382 Cards)
 
 ## Implementation List
 

--- a/Sources/Rosetta/PlayMode/CardSets/TgtCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TgtCardsGen.cpp
@@ -1202,6 +1202,21 @@ void TgtCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddPowerTask(nullptr);
     cards.emplace("AT_132_SHAMANd", CardDef(power));
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [AT_132_SHAMANe] Strength Totem (*) - COST:0 [ATK:0/HP:2]
+    // - Set: Tgt
+    // --------------------------------------------------------
+    // Text: At the end of your turn,
+    //       give another friendly minion +1 Attack.
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->tasks = {
+        std::make_shared<RandomTask>(EntityType::MINIONS_NOSOURCE, 1),
+        std::make_shared<AddEnchantmentTask>("CS2_058e", EntityType::STACK)
+    };
+    cards.emplace("AT_132_SHAMANe", CardDef(power));
 }
 
 void TgtCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -320,6 +320,14 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Restore 2 Health.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<HealTask>(EntityType::TARGET, 2));
+    cards.emplace(
+        "VAN_HERO_09bp",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ------------------------------------ HERO_POWER - PRIEST
     // [VAN_HERO_09bp2] Heal - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -266,6 +266,11 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Draw a card and take 2 damage.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::HERO, 2, false));
+    power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cards.emplace("VAN_HERO_07bp", CardDef(power));
 
     // ----------------------------------- HERO_POWER - WARLOCK
     // [VAN_HERO_07bp2] Soul Tap - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -206,6 +206,17 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Deal 2 damage to the enemy hero.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_STEADY_SHOT = 0
+    // - REQ_MINION_OR_ENEMY_HERO = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 2, false));
+    cards.emplace(
+        "VAN_HERO_05bp",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_STEADY_SHOT, 0 },
+                                 { PlayReq::REQ_MINION_OR_ENEMY_HERO, 0 } }));
 
     // ------------------------------------ HERO_POWER - HUNTER
     // [VAN_HERO_05bp2] Ballista Shot - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -154,6 +154,9 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Equip a 1/2 Dagger.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<WeaponTask>("VAN_CS2_082"));
+    cards.emplace("VAN_HERO_03bp", CardDef(power));
 
     // ------------------------------------- HERO_POWER - ROGUE
     // [VAN_HERO_03bp2] Poisoned Daggers - COST:2
@@ -2029,10 +2032,15 @@ void VanillaCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 
 void VanillaCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- WEAPON - ROGUE
     // [VAN_CS2_082] Wicked Knife - COST:1
     // - Set: VANILLA, Rarity: Free
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_082", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - ROGUE
     // [VAN_EX1_145o] Preparation - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -164,6 +164,9 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Equip a 2/2 Weapon.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<WeaponTask>("AT_132_ROGUEt"));
+    cards.emplace("VAN_HERO_03bp2", CardDef(power));
 
     // ----------------------------------- HERO_POWER - PALADIN
     // [VAN_HERO_04bp] Reinforce - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -254,6 +254,11 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> +2 Attack this turn. +2 Armor.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<AddEnchantmentTask>("AT_132_DRUIDe",
+                                                            EntityType::HERO));
+    power.AddPowerTask(std::make_shared<ArmorTask>(2));
+    cards.emplace("VAN_HERO_06bp2", CardDef(power));
 
     // ----------------------------------- HERO_POWER - WARLOCK
     // [VAN_HERO_07bp] Life Tap - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -288,6 +288,15 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Deal 1 damage.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 1, false));
+    cards.emplace(
+        "VAN_HERO_08bp",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // -------------------------------------- HERO_POWER - MAGE
     // [VAN_HERO_08bp2] Fireblast Rank 2 - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -63,6 +63,9 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Gain 4 Armor.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ArmorTask>(4));
+    cards.emplace("VAN_HERO_01bp2", CardDef(power));
 
     // ------------------------------------ HERO_POWER - SHAMAN
     // [VAN_HERO_02bp] Totemic Call - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -174,6 +174,15 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Summon a 1/1 Silver Hand Recruit.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("VAN_CS2_101t", SummonSide::DEFAULT));
+    cards.emplace(
+        "VAN_HERO_04bp",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ----------------------------------- HERO_POWER - PALADIN
     // [VAN_HERO_04bp2] The Silver Hand - COST:2
@@ -1564,10 +1573,15 @@ void VanillaCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 void VanillaCardsGen::AddPaladinNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - PALADIN
     // [VAN_CS2_101t] Silver Hand Recruit - COST:1 [ATK:1/HP:1]
     // - Set: VANILLA, Rarity: Free
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_101t", CardDef(power));
 
     // --------------------------------------- MINION - PALADIN
     // [VAN_EX1_130a] Defender - COST:1 [ATK:2/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -53,6 +53,9 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Gain 2 Armor.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ArmorTask>(2));
+    cards.emplace("VAN_HERO_01bp", CardDef(power));
 
     // ----------------------------------- HERO_POWER - WARRIOR
     // [VAN_HERO_01bp2] Tank Up! - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -224,6 +224,17 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Deal 3 damage to the enemy hero.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_STEADY_SHOT = 0
+    // - REQ_MINION_OR_ENEMY_HERO = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 3, false));
+    cards.emplace(
+        "VAN_HERO_05bp2",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_STEADY_SHOT, 0 },
+                                 { PlayReq::REQ_MINION_OR_ENEMY_HERO, 0 } }));
 
     // ------------------------------------- HERO_POWER - DRUID
     // [VAN_HERO_06bp] Shapeshift - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -361,6 +361,10 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> +2 Attack this turn.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<AddEnchantmentTask>("VAN_HERO_10pe2",
+                                                            EntityType::HERO));
+    cards.emplace("VAN_HERO_10bp2", CardDef(power));
 }
 
 void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
@@ -3002,6 +3006,9 @@ void VanillaCardsGen::AddDemonHunterNonCollect(
     // GameTag:
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("VAN_HERO_10pe2"));
+    cards.emplace("VAN_HERO_10pe2", CardDef(power));
 }
 
 void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -350,6 +350,10 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> +1 Attack this turn.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<AddEnchantmentTask>("VAN_HERO_10bpe",
+                                                            EntityType::HERO));
+    cards.emplace("VAN_HERO_10bp", CardDef(power));
 
     // ------------------------------- HERO_POWER - DEMONHUNTER
     // [VAN_HERO_10bp2] Demon's Bite - COST:1
@@ -2974,6 +2978,8 @@ void VanillaCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 void VanillaCardsGen::AddDemonHunterNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [VAN_HERO_10bpe] Demon Claws - COST:0
     // - Set: VANILLA
@@ -2983,6 +2989,9 @@ void VanillaCardsGen::AddDemonHunterNonCollect(
     // GameTag:
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("VAN_HERO_10bpe"));
+    cards.emplace("VAN_HERO_10bpe", CardDef(power));
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [VAN_HERO_10pe2] Demon's Bite - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -304,6 +304,15 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Deal 2 damage.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 2, false));
+    cards.emplace(
+        "VAN_HERO_08bp2",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ------------------------------------ HERO_POWER - PRIEST
     // [VAN_HERO_09bp] Lesser Heal - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -278,6 +278,9 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Draw a card.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cards.emplace("VAN_HERO_07bp2", CardDef(power));
 
     // -------------------------------------- HERO_POWER - MAGE
     // [VAN_HERO_08bp] Fireblast - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -20,12 +20,17 @@ void VanillaCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 
 void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------- HERO_POWER - WARRIOR
     // [VAN_CS2_102_H3] Armor Up! - COST:2
     // - Set: VANILLA, Rarity: Free
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Gain 2 Armor.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ArmorTask>(2));
+    cards.emplace("VAN_CS2_102_H3", CardDef(power));
 
     // ----------------------------------- HERO_POWER - WARLOCK
     // [VAN_EX1_tk33] INFERNO! - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -242,6 +242,11 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> +1 Attack this turn. +1 Armor.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("CS2_017o", EntityType::HERO));
+    power.AddPowerTask(std::make_shared<ArmorTask>(1));
+    cards.emplace("VAN_HERO_06bp", CardDef(power));
 
     // ------------------------------------- HERO_POWER - DRUID
     // [VAN_HERO_06bp2] Dire Shapeshift - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -138,6 +138,15 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Summon a Totem of your choice.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DiscoverTask>(DiscoverType::BASIC_TOTEM_CLASSIC, 4));
+    cards.emplace(
+        "VAN_HERO_02bp2",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ------------------------------------- HERO_POWER - ROGUE
     // [VAN_HERO_03bp] Dagger Mastery - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -38,6 +38,14 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Summon a 6/6 Infernal.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("VAN_EX1_tk34"));
+    cards.emplace(
+        "VAN_EX1_tk33",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ----------------------------------- HERO_POWER - WARRIOR
     // [VAN_HERO_01bp] Armor Up! - COST:2
@@ -2287,6 +2295,8 @@ void VanillaCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
 void VanillaCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- SPELL - WARLOCK
     // [VAN_CS2_057] Shadow Bolt - COST:3
     // - Set: VANILLA, Rarity: Free
@@ -2497,6 +2507,10 @@ void VanillaCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ReplaceHeroTask>(
+        "EX1_323h", "VAN_EX1_tk33", "EX1_323w"));
+    cards.emplace("VAN_EX1_323", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [VAN_EX1_596] Demonfire - COST:2
@@ -2517,10 +2531,15 @@ void VanillaCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 void VanillaCardsGen::AddWarlockNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - WARLOCK
     // [VAN_EX1_tk34] Infernal - COST:6 [ATK:6/HP:6]
     // - Race: Demon, Set: VANILLA
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_EX1_tk34", CardDef(power));
 }
 
 void VanillaCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -335,6 +335,14 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Restore 4 Health.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<HealTask>(EntityType::TARGET, 4));
+    cards.emplace(
+        "VAN_HERO_09bp2",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ------------------------------- HERO_POWER - DEMONHUNTER
     // [VAN_HERO_10bp] Demon Claws - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -190,6 +190,15 @@ void VanillaCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b> Summon two 1/1 Recruits.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("VAN_CS2_101t", 2, SummonSide::DEFAULT));
+    cards.emplace(
+        "VAN_HERO_04bp2",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ------------------------------------ HERO_POWER - HUNTER
     // [VAN_HERO_05bp] Steady Shot - COST:2

--- a/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
@@ -128,7 +128,8 @@ void CardLoader::Load(std::vector<Card*>& cards)
         // NOTE: Carousel Gryphon (DMF_064) doesn't have GameTag::DIVINE_SHIELD
         // NOTE: Healing Totem (AT_132_SHAMANa), Searing Totem (AT_132_SHAMANb),
         //       Stoneclaw Totem (AT_132_SHAMANc), Wrath of Air Totem
-        //       (AT_132_SHAMANd) doesn't have Race::TOTEM
+        //       (AT_132_SHAMANd), Strength Totem (AT_132_SHAMANe)
+        //       doesn't have Race::TOTEM
         // NOTE: Wailing Demon (WC_003t) doesn't have GameTag::TAUNT
         if (dbfID == 56091)
         {
@@ -139,7 +140,7 @@ void CardLoader::Load(std::vector<Card*>& cards)
             gameTags.emplace(GameTag::DIVINE_SHIELD, 1);
         }
         else if (dbfID == 16221 || dbfID == 16222 || dbfID == 16223 ||
-                 dbfID == 16225)
+                 dbfID == 16225 || dbfID == 72268)
         {
             cardRace = static_cast<int>(Race::TOTEM);
         }

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
@@ -276,6 +276,13 @@ auto DiscoverTask::Discover(Game* game, Player* player,
                                    Cards::FindCardByID("AT_132_SHAMANc"),
                                    Cards::FindCardByID("AT_132_SHAMANe") };
             break;
+        case DiscoverType::BASIC_TOTEM_CLASSIC:
+            choiceAction = ChoiceAction::SUMMON;
+            cardsForGeneration = { Cards::FindCardByID("AT_132_SHAMANa"),
+                                   Cards::FindCardByID("AT_132_SHAMANb"),
+                                   Cards::FindCardByID("AT_132_SHAMANc"),
+                                   Cards::FindCardByID("AT_132_SHAMANd") };
+            break;
         case DiscoverType::CHOOSE_ONE:
             choiceAction = ChoiceAction::HAND;
             for (auto& card : allCards)

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
@@ -274,7 +274,7 @@ auto DiscoverTask::Discover(Game* game, Player* player,
             cardsForGeneration = { Cards::FindCardByID("AT_132_SHAMANa"),
                                    Cards::FindCardByID("AT_132_SHAMANb"),
                                    Cards::FindCardByID("AT_132_SHAMANc"),
-                                   Cards::FindCardByID("AT_132_SHAMANd") };
+                                   Cards::FindCardByID("AT_132_SHAMANe") };
             break;
         case DiscoverType::CHOOSE_ONE:
             choiceAction = ChoiceAction::HAND;

--- a/Tests/UnitTests/PlayMode/CardSets/UldumCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/UldumCardsGenTests.cpp
@@ -3665,10 +3665,10 @@ TEST_CASE("[Paladin : Minion] - ULD_500 : Sir Finley of the Sands")
             CHECK_EQ(curField[1]->card->name, "Stoneclaw Totem");
         }
 
-        SUBCASE("Shaman - Wrath of Air Totem")
+        SUBCASE("Shaman - Strength Totem")
         {
             TestUtils::ChooseNthChoice(game, 4);
-            CHECK_EQ(curField[1]->card->name, "Wrath of Air Totem");
+            CHECK_EQ(curField[1]->card->name, "Strength Totem");
         }
     }
 

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -236,6 +236,42 @@ TEST_CASE("[Paladin : Hero Power] - VAN_HERO_04bp : Reinforce")
     CHECK_EQ(curField[0]->GetHealth(), 1);
 }
 
+// ------------------------------------ HERO_POWER - HUNTER
+// [VAN_HERO_05bp] Steady Shot - COST:2
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Hero Power</b> Deal 2 damage to the enemy hero.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_STEADY_SHOT = 0
+// - REQ_MINION_OR_ENEMY_HERO = 0
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Hero Power] - VAN_HERO_05bp : Steady Shot")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    game.Process(curPlayer, HeroPowerTask());
+
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [VAN_CS2_005] Claw - COST:1
 // - Set: VANILLA, Rarity: Free

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -417,6 +417,50 @@ TEST_CASE("[Mage : Hero Power] - VAN_HERO_08bp : Fireblast")
     CHECK_EQ(opField[0]->GetHealth(), 2);
 }
 
+// ------------------------------------ HERO_POWER - PRIEST
+// [VAN_HERO_09bp] Lesser Heal - COST:2
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Hero Power</b> Restore 2 Health.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Hero Power] - VAN_HERO_09bp : Lesser Heal")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 29);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, HeroPowerTask(curPlayer->GetHero()));
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [VAN_CS2_005] Claw - COST:1
 // - Set: VANILLA, Rarity: Free

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -197,6 +197,45 @@ TEST_CASE("[Rogue : Hero Power] - VAN_HERO_03bp : Dagger Mastery")
     CHECK_EQ(curPlayer->GetWeapon().GetDurability(), 1);
 }
 
+// ----------------------------------- HERO_POWER - PALADIN
+// [VAN_HERO_04bp] Reinforce - COST:2
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Hero Power</b> Summon a 1/1 Silver Hand Recruit.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Hero Power] - VAN_HERO_04bp : Reinforce")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    game.Process(curPlayer, HeroPowerTask());
+
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [VAN_CS2_005] Claw - COST:1
 // - Set: VANILLA, Rarity: Free

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -333,6 +333,41 @@ TEST_CASE("[Druid : Hero Power] - VAN_HERO_06bp : Shapeshift")
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
 }
 
+// ----------------------------------- HERO_POWER - WARLOCK
+// [VAN_HERO_07bp] Life Tap - COST:2
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Hero Power</b> Draw a card and take 2 damage.
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Hero Power] - VAN_HERO_07bp : Life Tap")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 4);
+
+    game.Process(curPlayer, HeroPowerTask());
+
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 28);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [VAN_CS2_005] Claw - COST:1
 // - Set: VANILLA, Rarity: Free

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -272,6 +272,67 @@ TEST_CASE("[Hunter : Hero Power] - VAN_HERO_05bp : Steady Shot")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
 }
 
+// ------------------------------------- HERO_POWER - DRUID
+// [VAN_HERO_06bp] Shapeshift - COST:2
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Hero Power</b> +1 Attack this turn. +1 Armor.
+// --------------------------------------------------------
+TEST_CASE("[Druid : Hero Power] - VAN_HERO_06bp : Shapeshift")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Northshire Cleric"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
+    CHECK_EQ(opField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer, HeroPowerTask());
+
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 1);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 1);
+
+    game.Process(curPlayer, AttackTask(curPlayer->GetHero(), card1));
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 1);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
+    CHECK_EQ(opField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [VAN_CS2_005] Claw - COST:1
 // - Set: VANILLA, Rarity: Free

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -85,6 +85,78 @@ TEST_CASE("[Warrior : Hero Power] - VAN_HERO_01bp : Armor Up!")
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 2);
 }
 
+// ------------------------------------ HERO_POWER - SHAMAN
+// [VAN_HERO_02bp] Totemic Call - COST:2
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Hero Power</b> Summon a random Totem.
+// --------------------------------------------------------
+// Entourage: VAN_CS2_050, VAN_CS2_051, VAN_CS2_052, VAN_NEW1_009
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// - REQ_ENTIRE_ENTOURAGE_NOT_IN_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Hero Power] - VAN_HERO_02bp : Totemic Call")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    game.Process(curPlayer, HeroPowerTask());
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask());
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, HeroPowerTask());
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask());
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, HeroPowerTask());
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask());
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, HeroPowerTask());
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask());
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 4);
+    CHECK_EQ(opField.GetCount(), 4);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [VAN_CS2_005] Claw - COST:1
 // - Set: VANILLA, Rarity: Free

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -368,6 +368,55 @@ TEST_CASE("[Warlock : Hero Power] - VAN_HERO_07bp : Life Tap")
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 28);
 }
 
+// -------------------------------------- HERO_POWER - MAGE
+// [VAN_HERO_08bp] Fireblast - COST:2
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Hero Power</b> Deal 1 damage.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Mage : Hero Power] - VAN_HERO_08bp : Fireblast")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Northshire Cleric"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(opField[0]->GetHealth(), 3);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, HeroPowerTask(card1));
+
+    CHECK_EQ(opField[0]->GetHealth(), 2);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [VAN_CS2_005] Claw - COST:1
 // - Set: VANILLA, Rarity: Free

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -157,6 +157,46 @@ TEST_CASE("[Shaman : Hero Power] - VAN_HERO_02bp : Totemic Call")
     CHECK_EQ(opField.GetCount(), 4);
 }
 
+// ------------------------------------- HERO_POWER - ROGUE
+// [VAN_HERO_03bp] Dagger Mastery - COST:2
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Hero Power</b> Equip a 1/2 Dagger.
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Hero Power] - VAN_HERO_03bp : Dagger Mastery")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    CHECK_EQ(curPlayer->GetHero()->HasWeapon(), false);
+
+    game.Process(curPlayer, HeroPowerTask());
+
+    CHECK_EQ(curPlayer->GetHero()->HasWeapon(), true);
+    CHECK_EQ(curPlayer->GetWeapon().GetAttack(), 1);
+    CHECK_EQ(curPlayer->GetWeapon().GetDurability(), 2);
+
+    game.Process(curPlayer,
+                 AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetWeapon().GetDurability(), 1);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [VAN_CS2_005] Claw - COST:1
 // - Set: VANILLA, Rarity: Free

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -17,6 +17,40 @@ using namespace PlayMode;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ----------------------------------- HERO_POWER - WARRIOR
+// [VAN_CS2_102_H3] Armor Up! - COST:2
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Hero Power</b> Gain 2 Armor.
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Hero Power] - VAN_CS2_102_H3 : Armor Up!")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
+
+    game.Process(curPlayer, HeroPowerTask());
+
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 2);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [VAN_CS2_005] Claw - COST:1
 // - Set: VANILLA, Rarity: Free

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -51,6 +51,40 @@ TEST_CASE("[Warrior : Hero Power] - VAN_CS2_102_H3 : Armor Up!")
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 2);
 }
 
+// ----------------------------------- HERO_POWER - WARRIOR
+// [VAN_HERO_01bp] Armor Up! - COST:2
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Hero Power</b> Gain 2 Armor.
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Hero Power] - VAN_HERO_01bp : Armor Up!")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
+
+    game.Process(curPlayer, HeroPowerTask());
+
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 2);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [VAN_CS2_005] Claw - COST:1
 // - Set: VANILLA, Rarity: Free


### PR DESCRIPTION
This revision includes:
- Implement Classic mode cards (#674)
  - Armor Up! (VAN_CS2_102_H3)
  - Lord Jaraxxus (VAN_EX1_323)
  - Armor Up! (VAN_HERO_01bp)
  - Tank Up! (VAN_HERO_01bp2)
  - Totemic Call (VAN_HERO_02bp)
  - Totemic Slam (VAN_HERO_02bp2)
  - Dagger Mastery (VAN_HERO_03bp)
  - Poisoned Daggers (VAN_HERO_03bp2)
  - Reinforce (VAN_HERO_04bp)
  - The Silver Hand (VAN_HERO_04bp2)
  - Steady Shot (VAN_HERO_05bp)
  - Ballista Shot (VAN_HERO_05bp2)
  - Shapeshift (VAN_HERO_06bp)
  - Dire Shapeshift (VAN_HERO_06bp2)
  - Life Tap (VAN_HERO_07bp)
  - Soul Tap (VAN_HERO_07bp2)
  - Fireblast (VAN_HERO_08bp)
  - Fireblast Rank 2 (VAN_HERO_08bp2)
  - Lesser Heal (VAN_HERO_09bp)
  - Heal (VAN_HERO_09bp2)
  - Demon Claws (VAN_HERO_10bp)
  - Demon's Bite' (VAN_HERO_10bp2)
- Fix the logic of Shaman's hero power
  - Implement missing card 'Strength Totem' (AT_132_SHAMANe)
  - Correct the generation cards of enum 'DiscoverType::BASIC_TOTEM'
  - Add code to add 'Race::TOTEM' for 'Strength Totem' (AT_132_SHAMANe)
  - Apply changes of enum 'DiscoverType::BASIC_TOTEM'
  - Add enum value 'DiscoverType::BASIC_TOTEM_CLASSIC'
  - Add code to process 'DiscoverType::BASIC_TOTEM_CLASSIC'