### PR TITLE
Implement 8 STORMWIND cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -914,7 +914,7 @@ STORMWIND | DED_509 | Brilliant Macaw |
 STORMWIND | DED_510 | Edwin, Defias Kingpin |  
 STORMWIND | DED_511 | Suckerhook |  
 STORMWIND | DED_512 | Amulet of Undying |  
-STORMWIND | DED_513 | Defias Leper |  
+STORMWIND | DED_513 | Defias Leper | O
 STORMWIND | DED_514 | Copycat |  
 STORMWIND | DED_515 | Grey Sage Parrot |  
 STORMWIND | DED_516 | Deepwater Evoker |  
@@ -922,7 +922,7 @@ STORMWIND | DED_517 | Arcane Overflow |
 STORMWIND | DED_518 | Man the Cannons | O
 STORMWIND | DED_519 | Defias Cannoneer |  
 STORMWIND | DED_521 | Maddest Bomber |  
-STORMWIND | DED_522 | Cookie the Cook |  
+STORMWIND | DED_522 | Cookie the Cook | O
 STORMWIND | DED_523 | Golakka Glutton |  
 STORMWIND | DED_524 | Multicaster |  
 STORMWIND | DED_525 | Goliath, Sneed's Masterpiece |  
@@ -998,7 +998,7 @@ STORMWIND | SW_091 | The Demon Seed |
 STORMWIND | SW_092 | Anetheron |  
 STORMWIND | SW_093 | Stormwind Freebooter | O
 STORMWIND | SW_094 | Heavy Plate | O
-STORMWIND | SW_095 | Investment Opportunity |  
+STORMWIND | SW_095 | Investment Opportunity | O
 STORMWIND | SW_097 | Remote-Controlled Golem |  
 STORMWIND | SW_107 | Fire Sale | O
 STORMWIND | SW_108 | First Flame | O
@@ -1013,7 +1013,7 @@ STORMWIND | SW_305 | First Blade of Wrynn |
 STORMWIND | SW_306 | Encumbered Pack Mule |  
 STORMWIND | SW_307 | Traveling Merchant |  
 STORMWIND | SW_310 | Counterfeit Blade |  
-STORMWIND | SW_311 | Garrote |  
+STORMWIND | SW_311 | Garrote | O
 STORMWIND | SW_313 | Rise to the Occasion |  
 STORMWIND | SW_314 | Lightbringer's Hammer |  
 STORMWIND | SW_315 | Alliance Bannerman |  
@@ -1027,8 +1027,8 @@ STORMWIND | SW_323 | The Rat King |
 STORMWIND | SW_400 | Entrapped Sorceress |  
 STORMWIND | SW_405 | Sketchy Information |  
 STORMWIND | SW_411 | SI:7 Informant |  
-STORMWIND | SW_412 | SI:7 Extortion |  
-STORMWIND | SW_413 | SI:7 Operative |  
+STORMWIND | SW_412 | SI:7 Extortion | O
+STORMWIND | SW_413 | SI:7 Operative | O
 STORMWIND | SW_417 | SI:7 Assassin |  
 STORMWIND | SW_418 | SI:7 Skulker |  
 STORMWIND | SW_419 | Oracle of Elune | O
@@ -1038,7 +1038,7 @@ STORMWIND | SW_429 | Best in Shell | O
 STORMWIND | SW_431 | Park Panther | O
 STORMWIND | SW_432 | Kodo Mount | O
 STORMWIND | SW_433 | Seek Guidance |  
-STORMWIND | SW_434 | Loan Shark |  
+STORMWIND | SW_434 | Loan Shark | O
 STORMWIND | SW_436 | Wickerclaw | O
 STORMWIND | SW_437 | Composting | O
 STORMWIND | SW_439 | Vibrant Squirrel | O
@@ -1047,7 +1047,7 @@ STORMWIND | SW_441 | Shard of the Naaru | O
 STORMWIND | SW_442 | Void Shard | O
 STORMWIND | SW_443 | Elekk Mount | O
 STORMWIND | SW_444 | Twilight Deceptor |  
-STORMWIND | SW_445 | Psyfiend |  
+STORMWIND | SW_445 | Psyfiend | O
 STORMWIND | SW_446 | Voidtouched Attendant |  
 STORMWIND | SW_447 | Sheldras Moontree |  
 STORMWIND | SW_448 | Darkbishop Benedictus |  
@@ -1063,7 +1063,7 @@ STORMWIND | SW_460 | Devouring Swarm |
 STORMWIND | SW_462 | Hot Streak |  
 STORMWIND | SW_463 | Imported Tarantula |  
 
-- Progress: 18% (32 of 170 Cards)
+- Progress: 23% (40 of 170 Cards)
 
 ## Fractured in Alterac Valley
 

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -229,6 +229,10 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsHolySpell();
 
