### PR TITLE
Implement 10 STORMWIND cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -946,7 +946,7 @@ STORMWIND | SW_033 | Canal Slogger | O
 STORMWIND | SW_034 | Tiny Toys |  
 STORMWIND | SW_035 | Charged Call |  
 STORMWIND | SW_036 | Two-Faced Investor |  
-STORMWIND | SW_037 | Irebound Brute |  
+STORMWIND | SW_037 | Irebound Brute | O
 STORMWIND | SW_039 | Final Showdown |  
 STORMWIND | SW_040 | Fel Barrage |  
 STORMWIND | SW_041 | Sigil of Alacrity |  
@@ -968,7 +968,7 @@ STORMWIND | SW_059 | Deeprun Engineer |
 STORMWIND | SW_060 | Florist |  
 STORMWIND | SW_061 | Guild Trader | O
 STORMWIND | SW_062 | Goldshire Gnoll |  
-STORMWIND | SW_063 | Battleground Battlemaster |  
+STORMWIND | SW_063 | Battleground Battlemaster | O
 STORMWIND | SW_064 | Northshire Farmer |  
 STORMWIND | SW_065 | Pandaren Importer |  
 STORMWIND | SW_066 | Royal Librarian | O
@@ -985,17 +985,17 @@ STORMWIND | SW_076 | City Architect | O
 STORMWIND | SW_077 | Stockades Prisoner |  
 STORMWIND | SW_078 | Lady Prestor |  
 STORMWIND | SW_079 | Flightmaster Dungar |  
-STORMWIND | SW_080 | Cornelius Roame |  
+STORMWIND | SW_080 | Cornelius Roame | O
 STORMWIND | SW_081 | Varian, King of Stormwind |  
-STORMWIND | SW_084 | Bloodbound Imp |  
+STORMWIND | SW_084 | Bloodbound Imp | O
 STORMWIND | SW_085 | Dark Alley Pact |  
-STORMWIND | SW_086 | Shady Bartender |  
+STORMWIND | SW_086 | Shady Bartender | O
 STORMWIND | SW_087 | Dreaded Mount |  
-STORMWIND | SW_088 | Demonic Assault |  
+STORMWIND | SW_088 | Demonic Assault | O
 STORMWIND | SW_089 | Entitled Customer |  
-STORMWIND | SW_090 | Touch of the Nathrezim |  
+STORMWIND | SW_090 | Touch of the Nathrezim | O
 STORMWIND | SW_091 | The Demon Seed |  
-STORMWIND | SW_092 | Anetheron |  
+STORMWIND | SW_092 | Anetheron | O
 STORMWIND | SW_093 | Stormwind Freebooter | O
 STORMWIND | SW_094 | Heavy Plate | O
 STORMWIND | SW_095 | Investment Opportunity | O
@@ -1009,14 +1009,14 @@ STORMWIND | SW_112 | Prestor's Pyromancer |
 STORMWIND | SW_113 | Grand Magus Antonidas |  
 STORMWIND | SW_114 | Overdraft |  
 STORMWIND | SW_115 | Bolner Hammerbeak |  
-STORMWIND | SW_305 | First Blade of Wrynn |  
+STORMWIND | SW_305 | First Blade of Wrynn | O
 STORMWIND | SW_306 | Encumbered Pack Mule |  
 STORMWIND | SW_307 | Traveling Merchant |  
 STORMWIND | SW_310 | Counterfeit Blade |  
 STORMWIND | SW_311 | Garrote | O
 STORMWIND | SW_313 | Rise to the Occasion |  
 STORMWIND | SW_314 | Lightbringer's Hammer |  
-STORMWIND | SW_315 | Alliance Bannerman |  
+STORMWIND | SW_315 | Alliance Bannerman | O
 STORMWIND | SW_316 | Noble Mount | O
 STORMWIND | SW_317 | Catacomb Guard |  
 STORMWIND | SW_319 | Peasant |  
@@ -1063,7 +1063,7 @@ STORMWIND | SW_460 | Devouring Swarm |
 STORMWIND | SW_462 | Hot Streak |  
 STORMWIND | SW_463 | Imported Tarantula |  
 
-- Progress: 29% (50 of 170 Cards)
+- Progress: 35% (60 of 170 Cards)
 
 ## Fractured in Alterac Valley
 

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -39,6 +39,10 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsHandEmpty();
 
+    //! SelfCondition wrapper for checking the hand zone is full.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsHandFull();
+
     //! SelfCondition wrapper for checking the deck zone is empty.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsDeckEmpty();

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -402,6 +402,13 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsOddAttackMinion();
 
+    //! SelfCondition wrapper for checking the attack that satisfies
+    //! condition with \p value and \p relaSign.
+    //! \param value The value to check condition.
+    //! \param relaSign The comparer to check condition.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsAttack(int value, RelaSign relaSign);
+
     //! SelfCondition wrapper for checking the health that satisfies
     //! condition with \p value and \p relaSign.
     //! \param value The value to check condition.

