### PR TITLE
Implement 9 STORMWIND cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -892,6 +892,41 @@ THE_BARRENS | WC_806 | Floecaster | O
 
 Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
+STORMWIND | DED_001 | Druid of the Reef | O
+STORMWIND | DED_002 | Moonlit Guidance |  
+STORMWIND | DED_003 | Jerry Rig Carpenter |  
+STORMWIND | DED_004 | Blackwater Cutlass |  
+STORMWIND | DED_005 | Parrrley |  
+STORMWIND | DED_006 | Mr. Smite |  
+STORMWIND | DED_007 | Defias Blastfisher |  
+STORMWIND | DED_008 | Monstrous Parrot |  
+STORMWIND | DED_009 | Doggie Biscuit |  
+STORMWIND | DED_500 | Wealth Redistributor |  
+STORMWIND | DED_501 | Sunwing Squawker |  
+STORMWIND | DED_502 | Righteous Defense |  
+STORMWIND | DED_503 | Shadowblade Slinger |  
+STORMWIND | DED_504 | Wicked Shipment |  
+STORMWIND | DED_505 | Hullbreaker |  
+STORMWIND | DED_506 | Need for Greed |  
+STORMWIND | DED_507 | Crow's Nest Lookout |  
+STORMWIND | DED_508 | Proving Grounds |  
+STORMWIND | DED_509 | Brilliant Macaw |  
+STORMWIND | DED_510 | Edwin, Defias Kingpin |  
+STORMWIND | DED_511 | Suckerhook |  
+STORMWIND | DED_512 | Amulet of Undying |  
+STORMWIND | DED_513 | Defias Leper |  
+STORMWIND | DED_514 | Copycat |  
+STORMWIND | DED_515 | Grey Sage Parrot |  
+STORMWIND | DED_516 | Deepwater Evoker |  
+STORMWIND | DED_517 | Arcane Overflow |  
+STORMWIND | DED_518 | Man the Cannons |  
+STORMWIND | DED_519 | Defias Cannoneer |  
+STORMWIND | DED_521 | Maddest Bomber |  
+STORMWIND | DED_522 | Cookie the Cook |  
+STORMWIND | DED_523 | Golakka Glutton |  
+STORMWIND | DED_524 | Multicaster |  
+STORMWIND | DED_525 | Goliath, Sneed's Masterpiece |  
+STORMWIND | DED_527 | Blacksmithing Hammer |  
 STORMWIND | SW_001 | Celestial Ink Set |  
 STORMWIND | SW_003 | Runed Mithril Rod |  
 STORMWIND | SW_006 | Stubborn Suspect |  
@@ -996,17 +1031,17 @@ STORMWIND | SW_412 | SI:7 Extortion |
 STORMWIND | SW_413 | SI:7 Operative |  
 STORMWIND | SW_417 | SI:7 Assassin |  
 STORMWIND | SW_418 | SI:7 Skulker |  
-STORMWIND | SW_419 | Oracle of Elune |  
-STORMWIND | SW_422 | Sow the Soil |  
+STORMWIND | SW_419 | Oracle of Elune | O
+STORMWIND | SW_422 | Sow the Soil | O
 STORMWIND | SW_428 | Lost in the Park | O
-STORMWIND | SW_429 | Best in Shell |  
-STORMWIND | SW_431 | Park Panther |  
-STORMWIND | SW_432 | Kodo Mount |  
+STORMWIND | SW_429 | Best in Shell | O
+STORMWIND | SW_431 | Park Panther | O
+STORMWIND | SW_432 | Kodo Mount | O
 STORMWIND | SW_433 | Seek Guidance |  
 STORMWIND | SW_434 | Loan Shark |  
-STORMWIND | SW_436 | Wickerclaw |  
-STORMWIND | SW_437 | Composting |  
-STORMWIND | SW_439 | Vibrant Squirrel |  
+STORMWIND | SW_436 | Wickerclaw | O
+STORMWIND | SW_437 | Composting | O
+STORMWIND | SW_439 | Vibrant Squirrel | O
 STORMWIND | SW_440 | Call of the Grave |  
 STORMWIND | SW_441 | Shard of the Naaru |  
 STORMWIND | SW_442 | Void Shard |  