+    //! SelfCondition wrapper for checking the entity is shadow spell.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsShadowSpell();
+
     //! SelfCondition wrapper for checking the entity is weapon.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsWeapon();

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
   * 80% Forged in the Barrens (136 of 170 cards)
-  * 18% United in Stormwind (32 of 170 cards)
+  * 23% United in Stormwind (40 of 170 cards)
   * 1% Fractured in Alterac Valley (2 of 135 cards)
 
 ### Wild Format

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -1560,6 +1560,18 @@ void StormwindCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_DRAG_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE,
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsHoldingSpell(SpellSchool::SHADOW)) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 2) }));
+    cards.emplace("DED_513",
+                  CardDef(power, PlayReqs{ { PlayReq::REQ_DRAG_TO_PLAY, 0 } }));
 
     // ---------------------------------------- MINION - PRIEST
     // [DED_514] Copycat - COST:3 [ATK:3/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -1980,8 +1980,10 @@ void StormwindCardsGen::AddRogueNonCollect(
     // - TOPDECK = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddTopdeckTask(std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 2, true));
-    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 2, true));
+    power.AddTopdeckTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 2, true));
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 2, true));
     cards.emplace("SW_311t", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - ROGUE
@@ -2195,11 +2197,16 @@ void StormwindCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // - DEATHRATTLE = 1
     // - LIFESTEAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(std::make_shared<WeaponTask>("DED_522t"));
+    cards.emplace("DED_522", CardDef(power));
 }
 
 void StormwindCardsGen::AddShamanNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [SW_025e] Sold! - COST:0
     // - Set: STORMWIND
@@ -2285,6 +2292,9 @@ void StormwindCardsGen::AddShamanNonCollect(
     // - ELITE = 1
     // - LIFESTEAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("DED_522t", CardDef(power));
 }
 
 void StormwindCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -1817,6 +1817,12 @@ void StormwindCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::ENEMY_HAND, "GAME_005", 1));
+    power.AddDeathrattleTask(
+        std::make_shared<AddCardTask>(EntityType::HAND, "GAME_005", 2));
+    cards.emplace("SW_434", CardDef(power));
 
     // ----------------------------------------- WEAPON - ROGUE
     // [DED_004] Blackwater Cutlass - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -1674,6 +1674,8 @@ void StormwindCardsGen::AddPriestNonCollect(
 
 void StormwindCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- MINION - ROGUE
     // [SW_050] Maestra of the Masquerade - COST:2 [ATK:3/HP:2]
     // - Set: STORMWIND, Rarity: Legendary
@@ -1718,6 +1720,12 @@ void StormwindCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     //       Shuffle 2 Bleeds into your deck that
     //       deal 2 more when drawn.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 2, true));
+    power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::DECK, "SW_311t", 2));
+    cards.emplace("SW_311", CardDef(power));
 
     // ------------------------------------------ SPELL - ROGUE
     // [SW_405] Sketchy Information - COST:3
@@ -1826,6 +1834,8 @@ void StormwindCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 void StormwindCardsGen::AddRogueNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------ SPELL - ROGUE
     // [SW_052t] Learn the Truth - COST:1
     // - Set: STORMWIND, Rarity: Legendary
@@ -1943,6 +1953,10 @@ void StormwindCardsGen::AddRogueNonCollect(
     // GameTag:
     // - TOPDECK = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTopdeckTask(std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 2, true));
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 2, true));
+    cards.emplace("SW_311t", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - ROGUE
     // [SW_411e] Well Informed - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -1785,6 +1785,15 @@ void StormwindCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - STEALTH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsEventTargetIs(CardType::MINION)) };
+    power.GetTrigger()->tasks = { std::make_shared<SetGameTagTask>(
+        EntityType::SOURCE, GameTag::STEALTH, 1) };
+    cards.emplace("SW_413", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
     // [SW_417] SI:7 Assassin - COST:7 [ATK:4/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -1499,6 +1499,16 @@ void StormwindCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_CAST));
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsShadowSpell())
+    };
+    power.GetTrigger()->tasks = {
+        std::make_shared<DamageTask>(EntityType::HERO, 2),
+        std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 2)
+    };
+    cards.emplace("SW_445", CardDef(power));
 
     // ---------------------------------------- MINION - PRIEST
     // [SW_446] Voidtouched Attendant - COST:1 [ATK:1/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -1759,6 +1759,17 @@ void StormwindCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRADEABLE = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_UNDAMAGED_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
+    cards.emplace(
+        "SW_412",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_UNDAMAGED_TARGET, 0 } }));
 
     // ----------------------------------------- MINION - ROGUE
     // [SW_413] SI:7 Operative - COST:3 [ATK:2/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -2123,6 +2123,11 @@ void StormwindCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - OVERLOAD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(ComplexTask::DrawCardFromDeck(