--- a/Includes/Rosetta/PlayMode/Enchants/AuraEffects.hpp
+++ b/Includes/Rosetta/PlayMode/Enchants/AuraEffects.hpp
@@ -108,13 +108,13 @@ class AuraEffects
     //! \param value The value of GameTag::HEALTH to set.
     void SetHealth(int value);
 
-    //! Returns the value of GameTag::CHARGE.
-    //! \return The value of GameTag::CHARGE.
-    int GetCharge() const;
+    //! Returns the value of GameTag::WINDFURY.
+    //! \return The value of GameTag::WINDFURY.
+    int GetWindfury() const;
 
-    //! Sets the value of GameTag::CHARGE.
-    //! \param value The value of GameTag::CHARGE to set.
-    void SetCharge(int value);
+    //! Sets the value of GameTag::WINDFURY.
+    //! \param value The value of GameTag::WINDFURY to set.
+    void SetWindfury(int value);
 
     //! Returns the value of GameTag::TAUNT.
     //! \return The value of GameTag::TAUNT.
@@ -123,6 +123,14 @@ class AuraEffects
     //! Sets the value of GameTag::TAUNT.
     //! \param value The value of GameTag::TAUNT to set.
     void SetTaunt(int value);
+
+    //! Returns the value of GameTag::CHARGE.
+    //! \return The value of GameTag::CHARGE.
+    int GetCharge() const;
+
+    //! Sets the value of GameTag::CHARGE.
+    //! \param value The value of GameTag::CHARGE to set.
+    void SetCharge(int value);
 
     //! Returns the value of GameTag::LIFESTEAL.
     //! \return The value of GameTag::LIFESTEAL.
@@ -158,10 +166,11 @@ class AuraEffects
     // 4 : HEROPOWER_DAMAGE
     // Minion
     // 2 : HEALTH
-    // 3 : CHARGE
+    // 3 : WINDFURY
     // 4 : TAUNT
-    // 5 : LIFESTEAL
-    // 6 : CANT_ATTACK
+    // 5 : CHARGE
+    // 6 : LIFESTEAL
+    // 7 : CANT_ATTACK
     int* m_data = nullptr;
 };
 }  // namespace RosettaStone::PlayMode

--- a/Includes/Rosetta/PlayMode/Models/Player.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Player.hpp
@@ -203,6 +203,14 @@ class Player : public Entity
     //! \param isActive Whether combo is active.
     void SetComboActive(bool isActive);
 
+    //! Returns the number of cards that drawn this turn.
+    //! \return The number of cards that drawn this turn.
+    int GetNumCardsDrawnThisTurn() const;
+
+    //! Sets the number of cards that drawn this turn.
+    //! \param value The number of cards that drawn this turn.
+    void SetNumCardsDrawnThisTurn(int value);
+
     //! Returns the number of cards that played this turn.
     //! \return The number of cards that played this turn.
     int GetNumCardsPlayedThisTurn() const;

--- a/Includes/Rosetta/PlayMode/Triggers/MultiTrigger.hpp
+++ b/Includes/Rosetta/PlayMode/Triggers/MultiTrigger.hpp
@@ -34,14 +34,15 @@ class MultiTrigger : public Trigger
     //! \param source The source of trigger.
     //! \param activation The activation of trigger.
     //! \param cloning The flag to indicate that it is cloned.
+    //! \param isMulti The flag to indicate that it is multi trigger.
     //! \return A new instance of MultiTrigger object.
     std::shared_ptr<Trigger> Activate(
         Playable* source,
         TriggerActivation activation = TriggerActivation::PLAY,
-        bool cloning = false) override;
+        bool cloning = false, [[maybe_unused]] bool isMulti = false) override;
 
     //! Removes this object from game and unsubscribe from the related event.
-    void Remove() const override;
+    void Remove() override;
 
     std::vector<std::shared_ptr<Trigger>> m_triggers;
 };

--- a/Includes/Rosetta/PlayMode/Triggers/Trigger.hpp
+++ b/Includes/Rosetta/PlayMode/Triggers/Trigger.hpp
@@ -106,6 +106,7 @@ class Trigger
     TriggerType m_triggerType = TriggerType::NONE;
     SequenceType m_sequenceType = SequenceType::NONE;
 
+    bool m_isRemoved = false;
     bool m_isValidated = false;
 };
 }  // namespace RosettaStone::PlayMode

--- a/Includes/Rosetta/PlayMode/Triggers/Trigger.hpp
+++ b/Includes/Rosetta/PlayMode/Triggers/Trigger.hpp
@@ -46,14 +46,15 @@ class Trigger
     //! \param source The source of trigger.
     //! \param activation The activation of trigger.
     //! \param cloning The flag to indicate that it is cloned.
+    //! \param isMulti The flag to indicate that it is multi trigger.
     //! \return A new instance of Trigger object.
     virtual std::shared_ptr<Trigger> Activate(
         Playable* source,
         TriggerActivation activation = TriggerActivation::PLAY,
-        bool cloning = false);
+        bool cloning = false, bool isMulti = false);
 
     //! Removes this object from game and unsubscribe from the related event.
-    virtual void Remove() const;
+    virtual void Remove();
 
     //! Checks triggers related to the current Sequence at once before sequence
     //! starts.
