### PR TITLE
Implement keyword 'Honorable Kill'

### DIFF
--- a/Documents/AbilityList.md
+++ b/Documents/AbilityList.md
@@ -37,6 +37,7 @@
 * [x] Dormant
 * [x] Echo
 * [ ] Frenzy
+* [x] Honorable Kill
 * [x] Immune
 * [ ] Inspire
 * [x] Invoke

--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -1070,6 +1070,139 @@ STORMWIND | SW_463 | Imported Tarantula |
 Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
 ALTERAC_VALLEY | AV_100 | Drek'Thar |  
+ALTERAC_VALLEY | AV_101 | Herald of Lokholar |  
+ALTERAC_VALLEY | AV_102 | Popsicooler |  
+ALTERAC_VALLEY | AV_107 | Glaciate |  
+ALTERAC_VALLEY | AV_108 | Shield Shatter |  
+ALTERAC_VALLEY | AV_109 | Frozen Buckler |  
+ALTERAC_VALLEY | AV_112 | Snowblind Harpy |  
+ALTERAC_VALLEY | AV_113 | Beaststalker Tavish |  
+ALTERAC_VALLEY | AV_114 | Shivering Sorceress |  
+ALTERAC_VALLEY | AV_115 | Amplified Snowflurry |  
+ALTERAC_VALLEY | AV_116 | Arcane Brilliance |  
+ALTERAC_VALLEY | AV_118 | Battleworn Vanguard |  
+ALTERAC_VALLEY | AV_119 | To the Front! |  
+ALTERAC_VALLEY | AV_121 | Gnome Private | O
+ALTERAC_VALLEY | AV_122 | Corporal |  
+ALTERAC_VALLEY | AV_123 | Sneaky Scout |  
+ALTERAC_VALLEY | AV_124 | Direwolf Commander |  
+ALTERAC_VALLEY | AV_125 | Tower Sergeant |  
+ALTERAC_VALLEY | AV_126 | Bunker Sergeant |  
+ALTERAC_VALLEY | AV_127 | Ice Revenant |  
+ALTERAC_VALLEY | AV_128 | Frozen Mammoth |  
+ALTERAC_VALLEY | AV_129 | Blood Guard |  
+ALTERAC_VALLEY | AV_130 | Legionnaire |  
+ALTERAC_VALLEY | AV_131 | Knight-Captain |  
+ALTERAC_VALLEY | AV_132 | Troll Centurion |  
+ALTERAC_VALLEY | AV_133 | Icehoof Protector |  
+ALTERAC_VALLEY | AV_134 | Frostwolf Warmaster |  
+ALTERAC_VALLEY | AV_135 | Stormpike Marshal |  
+ALTERAC_VALLEY | AV_136 | Kobold Taskmaster |  
+ALTERAC_VALLEY | AV_137 | Irondeep Trogg |  
+ALTERAC_VALLEY | AV_138 | Grimtotem Bounty Hunter |  
+ALTERAC_VALLEY | AV_139 | Abominable Lieutenant |  
+ALTERAC_VALLEY | AV_141t | Lokholar the Ice Lord |  
+ALTERAC_VALLEY | AV_142t | Ivus, the Forest Lord |  
+ALTERAC_VALLEY | AV_143 | Korrak the Bloodrager |  
+ALTERAC_VALLEY | AV_145 | Captain Galvangar |  
+ALTERAC_VALLEY | AV_147 | Dun Baldar Bunker |  
+ALTERAC_VALLEY | AV_200 | Magister Dawngrasp |  
+ALTERAC_VALLEY | AV_201 | Coldtooth Yeti |  
+ALTERAC_VALLEY | AV_202 | Rokara, the Valorous |  
+ALTERAC_VALLEY | AV_203 | Shadowcrafter Scabbs |  
+ALTERAC_VALLEY | AV_204 | Kurtrus, Demon-Render |  
+ALTERAC_VALLEY | AV_205 | Wildheart Guff |  
+ALTERAC_VALLEY | AV_206 | Lightforged Cariel |  
+ALTERAC_VALLEY | AV_207 | Xyrella, the Devout |  
+ALTERAC_VALLEY | AV_209 | Dreadprison Glaive |  
+ALTERAC_VALLEY | AV_210 | Pathmaker |  
+ALTERAC_VALLEY | AV_211 | Dire Frostwolf |  
+ALTERAC_VALLEY | AV_212 | Siphon Mana |  
+ALTERAC_VALLEY | AV_213 | Vitality Surge |  
+ALTERAC_VALLEY | AV_215 | Frantic Hippogryph |  
+ALTERAC_VALLEY | AV_218 | Mass Polymorph |  
+ALTERAC_VALLEY | AV_219 | Ram Commander |  
+ALTERAC_VALLEY | AV_222 | Spammy Arcanist |  
 ALTERAC_VALLEY | AV_223 | Vanndar Stormpike |  
