### PR TITLE
Implement 10 STORMWIND cards and fix incorrect logic of some cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -920,7 +920,7 @@ STORMWIND | DED_515 | Grey Sage Parrot |
 STORMWIND | DED_516 | Deepwater Evoker |  
 STORMWIND | DED_517 | Arcane Overflow |  
 STORMWIND | DED_518 | Man the Cannons | O
-STORMWIND | DED_519 | Defias Cannoneer |  
+STORMWIND | DED_519 | Defias Cannoneer | O
 STORMWIND | DED_521 | Maddest Bomber |  
 STORMWIND | DED_522 | Cookie the Cook | O
 STORMWIND | DED_523 | Golakka Glutton |  
@@ -929,14 +929,14 @@ STORMWIND | DED_525 | Goliath, Sneed's Masterpiece |
 STORMWIND | DED_527 | Blacksmithing Hammer |  
 STORMWIND | SW_001 | Celestial Ink Set |  
 STORMWIND | SW_003 | Runed Mithril Rod |  
-STORMWIND | SW_006 | Stubborn Suspect |  
+STORMWIND | SW_006 | Stubborn Suspect | O
 STORMWIND | SW_012 | Shadowcloth Needle |  
 STORMWIND | SW_021 | Cowardly Grunt | O
 STORMWIND | SW_023 | Provoke |  
 STORMWIND | SW_024 | Lothar |  
 STORMWIND | SW_025 | Auctionhouse Gavel |  
 STORMWIND | SW_026 | Spirit Alpha |  
-STORMWIND | SW_027 | Shiver Their Timbers! |  
+STORMWIND | SW_027 | Shiver Their Timbers! | O
 STORMWIND | SW_028 | Raid the Docks |  
 STORMWIND | SW_029 | Harbor Scamp | O
 STORMWIND | SW_030 | Cargo Guard | O
@@ -951,7 +951,7 @@ STORMWIND | SW_039 | Final Showdown |
 STORMWIND | SW_040 | Fel Barrage |  
 STORMWIND | SW_041 | Sigil of Alacrity |  
 STORMWIND | SW_042 | Persistent Peddler |  
-STORMWIND | SW_043 | Felgorger |  
+STORMWIND | SW_043 | Felgorger | O
 STORMWIND | SW_044 | Jace Darkweaver |  
 STORMWIND | SW_045 | Auctioneer Jaxon |  
 STORMWIND | SW_046 | City Tax | O
@@ -960,7 +960,7 @@ STORMWIND | SW_048 | Prismatic Jewel Kit |
 STORMWIND | SW_049 | Blessed Goods |  
 STORMWIND | SW_050 | Maestra of the Masquerade |  
 STORMWIND | SW_052 | Find the Imposter |  
-STORMWIND | SW_054 | Stormwind Guard |  
+STORMWIND | SW_054 | Stormwind Guard | O
 STORMWIND | SW_055 | Impatient Shopkeep | O
 STORMWIND | SW_056 | Spice Bread Baker |  
 STORMWIND | SW_057 | Package Runner |  
@@ -971,12 +971,12 @@ STORMWIND | SW_062 | Goldshire Gnoll |
 STORMWIND | SW_063 | Battleground Battlemaster |  
 STORMWIND | SW_064 | Northshire Farmer |  
 STORMWIND | SW_065 | Pandaren Importer |  
-STORMWIND | SW_066 | Royal Librarian |  
+STORMWIND | SW_066 | Royal Librarian | O
 STORMWIND | SW_067 | Stockades Guard | O
 STORMWIND | SW_068 | Mo'arg Forgefiend | O
 STORMWIND | SW_069 | Enthusiastic Banker |  
-STORMWIND | SW_070 | Mailbox Dancer |  
-STORMWIND | SW_071 | Lion's Guard |  
+STORMWIND | SW_070 | Mailbox Dancer | O
+STORMWIND | SW_071 | Lion's Guard | O
 STORMWIND | SW_072 | Rustrot Viper | O
 STORMWIND | SW_073 | Cheesemonger |  
 STORMWIND | SW_074 | Nobleman |  
