### PR TITLE
Upgrade Windows build for GitHub Actions

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,12 +11,12 @@ jobs:
     strategy:
       matrix:
         include:
-          # Windows Server 2016 + Visual Studio 2017
-          - name: "Windows Server 2016 + Visual Studio 2017"
-            os: windows-2016
           # Windows Server 2019 + Visual Studio 2019
           - name: "Windows Server 2019 + Visual Studio 2019"
             os: windows-2019
+          # Windows Server 2022 + Visual Studio 2022
+          - name: "Windows Server 2022 + Visual Studio 2022"
+            os: windows-2022
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.name }}


### PR DESCRIPTION
This revision includes:
- Upgrade Windows build for GitHub Actions (Resolves #683)
  - Remove "Windows Server 2016 + Visual Studio 2017"
  - Add "Windows Server 2022 + Visual Studio 2022"