### PR TITLE
Implement 11 VANILLA cards

### DIFF
--- a/Documents/CardList - Classic.md
+++ b/Documents/CardList - Classic.md
@@ -204,12 +204,12 @@ VANILLA | VAN_EX1_160 | Power of the Wild | O
 VANILLA | VAN_EX1_161 | Naturalize | O
 VANILLA | VAN_EX1_162 | Dire Wolf Alpha |  
 VANILLA | VAN_EX1_164 | Nourish | O
-VANILLA | VAN_EX1_165 | Druid of the Claw |  
-VANILLA | VAN_EX1_166 | Keeper of the Grove |  
-VANILLA | VAN_EX1_169 | Innervate |  
+VANILLA | VAN_EX1_165 | Druid of the Claw | O
+VANILLA | VAN_EX1_166 | Keeper of the Grove | O
+VANILLA | VAN_EX1_169 | Innervate | O
 VANILLA | VAN_EX1_170 | Emperor Cobra |  
-VANILLA | VAN_EX1_173 | Starfire |  
-VANILLA | VAN_EX1_178 | Ancient of War |  
+VANILLA | VAN_EX1_173 | Starfire | O
+VANILLA | VAN_EX1_178 | Ancient of War | O
 VANILLA | VAN_EX1_238 | Lightning Bolt |  
 VANILLA | VAN_EX1_241 | Lava Burst |  
 VANILLA | VAN_EX1_243 | Dust Devil |  
@@ -251,7 +251,7 @@ VANILLA | VAN_EX1_317 | Sense Demons |
 VANILLA | VAN_EX1_319 | Flame Imp |  
 VANILLA | VAN_EX1_320 | Bane of Doom |  
 VANILLA | VAN_EX1_323 | Lord Jaraxxus | O
-VANILLA | VAN_EX1_332 | Silence |  
+VANILLA | VAN_EX1_332 | Silence | O
 VANILLA | VAN_EX1_334 | Shadow Madness |  
 VANILLA | VAN_EX1_335 | Lightspawn |  
 VANILLA | VAN_EX1_339 | Thoughtsteal |  
@@ -315,13 +315,13 @@ VANILLA | VAN_EX1_563 | Malygos |
 VANILLA | VAN_EX1_564 | Faceless Manipulator |  
 VANILLA | VAN_EX1_565 | Flametongue Totem |  
 VANILLA | VAN_EX1_567 | Doomhammer |  
-VANILLA | VAN_EX1_570 | Bite |  
+VANILLA | VAN_EX1_570 | Bite | O
 VANILLA | VAN_EX1_571 | Force of Nature |  
 VANILLA | VAN_EX1_572 | Ysera |  
-VANILLA | VAN_EX1_573 | Cenarius |  
+VANILLA | VAN_EX1_573 | Cenarius | O
 VANILLA | VAN_EX1_575 | Mana Tide Totem |  
 VANILLA | VAN_EX1_577 | The Beast |  
-VANILLA | VAN_EX1_578 | Savagery |  
+VANILLA | VAN_EX1_578 | Savagery | O
 VANILLA | VAN_EX1_581 | Sap |  
 VANILLA | VAN_EX1_582 | Dalaran Mage |  
 VANILLA | VAN_EX1_583 | Priestess of Elune |  
@@ -359,8 +359,8 @@ VANILLA | VAN_EX1_626 | Mass Dispel |
 VANILLA | VAN_NEW1_003 | Sacrificial Pact |  
 VANILLA | VAN_NEW1_004 | Vanish |  
 VANILLA | VAN_NEW1_005 | Kidnapper |  
-VANILLA | VAN_NEW1_007 | Starfall |  
-VANILLA | VAN_NEW1_008 | Ancient of Lore |  
+VANILLA | VAN_NEW1_007 | Starfall | O
+VANILLA | VAN_NEW1_008 | Ancient of Lore | O
 VANILLA | VAN_NEW1_010 | Al'Akir the Windlord |  
 VANILLA | VAN_NEW1_011 | Kor'kron Elite |  
 VANILLA | VAN_NEW1_012 | Mana Wyrm |  
@@ -389,4 +389,4 @@ VANILLA | VAN_PRO_001 | Elite Tauren Chieftain |
 VANILLA | VAN_tt_004 | Flesheating Ghoul |  
 VANILLA | VAN_tt_010 | Spellbender |  
 