@@ -79,6 +80,10 @@ class Trigger
     bool eitherTurn = false;
     bool fastExecution = false;
     bool removeAfterTriggered = false;
+    bool isMultiTrigger = false;
+
+ protected:
+    Playable* m_owner = nullptr;
 
  private:
     //! Processes trigger to apply the effect.
@@ -97,8 +102,6 @@ class Trigger
     //! sequence starts.
     //! \param source The source of trigger.
     void Validate(Entity* source);
-
-    Playable* m_owner = nullptr;
 
     TriggerType m_triggerType = TriggerType::NONE;
     SequenceType m_sequenceType = SequenceType::NONE;

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
   * 80% Forged in the Barrens (136 of 170 cards)
-  * 29% United in Stormwind (50 of 170 cards)
+  * 35% United in Stormwind (60 of 170 cards)
   * 1% Fractured in Alterac Valley (2 of 135 cards)
 
 ### Wild Format

--- a/Sources/Rosetta/PlayMode/Actions/Draw.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Draw.cpp
@@ -34,6 +34,10 @@ Playable* Draw(Player* player, Playable* cardToDraw)
         cardToDraw != nullptr ? cardToDraw
                               : player->GetDeckZone()->GetTopCard());
 
+    // Increase the number of cards drawn this turn
+    const int val = player->GetNumCardsDrawnThisTurn();
+    player->SetNumCardsDrawnThisTurn(val + 1);
+
     // Add card to hand
     if (AddCardToHand(player, playable))
     {

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -2401,6 +2401,22 @@ void StormwindCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // Text: Deal 2 damage to a minion.
     //       If it dies, restore 4 Health to your hero.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 2, true));
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::TARGET, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsDead()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<HealTask>(EntityType::HERO, 4) }));
+    cards.emplace(
+        "SW_090",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [SW_091] The Demon Seed - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -3,6 +3,7 @@
 // Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
+#include <Rosetta/PlayMode/Auras/AdjacentAura.hpp>
 #include <Rosetta/PlayMode/CardSets/StormwindCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
@@ -3235,6 +3236,9 @@ void StormwindCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - WINDFURY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<AdjacentAura>("SW_063e"));
+    cards.emplace("SW_063", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SW_064] Northshire Farmer - COST:3 [ATK:3/HP:3]
@@ -3759,6 +3763,9 @@ void StormwindCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: <b>Windfury</b>
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("SW_063e"));
+    cards.emplace("SW_063e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [SW_064e] Raised in a Barn - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -2827,6 +2827,11 @@ void StormwindCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<AdaptiveCostEffect>([](Playable* playable) {
+        return playable->player->GetNumCardsDrawnThisTurn();
+    }));
+    cards.emplace("SW_037", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [SW_039] Final Showdown - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -2367,9 +2367,20 @@ void StormwindCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // Text: Deal 3 damage.
     //       Summon two 1/3 Voidwalkers with <b>Taunt</b>.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("CS2_065", 2, SummonSide::SPELL));
+    cards.emplace(
+        "SW_088",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // --------------------------------------- MINION - WARLOCK
     // [SW_089] Entitled Customer - COST:6 [ATK:3/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -1188,6 +1188,14 @@ void StormwindCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsAttack(4, RelaSign::GEQ)) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<SetGameTagTask>(EntityType::SOURCE,
+                                                         GameTag::RUSH, 1) }));
+    cards.emplace("SW_305", CardDef(power));
 
     // ---------------------------------------- SPELL - PALADIN
     // [SW_313] Rise to the Occasion - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -2337,6 +2337,12 @@ void StormwindCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    power.GetTrigger()->tasks = { std::make_shared<DamageTask>(EntityType::HERO,
+                                                               2) };
+    cards.emplace("SW_084", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [SW_085] Dark Alley Pact - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -1221,6 +1221,11 @@ void StormwindCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawMinionTask>(1, false));
+    power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
+        "SW_315e", EntityType::MINIONS_HAND));
+    cards.emplace("SW_315", CardDef(power));
 
     // ---------------------------------------- SPELL - PALADIN
     // [SW_316] Noble Mount - COST:2