+ALTERAC_VALLEY | AV_224 | Spring the Trap |  
+ALTERAC_VALLEY | AV_226 | Ice Trap |  
+ALTERAC_VALLEY | AV_238 | Gankster |  
+ALTERAC_VALLEY | AV_244 | Bloodseeker |  
+ALTERAC_VALLEY | AV_250 | Snowball Fight! |  
+ALTERAC_VALLEY | AV_251 | Cheaty Snobold |  
+ALTERAC_VALLEY | AV_255 | Snowfall Guardian |  
+ALTERAC_VALLEY | AV_256 | Reflecto Engineer |  
+ALTERAC_VALLEY | AV_257 | Bearon Gla'shear |  
+ALTERAC_VALLEY | AV_258 | Bru'kan of the Elements |  
+ALTERAC_VALLEY | AV_259 | Frostbite |  
+ALTERAC_VALLEY | AV_260 | Sleetbreaker |  
+ALTERAC_VALLEY | AV_261 | Flag Runner |  
+ALTERAC_VALLEY | AV_262 | Warden of Chains |  
+ALTERAC_VALLEY | AV_264 | Sigil of Reckoning |  
+ALTERAC_VALLEY | AV_265 | Ur'zul Giant |  
+ALTERAC_VALLEY | AV_266 | Windchill |  
+ALTERAC_VALLEY | AV_267 | Caria Felsoul |  
+ALTERAC_VALLEY | AV_268 | Wildpaw Cavern |  
+ALTERAC_VALLEY | AV_269 | Flanking Maneuver |  
+ALTERAC_VALLEY | AV_277 | Seeds of Destruction |  
+ALTERAC_VALLEY | AV_281 | Felfire in the Hole! |  
+ALTERAC_VALLEY | AV_282 | Build a Snowman |  
+ALTERAC_VALLEY | AV_283 | Rune of the Archmage |  
+ALTERAC_VALLEY | AV_284 | Balinda Stonehearth |  
+ALTERAC_VALLEY | AV_285 | Full-Blown Evil |  
+ALTERAC_VALLEY | AV_286 | Felwalker |  
+ALTERAC_VALLEY | AV_290 | Iceblood Tower |  
+ALTERAC_VALLEY | AV_291 | Frostsaber Matriarch |  
+ALTERAC_VALLEY | AV_292 | Heart of the Wild |  
+ALTERAC_VALLEY | AV_293 | Wing Commander Mulverick |  
+ALTERAC_VALLEY | AV_294 | Clawfury Adept |  
+ALTERAC_VALLEY | AV_295 | Capture Coldtooth Mine |  
+ALTERAC_VALLEY | AV_296 | Pride Seeker |  
+ALTERAC_VALLEY | AV_298 | Wildpaw Gnoll |  
+ALTERAC_VALLEY | AV_308 | Grave Defiler |  
+ALTERAC_VALLEY | AV_309 | Piggyback Imp |  
+ALTERAC_VALLEY | AV_312 | Sacrificial Summoner |  
+ALTERAC_VALLEY | AV_313 | Hollow Abomination |  
+ALTERAC_VALLEY | AV_315 | Deliverance |  
+ALTERAC_VALLEY | AV_316 | Dreadlich Tamsin |  
+ALTERAC_VALLEY | AV_317 | Tamsin's Phylactery |  
+ALTERAC_VALLEY | AV_321 | Glory Chaser |  
+ALTERAC_VALLEY | AV_322 | Snowed In |  
+ALTERAC_VALLEY | AV_323 | Scrapsmith |  
+ALTERAC_VALLEY | AV_324 | Shadow Word: Devour |  
+ALTERAC_VALLEY | AV_325 | Undying Disciple |  
+ALTERAC_VALLEY | AV_326 | Luminous Geode |  
+ALTERAC_VALLEY | AV_328 | Spirit Guide |  
+ALTERAC_VALLEY | AV_329 | Bless |  
+ALTERAC_VALLEY | AV_330 | Gift of the Naaru |  
+ALTERAC_VALLEY | AV_331 | Najak Hexxen |  
+ALTERAC_VALLEY | AV_333 | Revive Pet |  
+ALTERAC_VALLEY | AV_334 | Stormpike Battle Ram |  
+ALTERAC_VALLEY | AV_335 | Ram Tamer |  
+ALTERAC_VALLEY | AV_336 | Wing Commander Ichman |  
+ALTERAC_VALLEY | AV_337 | Mountain Bear |  
+ALTERAC_VALLEY | AV_338 | Hold the Bridge |  
+ALTERAC_VALLEY | AV_339 | Templar Captain |  
+ALTERAC_VALLEY | AV_340 | Brasswing |  
+ALTERAC_VALLEY | AV_341 | Cavalry Horn |  
+ALTERAC_VALLEY | AV_342 | Protect the Innocent |  
+ALTERAC_VALLEY | AV_343 | Stonehearth Vindicator |  
+ALTERAC_VALLEY | AV_344 | Dun Baldar Bridge |  
+ALTERAC_VALLEY | AV_345 | Saidan the Scarlet |  
+ALTERAC_VALLEY | AV_360 | Frostwolf Kennels |  
+ALTERAC_VALLEY | AV_400 | Snowfall Graveyard |  
+ALTERAC_VALLEY | AV_401 | Stormpike Quartermaster |  
+ALTERAC_VALLEY | AV_402 | The Lobotomizer |  
+ALTERAC_VALLEY | AV_403 | Cera'thine Fleetrunner |  
+ALTERAC_VALLEY | AV_405 | Contraband Stash |  
+ALTERAC_VALLEY | AV_565 | Axe Berserker |  
+ALTERAC_VALLEY | AV_601 | Forsaken Lieutenant |  
+ALTERAC_VALLEY | AV_657 | Desecrated Graveyard |  
+ALTERAC_VALLEY | AV_660 | Iceblood Garrison |  
+ALTERAC_VALLEY | AV_661 | Field of Strife |  
+ALTERAC_VALLEY | AV_664 | Stormpike Aid Station |  
+ALTERAC_VALLEY | AV_704 | Humongous Owl |  
+ALTERAC_VALLEY | AV_710 | Reconnaissance |  
+ALTERAC_VALLEY | AV_711 | Double Agent |  
 