@@ -1052,8 +1052,8 @@ STORMWIND | SW_446 | Voidtouched Attendant |
 STORMWIND | SW_447 | Sheldras Moontree |  
 STORMWIND | SW_448 | Darkbishop Benedictus |  
 STORMWIND | SW_450 | Sorcerer's Gambit |  
-STORMWIND | SW_451 | Metamorfin |  
-STORMWIND | SW_452 | Chaos Leech |  
+STORMWIND | SW_451 | Metamorfin | O
+STORMWIND | SW_452 | Chaos Leech | O
 STORMWIND | SW_454 | Lion's Frenzy |  
 STORMWIND | SW_455 | Rodent Nest | O
 STORMWIND | SW_457 | Leatherworking Kit |  
@@ -1063,7 +1063,7 @@ STORMWIND | SW_460 | Devouring Swarm |
 STORMWIND | SW_462 | Hot Streak |  
 STORMWIND | SW_463 | Imported Tarantula |  
 
-- Progress: 23% (40 of 170 Cards)
+- Progress: 29% (50 of 170 Cards)
 
 ## Fractured in Alterac Valley
 

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -520,6 +520,11 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition Cast5MoreCostSpellInThisTurn();
 
+    //! SelfCondition wrapper for checking the player casts a Fel spell
+    //! this turn.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition CastFelSpellInThisTurn();
+
     //! SelfCondition wrapper for checking the player controls this card.
     //! \param num The number of card to control.
     //! \return Generated SelfCondition for intended purpose.

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -233,6 +233,10 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsShadowSpell();
 
+    //! SelfCondition wrapper for checking the entity is fel spell.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsFelSpell();
+
     //! SelfCondition wrapper for checking the entity is weapon.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsWeapon();

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
   * 80% Forged in the Barrens (136 of 170 cards)
-  * 23% United in Stormwind (40 of 170 cards)
+  * 29% United in Stormwind (50 of 170 cards)
   * 1% Fractured in Alterac Valley (2 of 135 cards)
 
 ### Wild Format

--- a/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
@@ -2932,12 +2932,13 @@ void DragonsCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
         EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
                                 SelfCondition::IsHoldingRace(Race::DRAGON)) }));
     power.AddPowerTask(std::make_shared<FlagTask>(
-        true, TaskList{ std::make_shared<SetGameTagTask>(EntityType::SOURCE,
-                                                         GameTag::LIFESTEAL, 1),
-                        std::make_shared<DamageTask>(EntityType::TARGET, 4) }));
+        true,
+        TaskList{ std::make_shared<SetGameTagTask>(EntityType::SOURCE,
+                                                   GameTag::LIFESTEAL, 1),
+                  std::make_shared<DamageTask>(EntityType::TARGET, 4, true) }));
     power.AddPowerTask(std::make_shared<FlagTask>(
         false,
-        TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 2) }));
+        TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 2, true) }));
     cards.emplace(
         "DRG_205",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));