@@ -3981,6 +3986,9 @@ void StormwindCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("SW_315e"));
+    cards.emplace("SW_315e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [SW_316e] On a Horse - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -8,6 +8,7 @@
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
+#include <Rosetta/PlayMode/Triggers/MultiTrigger.hpp>
 
 using namespace RosettaStone::PlayMode::SimpleTasks;
 
@@ -3513,6 +3514,16 @@ void StormwindCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    auto trigger1 = std::make_shared<Trigger>(TriggerType::TURN_START);
+    trigger1->eitherTurn = true;
+    trigger1->tasks = { std::make_shared<DrawTask>(1) };
+    auto trigger2 = std::make_shared<Trigger>(TriggerType::TURN_END);
+    trigger2->eitherTurn = true;
+    trigger2->tasks = { std::make_shared<DrawTask>(1) };
+    power.AddTrigger(std::make_shared<MultiTrigger>(
+        std::vector<std::shared_ptr<Trigger>>{ trigger1, trigger2 }));
+    cards.emplace("SW_080", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [SW_081] Varian, King of Stormwind - COST:8 [ATK:7/HP:7]

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -2440,6 +2440,11 @@ void StormwindCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - ELITE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<AdaptiveCostEffect>(
+        [](Playable* playable) { return 1; }, EffectOperator::SET,
+        SelfCondition::IsHandFull()));
+    cards.emplace("SW_092", CardDef(power));
 
     // --------------------------------------- MINION - WARLOCK
     // [DED_503] Shadowblade Slinger - COST:1 [ATK:2/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -2300,6 +2300,8 @@ void StormwindCardsGen::AddShamanNonCollect(
 
 void StormwindCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- WEAPON - WARLOCK
     // [SW_003] Runed Mithril Rod - COST:4
     // - Set: STORMWIND, Rarity: Rare
@@ -2341,6 +2343,13 @@ void StormwindCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - TRADEABLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::MINIONS));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::DEMON)) }));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("SW_086e", EntityType::STACK));
+    cards.emplace("SW_086", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [SW_087] Dreaded Mount - COST:3
@@ -3865,6 +3874,9 @@ void StormwindCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("SW_086e"));
+    cards.emplace("SW_086e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [SW_087e] On a Dreadsteed - COST:0

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -832,30 +832,36 @@ SelfCondition SelfCondition::IsOddAttackMinion()
 SelfCondition SelfCondition::IsAttack(int value, RelaSign relaSign)
 {
     return SelfCondition([value, relaSign](Playable* playable) {
-        const auto character = dynamic_cast<Character*>(playable);
-        if (!character)
+        if (const auto character = dynamic_cast<Character*>(playable);
+            character)
         {
-            return false;
+            return (relaSign == RelaSign::EQ &&
+                    character->GetAttack() == value) ||
+                   (relaSign == RelaSign::GEQ &&
+                    character->GetAttack() >= value) ||
+                   (relaSign == RelaSign::LEQ &&
+                    character->GetAttack() <= value);
         }
 
-        return (relaSign == RelaSign::EQ && character->GetAttack() == value) ||
-               (relaSign == RelaSign::GEQ && character->GetAttack() >= value) ||
-               (relaSign == RelaSign::LEQ && character->GetAttack() <= value);
+        return false;
     });
 }
 
 SelfCondition SelfCondition::IsHealth(int value, RelaSign relaSign)
 {
     return SelfCondition([value, relaSign](Playable* playable) {
-        const auto character = dynamic_cast<Character*>(playable);
-        if (!character)
+        if (const auto character = dynamic_cast<Character*>(playable);
+            character)
         {
-            return false;
+            return (relaSign == RelaSign::EQ &&
+                    character->GetHealth() == value) ||
+                   (relaSign == RelaSign::GEQ &&
+                    character->GetHealth() >= value) ||
+                   (relaSign == RelaSign::LEQ &&
+                    character->GetHealth() <= value);
         }
 
-        return (relaSign == RelaSign::EQ && character->GetHealth() == value) ||
-               (relaSign == RelaSign::GEQ && character->GetHealth() >= value) ||
-               (relaSign == RelaSign::LEQ && character->GetHealth() <= value);
+        return false;
     });
 }
 

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -829,11 +829,26 @@ SelfCondition SelfCondition::IsOddAttackMinion()
     });
 }
 
+SelfCondition SelfCondition::IsAttack(int value, RelaSign relaSign)
+{
+    return SelfCondition([value, relaSign](Playable* playable) {
+        const auto character = dynamic_cast<Character*>(playable);
+        if (!character)
+        {
+            return false;
+        }
+
+        return (relaSign == RelaSign::EQ && character->GetAttack() == value) ||
+               (relaSign == RelaSign::GEQ && character->GetAttack() >= value) ||
+               (relaSign == RelaSign::LEQ && character->GetAttack() <= value);
+    });
+}
+
 SelfCondition SelfCondition::IsHealth(int value, RelaSign relaSign)
 {
     return SelfCondition([value, relaSign](Playable* playable) {
         const auto character = dynamic_cast<Character*>(playable);
-        if (character == nullptr)
+        if (!character)
         {
             return false;
         }

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -49,6 +49,13 @@ SelfCondition SelfCondition::IsHandEmpty()
     });
 }
 
+SelfCondition SelfCondition::IsHandFull()
+{
+    return SelfCondition([](Playable* playable) {
+        return playable->player->GetHandZone()->IsFull();
+    });
+}
+
 SelfCondition SelfCondition::IsDeckEmpty()
 {
     return SelfCondition([](Playable* playable) {

--- a/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
@@ -188,12 +188,12 @@ void AuraEffects::SetHealth(int value)
     m_data[2] = value;
 }
 
-int AuraEffects::GetCharge() const
+int AuraEffects::GetWindfury() const
 {
     return m_data[3];
 }
 
-void AuraEffects::SetCharge(int value)
+void AuraEffects::SetWindfury(int value)
 {
     m_data[3] = value;
 }
@@ -208,23 +208,33 @@ void AuraEffects::SetTaunt(int value)
     m_data[4] = value;
 }
 
-int AuraEffects::GetLifesteal() const
+int AuraEffects::GetCharge() const
 {
     return m_data[5];
 }
 
-void AuraEffects::SetLifesteal(int value)
+void AuraEffects::SetCharge(int value)
 {
     m_data[5] = value;
 }
 
-int AuraEffects::GetCantAttack() const
+int AuraEffects::GetLifesteal() const
 {
     return m_data[6];
 }
 
-void AuraEffects::SetCantAttack(int value)
+void AuraEffects::SetLifesteal(int value)
 {
     m_data[6] = value;
+}
+
+int AuraEffects::GetCantAttack() const
+{
+    return m_data[7];
+}
+
+void AuraEffects::SetCantAttack(int value)
+{
+    m_data[7] = value;
 }
 }  // namespace RosettaStone::PlayMode