-- Progress: 4% (16 of 382 Cards)
+- Progress: 7% (27 of 382 Cards)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Classic Format
 
-  * 4% Vanilla Set (16 of 382 Cards)
+  * 7% Vanilla Set (27 of 382 Cards)
 
 ## Implementation List
 

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -374,8 +374,7 @@ void Expert1CardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - Set: Expert1, Rarity: Rare
     // - Spell School: Arcane
     // --------------------------------------------------------
-    // Text: <b>Choose One -</b>
-    //       Deal 5 damage to a minion;
+    // Text: <b>Choose One -</b> Deal 5 damage to a minion;
     //       or 2 damage to all enemy minions.
     // --------------------------------------------------------
     // GameTag:

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -270,7 +270,8 @@ void Expert1CardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // [EX1_178] Ancient of War - COST:7 [ATK:5/HP:5]
     // - Faction: Neutral, Set: Expert1, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Choose One -</b>+5 Attack; or +5 Health and <b>Taunt</b>.
+    // Text: <b>Choose One -</b>+5 Attack;
+    //       or +5 Health and <b>Taunt</b>.
     // --------------------------------------------------------
     // GameTag:
     // - CHOOSE_ONE = 1

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -247,7 +247,8 @@ void Expert1CardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // [EX1_166] Keeper of the Grove - COST:4 [ATK:2/HP:4]
     // - Faction: Neutral, Set: Expert1, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Choose One -</b> Deal 2 damage; or <b>Silence</b> a minion.
+    // Text: <b>Choose One -</b> Deal 2 damage;
+    //       or <b>Silence</b> a minion.
     // --------------------------------------------------------
     // GameTag:
     // - CHOOSE_ONE = 1

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -396,7 +396,8 @@ void Expert1CardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // [NEW1_008] Ancient of Lore - COST:7 [ATK:5/HP:5]
     // - Set: Expert1, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Choose One -</b> Draw 2 cards; or Restore 5 Health.
+    // Text: <b>Choose One -</b> Draw 2 cards;
+    //       or Restore 5 Health.
     // --------------------------------------------------------
     // GameTag:
     // - CHOOSE_ONE = 1

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -656,7 +656,7 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     cards.emplace("EX1_165b", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
-    // [EX1_165t1] Druid of the Claw (*) - COST:5 [ATK:4/HP:4]
+    // [EX1_165t1] Druid of the Claw (*) - COST:5 [ATK:5/HP:4]
     // - Race: Beast, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Charge</b>
@@ -669,7 +669,7 @@ void Expert1CardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     cards.emplace("EX1_165t1", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
-    // [EX1_165t2] Druid of the Claw (*) - COST:5 [ATK:4/HP:6]
+    // [EX1_165t2] Druid of the Claw (*) - COST:5 [ATK:5/HP:6]
     // - Race: Beast, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -789,6 +789,15 @@ void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CHOOSE_ONE = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace(
+        "VAN_NEW1_008",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } },
+                ChooseCardIDs{ "VAN_NEW1_008a", "VAN_NEW1_008b" }));
 }
 
 void VanillaCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
@@ -1116,6 +1125,9 @@ void VanillaCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Draw 2 cards.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawTask>(2));
+    cards.emplace("VAN_NEW1_008a", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_NEW1_008b] Ancient Secrets - COST:7
@@ -1123,6 +1135,14 @@ void VanillaCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Restore 5 Health.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<HealTask>(EntityType::TARGET, 5));
+    cards.emplace(
+        "VAN_NEW1_008b",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 }
 
 void VanillaCardsGen::AddHunter(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -616,6 +616,12 @@ void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - CHARGE = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<TransformTask>(EntityType::SOURCE, "OG_044a"));
+    cards.emplace(
+        "VAN_EX1_165",
+        CardDef(power, ChooseCardIDs{ "VAN_EX1_165a", "VAN_EX1_165b" }));
 
     // ----------------------------------------- MINION - DRUID
     // [VAN_EX1_166] Keeper of the Grove - COST:4 [ATK:2/HP:4]