--- a/Sources/Rosetta/PlayMode/CardSets/LegacyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LegacyCardsGen.cpp
@@ -571,7 +571,14 @@ void LegacyCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // Text: Gain an empty Mana Crystal.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<ManaCrystalTask>(1, false));
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsManaCrystalFull()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<AddCardTask>(EntityType::HAND,
+                                                      "CS2_013t", 1) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        false, TaskList{ std::make_shared<ManaCrystalTask>(1, false) }));
     cards.emplace("CS2_013", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID

--- a/Sources/Rosetta/PlayMode/CardSets/LegacyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LegacyCardsGen.cpp
@@ -656,6 +656,17 @@ void LegacyCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     power.AddEnchant(Enchants::GetEnchantFromText("CS2_011o"));
     cards.emplace("CS2_011o", CardDef(power));
 
+    // ------------------------------------------ SPELL - DRUID
+    // [CS2_013t] Excess Mana (*) - COST:0
+    // - Set: Legacy
+    // --------------------------------------------------------
+    // Text: Draw a card.
+    //       <i>(You can only have 10 Mana in your tray.)</i>
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cards.emplace("CS2_013t", CardDef(power));
+
     // ------------------------------------ ENCHANTMENT - DRUID
     // [CS2_017o] Claws (*) - COST:0
     // - Set: Legacy

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -2837,6 +2837,15 @@ void StormwindCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::DECK));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsFelSpell()) }));
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddPowerTask(std::make_shared<DrawStackTask>(true));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("SW_043e", EntityType::STACK));
+    cards.emplace("SW_043", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [SW_044] Jace Darkweaver - COST:8 [ATK:7/HP:5]
@@ -3620,6 +3629,9 @@ void StormwindCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: Costs (2) less.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(std::make_unique<Enchant>(Effects::ReduceCost(2)));
+    cards.emplace("SW_043e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [SW_047e] Highlord's Blessing - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -3086,6 +3086,12 @@ void StormwindCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<IncludeAdjacentTask>(EntityType::SOURCE));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("SW_054e", EntityType::STACK));
+    cards.emplace("SW_054", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SW_055] Impatient Shopkeep - COST:3 [ATK:3/HP:3]
@@ -3666,6 +3672,9 @@ void StormwindCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("SW_054e"));
+    cards.emplace("SW_054e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [SW_060t] Pretty Flowers - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -2773,6 +2773,8 @@ void StormwindCardsGen::AddWarriorNonCollect(
 
 void StormwindCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------- MINION - DEMONHUNTER
     // [SW_037] Irebound Brute - COST:8 [ATK:6/HP:7]
     // - Race: Demon, Set: STORMWIND, Rarity: Common
@@ -2869,10 +2871,29 @@ void StormwindCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // Text: <b>Lifesteal</b>. Deal 3 damage to a minion.
     //       <b>Outcast:</b> Deal 5 instead.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
     // GameTag:
     // - LIFESTEAL = 1
     // - OUTCAST = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE,
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsLeftOrRightMostCardInHand()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true,
+        TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 5, true) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        false,
+        TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 3, true) }));
+    cards.emplace(
+        "SW_452",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ----------------------------------- WEAPON - DEMONHUNTER
     // [SW_454] Lion's Frenzy - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -3322,6 +3322,14 @@ void StormwindCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::HERO, SelfCondList{ std::make_shared<SelfCondition>(
+                              SelfCondition::IsHealth(15, RelaSign::LEQ)) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<AddEnchantmentTask>(
+                  "SW_071e", EntityType::SOURCE) }));
+    cards.emplace("SW_071", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SW_072] Rustrot Viper - COST:3 [ATK:3/HP:4]
@@ -3726,6 +3734,9 @@ void StormwindCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +2/+4 and <b>Taunt</b>
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("SW_071e"));
+    cards.emplace("SW_071e", CardDef(power));
 
     // --------------------------------------- WEAPON - NEUTRAL
     // [SW_075t] Sword of a Thousand Truths - COST:10

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -2560,14 +2560,15 @@ void StormwindCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
         EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
                                 SelfCondition::IsHoldingRace(Race::PIRATE)) }));
     power.AddPowerTask(std::make_shared<FlagTask>(
-        true, TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 5, true) }));
+        true,
+        TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 5, true) }));
     power.AddPowerTask(std::make_shared<FlagTask>(
         false,
         TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 2, true) }));
     cards.emplace(
         "SW_027",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
-                                 { PlayReq::REQ_MINION_TARGET, 0 }}));
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [SW_028] Raid the Docks - COST:1
@@ -2679,6 +2680,14 @@ void StormwindCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->tasks = { std::make_shared<EnqueueTask>(
+        TaskList{ std::make_shared<RandomTask>(EntityType::ENEMIES, 1),
+                  std::make_shared<DamageTask>(EntityType::STACK, 2) },
+        2, false) };
+    cards.emplace("DED_519", CardDef(power));
 
     // --------------------------------------- WEAPON - WARRIOR
     // [DED_527] Blacksmithing Hammer - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -12,6 +12,7 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 
 namespace RosettaStone::PlayMode
 {
+using TagValues = std::vector<TagValue>;
 using PlayReqs = std::map<PlayReq, int>;
 using ChooseCardIDs = std::vector<std::string>;
 using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
@@ -3040,6 +3041,11 @@ void StormwindCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(std::make_shared<RandomMinionTask>(
+        TagValues{ { GameTag::COST, 3, RelaSign::EQ } }));
+    power.AddDeathrattleTask(std::make_shared<SummonStackTask>());
+    cards.emplace("SW_006", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SW_036] Two-Faced Investor - COST:3 [ATK:2/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -3220,6 +3220,10 @@ void StormwindCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // Text: <b>Tradeable</b>
     //       <b>Battlecry:</b> <b>Silence</b> a minion.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
     // - TRADEABLE = 1
@@ -3227,6 +3231,12 @@ void StormwindCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SILENCE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SilenceTask>(EntityType::TARGET));
+    cards.emplace(
+        "SW_066",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SW_067] Stockades Guard - COST:1 [ATK:1/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -2862,6 +2862,14 @@ void StormwindCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::CastFelSpellInThisTurn()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<AddEnchantmentTask>(
+                  "SW_451e", EntityType::SOURCE) }));
+    cards.emplace("SW_451", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [SW_452] Chaos Leech - COST:3
@@ -2937,6 +2945,8 @@ void StormwindCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
 void StormwindCardsGen::AddDemonHunterNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [SW_037e] Prepped to Strike - COST:0
     // - Set: STORMWIND
@@ -3003,6 +3013,9 @@ void StormwindCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("SW_451e"));
+    cards.emplace("SW_451e", CardDef(power));
 }
 
 void StormwindCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -3302,6 +3302,12 @@ void StormwindCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::HAND, "GAME_005", 1));
