### PR TITLE
Implement 5 STORMWIND cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -966,14 +966,14 @@ STORMWIND | SW_056 | Spice Bread Baker |
 STORMWIND | SW_057 | Package Runner |  
 STORMWIND | SW_059 | Deeprun Engineer |  
 STORMWIND | SW_060 | Florist |  
-STORMWIND | SW_061 | Guild Trader |  
+STORMWIND | SW_061 | Guild Trader | O
 STORMWIND | SW_062 | Goldshire Gnoll |  
 STORMWIND | SW_063 | Battleground Battlemaster |  
 STORMWIND | SW_064 | Northshire Farmer |  
 STORMWIND | SW_065 | Pandaren Importer |  
 STORMWIND | SW_066 | Royal Librarian |  
 STORMWIND | SW_067 | Stockades Guard |  
-STORMWIND | SW_068 | Mo'arg Forgefiend |  
+STORMWIND | SW_068 | Mo'arg Forgefiend | O
 STORMWIND | SW_069 | Enthusiastic Banker |  
 STORMWIND | SW_070 | Mailbox Dancer |  
 STORMWIND | SW_071 | Lion's Guard |  
@@ -1000,7 +1000,7 @@ STORMWIND | SW_093 | Stormwind Freebooter |
 STORMWIND | SW_094 | Heavy Plate |  
 STORMWIND | SW_095 | Investment Opportunity |  
 STORMWIND | SW_097 | Remote-Controlled Golem |  
-STORMWIND | SW_107 | Fire Sale |  
+STORMWIND | SW_107 | Fire Sale | O
 STORMWIND | SW_108 | First Flame |  
 STORMWIND | SW_109 | Clumsy Courier |  
 STORMWIND | SW_110 | Ignite |  
@@ -1021,7 +1021,7 @@ STORMWIND | SW_316 | Noble Mount |
 STORMWIND | SW_317 | Catacomb Guard |  
 STORMWIND | SW_319 | Peasant |  
 STORMWIND | SW_320 | Rats of Extraordinary Size |  
-STORMWIND | SW_321 | Aimed Shot |  
+STORMWIND | SW_321 | Aimed Shot | O
 STORMWIND | SW_322 | Defend the Dwarven District |  
 STORMWIND | SW_323 | The Rat King |  
 STORMWIND | SW_400 | Entrapped Sorceress |  
@@ -1055,7 +1055,7 @@ STORMWIND | SW_450 | Sorcerer's Gambit |
 STORMWIND | SW_451 | Metamorfin |  
 STORMWIND | SW_452 | Chaos Leech |  
 STORMWIND | SW_454 | Lion's Frenzy |  
-STORMWIND | SW_455 | Rodent Nest |  
+STORMWIND | SW_455 | Rodent Nest | O
 STORMWIND | SW_457 | Leatherworking Kit |  
 STORMWIND | SW_458 | Ramming Mount |  
 STORMWIND | SW_459 | Stormwind Piper |  
@@ -1063,7 +1063,7 @@ STORMWIND | SW_460 | Devouring Swarm |
 STORMWIND | SW_462 | Hot Streak |  
 STORMWIND | SW_463 | Imported Tarantula |  
 
-- Progress: 6% (11 of 170 Cards)
+- Progress: 9% (16 of 170 Cards)
 
 ## Fractured in Alterac Valley
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
   * 80% Forged in the Barrens (136 of 170 cards)
-  * 6% United in Stormwind (11 of 170 cards)
+  * 9% United in Stormwind (16 of 170 cards)
   * 0% Fractured in Alterac Valley (0 of 2 cards)
 
 ### Wild Format

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -835,6 +835,8 @@ void StormwindCardsGen::AddHunterNonCollect(
 
 void StormwindCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------ WEAPON - MAGE
     // [SW_001] Celestial Ink Set - COST:2
     // - Set: STORMWIND, Rarity: Rare
@@ -858,6 +860,10 @@ void StormwindCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - TRADEABLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ALL_MINIONS, 3, true));
+    cards.emplace("SW_107", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [SW_108] First Flame - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -543,6 +543,8 @@ void StormwindCardsGen::AddDruidNonCollect(
 
 void StormwindCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- SPELL - HUNTER
     // [SW_320] Rats of Extraordinary Size - COST:6
     // - Set: STORMWIND, Rarity: Epic
@@ -559,6 +561,17 @@ void StormwindCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // Text: Deal 3 damage.
     //       Your next Hero Power deals 2 more damage.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("SW_321e", EntityType::HERO));
+    cards.emplace(
+        "SW_321",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ----------------------------------------- SPELL - HUNTER
     // [SW_322] Defend the Dwarven District - COST:1
@@ -696,6 +709,8 @@ void StormwindCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 void StormwindCardsGen::AddHunterNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [SW_320e] Extraordinarily Sized - COST:0
     // - Set: STORMWIND
@@ -709,6 +724,13 @@ void StormwindCardsGen::AddHunterNonCollect(
     // --------------------------------------------------------
     // Text: Your next Hero Power deals 2 more damage.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(std::make_unique<Enchant>(GameTag::HEROPOWER_DAMAGE,
+                                               EffectOperator::ADD, 2));
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::INSPIRE));
+    power.GetTrigger()->tasks = { std::make_shared<RemoveEnchantmentTask>() };
+    power.GetTrigger()->removeAfterTriggered = true;
+    cards.emplace("SW_321e", CardDef(power));
 
     // ----------------------------------------- SPELL - HUNTER
     // [SW_322t] Take the High Ground - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -2879,6 +2879,9 @@ void StormwindCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - SPELLPOWER = 1
     // - TRADEABLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("SW_061", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SW_062] Goldshire Gnoll - COST:10 [ATK:5/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -2969,6 +2969,9 @@ void StormwindCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - DEATHRATTLE = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(std::make_shared<ArmorTask>(8));