+        1, SelfCondList{ std::make_shared<SelfCondition>(
+               SelfCondition::IsOverloadCard()) }));
+    cards.emplace("SW_095", CardDef(power));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [SW_114] Overdraft - COST:1

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -455,6 +455,19 @@ SelfCondition SelfCondition::IsHolySpell()
     });
 }
 
+SelfCondition SelfCondition::IsShadowSpell()
+{
+    return SelfCondition([](Playable* playable) {
+        auto spell = dynamic_cast<Spell*>(playable);
+        if (!spell)
+        {
+            return false;
+        }
+
+        return spell->GetSpellSchool() == SpellSchool::SHADOW;
+    });
+}
+
 SelfCondition SelfCondition::IsWeapon()
 {
     return SelfCondition([](Playable* playable) {

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -1315,6 +1315,54 @@ TEST_CASE("[Rogue : Spell] - SW_311 : Garrote")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 7);
 }
 
+// ------------------------------------------ SPELL - ROGUE
+// [SW_412] SI:7 Extortion - COST:1
+// - Set: STORMWIND, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Tradeable</b>
+//       Deal 3 damage to an undamaged character.
+// --------------------------------------------------------
+// GameTag:
+// - TRADEABLE = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_UNDAMAGED_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Spell] - SW_412 : SI:7 Extortion")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("SI:7 Extortion"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("SI:7 Extortion"));
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card1, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
+}
+
 // ---------------------------------------- MINION - SHAMAN
 // [SW_033] Canal Slogger - COST:4 [ATK:6/HP:4]
 // - Race: Elemental, Set: STORMWIND, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -1363,6 +1363,62 @@ TEST_CASE("[Rogue : Spell] - SW_412 : SI:7 Extortion")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
 }
 
+// ----------------------------------------- MINION - ROGUE
+// [SW_413] SI:7 Operative - COST:3 [ATK:2/HP:4]
+// - Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Rush</b>
+//       After this attacks a minion, gain <b>Stealth</b>.
+// --------------------------------------------------------
+// GameTag:
+// - RUSH = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+// RefTag:
+// - STEALTH = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - SW_413 : SI:7 Operative")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("SI:7 Operative"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasStealth(), false);
+
+    game.Process(curPlayer, AttackTask(card1, card2));
+    CHECK_EQ(curField[0]->HasStealth(), true);
+}
+
 // ---------------------------------------- MINION - SHAMAN
 // [SW_033] Canal Slogger - COST:4 [ATK:6/HP:4]
 // - Race: Elemental, Set: STORMWIND, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -1534,6 +1534,56 @@ TEST_CASE("[Shaman : Spell] - SW_095 : Investment Opportunity")
     CHECK_EQ(curHand[4]->HasOverload(), true);
 }
 
+// ---------------------------------------- MINION - SHAMAN
+// [DED_522] Cookie the Cook - COST:3 [ATK:2/HP:3]
+// - Race: Murloc, Set: STORMWIND, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Lifesteal</b>
+//       <b>Deathrattle:</b> Equip a 2/3 Stirring Rod
+//       with <b>Lifesteal</b>.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - DEATHRATTLE = 1
+// - LIFESTEAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Minion] - DED_522 : Cookie the Cook")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Cookie the Cook"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curPlayer->GetHero()->HasWeapon(), true);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetAttack(), 2);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 3);
+    CHECK_EQ(curPlayer->GetHero()->weapon->HasLifesteal(), true);
+}
+
 // --------------------------------------- MINION - WARRIOR
 // [SW_021] Cowardly Grunt - COST:6 [ATK:6/HP:2]
 // - Set: STORMWIND, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -1419,6 +1419,58 @@ TEST_CASE("[Rogue : Minion] - SW_413 : SI:7 Operative")
     CHECK_EQ(curField[0]->HasStealth(), true);
 }
 
+// ----------------------------------------- MINION - ROGUE
+// [SW_434] Loan Shark - COST:3 [ATK:3/HP:4]
+// - Race: Beast, Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give your opponent a Coin.
+//       <b>Deathrattle:</b> You get two.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - SW_434 : Loan Shark")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& opHand = *(opPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Loan Shark"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(opHand.GetCount(), 3);
+    CHECK_EQ(opHand[2]->card->name, "The Coin");
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curHand.GetCount(), 2);
+    CHECK_EQ(curHand[0]->card->name, "The Coin");
+    CHECK_EQ(curHand[1]->card->name, "The Coin");
+}
+
 // ---------------------------------------- MINION - SHAMAN
 // [SW_033] Canal Slogger - COST:4 [ATK:6/HP:4]
 // - Race: Elemental, Set: STORMWIND, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -1210,6 +1210,56 @@ TEST_CASE("[Priest : Minion] - SW_445 : Psyfiend")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
 }
 