+    power.AddDeathrattleTask(
+        std::make_shared<AddCardTask>(EntityType::ENEMY_HAND, "GAME_005", 1));
+    cards.emplace("SW_070", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SW_071] Lion's Guard - COST:5 [ATK:4/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -2551,6 +2551,23 @@ void StormwindCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // Text: Deal 2 damage to a minion.
     //       If you control a Pirate, deal 5 instead.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsHoldingRace(Race::PIRATE)) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 5, true) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        false,
+        TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 2, true) }));
+    cards.emplace(
+        "SW_027",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 }}));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [SW_028] Raid the Docks - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -20,6 +20,7 @@ namespace RosettaStone::PlayMode
 using PlayReqs = std::map<PlayReq, int>;
 using ChooseCardIDs = std::vector<std::string>;
 using Entourages = std::vector<std::string>;
+using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
 
 void VanillaCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
@@ -474,7 +475,14 @@ void VanillaCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // Text: Gain an empty Mana Crystal.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<ManaCrystalTask>(1, false));
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsManaCrystalFull()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<AddCardTask>(EntityType::HAND,
+                                                      "CS2_013t", 1) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        false, TaskList{ std::make_shared<ManaCrystalTask>(1, false) }));
     cards.emplace("VAN_CS2_013", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -468,6 +468,19 @@ SelfCondition SelfCondition::IsShadowSpell()
     });
 }
 
+SelfCondition SelfCondition::IsFelSpell()
+{
+    return SelfCondition([](Playable* playable) {
+        auto spell = dynamic_cast<Spell*>(playable);
+        if (!spell)
+        {
+            return false;
+        }
+
+        return spell->GetSpellSchool() == SpellSchool::FEL;
+    });
+}
+
 SelfCondition SelfCondition::IsWeapon()
 {
     return SelfCondition([](Playable* playable) {

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -1090,6 +1090,22 @@ SelfCondition SelfCondition::Cast5MoreCostSpellInThisTurn()
     });
 }
 