-- Progress: 0% (0 of 2 Cards)
+- Progress: 0% (1 of 135 Cards)

--- a/Includes/Rosetta/Common/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/TaskEnums.hpp
@@ -28,6 +28,7 @@ enum class PowerType
     OUTCAST,
     SPELLBURST,
     FRENZY,
+    HONORABLE_KILL,
     START_OF_COMBAT,
 };
 

--- a/Includes/Rosetta/PlayMode/Enchants/Power.hpp
+++ b/Includes/Rosetta/PlayMode/Enchants/Power.hpp
@@ -73,6 +73,10 @@ class Power
     //! \return A list of frenzy tasks.
     std::vector<std::shared_ptr<ITask>>& GetFrenzyTask();
 
+    //! Returns a list of honorable kill tasks.
+    //! \return A list of honorable kill tasks.
+    std::vector<std::shared_ptr<ITask>>& GetHonorableKillTask();
+
     //! Clears power task and enchant.
     void ClearData();
 

--- a/Includes/Rosetta/PlayMode/Enchants/Power.hpp
+++ b/Includes/Rosetta/PlayMode/Enchants/Power.hpp
@@ -136,6 +136,10 @@ class Power
     //! \param tasks A list of frenzy task.
     void AddFrenzyTask(TaskList tasks);
 