@@ -876,6 +882,10 @@ void VanillaCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Charge</b>
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<TransformTask>(EntityType::SOURCE, "VAN_EX1_165t1"));
+    cards.emplace("VAN_EX1_165a", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_EX1_165b] Bear Form - COST:0
@@ -883,6 +893,10 @@ void VanillaCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: +2 Health and <b>Taunt</b>
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<TransformTask>(EntityType::SOURCE, "VAN_EX1_165t2"));
+    cards.emplace("VAN_EX1_165b", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [VAN_EX1_165t1] Druid of the Claw - COST:5 [ATK:4/HP:4]
@@ -893,6 +907,9 @@ void VanillaCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CHARGE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_EX1_165t1", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [VAN_EX1_165t2] Druid of the Claw - COST:5 [ATK:4/HP:6]
@@ -903,6 +920,9 @@ void VanillaCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_EX1_165t2", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_EX1_166a] Moonfire - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -662,6 +662,15 @@ void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 5 damage. Draw a card.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::TARGET, 5));
+    power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cards.emplace(
+        "VAN_EX1_173",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ----------------------------------------- MINION - DRUID
     // [VAN_EX1_178] Ancient of War - COST:7 [ATK:5/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -743,6 +743,19 @@ void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - AFFECTED_BY_SPELL_POWER = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<GetGameTagTask>(EntityType::HERO, GameTag::ATK));
+    power.AddPowerTask(
+        std::make_shared<DamageNumberTask>(EntityType::TARGET, true));
+    cards.emplace(
+        "VAN_EX1_578",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_NEW1_007] Starfall - COST:5

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -697,6 +697,11 @@ void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Give your hero +4 Attack this turn. Gain 4 Armor.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("EX1_570e", EntityType::HERO));
+    power.AddPowerTask(std::make_shared<ArmorTask>(4));
+    cards.emplace("VAN_EX1_570", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_EX1_571] Force of Nature - COST:6

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -767,6 +767,17 @@ void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CHOOSE_ONE = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_NEW1_007",
+                  CardDef(power,
+                          PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },
+                                    { PlayReq::REQ_MINION_TARGET, 0 } },
+                          ChooseCardIDs{ "VAN_NEW1_007a", "VAN_NEW1_007b" }));
 
     // ----------------------------------------- MINION - DRUID
     // [VAN_NEW1_008] Ancient of Lore - COST:7 [ATK:5/HP:5]