+SelfCondition SelfCondition::CastFelSpellInThisTurn()
+{
+    return SelfCondition([](Playable* playable) {
+        for (auto& card : playable->player->cardsPlayedThisTurn)
+        {
+            if (card->GetCardType() == CardType::SPELL &&
+                card->GetSpellSchool() == SpellSchool::FEL)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    });
+}
+
 SelfCondition SelfCondition::ControlThisCard(int num)
 {
     return SelfCondition([num](Playable* playable) {

--- a/Tests/UnitTests/PlayMode/CardSets/LegacyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LegacyCardsGenTests.cpp
@@ -849,18 +849,26 @@ TEST_CASE("[Druid : Spell] - CS2_013 : Wild Growth")
     opPlayer->SetTotalMana(10);
     opPlayer->SetUsedMana(0);
 
+    auto& curHand = *(curPlayer->GetHandZone());
+
     const auto card1 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Wild Growth"));
     const auto card2 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Wild Growth"));
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
     CHECK_EQ(curPlayer->GetRemainingMana(), 6);
     CHECK_EQ(curPlayer->GetTotalMana(), 10);
 
     game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->card->name, "Excess Mana");
     CHECK_EQ(curPlayer->GetRemainingMana(), 3);
     CHECK_EQ(curPlayer->GetTotalMana(), 10);
+
+    game.Process(curPlayer, PlayCardTask::Spell(curHand[4]));
+    CHECK_EQ(curHand.GetCount(), 5);
 }
 
 // ----------------------------------------- MINION - DRUID

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -2180,6 +2180,60 @@ TEST_CASE("[Neutral : Minion] - SW_006 : Stubborn Suspect")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [SW_054] Stormwind Guard - COST:5 [ATK:4/HP:5]
+// - Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Battlecry:</b> Give adjacent minions +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SW_054 : Stormwind Guard")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Stormwind Guard"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bloodfen Raptor"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask(card1, nullptr, 1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[2]->GetAttack(), 4);
+    CHECK_EQ(curField[2]->GetHealth(), 3);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [SW_055] Impatient Shopkeep - COST:3 [ATK:3/HP:3]
 // - Set: STORMWIND, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -2434,6 +2434,58 @@ TEST_CASE("[Neutral : Minion] - SW_068 : Mo'arg Forgefiend")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [SW_070] Mailbox Dancer - COST:2 [ATK:3/HP:2]
+// - Set: STORMWIND, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Add a Coin to your hand.
+//       <b>Deathrattle:</b> Give your opponent one.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SW_070 : Mailbox Dancer")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& opHand = *(opPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mailbox Dancer"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->name, "The Coin");
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(opHand.GetCount(), 2);
+    CHECK_EQ(opHand[0]->card->name, "The Coin");
+    CHECK_EQ(opHand[1]->card->name, "The Coin");
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [SW_072] Rustrot Viper - COST:3 [ATK:3/HP:4]
 // - Race: Beast, Set: STORMWIND, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -576,24 +576,6 @@ TEST_CASE("[Neutral : Minion] - SW_439 : Vibrant Squirrel")
     CHECK_EQ(curField[3]->GetHealth(), 1);
 }
 
-// --------------------------------------- MINION - NEUTRAL
-// [SW_055] Impatient Shopkeep - COST:3 [ATK:3/HP:3]
-// - Set: STORMWIND, Rarity: Common
-// --------------------------------------------------------
-// Text: <b>Tradeable</b>
-//       <b>Rush</b>
-// --------------------------------------------------------
-// GameTag:
-// - RUSH = 1
-// --------------------------------------------------------
-// RefTag:
-// - TRADEABLE = 1
-// --------------------------------------------------------
-TEST_CASE("[Neutral : Minion] - SW_055 : Impatient Shopkeep")
-{
-    // Do nothing
-}
-
 // ----------------------------------------- MINION - DRUID
 // [DED_001] Druid of the Reef - COST:1 [ATK:1/HP:1]
 // - Set: STORMWIND, Rarity: Common
@@ -2195,6 +2177,24 @@ TEST_CASE("[Neutral : Minion] - SW_006 : Stubborn Suspect")
     game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
     CHECK_EQ(curField.GetCount(), 1);
     CHECK_EQ(curField[0]->card->GetCost(), 3);
+}
+
+// --------------------------------------- MINION - NEUTRAL
+// [SW_055] Impatient Shopkeep - COST:3 [ATK:3/HP:3]
+// - Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Tradeable</b>
+//       <b>Rush</b>
+// --------------------------------------------------------
+// GameTag:
+// - RUSH = 1
+// --------------------------------------------------------
+// RefTag:
+// - TRADEABLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SW_055 : Impatient Shopkeep")
+{
+    // Do nothing
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -1984,6 +1984,59 @@ TEST_CASE("[Warrior : Minion] - DED_519 : Defias Cannoneer")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 23);
 }
 