+    //! Adds honorable kill task.
+    //! \param task A pointer to honorable kill task.
+    void AddHonorableKillTask(std::shared_ptr<ITask> task);
+
  private:
     std::shared_ptr<IAura> m_aura;
     std::shared_ptr<Enchant> m_enchant;

--- a/Includes/Rosetta/PlayMode/Enchants/Power.hpp
+++ b/Includes/Rosetta/PlayMode/Enchants/Power.hpp
@@ -149,6 +149,7 @@ class Power
     std::vector<std::shared_ptr<ITask>> m_outcastTask;
     std::vector<std::shared_ptr<ITask>> m_spellburstTask;
     std::vector<std::shared_ptr<ITask>> m_frenzyTask;
+    std::vector<std::shared_ptr<ITask>> m_honorableKillTask;
 };
 }  // namespace RosettaStone::PlayMode
 

--- a/Includes/Rosetta/PlayMode/Models/Playable.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Playable.hpp
@@ -129,6 +129,10 @@ class Playable : public Entity
     //! \return The flag that indicates whether it has tradeable.
     bool HasTradeable() const;
 
+    //! Returns the flag that indicates whether it has honorable kill.
+    //! \return The flag that indicates whether it has honorable kill.
+    bool HasHonorableKill() const;
+
     //! Returns the flag that indicates it can activate 'Spellbrust'.
     //! \return The flag that indicates it can activate 'Spellbrust'.
     bool CanActivateSpellburst() const;

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
   * 80% Forged in the Barrens (136 of 170 cards)
   * 9% United in Stormwind (16 of 170 cards)
-  * 0% Fractured in Alterac Valley (0 of 2 cards)
+  * 0% Fractured in Alterac Valley (1 of 135 cards)
 
 ### Wild Format
 

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -4,6 +4,10 @@
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
 #include <Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.hpp>
+#include <Rosetta/PlayMode/Enchants/Enchants.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
+
+using namespace RosettaStone::PlayMode::SimpleTasks;
 
 namespace RosettaStone::PlayMode
 {
@@ -2190,6 +2194,8 @@ void AlteracValleyCardsGen::AddDemonHunterNonCollect(
 
 void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - NEUTRAL
     // [AV_100] Drek'Thar - COST:4 [ATK:4/HP:4]
     // - Set: ALTERAC_VALLEY, Rarity: Legendary
@@ -2246,6 +2252,10 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - HONORABLEKILL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddHonorableKillTask(
+        std::make_shared<AddEnchantmentTask>("AV_121e", EntityType::SOURCE));
+    cards.emplace("AV_121", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_122] Corporal - COST:2 [ATK:2/HP:3]
@@ -2606,12 +2616,17 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 void AlteracValleyCardsGen::AddNeutralNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [AV_121e] Gnome's Honor - COST:0
     // - Set: ALTERAC_VALLEY
     // --------------------------------------------------------
     // Text: +2 Attack.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("AV_121e"));
+    cards.emplace("AV_121e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [AV_123e] Scouted - COST:0

--- a/Sources/Rosetta/PlayMode/Enchants/Power.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/Power.cpp
@@ -79,6 +79,7 @@ void Power::ClearData()
     m_outcastTask.clear();
     m_spellburstTask.clear();
     m_frenzyTask.clear();
+    m_honorableKillTask.clear();
 }
 
 void Power::AddAura(std::shared_ptr<IAura> aura)

--- a/Sources/Rosetta/PlayMode/Enchants/Power.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/Power.cpp
@@ -156,4 +156,9 @@ void Power::AddFrenzyTask(TaskList tasks)
 {
     m_frenzyTask.insert(m_frenzyTask.end(), tasks.begin(), tasks.end());
 }
+
+void Power::AddHonorableKillTask(std::shared_ptr<ITask> task)
+{
+    m_honorableKillTask.emplace_back(task);
+}
 }  // namespace RosettaStone::PlayMode

--- a/Sources/Rosetta/PlayMode/Enchants/Power.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/Power.cpp
@@ -65,6 +65,11 @@ std::vector<std::shared_ptr<ITask>>& Power::GetFrenzyTask()
     return m_frenzyTask;
 }
 