--- a/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
@@ -53,10 +53,12 @@ int AuraEffects::GetGameTag(GameTag tag) const
             return GetHeroPowerDamage();
         case GameTag::HEALTH:
             return GetHealth();
-        case GameTag::CHARGE:
-            return GetCharge();
+        case GameTag::WINDFURY:
+            return GetWindfury();
         case GameTag::TAUNT:
             return GetTaunt();
+        case GameTag::CHARGE:
+            return GetCharge();
         case GameTag::LIFESTEAL:
             return GetLifesteal();
         case GameTag::CANT_ATTACK:
@@ -89,11 +91,14 @@ void AuraEffects::SetGameTag(GameTag tag, int value)
         case GameTag::HEALTH:
             SetHealth(value);
             break;
-        case GameTag::CHARGE:
-            SetCharge(value);
+        case GameTag::WINDFURY:
+            SetWindfury(value);
             break;
         case GameTag::TAUNT:
             SetTaunt(value);
+            break;
+        case GameTag::CHARGE:
+            SetCharge(value);
             break;
         case GameTag::LIFESTEAL:
             SetLifesteal(value);

--- a/Sources/Rosetta/PlayMode/Games/Game.cpp
+++ b/Sources/Rosetta/PlayMode/Games/Game.cpp
@@ -340,6 +340,7 @@ void Game::MainReady()
         }
 
         // Player
+        player.SetNumCardsDrawnThisTurn(0);
         player.SetNumCardsPlayedThisTurn(0);
         player.SetNumMinionsPlayedThisTurn(0);
         player.SetNumTauntMinionsPlayedThisTurn(0);

--- a/Sources/Rosetta/PlayMode/Models/Player.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Player.cpp
@@ -245,6 +245,16 @@ void Player::SetComboActive(bool isActive)
     SetGameTag(GameTag::COMBO_ACTIVE, isActive ? 1 : 0);
 }
 