+// ----------------------------------- MINION - DEMONHUNTER
+// [SW_451] Metamorfin - COST:1 [ATK:1/HP:2]
+// - Race: Murloc, Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Battlecry:</b> If you've cast a Fel spell
+//       this turn, gain +2/+2.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - SW_451 : Metamorfin")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Metamorfin"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Metamorfin"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Chaos Leech"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card1));
+    CHECK_EQ(curField.GetCount(), 0);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+}
+
 // ------------------------------------ SPELL - DEMONHUNTER
 // [SW_452] Chaos Leech - COST:3
 // - Set: STORMWIND, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -2486,6 +2486,60 @@ TEST_CASE("[Neutral : Minion] - SW_070 : Mailbox Dancer")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [SW_071] Lion's Guard - COST:5 [ATK:4/HP:6]
+// - Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you have 15 or less Health,
+//       gain +2/+4 and <b>Taunt</b>.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SW_071 : Lion's Guard")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::ROGUE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Lion's Guard"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Lion's Guard"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+    CHECK_EQ(curField[0]->HasTaunt(), false);
+
+    curPlayer->GetHero()->SetDamage(15);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 6);
+    CHECK_EQ(curField[1]->GetHealth(), 10);
+    CHECK_EQ(curField[1]->HasTaunt(), true);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [SW_072] Rustrot Viper - COST:3 [ATK:3/HP:4]
 // - Race: Beast, Set: STORMWIND, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -2268,6 +2268,75 @@ TEST_CASE("[Neutral : Minion] - SW_061 : Guild Trader")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [SW_066] Royal Librarian - COST:4 [ATK:3/HP:4]
+// - Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Tradeable</b>
+//       <b>Battlecry:</b> <b>Silence</b> a minion.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - TRADEABLE = 1
+// --------------------------------------------------------
+// RefTag:
+// - SILENCE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SW_066 : Royal Librarian")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Royal Librarian"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Royal Librarian"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Leper Gnome"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[0]->HasDeathrattle(), true);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card1, card3));
+    CHECK_EQ(curField[0]->HasDeathrattle(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opField[0]->GetSpellPower(), 5);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card4));
+    CHECK_EQ(opField[0]->GetSpellPower(), 0);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [SW_067] Stockades Guard - COST:1 [ATK:1/HP:3]
 // - Set: STORMWIND, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -1940,6 +1940,50 @@ TEST_CASE("[Warrior : Spell] - DED_518 : Man the Cannons")
     CHECK_EQ(opField[1]->GetHealth(), 4);
 }
 
+// --------------------------------------- MINION - WARRIOR
+// [DED_519] Defias Cannoneer - COST:3 [ATK:3/HP:3]
+// - Race: Pirate, Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: After your hero attacks,
+//       deal 2 damage to a random enemy twice.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - DED_519 : Defias Cannoneer")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Defias Cannoneer"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fiery War Axe"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card2));
+    game.Process(curPlayer,
+                 AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 23);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [SW_061] Guild Trader - COST:4 [ATK:3/HP:4]
 // - Set: STORMWIND, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -2152,6 +2152,52 @@ TEST_CASE("[Demon Hunter : Spell] - SW_452 : Chaos Leech")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [SW_006] Stubborn Suspect - COST:4 [ATK:3/HP:3]
+// - Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Summon a random 3-Cost minion.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SW_006 : Stubborn Suspect")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Stubborn Suspect"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->GetCost(), 3);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [SW_061] Guild Trader - COST:4 [ATK:3/HP:4]
 // - Set: STORMWIND, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -1984,6 +1984,72 @@ TEST_CASE("[Warrior : Minion] - DED_519 : Defias Cannoneer")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 23);
 }
 