@@ -1027,43 +1062,8 @@ STORMWIND | SW_459 | Stormwind Piper |
 STORMWIND | SW_460 | Devouring Swarm |  
 STORMWIND | SW_462 | Hot Streak |  
 STORMWIND | SW_463 | Imported Tarantula |  
-STORMWIND | DED_001 | Druid of the Reef |  
-STORMWIND | DED_002 | Moonlit Guidance |  
-STORMWIND | DED_003 | Jerry Rig Carpenter |  
-STORMWIND | DED_004 | Blackwater Cutlass |  
-STORMWIND | DED_005 | Parrrley |  
-STORMWIND | DED_006 | Mr. Smite |  
-STORMWIND | DED_007 | Defias Blastfisher |  
-STORMWIND | DED_008 | Monstrous Parrot |  
-STORMWIND | DED_009 | Doggie Biscuit |  
-STORMWIND | DED_500 | Wealth Redistributor |  
-STORMWIND | DED_501 | Sunwing Squawker |  
-STORMWIND | DED_502 | Righteous Defense |  
-STORMWIND | DED_503 | Shadowblade Slinger |  
-STORMWIND | DED_504 | Wicked Shipment |  
-STORMWIND | DED_505 | Hullbreaker |  
-STORMWIND | DED_506 | Need for Greed |  
-STORMWIND | DED_507 | Crow's Nest Lookout |  
-STORMWIND | DED_508 | Proving Grounds |  
-STORMWIND | DED_509 | Brilliant Macaw |  
-STORMWIND | DED_510 | Edwin, Defias Kingpin |  
-STORMWIND | DED_511 | Suckerhook |  
-STORMWIND | DED_512 | Amulet of Undying |  
-STORMWIND | DED_513 | Defias Leper |  
-STORMWIND | DED_514 | Copycat |  
-STORMWIND | DED_515 | Grey Sage Parrot |  
-STORMWIND | DED_516 | Deepwater Evoker |  
-STORMWIND | DED_517 | Arcane Overflow |  
-STORMWIND | DED_518 | Man the Cannons |  
-STORMWIND | DED_519 | Defias Cannoneer |  
-STORMWIND | DED_521 | Maddest Bomber |  
-STORMWIND | DED_522 | Cookie the Cook |  
-STORMWIND | DED_523 | Golakka Glutton |  
-STORMWIND | DED_524 | Multicaster |  
-STORMWIND | DED_525 | Goliath, Sneed's Masterpiece |  
-STORMWIND | DED_527 | Blacksmithing Hammer |  
 
-- Progress: 1% (2 of 170 Cards)
+- Progress: 6% (11 of 170 Cards)
 
 ## Fractured in Alterac Valley
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
   * 80% Forged in the Barrens (136 of 170 cards)