+int Player::GetNumCardsDrawnThisTurn() const
+{
+    return GetGameTag(GameTag::NUM_CARDS_DRAWN_THIS_TURN);
+}
+
+void Player::SetNumCardsDrawnThisTurn(int value)
+{
+    SetGameTag(GameTag::NUM_CARDS_DRAWN_THIS_TURN, value);
+}
+
 int Player::GetNumCardsPlayedThisTurn() const
 {
     return GetGameTag(GameTag::NUM_CARDS_PLAYED_THIS_TURN);

--- a/Sources/Rosetta/PlayMode/Triggers/MultiTrigger.cpp
+++ b/Sources/Rosetta/PlayMode/Triggers/MultiTrigger.cpp
@@ -31,10 +31,11 @@ std::shared_ptr<Trigger> MultiTrigger::Activate(Playable* source,
     triggers.reserve(m_triggers.size());
 
     bool flag = false;
+
     for (auto& trigger : m_triggers)
     {
-        auto trig = trigger->Activate(source, activation, cloning, true);
-        if (trig != nullptr)
+        if (auto trig = trigger->Activate(source, activation, cloning, true);
+            trig)
         {
             triggers.emplace_back(trig);
             flag = true;

--- a/Sources/Rosetta/PlayMode/Triggers/MultiTrigger.cpp
+++ b/Sources/Rosetta/PlayMode/Triggers/MultiTrigger.cpp
@@ -25,7 +25,7 @@ MultiTrigger::MultiTrigger(std::vector<std::shared_ptr<Trigger>> triggers,
 
 std::shared_ptr<Trigger> MultiTrigger::Activate(Playable* source,
                                                 TriggerActivation activation,
-                                                bool cloning)
+                                                bool cloning, bool isMulti)
 {
     std::vector<std::shared_ptr<Trigger>> triggers;
     triggers.reserve(m_triggers.size());
@@ -33,7 +33,7 @@ std::shared_ptr<Trigger> MultiTrigger::Activate(Playable* source,
     bool flag = false;
     for (auto& trigger : m_triggers)
     {
-        auto trig = trigger->Activate(source, activation, cloning);
+        auto trig = trigger->Activate(source, activation, cloning, true);
         if (trig != nullptr)
         {
             triggers.emplace_back(trig);
@@ -48,14 +48,24 @@ std::shared_ptr<Trigger> MultiTrigger::Activate(Playable* source,
 
     auto instance = std::make_shared<MultiTrigger>(triggers, *this, *source);
 
+    if (!isMulti)
+    {
+        source->activatedTrigger = instance;
+    }
+
     return instance;
 }
 
-void MultiTrigger::Remove() const
+void MultiTrigger::Remove()
 {
     for (auto& trigger : m_triggers)
     {
         trigger->Remove();
+    }
+
+    if (!isMultiTrigger)
+    {
+        m_owner->activatedTrigger = nullptr;
     }
 }
 }  // namespace RosettaStone::PlayMode

--- a/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
+++ b/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
@@ -57,6 +57,7 @@ Trigger::Trigger(Trigger& prototype, Entity& owner)
       eitherTurn(prototype.eitherTurn),
       fastExecution(prototype.fastExecution),
       removeAfterTriggered(prototype.removeAfterTriggered),
+      isMultiTrigger(prototype.isMultiTrigger),
       m_owner(dynamic_cast<Playable*>(&owner)),
       m_triggerType(prototype.m_triggerType),
       m_sequenceType(prototype.m_sequenceType)
@@ -73,7 +74,7 @@ Trigger::Trigger(Trigger& prototype, Entity& owner)
 
 std::shared_ptr<Trigger> Trigger::Activate(Playable* source,
                                            TriggerActivation activation,
-                                           bool cloning)
+                                           bool cloning, bool isMulti)
 {
     if (!cloning && activation != triggerActivation)
     {
@@ -86,7 +87,14 @@ std::shared_ptr<Trigger> Trigger::Activate(Playable* source,
     auto instance = std::make_shared<Trigger>(*this, *source);
     Game* game = source->game;
 
-    source->activatedTrigger = instance;
+    if (isMulti)
+    {
+        instance->isMultiTrigger = true;
+    }
+    else if (!isMultiTrigger)
+    {
+        source->activatedTrigger = instance;
+    }
 
     if (m_sequenceType != SequenceType::NONE)
     {
@@ -269,7 +277,7 @@ std::shared_ptr<Trigger> Trigger::Activate(Playable* source,
     return instance;
 }
 
-void Trigger::Remove() const
+void Trigger::Remove()
 {
     Game* game = m_owner->game;
 
@@ -441,6 +449,11 @@ void Trigger::Remove() const
             break;
         default:
             break;
+    }
+
+    if (!isMultiTrigger)
+    {
+        m_owner->activatedTrigger = nullptr;
     }
 
     if (m_sequenceType != SequenceType::NONE)

--- a/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
+++ b/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
@@ -520,6 +520,14 @@ void Trigger::ProcessInternal(Entity* source)
 {
     m_isValidated = false;
 
+    ProcessTasks(source);
+
+    if (const auto spell = dynamic_cast<Spell*>(m_owner);
+        spell && spell->IsSecret() && spell->player->ExtraTriggerSecret())
+    {
+        ProcessTasks(source);
+    }
+
     if (removeAfterTriggered)
     {
         Remove();
@@ -533,14 +541,6 @@ void Trigger::ProcessInternal(Entity* source)
         {
             Remove();
         }
-    }
-
-    ProcessTasks(source);
-
-    if (const auto spell = dynamic_cast<Spell*>(m_owner);
-        spell && spell->IsSecret() && spell->player->ExtraTriggerSecret())
-    {
-        ProcessTasks(source);
     }
 
     m_isValidated = false;

--- a/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
+++ b/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
@@ -279,6 +279,11 @@ std::shared_ptr<Trigger> Trigger::Activate(Playable* source,
 
 void Trigger::Remove()
 {
+    if (m_isRemoved)
+    {
+        return;
+    }
+
     Game* game = m_owner->game;
 
     switch (m_triggerType)
@@ -462,6 +467,8 @@ void Trigger::Remove()
             return trigger.get() == this;
         });
     }
+
+    m_isRemoved = true;
 }
 
 void Trigger::ValidateTriggers(Game* game, Entity* source, SequenceType type)
@@ -491,6 +498,11 @@ void Trigger::ValidateTriggers(Game* game, Entity* source, SequenceType type)
 
 void Trigger::Process(Entity* source)
 {
+    if (m_isRemoved)
+    {
+        return;
+    }
+
     if (m_sequenceType == SequenceType::NONE)
     {
         Validate(source);

--- a/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
+++ b/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
@@ -456,10 +456,11 @@ void Trigger::Remove()
             break;
     }
 
-    if (!isMultiTrigger)
-    {
-        m_owner->activatedTrigger = nullptr;
-    }
+    // TODO: Is it correct? :thinking:
+    //if (!isMultiTrigger)
+    //{
+    //    m_owner->activatedTrigger = nullptr;
+    //}
 
     if (m_sequenceType != SequenceType::NONE)
     {

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -920,6 +920,66 @@ TEST_CASE("[Paladin : Spell] - SW_046 : City Tax")
 }
 
 // --------------------------------------- MINION - PALADIN
+// [SW_305] First Blade of Wrynn - COST:4 [ATK:3/HP:5]
+// - Set: STORMWIND, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Divine Shield</b>
+//       <b>Battlecry:</b> Gain <b>Rush</b>
+//       if this has at least 4 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - DIVINE_SHIELD = 1
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Minion] - SW_305 : First Blade of Wrynn")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("First Blade of Wrynn"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("First Blade of Wrynn"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Alliance Bannerman"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasDivineShield(), true);
+    CHECK_EQ(curField[0]->HasRush(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[2]->HasDivineShield(), true);
+    CHECK_EQ(curField[2]->HasRush(), true);
+}
+
+// --------------------------------------- MINION - PALADIN
 // [SW_315] Alliance Bannerman - COST:3 [ATK:2/HP:2]
 // - Set: STORMWIND, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -1620,6 +1620,59 @@ TEST_CASE("[Warlock : Minion] - SW_086 : Shady Bartender")
     CHECK_EQ(curField[1]->GetHealth(), 3);
 }
 
+// ---------------------------------------- SPELL - WARLOCK
+// [SW_088] Demonic Assault - COST:4
+// - Set: STORMWIND, Rarity: Common
+// - Spell School: Fel
+// --------------------------------------------------------
+// Text: Deal 3 damage.
+//       Summon two 1/3 Voidwalkers with <b>Taunt</b>.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Spell] - SW_088 : Demonic Assault")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Demonic Assault"));
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card1, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Voidwalker");
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+    CHECK_EQ(curField[1]->card->name, "Voidwalker");
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+    CHECK_EQ(curField[1]->HasTaunt(), true);
+}
+
 // --------------------------------------- MINION - WARRIOR
 // [SW_021] Cowardly Grunt - COST:6 [ATK:6/HP:2]
 // - Set: STORMWIND, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -919,6 +919,55 @@ TEST_CASE("[Paladin : Spell] - SW_046 : City Tax")
     CHECK_EQ(opField[1]->GetHealth(), 4);
 }
 
+// --------------------------------------- MINION - PALADIN
+// [SW_315] Alliance Bannerman - COST:3 [ATK:2/HP:2]
+// - Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Draw a minion.
+//       Give minions in your hand +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Minion] - SW_315 : Alliance Bannerman")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("City Tax");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Malygos");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Noble Mount");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Alliance Bannerman"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->card->GetCardType(), CardType::MINION);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[4])->GetAttack(), 5);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[4])->GetHealth(), 13);
+}
+
 // ---------------------------------------- SPELL - PALADIN
 // [SW_316] Noble Mount - COST:2
 // - Set: STORMWIND, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -3122,3 +3122,57 @@ TEST_CASE("[Neutral : Minion] - SW_076 : City Architect")
     CHECK_EQ(curField[2]->GetHealth(), 5);
     CHECK_EQ(curField[2]->HasTaunt(), true);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [SW_080] Cornelius Roame - COST:6 [ATK:4/HP:5]
+// - Set: STORMWIND, Rarity: Legendary
+// --------------------------------------------------------
+// Text: At the start and end of each player's turn,
+//       draw a card.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SW_080 : Cornelius Roame")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& opHand = *(opPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Cornelius Roame"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 4);
+    CHECK_EQ(opHand.GetCount(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(opHand.GetCount(), 6);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curHand.GetCount(), 9);
+    CHECK_EQ(opHand.GetCount(), 6);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -1732,6 +1732,62 @@ TEST_CASE("[Warlock : Spell] - SW_090 : Touch of the Nathrezim")
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 19);
 }
 
+// --------------------------------------- MINION - WARLOCK
+// [SW_092] Anetheron - COST:6 [ATK:8/HP:6]
+// - Race: Demon, Set: STORMWIND, Rarity: Legendary
+// --------------------------------------------------------
+// Text: Costs (1) if your hand is full.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - SW_092 : Anetheron")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Anetheron"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    [[maybe_unused]] const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    [[maybe_unused]] const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    [[maybe_unused]] const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    [[maybe_unused]] const auto card6 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    CHECK_EQ(card1->GetCost(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(card1->GetCost(), 6);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card1->GetCost(), 1);
+}
+
 // --------------------------------------- MINION - WARRIOR
 // [SW_021] Cowardly Grunt - COST:6 [ATK:6/HP:2]
 // - Set: STORMWIND, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -1566,6 +1566,60 @@ TEST_CASE("[Shaman : Minion] - DED_522 : Cookie the Cook")
     CHECK_EQ(curPlayer->GetHero()->weapon->HasLifesteal(), true);
 }
 
+// --------------------------------------- MINION - WARLOCK
+// [SW_086] Shady Bartender - COST:5 [ATK:4/HP:4]
+// - Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Tradeable</b>
+//       <b>Battlecry:</b> Give your Demons +2/+2.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - TRADEABLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - SW_086 : Shady Bartender")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Shady Bartender"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Murloc Tinyfin"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Desk Imp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+}
+
 // --------------------------------------- MINION - WARRIOR
 // [SW_021] Cowardly Grunt - COST:6 [ATK:6/HP:2]
 // - Set: STORMWIND, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -2189,6 +2189,55 @@ TEST_CASE("[Warrior : Minion] - DED_519 : Defias Cannoneer")
 }
 
 // ----------------------------------- MINION - DEMONHUNTER