@@ -1076,6 +1087,10 @@ void VanillaCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 2 damage to all enemy minions.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 2, true));
+    cards.emplace("VAN_NEW1_007a", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_NEW1_007b] Starlord - COST:5
@@ -1083,6 +1098,17 @@ void VanillaCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 5 damage to a minion.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 5, true));
+    cards.emplace(
+        "VAN_NEW1_007b",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_NEW1_008a] Ancient Teachings - COST:7

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -685,6 +685,11 @@ void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace(
+        "VAN_EX1_178",
+        CardDef(power, ChooseCardIDs{ "VAN_EX1_178a", "VAN_EX1_178b" }));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_EX1_570] Bite - COST:4
@@ -986,6 +991,10 @@ void VanillaCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: +5 Health and <b>Taunt</b>.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("EX1_178ae", EntityType::SOURCE));
+    cards.emplace("VAN_EX1_178a", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_EX1_178b] Uproot - COST:7
@@ -993,6 +1002,10 @@ void VanillaCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: +5 Attack.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("EX1_178be", EntityType::SOURCE));
+    cards.emplace("VAN_EX1_178b", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_EX1_573a] Demigod's Favor - COST:9

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -1865,6 +1865,8 @@ void VanillaCardsGen::AddPaladinNonCollect(
 
 void VanillaCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- SPELL - PRIEST
     // [VAN_CS1_112] Holy Nova - COST:5
     // - Set: VANILLA, Rarity: Free
@@ -1960,6 +1962,16 @@ void VanillaCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - SILENCE = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SilenceTask>(EntityType::TARGET));
+    cards.emplace(
+        "VAN_EX1_332",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ----------------------------------------- SPELL - PRIEST
     // [VAN_EX1_334] Shadow Madness - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -633,9 +633,18 @@ void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CHOOSE_ONE = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
     // RefTag:
     // - SILENCE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace(
+        "VAN_EX1_166",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } },
+                ChooseCardIDs{ "VAN_EX1_166a", "VAN_EX1_166b" }));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_EX1_169] Innervate - COST:0
@@ -930,6 +939,14 @@ void VanillaCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 2 damage.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::TARGET, 2));
+    cards.emplace(
+        "VAN_EX1_166a",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_EX1_166b] Dispel - COST:4
@@ -940,6 +957,16 @@ void VanillaCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - SILENCE = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SilenceTask>(EntityType::TARGET));
+    cards.emplace(
+        "VAN_EX1_166b",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_EX1_178a] Rooted - COST:7

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -652,6 +652,9 @@ void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Gain 2 Mana Crystals this turn only.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<TempManaTask>(2));
+    cards.emplace("VAN_EX1_169", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_EX1_173] Starfire - COST:6

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -728,6 +728,11 @@ void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace(
+        "VAN_EX1_573",
+        CardDef(power, ChooseCardIDs{ "VAN_EX1_573a", "VAN_EX1_573b" }));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_EX1_578] Savagery - COST:1
@@ -1018,6 +1023,10 @@ void VanillaCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Give your other minions +2/+2.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
+        "EX1_573ae", EntityType::MINIONS_NOSOURCE));
+    cards.emplace("VAN_EX1_573a", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [VAN_EX1_573b] Shan'do's Lesson - COST:9
@@ -1025,6 +1034,12 @@ void VanillaCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Summon two 2/2 Treants with <b>Taunt</b>.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<EnqueueTask>(
+        TaskList{ std::make_shared<SummonTask>("EX1_573t", SummonSide::RIGHT),
+                  std::make_shared<SummonTask>("EX1_573t", SummonSide::LEFT) },
+        1));
+    cards.emplace("VAN_EX1_573b", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [VAN_EX1_tk9] Treant - COST:1 [ATK:2/HP:2]

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -501,7 +501,8 @@ TEST_CASE("[Druid : Minion] - EX1_165 : Druid of the Claw")
 // [EX1_166] Keeper of the Grove - COST:4 [ATK:2/HP:4]
 // - Faction: Neutral, Set: Expert1, Rarity: Rare
 // --------------------------------------------------------
-// Text: <b>Choose One -</b> Deal 2 damage; or <b>Silence</b> a minion.
+// Text: <b>Choose One -</b> Deal 2 damage;
+//       or <b>Silence</b> a minion.
 // --------------------------------------------------------
 // GameTag:
 // - CHOOSE_ONE = 1

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -1004,7 +1004,8 @@ TEST_CASE("[Druid : Spell] - NEW1_007 : Starfall")
 // [NEW1_008] Ancient of Lore - COST:7 [ATK:5/HP:5]
 // - Set: Expert1, Rarity: Epic
 // --------------------------------------------------------
-// Text: <b>Choose One -</b> Draw 2 cards; or Restore 5 Health.
+// Text: <b>Choose One -</b> Draw 2 cards;
+//       or Restore 5 Health.
 // --------------------------------------------------------
 // GameTag:
 // - CHOOSE_ONE = 1

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -930,8 +930,7 @@ TEST_CASE("[Druid : Spell] - EX1_578 : Savagery")
 // - Set: Expert1, Rarity: Rare
 // - Spell School: Arcane
 // --------------------------------------------------------
-// Text: <b>Choose One -</b>
-//       Deal 5 damage to a minion;
+// Text: <b>Choose One -</b> Deal 5 damage to a minion;
 //       or 2 damage to all enemy minions.
 // --------------------------------------------------------
 // GameTag:

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -561,7 +561,8 @@ TEST_CASE("[Druid : Minion] - EX1_166 : Keeper of the Grove")
 // [EX1_178] Ancient of War - COST:7 [ATK:5/HP:5]
 // - Faction: Neutral, Set: Expert1, Rarity: Epic
 // --------------------------------------------------------
-// Text: <b>Choose One -</b>+5 Attack; or +5 Health and <b>Taunt</b>.
+// Text: <b>Choose One -</b>+5 Attack;
+//       or +5 Health and <b>Taunt</b>.
 // --------------------------------------------------------
 // GameTag:
 // - CHOOSE_ONE = 1

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -481,20 +481,20 @@ TEST_CASE("[Druid : Minion] - EX1_165 : Druid of the Claw")
     game.Process(curPlayer, PlayCardTask::Minion(card1, 1));
     CHECK_EQ(curField[0]->GetAttack(), 5);
     CHECK_EQ(curField[0]->GetHealth(), 4);
-    CHECK(curField[0]->CanAttack());
-    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAUNT), 0);
+    CHECK_EQ(curField[0]->CanAttack(), true);
+    CHECK_EQ(curField[0]->HasTaunt(), false);
 
     game.Process(curPlayer, PlayCardTask::Minion(card2, 2));
     CHECK_EQ(curField[1]->GetAttack(), 5);
     CHECK_EQ(curField[1]->GetHealth(), 6);