+// ---------------------------------------- MINION - PRIEST
+// [DED_513] Defias Leper - COST:2 [ATK:3/HP:2]
+// - Race: Pirate, Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you're holding a Shadow spell,
+//       deal 2 damage.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_DRAG_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - SW_445 : Psyfiend")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Defias Leper"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Defias Leper"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mortal Coil"));
+
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card1, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card1));
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+}
+
 // ---------------------------------------- MINION - SHAMAN
 // [SW_033] Canal Slogger - COST:4 [ATK:6/HP:4]
 // - Race: Elemental, Set: STORMWIND, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -1488,6 +1488,52 @@ TEST_CASE("[Shaman : Minion] - SW_033 : Canal Slogger")
     // Do nothing
 }
 
+// ----------------------------------------- SPELL - SHAMAN
+// [SW_095] Investment Opportunity - COST:1
+// - Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: Draw an <b>Overload</b> card.
+// --------------------------------------------------------
+// RefTag:
+// - OVERLOAD = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - SW_095 : Investment Opportunity")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Feral Spirit");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Malygos");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Wisp");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Investment Opportunity"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->HasOverload(), true);
+}
+
 // --------------------------------------- MINION - WARRIOR
 // [SW_021] Cowardly Grunt - COST:6 [ATK:6/HP:2]
 // - Set: STORMWIND, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -1169,6 +1169,47 @@ TEST_CASE("[Priest : Spell] - SW_443 : Elekk Mount")
     CHECK_EQ(curField[0]->HasTaunt(), true);
 }
 
+// ---------------------------------------- MINION - PRIEST
+// [SW_445] Psyfiend - COST:3 [ATK:3/HP:4]
+// - Set: STORMWIND, Rarity: Rare
+// --------------------------------------------------------
+// Text: After you cast a Shadow spell,
+//       deal 2 damage to each Hero.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - SW_445 : Psyfiend")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Psyfiend"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mortal Coil"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 28);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+}
+
 // ---------------------------------------- MINION - SHAMAN
 // [SW_033] Canal Slogger - COST:4 [ATK:6/HP:4]
 // - Race: Elemental, Set: STORMWIND, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -1123,7 +1123,7 @@ TEST_CASE("[Priest : Spell] - SW_442 : Void Shard")
 TEST_CASE("[Priest : Spell] - SW_443 : Elekk Mount")
 {
     GameConfig config;
-    config.player1Class = CardClass::PALADIN;
+    config.player1Class = CardClass::PRIEST;
     config.player2Class = CardClass::MAGE;
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = true;
@@ -1182,7 +1182,7 @@ TEST_CASE("[Priest : Spell] - SW_443 : Elekk Mount")
 TEST_CASE("[Priest : Minion] - SW_445 : Psyfiend")
 {
     GameConfig config;
-    config.player1Class = CardClass::PALADIN;
+    config.player1Class = CardClass::PRIEST;
     config.player2Class = CardClass::MAGE;
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = true;
@@ -1226,7 +1226,7 @@ TEST_CASE("[Priest : Minion] - SW_445 : Psyfiend")
 TEST_CASE("[Priest : Minion] - SW_445 : Psyfiend")
 {
     GameConfig config;
-    config.player1Class = CardClass::PALADIN;
+    config.player1Class = CardClass::PRIEST;
     config.player2Class = CardClass::MAGE;
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = true;
@@ -1258,6 +1258,61 @@ TEST_CASE("[Priest : Minion] - SW_445 : Psyfiend")
     game.Process(curPlayer,
                  PlayCardTask::MinionTarget(card2, opPlayer->GetHero()));
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+}
+
+// ------------------------------------------ SPELL - ROGUE
+// [SW_311] Garrote - COST:2
+// - Set: STORMWIND, Rarity: Epic
+// --------------------------------------------------------
+// Text: Deal 2 damage to the enemy hero.
+//       Shuffle 2 Bleeds into your deck that
+//       deal 2 more when drawn.
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Spell] - SW_311 : Garrote")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curDeck = *(curPlayer->GetDeckZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Garrote"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Bloodmage Thalnos"));
+
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 18);
+    CHECK_EQ(curDeck.GetCount(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 13);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curDeck.GetCount(), 0);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 7);
 }
 
 // ---------------------------------------- MINION - SHAMAN


### PR DESCRIPTION
This revision includes:
- Implement 8 STORMWIND cards
  - Investment Opportunity (SW_095)
  - Garrote (SW_311)
  - SI:7 Extortion (SW_412)
  - SI:7 Operative (SW_413)
  - Loan Shark (SW_434)
  - Psyfiend (SW_445)
  - Defias Leper (DED_513)
  - Cookie the Cook (DED_522)
- Add method 'IsShadowSpell()'
  - SelfCondition wrapper for checking the entity is shadow spell