+// [SW_037] Irebound Brute - COST:8 [ATK:6/HP:7]
+// - Race: Demon, Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       Costs (1) less for each card drawn this turn.
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - SW_037 : Irebound Brute")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Irebound Brute"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Chaos Strike"));
+
+    CHECK_EQ(card1->GetCost(), 7);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(card1->GetCost(), 6);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card1->GetCost(), 7);
+}
+
+// ----------------------------------- MINION - DEMONHUNTER
 // [SW_043] Felgorger - COST:4 [ATK:4/HP:3]
 // - Race: Demon, Set: STORMWIND, Rarity: Epic
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -1673,6 +1673,65 @@ TEST_CASE("[Warlock : Spell] - SW_088 : Demonic Assault")
     CHECK_EQ(curField[1]->HasTaunt(), true);
 }
 
+// ---------------------------------------- SPELL - WARLOCK
+// [SW_090] Touch of the Nathrezim - COST:1
+// - Set: STORMWIND, Rarity: Rare
+// - Spell School: Shadow
+// --------------------------------------------------------
+// Text: Deal 2 damage to a minion.
+//       If it dies, restore 4 Health to your hero.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Spell] - SW_090 : Touch of the Nathrezim")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Touch of the Nathrezim"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Touch of the Nathrezim"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Chillwind Yeti"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 15);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 19);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card4));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 19);
+}
+
 // --------------------------------------- MINION - WARRIOR
 // [SW_021] Cowardly Grunt - COST:6 [ATK:6/HP:2]
 // - Set: STORMWIND, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -2539,6 +2539,67 @@ TEST_CASE("[Neutral : Minion] - SW_061 : Guild Trader")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [SW_063] Battleground Battlemaster - COST:6 [ATK:5/HP:5]
+// - Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: Adjacent minions have <b>Windfury</b>.
+// --------------------------------------------------------
+// GameTag:
+// - AURA = 1
+// --------------------------------------------------------
+// RefTag:
+// - WINDFURY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - SW_063 : Battleground Battlemaster")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Battleground Battlemaster"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[0]->HasWindfury(), false);
+    CHECK_EQ(curField[1]->HasWindfury(), false);
+
+    game.Process(curPlayer, PlayCardTask(card1, nullptr, 1));
+    CHECK_EQ(curField[0]->HasWindfury(), true);
+    CHECK_EQ(curField[1]->HasWindfury(), false);
+    CHECK_EQ(curField[2]->HasWindfury(), true);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card1));
+    CHECK_EQ(curField[0]->HasWindfury(), false);
+    CHECK_EQ(curField[1]->HasWindfury(), false);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [SW_066] Royal Librarian - COST:4 [ATK:3/HP:4]
 // - Set: STORMWIND, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -1676,6 +1676,51 @@ TEST_CASE("[Shaman : Minion] - DED_522 : Cookie the Cook")
 }
 
 // --------------------------------------- MINION - WARLOCK
+// [SW_084] Bloodbound Imp - COST:2 [ATK:2/HP:5]
+// - Race: Demon, Set: STORMWIND, Rarity: Common
+// --------------------------------------------------------
+// Text: Whenever this attacks, deal 2 damage to your hero.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - SW_084 : Bloodbound Imp")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bloodbound Imp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(card1, opPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 28);
+}
+
+// --------------------------------------- MINION - WARLOCK
 // [SW_086] Shady Bartender - COST:5 [ATK:4/HP:4]
 // - Set: STORMWIND, Rarity: Common
 // --------------------------------------------------------


### PR DESCRIPTION
This revision includes:
- Implement 10 STORMWIND cards
  - Irebound Brute (SW_037)
  - Battleground Battlemaster (SW_063)
  - Cornelius Roame (SW_080)
  - Bloodbound Imp (SW_084)
  - Shady Bartender (SW_086)
  - Demonic Assault (SW_088)
  - Touch of the Nathrezim (SW_090)
  - Anetheron (SW_092)
  - First Blade of Wrynn (SW_305)
  - Alliance Bannerman (SW_315)
- Add some self condition methods
  - IsHandFull(): SelfCondition wrapper for checking the hand zone is full
  - IsAttack(): SelfCondition wrapper for checking the attack that satisfies condition with value and relaSign
- Add getter/setter for 'NUM_CARDS_DRAWN_THIS_TURN'
  - GetNumCardsDrawnThisTurn(): Returns the number of cards that drawn this turn
  - SetNumCardsDrawnThisTurn(): Sets the number of cards that drawn this turn
  - Add code to increase number of cards drawn this turn
  - Add code to reset the number of cards drawn this turn
- Add getter/setter for 'GameTag::WINDFURY'
  - GetWindfury(): Returns the value of GameTag::WINDFURY
  - SetWindfury(): Sets the value of GameTag::WINDFURY
  - Add code to get/set the value of 'GameTag::WINDFURY'
- Fix incorrect logic of class 'Trigger' and 'MultiTrigger'
  - Add variable 'isMultiTrigger' and code to process it
  - Add variable 'm_isRemoved' and code to process it
  - Move code to process a list of tasks
- Refactor code
  - Apply C++17 feature 'if (init; condition)' statement