+std::vector<std::shared_ptr<ITask>>& Power::GetHonorableKillTask()
+{
+    return m_honorableKillTask;
+}
+
 void Power::ClearData()
 {
     m_aura.reset();

--- a/Sources/Rosetta/PlayMode/Models/Playable.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Playable.cpp
@@ -174,6 +174,11 @@ bool Playable::HasTradeable() const
     return GetGameTag(GameTag::TRADEABLE) == 1;
 }
 
+bool Playable::HasHonorableKill() const
+{
+    return GetGameTag(GameTag::HONORABLEKILL) == 1;
+}
+
 bool Playable::CanActivateSpellburst() const
 {
     if (!HasSpellburst())

--- a/Sources/Rosetta/PlayMode/Models/Playable.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Playable.cpp
@@ -626,6 +626,9 @@ void Playable::ActivateTask(PowerType type, Character* target, int chooseOne,
         case PowerType::FRENZY:
             tasks = card->power.GetFrenzyTask();
             break;
+        case PowerType::HONORABLE_KILL:
+            tasks = card->power.GetHonorableKillTask();
+            break;
         default:
             throw std::invalid_argument(
                 "Playable::ActivateTask() - Invalid power type");

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -4,9 +4,101 @@
 // personal capacity and are not conveying any rights to any intellectual
 // property of any third parties.
 
-#include <Utils/CardSetUtils.hpp>
+#include "doctest_proxy.hpp"
 
-TEST_CASE("[AlteracValleyCardsGen] - Temp")
+#include <Utils/CardSetUtils.hpp>
+#include <Utils/TestUtils.hpp>
+
+#include <Rosetta/PlayMode/Actions/Draw.hpp>
+#include <Rosetta/PlayMode/Cards/Cards.hpp>
+#include <Rosetta/PlayMode/Zones/FieldZone.hpp>
+
+using namespace RosettaStone;
+using namespace PlayMode;
+using namespace PlayerTasks;
+using namespace SimpleTasks;
+
+// --------------------------------------- MINION - NEUTRAL
+// [AV_121] Gnome Private - COST:1 [ATK:1/HP:3]
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Honorable Kill:</b> Gain +2 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - HONORABLEKILL = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - AV_121 : Gnome Private")
 {
-    CHECK(true);
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Gnome Private"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Gnome Private"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(card1, card3));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(card1, card2));
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+
+    game.Process(curPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(card1, card4));
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
 }


### PR DESCRIPTION
This revision includes:
- Implement keyword 'Honorable Kill' (Resolves #686)
  - Add methods
    - AddHonorableKillTask(): Adds honorable kill task
    - GetHonorableKillTask(): Returns a list of honorable kill tasks
    - HasHonorableKill(): Returns the flag that indicates whether it has honorable kill
    - Add code to clear a list of honorable kill tasks
  - Add enum value 'PowerType::HONORABLE_KILL'
    - Add code to process 'PowerType::HONORABLE_KILL'
- Implement 1 ALTERAC_VALLEY card
  - Gnome Private (AV_121)