-  * 1% United in Stormwind (2 of 170 cards)
+  * 6% United in Stormwind (11 of 170 cards)
   * 0% Fractured in Alterac Valley (0 of 2 cards)
 
 ### Wild Format

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -161,6 +161,10 @@ void StormwindCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<AddCardTask>(EntityType::DECK, "SW_439t", 4));
+    cards.emplace("SW_439", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [SW_447] Sheldras Moontree - COST:8 [ATK:5/HP:5]
@@ -388,11 +392,18 @@ void StormwindCardsGen::AddDruidNonCollect(
     // GameTag:
     // - TOPDECK = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTopdeckTask(std::make_shared<SummonTask>("SW_439t2"));
+    power.AddPowerTask(std::make_shared<SummonTask>("SW_439t2"));
+    cards.emplace("SW_439t", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [SW_439t2] Satisfied Squirrel - COST:1 [ATK:2/HP:1]
     // - Race: Beast, Set: STORMWIND
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("SW_439t2", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [SW_447e] Elune's Guidance - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -11,6 +11,8 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 
 namespace RosettaStone::PlayMode
 {
+using ChooseCardIDs = std::vector<std::string>;
+
 void StormwindCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
     // Do nothing
@@ -47,6 +49,10 @@ void StormwindCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CHOOSE_ONE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("SW_422",
+                  CardDef(power, ChooseCardIDs{ "SW_422a", "SW_422b" }));
 
     // ------------------------------------------ SPELL - DRUID
     // [SW_428] Lost in the Park - COST:1
@@ -200,6 +206,10 @@ void StormwindCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
     // Text: Summon a 2/2 Treant.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("EX1_158t", SummonSide::DEFAULT));
+    cards.emplace("SW_422a", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [SW_422b] Fertilizer - COST:1
@@ -208,6 +218,10 @@ void StormwindCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
     // Text: Give your minions +1 Attack.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("SW_422e", EntityType::MINIONS));
+    cards.emplace("SW_422b", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [SW_422e] Replanted - COST:0
@@ -215,6 +229,9 @@ void StormwindCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
     // Text: +1 Attack.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("SW_422e"));
+    cards.emplace("SW_422e", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [SW_422t] Treant - COST:2 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -107,6 +107,12 @@ void StormwindCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - RUSH = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "SW_431e", EntityType::HERO) };
+    cards.emplace("SW_431", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [SW_432] Kodo Mount - COST:4
@@ -339,6 +345,9 @@ void StormwindCardsGen::AddDruidNonCollect(
     // GameTag:
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("SW_431e"));
+    cards.emplace("SW_431e", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [SW_432e] On a Kodo - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -121,9 +121,20 @@ void StormwindCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // Text: Give a minion +4/+2 and <b>Rush</b>.
     //       When it dies, summon a Kodo.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("SW_432e", EntityType::TARGET));
+    cards.emplace(
+        "SW_432",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ----------------------------------------- MINION - DRUID
     // [SW_436] Wickerclaw - COST:2 [ATK:1/HP:4]
@@ -370,6 +381,11 @@ void StormwindCardsGen::AddDruidNonCollect(
     // Text: +4/+2 and <b>Rush</b>.
     //       <b>Deathrattle:</b> Summon a Kodo.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("SW_432e"));
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("SW_432t", SummonSide::DEATHRATTLE));
+    cards.emplace("SW_432e", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [SW_432t] Guff's Kodo - COST:3 [ATK:4/HP:2]
@@ -380,6 +396,9 @@ void StormwindCardsGen::AddDruidNonCollect(
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("SW_432t", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [SW_436e] Wicked Claws - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -146,6 +146,10 @@ void StormwindCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("SW_437e", EntityType::MINIONS));
+    cards.emplace("SW_437", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [SW_439] Vibrant Squirrel - COST:1 [ATK:2/HP:1]
@@ -3147,6 +3151,8 @@ void StormwindCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 void StormwindCardsGen::AddNeutralNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [SW_001e] Inscription Enchant - COST:0
     // - Set: STORMWIND
@@ -3515,6 +3521,9 @@ void StormwindCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Draw a card.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(std::make_shared<DrawTask>(1));
+    cards.emplace("SW_437e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [SW_457e] Reinforced Hide - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -135,6 +135,12 @@ void StormwindCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::GAIN_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "SW_436e", EntityType::SOURCE) };
+    cards.emplace("SW_436", CardDef(power, 4, 0));
 
     // ------------------------------------------ SPELL - DRUID
     // [SW_437] Composting - COST:2
@@ -381,6 +387,9 @@ void StormwindCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
     // Text: +2 Attack.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("SW_436e"));
+    cards.emplace("SW_436e", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [SW_439t] Acorn - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -13,6 +13,7 @@ namespace RosettaStone::PlayMode
 {
 using PlayReqs = std::map<PlayReq, int>;
 using ChooseCardIDs = std::vector<std::string>;
+using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
 
 void StormwindCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
@@ -38,6 +39,14 @@ void StormwindCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_PLAY_MINION));
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsCost(2, RelaSign::LEQ))
+    };
+    power.GetTrigger()->tasks = { std::make_shared<SummonCopyTask>(
+        EntityType::TARGET) };
+    cards.emplace("SW_419", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [SW_422] Sow the Soil - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -11,6 +11,7 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 
 namespace RosettaStone::PlayMode
 {
+using PlayReqs = std::map<PlayReq, int>;
 using ChooseCardIDs = std::vector<std::string>;
 
 void StormwindCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
@@ -82,9 +83,18 @@ void StormwindCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRADEABLE = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("SW_429t", 2, SummonSide::SPELL));
+    cards.emplace(
+        "SW_429",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ----------------------------------------- MINION - DRUID
     // [SW_431] Park Panther - COST:4 [ATK:4/HP:4]
@@ -316,6 +326,9 @@ void StormwindCardsGen::AddDruidNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("SW_429t", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [SW_431e] Rawr! - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -219,6 +219,11 @@ void StormwindCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - RUSH = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<TransformTask>(EntityType::SOURCE, "DED_001c"));
+    cards.emplace("DED_001",
+                  CardDef(power, ChooseCardIDs{ "DED_001a", "DED_001b" }));
 
     // ------------------------------------------ SPELL - DRUID
     // [DED_002] Moonlit Guidance - COST:2
@@ -465,6 +470,10 @@ void StormwindCardsGen::AddDruidNonCollect(
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<TransformTask>(EntityType::SOURCE, "DED_001at"));
+    cards.emplace("DED_001a", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [DED_001at] Druid of the Reef - COST:1 [ATK:3/HP:1]
@@ -475,6 +484,9 @@ void StormwindCardsGen::AddDruidNonCollect(
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DED_001at", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [DED_001b] Sea Turtle Form - COST:1 [ATK:1/HP:3]
@@ -485,6 +497,10 @@ void StormwindCardsGen::AddDruidNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<TransformTask>(EntityType::SOURCE, "DED_001bt"));
+    cards.emplace("DED_001b", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [DED_001bt] Druid of the Reef - COST:1 [ATK:1/HP:3]
@@ -495,6 +511,9 @@ void StormwindCardsGen::AddDruidNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DED_001bt", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [DED_001c] Druid of the Reef - COST:1 [ATK:3/HP:3]
@@ -507,6 +526,9 @@ void StormwindCardsGen::AddDruidNonCollect(
     // - RUSH = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DED_001c", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [DED_002e] Path of the Moon - COST:0

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -21,6 +21,55 @@ using namespace PlayMode;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ----------------------------------------- MINION - DRUID
+// [SW_419] Oracle of Elune - COST:3 [ATK:2/HP:4]
+// - Set: STORMWIND, Rarity: Epic
+// --------------------------------------------------------
+// Text: After you play a minion that costs (2) or less,
+//       summon a copy of it.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - SW_419 : Oracle of Elune")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Oracle of Elune"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField.GetCount(), 4);
+    CHECK_EQ(curField[2]->card->name, "Wisp");
+    CHECK_EQ(curField[3]->card->name, "Wisp");
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [SW_422] Sow the Soil - COST:1
 // - Set: STORMWIND, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -349,6 +349,71 @@ TEST_CASE("[Shaman : Spell] - SW_437 : Composting")
     CHECK_EQ(curField.GetCount(), 1);
 }
 
+// ----------------------------------------- MINION - DRUID
+// [SW_439] Vibrant Squirrel - COST:1 [ATK:2/HP:1]
+// - Race: Beast, Set: STORMWIND, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Shuffle 4 Acorns into your deck.
+//       When drawn, summon a 2/1 Squirrel.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SW_439 : Vibrant Squirrel")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curDeck = *(curPlayer->GetDeckZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Vibrant Squirrel"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curDeck.GetCount(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField.GetCount(), 0);
+    CHECK_EQ(curDeck.GetCount(), 4);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 4);
+    CHECK_EQ(curField[0]->card->name, "Satisfied Squirrel");
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->card->name, "Satisfied Squirrel");
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+    CHECK_EQ(curField[2]->card->name, "Satisfied Squirrel");
+    CHECK_EQ(curField[2]->GetAttack(), 2);
+    CHECK_EQ(curField[2]->GetHealth(), 1);
+    CHECK_EQ(curField[3]->card->name, "Satisfied Squirrel");
+    CHECK_EQ(curField[3]->GetAttack(), 2);
+    CHECK_EQ(curField[3]->GetHealth(), 1);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [SW_055] Impatient Shopkeep - COST:3 [ATK:3/HP:3]
 // - Set: STORMWIND, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -283,6 +283,57 @@ TEST_CASE("[Druid : Minion] - SW_431 : Park Panther")
     CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
 }
 
+// ----------------------------------------- MINION - DRUID
+// [SW_436] Wickerclaw - COST:2 [ATK:1/HP:4]
+// - Race: Beast, Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: After your hero gains Attack,
+//       this minion gains +2 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - SW_436 : Wickerclaw")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wickerclaw"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [SW_437] Composting - COST:2
 // - Set: STORMWIND, Rarity: Epic

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -173,6 +173,59 @@ TEST_CASE("[Druid : Spell] - SW_428 : Lost in the Park")
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 19);
 }
 
+// ------------------------------------------ SPELL - DRUID
+// [SW_429] Best in Shell - COST:6
+// - Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Tradeable</b>
+//       Summon two 2/7 Turtles with <b>Taunt</b>.
+// --------------------------------------------------------
+// GameTag:
+// - TRADEABLE = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - SW_429 : Best in Shell")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Best in Shell"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Goldshell Turtle");
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 7);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+    CHECK_EQ(curField[1]->card->name, "Goldshell Turtle");
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 7);
+    CHECK_EQ(curField[1]->HasTaunt(), true);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [SW_055] Impatient Shopkeep - COST:3 [ATK:3/HP:3]
 // - Set: STORMWIND, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -283,6 +283,68 @@ TEST_CASE("[Druid : Minion] - SW_431 : Park Panther")
     CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
 }
 
+// ------------------------------------------ SPELL - DRUID
+// [SW_432] Kodo Mount - COST:4
+// - Set: STORMWIND, Rarity: Rare
+// --------------------------------------------------------
+// Text: Give a minion +4/+2 and <b>Rush</b>.
+//       When it dies, summon a Kodo.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - SW_432 : Kodo Mount")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Kodo Mount"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card2));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Guff's Kodo");
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->HasRush(), true);
+}
+
 // ----------------------------------------- MINION - DRUID
 // [SW_436] Wickerclaw - COST:2 [ATK:1/HP:4]
 // - Race: Beast, Set: STORMWIND, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -11,6 +11,7 @@
 
 #include <Rosetta/PlayMode/Actions/Draw.hpp>
 #include <Rosetta/PlayMode/Cards/Cards.hpp>
+#include <Rosetta/PlayMode/Zones/FieldZone.hpp>
 #include <Rosetta/PlayMode/Zones/HandZone.hpp>
 #include <Rosetta/PlayMode/Zones/SecretZone.hpp>
 
@@ -18,6 +19,55 @@ using namespace RosettaStone;
 using namespace PlayMode;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
+
+// ------------------------------------------ SPELL - DRUID
+// [SW_422] Sow the Soil - COST:1
+// - Set: STORMWIND, Rarity: Common
+// - Spell School: Nature
+// --------------------------------------------------------
+// Text: <b>Choose One</b> - Give your minions +1 Attack;
+//       or Summon a 2/2 Treant.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - SW_422 : Sow the Soil")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Sow the Soil"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Sow the Soil"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1, 1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Treant");
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2, 2));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+}
 
 // ------------------------------------------ SPELL - DRUID
 // [SW_428] Lost in the Park - COST:1
@@ -52,8 +102,8 @@ TEST_CASE("[Druid : Spell] - SW_428 : Lost in the Park")
     auto& curHand = *(curPlayer->GetHandZone());
     const auto curSecret = curPlayer->GetSecretZone();
 
-    const auto card1 = Generic::DrawCard(
-        curPlayer, Cards::FindCardByName("Lost in the Park"));
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Lost in the Park"));
     const auto card2 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Feral Rage"));
     const auto card3 =

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -593,3 +593,58 @@ TEST_CASE("[Neutral : Minion] - SW_055 : Impatient Shopkeep")
 {
     // Do nothing
 }
+
+// ----------------------------------------- MINION - DRUID
+// [DED_001] Druid of the Reef - COST:1 [ATK:1/HP:1]
+// - Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Choose One - </b>Transform into
+//       a 3/1 Shark with <b>Rush</b>; or
+//       a 1/3 Turtle with <b>Taunt</b>.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - DED_001 : Druid of the Reef")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Druid of the Reef"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Druid of the Reef"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1, 1));
+    CHECK_EQ(curField[0]->card->name, "Druid of the Reef");
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[0]->HasRush(), true);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2, 2));
+    CHECK_EQ(curField[1]->card->name, "Druid of the Reef");
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+    CHECK_EQ(curField[1]->HasTaunt(), true);
+}


### PR DESCRIPTION
This revision includes:
- Implement 9 STORMWIND cards
  - Oracle of Elune (SW_419)
  - Sow the Soil (SW_422)
  - Best in Shell (SW_429)
  - Park Panther (SW_431)
  - Kodo Mount (SW_432)
  - Wickerclaw (SW_436)
  - Composting (SW_437)
  - Vibrant Squirrel (SW_439)
  - Druid of the Reef (DED_001)