-    CHECK_FALSE(curField[1]->CanAttack());
-    CHECK_EQ(curField[1]->GetGameTag(GameTag::TAUNT), 1);
+    CHECK_EQ(curField[1]->CanAttack(), false);
+    CHECK_EQ(curField[1]->HasTaunt(), true);
 
     game.Process(curPlayer, PlayCardTask::SpellTarget(card3, curField[1]));
     CHECK_EQ(curField[1]->GetAttack(), 5);
     CHECK_EQ(curField[1]->GetHealth(), 6);
-    CHECK_FALSE(curField[1]->CanAttack());
-    CHECK_EQ(curField[1]->GetGameTag(GameTag::TAUNT), 0);
+    CHECK_EQ(curField[1]->CanAttack(), false);
+    CHECK_EQ(curField[1]->HasTaunt(), false);
 }
 
 // ----------------------------------------- MINION - DRUID

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -1426,6 +1426,66 @@ TEST_CASE("[Druid : Minion] - VAN_EX1_166 : Keeper of the Grove")
     CHECK_EQ(opPlayer->GetCurrentSpellPower(), 0);
 }
 
+// ------------------------------------------ SPELL - DRUID
+// [VAN_EX1_169] Innervate - COST:0
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Gain 2 Mana Crystals this turn only.
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - VAN_EX1_169 : Innervate")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(8);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Innervate", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Innervate", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Dragonling Mechanic", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 10);
+    CHECK_EQ(curPlayer->GetTemporaryMana(), 2);
+    CHECK_EQ(curPlayer->GetTotalMana(), 8);
+    CHECK_EQ(curPlayer->GetUsedMana(), 0);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 6);
+    CHECK_EQ(curPlayer->GetTemporaryMana(), 0);
+    CHECK_EQ(curPlayer->GetTotalMana(), 8);
+    CHECK_EQ(curPlayer->GetUsedMana(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 10);
+    CHECK_EQ(curPlayer->GetTemporaryMana(), 1);
+    CHECK_EQ(curPlayer->GetTotalMana(), 9);
+    CHECK_EQ(curPlayer->GetUsedMana(), 0);
+}
+
 // ---------------------------------------- SPELL - WARLOCK
 // [VAN_CS2_062] Hellfire - COST:4
 // - Set: VANILLA, Rarity: Free

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -1713,6 +1713,74 @@ TEST_CASE("[Druid : Minion] - VAN_EX1_573 : Cenarius")
     CHECK_EQ(curField[3]->HasTaunt(), false);
 }
 
+// ------------------------------------------ SPELL - DRUID
+// [VAN_EX1_578] Savagery - COST:1
+// - Set: VANILLA, Rarity: Rare
+// --------------------------------------------------------
+// Text: Deal damage equal to your hero's Attack to a minion.
+// --------------------------------------------------------
+// GameTag:
+// - AFFECTED_BY_SPELL_POWER = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINION_TARGET = 0
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - VAN_EX1_578 : Savagery")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Malygos", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Savagery", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Savagery", FormatType::CLASSIC));
+    const auto card4 = Generic::DrawCard(
+        opPlayer,
+        Cards::FindCardByName("Bloodmage Thalnos", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetHealth(), 12);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask());
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField[0]->GetHealth(), 11);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask());
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
+    CHECK_EQ(curField[0]->GetHealth(), 9);
+}
+
 // ----------------------------------------- SPELL - PRIEST
 // [VAN_EX1_332] Silence - COST:0
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -1240,7 +1240,7 @@ TEST_CASE("[Druid : Spell] - VAN_EX1_161 : Naturalize")
     CHECK_EQ(curPlayer->GetFieldZone()->GetCount(), 0);
 }
 