+    cards.emplace("SW_068", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SW_069] Enthusiastic Banker - COST:3 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -606,6 +606,10 @@ void StormwindCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("SW_455t", 5, SummonSide::DEATHRATTLE));
+    cards.emplace("SW_455", CardDef(power));
 
     // ---------------------------------------- WEAPON - HUNTER
     // [SW_457] Leatherworking Kit - COST:1
@@ -780,6 +784,9 @@ void StormwindCardsGen::AddHunterNonCollect(
     // [SW_455t] Rat - COST:1 [ATK:1/HP:1]
     // - Race: Beast, Set: STORMWIND
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("SW_455t", CardDef(power));
 
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [SW_458e] On a Ram - COST:0

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -834,3 +834,49 @@ TEST_CASE("[Neutral : Minion] - SW_061 : Guild Trader")
 {
     // Do nothing
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [SW_068] Mo'arg Forgefiend - COST:8 [ATK:8/HP:8]
+// - Race: Demon, Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Deathrattle:</b> Gain 8 Armor.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SW_068 : Mo'arg Forgefiend")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Mo'arg Forgefiend"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Pyroblast"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 8);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -699,3 +699,64 @@ TEST_CASE("[Hunter : Spell] - SW_321 : Aimed Shot")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 23);
     CHECK_EQ(curPlayer->GetHero()->GetHeroPowerDamage(), 0);
 }
+
+// ---------------------------------------- MINION - HUNTER
+// [SW_455] Rodent Nest - COST:4 [ATK:2/HP:2]
+// - Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Summon five 1/1 Rats.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - SW_455 : Rodent Nest")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Rodent Nest"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField.GetCount(), 5);
+    CHECK_EQ(curField[0]->card->name, "Rat");
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->card->name, "Rat");
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+    CHECK_EQ(curField[2]->card->name, "Rat");
+    CHECK_EQ(curField[2]->GetAttack(), 1);
+    CHECK_EQ(curField[2]->GetHealth(), 1);
+    CHECK_EQ(curField[3]->card->name, "Rat");
+    CHECK_EQ(curField[3]->GetAttack(), 1);
+    CHECK_EQ(curField[3]->GetHealth(), 1);
+    CHECK_EQ(curField[4]->card->name, "Rat");
+    CHECK_EQ(curField[4]->GetAttack(), 1);
+    CHECK_EQ(curField[4]->GetHealth(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -760,3 +760,61 @@ TEST_CASE("[Hunter : Minion] - SW_455 : Rodent Nest")
     CHECK_EQ(curField[4]->GetAttack(), 1);
     CHECK_EQ(curField[4]->GetHealth(), 1);
 }
+
+// ------------------------------------------- SPELL - MAGE
+// [SW_107] Fire Sale - COST:4
+// - Set: STORMWIND, Rarity: Common
+// - Spell School: Fire
+// --------------------------------------------------------
+// Text: <b>Tradeable</b>
+//       Deal 3 damage to all minions.
+// --------------------------------------------------------
+// RefTag:
+// - TRADEABLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - SW_107 : Fire Sale")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fire Sale"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Chillwind Yeti"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Chillwind Yeti"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField[0]->GetHealth(), 5);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(opField[0]->GetHealth(), 2);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -818,3 +818,19 @@ TEST_CASE("[Mage : Spell] - SW_107 : Fire Sale")
     CHECK_EQ(curField[0]->GetHealth(), 2);
     CHECK_EQ(opField[0]->GetHealth(), 2);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [SW_061] Guild Trader - COST:4 [ATK:3/HP:4]
+// - Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Tradeable</b>
+//       <b>Spell Damage +2</b>
+// --------------------------------------------------------
+// GameTag:
+// - SPELLPOWER = 1
+// - TRADEABLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SW_061 : Guild Trader")
+{
+    // Do nothing
+}


### PR DESCRIPTION
This revision includes:
- Implement 5 STORMWIND cards
  - Guild Trader (SW_061)
  - Mo'arg Forgefiend (SW_068)
  - Fire Sale (SW_107)
  - Aimed Shot (SW_321)
  - Rodent Nest (SW_455)