+// ------------------------------------ SPELL - DEMONHUNTER
+// [SW_452] Chaos Leech - COST:3
+// - Set: STORMWIND, Rarity: Rare
+// - Spell School: Fel
+// --------------------------------------------------------
+// Text: <b>Lifesteal</b>. Deal 3 damage to a minion.
+//       <b>Outcast:</b> Deal 5 instead.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+// GameTag:
+// - LIFESTEAL = 1
+// - OUTCAST = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Spell] - SW_452 : Chaos Leech")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto curHero = curPlayer->GetHero();
+    auto opHero = opPlayer->GetHero();
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Chaos Leech"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Chaos Leech"));
+    [[maybe_unused]] const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Chaos Leech"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opField[0]->GetHealth(), 12);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card4));
+    CHECK_EQ(opField[0]->GetHealth(), 9);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card4));
+    CHECK_EQ(opField[0]->GetHealth(), 4);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [SW_061] Guild Trader - COST:4 [ATK:3/HP:4]
 // - Set: STORMWIND, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -1985,6 +1985,54 @@ TEST_CASE("[Warrior : Minion] - DED_519 : Defias Cannoneer")
 }
 
 // ----------------------------------- MINION - DEMONHUNTER
+// [SW_043] Felgorger - COST:4 [ATK:4/HP:3]
+// - Race: Demon, Set: STORMWIND, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Draw a Fel spell.
+//       Reduce its Cost by (2).
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - SW_043 : Felgorger")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Feral Spirit");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Chaos Nova");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Fireball");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Felgorger"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->card->GetSpellSchool(), SpellSchool::FEL);
+    CHECK_EQ(curHand[4]->GetCost(), 3);
+}
+
+// ----------------------------------- MINION - DEMONHUNTER
 // [SW_451] Metamorfin - COST:1 [ATK:1/HP:2]
 // - Race: Murloc, Set: STORMWIND, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -899,18 +899,26 @@ TEST_CASE("[Druid : Spell] - VAN_CS2_013 : Wild Growth")
     opPlayer->SetTotalMana(10);
     opPlayer->SetUsedMana(0);
 
+    auto& curHand = *(curPlayer->GetHandZone());
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::FindCardByName("Wild Growth", FormatType::CLASSIC));
     const auto card2 = Generic::DrawCard(
         curPlayer, Cards::FindCardByName("Wild Growth", FormatType::CLASSIC));
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
     CHECK_EQ(curPlayer->GetRemainingMana(), 7);
     CHECK_EQ(curPlayer->GetTotalMana(), 10);
 
     game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->card->name, "Excess Mana");
     CHECK_EQ(curPlayer->GetRemainingMana(), 5);
     CHECK_EQ(curPlayer->GetTotalMana(), 10);
+
+    game.Process(curPlayer, PlayCardTask::Spell(curHand[4]));
+    CHECK_EQ(curHand.GetCount(), 5);
 }
 
 // ----------------------------------------- MINION - DRUID


### PR DESCRIPTION
This revision includes:
- Implement 10 STORMWIND cards
  - Stubborn Suspect (SW_006)
  - Shiver Their Timbers! (SW_027)
  - Felgorger (SW_043)
  - Stormwind Guard (SW_054)
  - Royal Librarian (SW_066)
  - Mailbox Dancer (SW_070)
  - Lion's Guard (SW_071)
  - Metamorfin (SW_451)
  - Chaos Leech (SW_452)
  - Defias Cannoneer (DED_519)
- Add some self condition methods
  - CastFelSpellInThisTurn(): SelfCondition wrapper for checking the player casts a Fel spell this turn
  - IsFelSpell(): SelfCondition wrapper for checking the entity is fel spell
- Fix incorrect logic of some cards (Resolves #678)
  - Wild Growth (CS2_013, VAN_CS2_013)
    - Implement card 'Excess Mana' (CS2_013t)
  - Nether Breath (DRG_205)