- // ------------------------------------------ SPELL - DRUID
+// ------------------------------------------ SPELL - DRUID
 // [VAN_EX1_164] Nourish - COST:5
 // - Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------
@@ -1296,6 +1296,71 @@ TEST_CASE("[Druid : Spell] - VAN_EX1_164 : Nourish")
 
     game.Process(curPlayer, PlayCardTask::Spell(card2, 2));
     CHECK_EQ(curHand.GetCount(), 8);
+}
+
+// ----------------------------------------- MINION - DRUID
+// [VAN_EX1_165] Druid of the Claw - COST:5 [ATK:4/HP:4]
+// - Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Choose One -</b> <b>Charge</b>;
+//       or +2 Health and <b>Taunt</b>.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// --------------------------------------------------------
+// RefTag:
+// - CHARGE = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - VAN_EX1_165 : Druid of the Claw")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Druid of the Claw", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Druid of the Claw", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Silence", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1, 1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(curField[0]->CanAttack(), true);
+    CHECK_EQ(curField[0]->HasTaunt(), false);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2, 2));
+    CHECK_EQ(curField[1]->GetAttack(), 4);
+    CHECK_EQ(curField[1]->GetHealth(), 6);
+    CHECK_EQ(curField[1]->CanAttack(), false);
+    CHECK_EQ(curField[1]->HasTaunt(), true);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, curField[1]));
+    CHECK_EQ(curField[1]->GetAttack(), 4);
+    CHECK_EQ(curField[1]->GetHealth(), 6);
+    CHECK_EQ(curField[1]->CanAttack(), false);
+    CHECK_EQ(curField[1]->HasTaunt(), false);
 }
 
 // ---------------------------------------- SPELL - WARLOCK

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -1637,6 +1637,82 @@ TEST_CASE("[Druid : Spell] - VAN_EX1_570 : Bite")
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
 }
 
+// ----------------------------------------- MINION - DRUID
+// [VAN_EX1_573] Cenarius - COST:9 [ATK:5/HP:8]
+// - Set: VANILLA, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Choose One -</b> Give your other minions +2/+2;
+//       or Summon two 2/2 Treants with <b>Taunt</b>.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - CHOOSE_ONE = 1
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - VAN_EX1_573 : Cenarius")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Cenarius", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Cenarius", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1, 2));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+    CHECK_EQ(curField[1]->GetAttack(), 5);
+    CHECK_EQ(curField[1]->GetHealth(), 8);
+    CHECK_EQ(curField[1]->HasTaunt(), false);
+    CHECK_EQ(curField[2]->GetAttack(), 2);
+    CHECK_EQ(curField[2]->GetHealth(), 2);
+    CHECK_EQ(curField[2]->HasTaunt(), true);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2, 1));
+    CHECK_EQ(curField.GetCount(), 4);
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+    CHECK_EQ(curField[1]->GetAttack(), 7);
+    CHECK_EQ(curField[1]->GetHealth(), 10);
+    CHECK_EQ(curField[1]->HasTaunt(), false);
+    CHECK_EQ(curField[2]->GetAttack(), 4);
+    CHECK_EQ(curField[2]->GetHealth(), 4);
+    CHECK_EQ(curField[2]->HasTaunt(), true);
+    CHECK_EQ(curField[3]->GetAttack(), 5);
+    CHECK_EQ(curField[3]->GetHealth(), 8);
+    CHECK_EQ(curField[3]->HasTaunt(), false);
+}
+
 // ----------------------------------------- SPELL - PRIEST
 // [VAN_EX1_332] Silence - COST:0
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -1592,6 +1592,51 @@ TEST_CASE("[Druid : Minion] - VAN_EX1_178 : Ancient of War")
     CHECK_EQ(opField[0]->GetAttack(), 10);
 }
 
+// ------------------------------------------ SPELL - DRUID
+// [VAN_EX1_570] Bite - COST:4
+// - Set: VANILLA, Rarity: Rare
+// --------------------------------------------------------
+// Text: Give your hero +4 Attack this turn. Gain 4 Armor.
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - VAN_EX1_570 : Bite")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Bite", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 4);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 4);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 5);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+}
+
 // ----------------------------------------- SPELL - PRIEST
 // [VAN_EX1_332] Silence - COST:0
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -1538,6 +1538,60 @@ TEST_CASE("[Druid : Spell] - VAN_EX1_173 : Starfire")
     CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
 }
 
+// ----------------------------------------- MINION - DRUID
+// [VAN_EX1_178] Ancient of War - COST:7 [ATK:5/HP:5]
+// - Set: VANILLA, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Choose One -</b> +5 Attack;
+//       or +5 Health and <b>Taunt</b>.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - VAN_EX1_178 : Ancient of War")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Ancient of War", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Ancient of War", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1, 1));
+    CHECK_EQ(curField[0]->GetHealth(), 10);
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAUNT), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2, 2));
+    CHECK_EQ(opField[0]->GetAttack(), 10);
+}
+
 // ----------------------------------------- SPELL - PRIEST
 // [VAN_EX1_332] Silence - COST:0
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -1486,6 +1486,58 @@ TEST_CASE("[Druid : Spell] - VAN_EX1_169 : Innervate")
     CHECK_EQ(curPlayer->GetUsedMana(), 0);
 }
 
+// ------------------------------------------ SPELL - DRUID
+// [VAN_EX1_173] Starfire - COST:6
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Deal 5 damage. Draw a card.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - VAN_EX1_173 : Starfire")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Starfire", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        opPlayer,
+        Cards::FindCardByName("Boulderfist Ogre", FormatType::CLASSIC));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(opField[0]->GetHealth(), 7);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card1, card2));
+    CHECK_EQ(opField[0]->GetHealth(), 2);
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+}
+
 // ----------------------------------------- SPELL - PRIEST
 // [VAN_EX1_332] Silence - COST:0
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -1363,6 +1363,69 @@ TEST_CASE("[Druid : Minion] - VAN_EX1_165 : Druid of the Claw")
     CHECK_EQ(curField[1]->HasTaunt(), false);
 }
 
+// ----------------------------------------- MINION - DRUID
+// [VAN_EX1_166] Keeper of the Grove - COST:4 [ATK:2/HP:4]
+// - Set: VANILLA, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Choose One -</b> Deal 2 damage;
+//       or <b>Silence</b> a minion.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// --------------------------------------------------------
+// RefTag:
+// - SILENCE = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - VAN_EX1_166 : Keeper of the Grove")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Keeper of the Grove", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Keeper of the Grove", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Archmage", FormatType::CLASSIC));
+
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card1, opPlayer->GetHero(), 1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opPlayer->GetCurrentSpellPower(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card3, 2));
+    CHECK_EQ(opPlayer->GetCurrentSpellPower(), 0);
+}
+
 // ---------------------------------------- SPELL - WARLOCK
 // [VAN_CS2_062] Hellfire - COST:4
 // - Set: VANILLA, Rarity: Free

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -1857,6 +1857,63 @@ TEST_CASE("[Druid : Spell] - VAN_NEW1_007 : Starfall")
     CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 0);
 }
 
+// ----------------------------------------- MINION - DRUID
+// [VAN_NEW1_008] Ancient of Lore - COST:7 [ATK:5/HP:5]
+// - Set: VANILLA, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Choose One -</b> Draw 2 cards;
+//       or Restore 5 Health.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - VAN_NEW1_008 : Ancient of Lore")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(15);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Ancient of Lore", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Ancient of Lore", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1, 1));
+    CHECK_EQ(card1->GetZoneType(), ZoneType::PLAY);
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 7);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card2, curPlayer->GetHero(), 2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+}
+
 // ----------------------------------------- SPELL - PRIEST
 // [VAN_EX1_332] Silence - COST:0
 // - Set: VANILLA, Rarity: Common


### PR DESCRIPTION
This revision includes:
- Implement 11 VANILLA cards (#674)
  - Druid of the Claw (VAN_EX1_165)
  - Keeper of the Grove (VAN_EX1_166)
  - Innervate (VAN_EX1_169)
  - Starfire (VAN_EX1_173)
  - Ancient of War (VAN_EX1_178)
  - Bite (VAN_EX1_570)
  - Cenarius (VAN_EX1_573)
  - Savagery (VAN_EX1_578)
  - Silence (VAN_EX1_332)
  - Starfall (VAN_NEW1_007)
  - Ancient of Lore (VAN_NEW1_008)
- Separate text to improve readability
- Cleanup unit test code of card 'Druid of the Claw' (EX1_165)