### PR TITLE
Implement 10 VANILLA cards

### DIFF
--- a/Documents/CardList - Classic.md
+++ b/Documents/CardList - Classic.md
@@ -25,13 +25,13 @@ VANILLA | VAN_CS2_022 | Polymorph | O
 VANILLA | VAN_CS2_023 | Arcane Intellect | O
 VANILLA | VAN_CS2_024 | Frostbolt | O
 VANILLA | VAN_CS2_025 | Arcane Explosion | O
-VANILLA | VAN_CS2_026 | Frost Nova |  
-VANILLA | VAN_CS2_027 | Mirror Image |  
-VANILLA | VAN_CS2_028 | Blizzard |  
+VANILLA | VAN_CS2_026 | Frost Nova | O
+VANILLA | VAN_CS2_027 | Mirror Image | O
+VANILLA | VAN_CS2_028 | Blizzard | O
 VANILLA | VAN_CS2_029 | Fireball | O
-VANILLA | VAN_CS2_031 | Ice Lance |  
-VANILLA | VAN_CS2_032 | Flamestrike |  
-VANILLA | VAN_CS2_033 | Water Elemental |  
+VANILLA | VAN_CS2_031 | Ice Lance | O
+VANILLA | VAN_CS2_032 | Flamestrike | O
+VANILLA | VAN_CS2_033 | Water Elemental | O
 VANILLA | VAN_CS2_037 | Frost Shock |  
 VANILLA | VAN_CS2_038 | Ancestral Spirit |  
 VANILLA | VAN_CS2_039 | Windfury |  
@@ -223,14 +223,14 @@ VANILLA | VAN_EX1_250 | Earth Elemental |
 VANILLA | VAN_EX1_251 | Forked Lightning |  
 VANILLA | VAN_EX1_258 | Unbound Elemental |  
 VANILLA | VAN_EX1_259 | Lightning Storm |  
-VANILLA | VAN_EX1_274 | Ethereal Arcanist |  
-VANILLA | VAN_EX1_275 | Cone of Cold |  
+VANILLA | VAN_EX1_274 | Ethereal Arcanist | O
+VANILLA | VAN_EX1_275 | Cone of Cold | O
 VANILLA | VAN_EX1_277 | Arcane Missiles |  
 VANILLA | VAN_EX1_278 | Shiv |  
 VANILLA | VAN_EX1_279 | Pyroblast |  
-VANILLA | VAN_EX1_283 | Frost Elemental |  
+VANILLA | VAN_EX1_283 | Frost Elemental | O
 VANILLA | VAN_EX1_284 | Azure Drake |  
-VANILLA | VAN_EX1_287 | Counterspell |  
+VANILLA | VAN_EX1_287 | Counterspell | O
 VANILLA | VAN_EX1_289 | Ice Barrier |  
 VANILLA | VAN_EX1_294 | Mirror Entity |  
 VANILLA | VAN_EX1_295 | Ice Block |  
@@ -389,4 +389,4 @@ VANILLA | VAN_PRO_001 | Elite Tauren Chieftain |
 VANILLA | VAN_tt_004 | Flesheating Ghoul |  
 VANILLA | VAN_tt_010 | Spellbender |  
 
-- Progress: 15% (58 of 382 Cards)
+- Progress: 17% (68 of 382 Cards)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Classic Format
 
-  * 15% Vanilla Set (58 of 382 Cards)
+  * 17% Vanilla Set (68 of 382 Cards)
 
 ## Implementation List
 

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -1361,8 +1361,8 @@ void Expert1CardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // [EX1_274] Ethereal Arcanist - COST:4 [ATK:3/HP:3]
     // - Set: Expert1, Rarity: Rare
     // --------------------------------------------------------
-    // Text: If you control a <b>Secret</b> at the end
-    //       of your turn, gain +2/+2.
+    // Text: If you control a <b>Secret</b> at the end of your turn,
+    //       gain +2/+2.
     // --------------------------------------------------------
     // GameTag:
     // - TRIGGER_VISUAL = 1

--- a/Sources/Rosetta/PlayMode/CardSets/LegacyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LegacyCardsGen.cpp
@@ -1143,7 +1143,20 @@ void LegacyCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 
 void LegacyCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
 {
-    (void)cards;
+    Power power;
+
+    // ------------------------------------------ MINION - MAGE
+    // [CS2_mirror] Mirror Image - COST:0 [ATK:0/HP:2]
+    // - Set: Legacy, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("CS2_mirror", CardDef(power));
 }
 
 void LegacyCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -1868,12 +1868,17 @@ void VanillaCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // [VAN_CS2_028] Blizzard - COST:6
     // - Set: VANILLA, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Deal 2 damage to all enemy minions
-    //       and <b>Freeze</b> them.
+    // Text: Deal 2 damage to all enemy minions and <b>Freeze</b> them.
     // --------------------------------------------------------
     // GameTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 2, true));
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(
+        EntityType::ENEMY_MINIONS, GameTag::FROZEN, 1));
+    cards.emplace("VAN_CS2_028", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [VAN_CS2_029] Fireball - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -1943,6 +1943,9 @@ void VanillaCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_033", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [VAN_EX1_274] Ethereal Arcanist - COST:4 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -2893,6 +2893,8 @@ void VanillaCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 
 void VanillaCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- SPELL - SHAMAN
     // [VAN_CS2_037] Frost Shock - COST:1
     // - Set: VANILLA, Rarity: Free
@@ -2975,7 +2977,17 @@ void VanillaCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // GameTag:
     // - OVERLOAD = 1
+    // - OVERLOAD_OWED = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
+    cards.emplace(
+        "VAN_EX1_238",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [VAN_EX1_241] Lava Burst - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -1901,12 +1901,27 @@ void VanillaCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - Set: VANILLA, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Freeze</b> a character.
-    //       If it was already <b>Frozen</b>,
-    //       deal 4 damage instead.
+    //       If it was already <b>Frozen</b>, deal 4 damage instead.
     // --------------------------------------------------------
     // GameTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::TARGET, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsFrozen()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true,
+        TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 4, true) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        false, TaskList{ std::make_shared<SetGameTagTask>(
+                   EntityType::TARGET, GameTag::FROZEN, 1) }));
+    cards.emplace(
+        "VAN_CS2_031",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ------------------------------------------- SPELL - MAGE
     // [VAN_CS2_032] Flamestrike - COST:7

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -1841,6 +1841,10 @@ void VanillaCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(
+        EntityType::ENEMY_MINIONS, GameTag::FROZEN, 1));
+    cards.emplace("VAN_CS2_026", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [VAN_CS2_027] Mirror Image - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -1852,9 +1852,17 @@ void VanillaCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Summon two 0/2 minions with <b>Taunt</b>.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("VAN_CS2_mirror", 2));
+    cards.emplace(
+        "VAN_CS2_027",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ------------------------------------------- SPELL - MAGE
     // [VAN_CS2_028] Blizzard - COST:6
@@ -2076,6 +2084,8 @@ void VanillaCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 
 void VanillaCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------ MINION - MAGE
     // [VAN_CS2_mirror] Mirror Image - COST:0 [ATK:0/HP:2]
     // - Set: VANILLA, Rarity: Common
@@ -2085,6 +2095,9 @@ void VanillaCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_mirror", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [VAN_tt_010a] Spellbender - COST:0 [ATK:1/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -2011,6 +2011,14 @@ void VanillaCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - COUNTER = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::CAST_SPELL));
+    power.GetTrigger()->triggerSource = TriggerSource::ENEMY_SPELLS;
+    power.GetTrigger()->tasks =
+        ComplexTask::ActivateSecret(TaskList{ std::make_shared<SetGameTagTask>(
+            EntityType::TARGET, GameTag::CANT_PLAY, 1) });
+    power.GetTrigger()->fastExecution = true;
+    cards.emplace("VAN_EX1_287", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [VAN_EX1_289] Ice Barrier - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -1929,6 +1929,10 @@ void VanillaCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 4 damage to all enemy minions.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 4, true));
+    cards.emplace("VAN_CS2_032", CardDef(power));
 
     // ------------------------------------------ MINION - MAGE
     // [VAN_CS2_033] Water Elemental - COST:4 [ATK:3/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -1979,6 +1979,21 @@ void VanillaCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<IncludeAdjacentTask>(EntityType::TARGET, true));
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::STACK,
+                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::STACK, 1, true));
+    cards.emplace(
+        "VAN_EX1_275",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ------------------------------------------- SPELL - MAGE
     // [VAN_EX1_277] Arcane Missiles - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -1960,6 +1960,14 @@ void VanillaCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsControllingSecret())
+    };
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "EX1_274e", EntityType::SOURCE) };
+    cards.emplace("VAN_EX1_274", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [VAN_EX1_275] Cone of Cold - COST:4

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -2300,8 +2300,8 @@ TEST_CASE("[Mage : Spell] - EX1_180 : Tome of Intellect")
 // [EX1_274] Ethereal Arcanist - COST:4 [ATK:3/HP:3]
 // - Set: Expert1, Rarity: Rare
 // --------------------------------------------------------
-// Text: If you control a <b>Secret</b> at the end
-//       of your turn, gain +2/+2.
+// Text: If you control a <b>Secret</b> at the end of your turn,
+//       gain +2/+2.
 // --------------------------------------------------------
 // GameTag:
 // - TRIGGER_VISUAL = 1

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -3944,6 +3944,65 @@ TEST_CASE("[Mage : Spell] - VAN_CS2_025 : Arcane Explosion")
 }
 
 // ------------------------------------------- SPELL - MAGE
+// [VAN_CS2_026] Frost Nova - COST:3
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Freeze</b> all enemy minions.
+// --------------------------------------------------------
+// GameTag:
+// - FREEZE = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - VAN_CS2_026 : Frost Nova")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Frost Nova", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        opPlayer,
+        Cards::FindCardByName("Acidic Swamp Ooze", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(opField[0]->GetHealth(), 2);
+    CHECK_EQ(opField[0]->IsFrozen(), true);
+    CHECK_EQ(opField[1]->GetHealth(), 1);
+    CHECK_EQ(opField[1]->IsFrozen(), true);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
+    CHECK_EQ(opPlayer->GetHero()->IsFrozen(), false);
+}
+
+// ------------------------------------------- SPELL - MAGE
 // [VAN_CS2_029] Fireball - COST:4
 // - Set: VANILLA, Rarity: Free
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -4003,6 +4003,70 @@ TEST_CASE("[Mage : Spell] - VAN_CS2_026 : Frost Nova")
 }
 
 // ------------------------------------------- SPELL - MAGE
+// [VAN_CS2_027] Mirror Image - COST:1
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Summon two 0/2 minions with <b>Taunt</b>.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - VAN_CS2_027 : Mirror Image")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Mirror Image", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Mirror Image", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Mirror Image", FormatType::CLASSIC));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Mirror Image", FormatType::CLASSIC));
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    CHECK_EQ(curField.GetCount(), 0);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->GetAttack(), 0);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAUNT), 1);
+    CHECK_EQ(curField[1]->GetAttack(), 0);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+    CHECK_EQ(curField[1]->GetGameTag(GameTag::TAUNT), 1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curField.GetCount(), 4);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(curField.GetCount(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card4));
+    CHECK_EQ(curField.GetCount(), 7);
+}
+
+// ------------------------------------------- SPELL - MAGE
 // [VAN_CS2_029] Fireball - COST:4
 // - Set: VANILLA, Rarity: Free
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -4478,6 +4478,88 @@ TEST_CASE("[Mage : Minion] - VAN_EX1_274 : Ethereal Arcanist")
 }
 
 // ------------------------------------------- SPELL - MAGE
+// [VAN_EX1_275] Cone of Cold - COST:4
+// - Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Freeze</b> a minion and the minions next to it,
+//       and deal 1 damage to them.
+// --------------------------------------------------------
+// GameTag:
+// - FREEZE = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - VAN_EX1_275 : Cone of Cold")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Flame Imp", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Flame Imp", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Flame Imp", FormatType::CLASSIC));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Flame Imp", FormatType::CLASSIC));
+    const auto card5 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Flame Imp", FormatType::CLASSIC));
+    const auto card6 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Cone of Cold", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->IsFrozen(), false);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+    CHECK_EQ(curField[1]->IsFrozen(), false);
+    CHECK_EQ(curField[2]->GetHealth(), 2);
+    CHECK_EQ(curField[2]->IsFrozen(), false);
+    CHECK_EQ(curField[3]->GetHealth(), 2);
+    CHECK_EQ(curField[3]->IsFrozen(), false);
+    CHECK_EQ(curField[4]->GetHealth(), 2);
+    CHECK_EQ(curField[4]->IsFrozen(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card6, card3));
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->IsFrozen(), false);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->IsFrozen(), true);
+    CHECK_EQ(curField[2]->GetHealth(), 1);
+    CHECK_EQ(curField[2]->IsFrozen(), true);
+    CHECK_EQ(curField[3]->GetHealth(), 1);
+    CHECK_EQ(curField[3]->IsFrozen(), true);
+    CHECK_EQ(curField[4]->GetHealth(), 2);
+    CHECK_EQ(curField[4]->IsFrozen(), false);
+}
+
+// ------------------------------------------- SPELL - MAGE
 // [VAN_EX1_287] Counterspell - COST:3
 // - Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -4340,6 +4340,65 @@ TEST_CASE("[Mage : Spell] - VAN_CS2_032 : Flamestrike")
     CHECK_EQ(opField[0]->GetHealth(), 3);
 }
 
+// ------------------------------------------ MINION - MAGE
+// [VAN_CS2_033] Water Elemental - COST:4 [ATK:3/HP:6]
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Freeze</b> any character damaged by this minion.
+// --------------------------------------------------------
+// GameTag:
+// - FREEZE = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - VAN_CS2_033 : Water Elemental")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Water Elemental", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Chillwind Yeti", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(card1, card2));
+
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(opField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->IsFrozen(), false);
+    CHECK_EQ(opField[0]->IsFrozen(), true);
+}
+
 // ----------------------------------------- SPELL - PRIEST
 // [VAN_EX1_332] Silence - COST:0
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -4287,6 +4287,59 @@ TEST_CASE("[Mage : Spell] - VAN_CS2_031 : Ice Lance")
     CHECK_EQ(card7->isDestroyed, true);
 }
 
+// ------------------------------------------- SPELL - MAGE
+// [VAN_CS2_032] Flamestrike - COST:7
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Deal 4 damage to all enemy minions.
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - VAN_CS2_032 : Flamestrike")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Flamestrike", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        opPlayer,
+        Cards::FindCardByName("Acidic Swamp Ooze", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        opPlayer,
+        Cards::FindCardByName("Boulderfist Ogre", FormatType::CLASSIC));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 3);
+}
+
 // ----------------------------------------- SPELL - PRIEST
 // [VAN_EX1_332] Silence - COST:0
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -4610,6 +4610,62 @@ TEST_CASE("[Priest : Spell] - VAN_EX1_332 : Silence")
     CHECK_EQ(opField[0]->GetSpellPower(), 0);
 }
 
+// ----------------------------------------- SPELL - SHAMAN
+// [VAN_EX1_238] Lightning Bolt - COST:1
+// - Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: Deal 3 damage. <b>Overload:</b> (1)
+// --------------------------------------------------------
+// GameTag:
+// - OVERLOAD = 1
+// - OVERLOAD_OWED = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - VAN_EX1_238 : Lightning Bolt")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Lightning Bolt", FormatType::CLASSIC));
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card1, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 9);
+    CHECK_EQ(curPlayer->GetOverloadOwed(), 1);
+    CHECK_EQ(curPlayer->GetOverloadLocked(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetRemainingMana(), 9);
+    CHECK_EQ(curPlayer->GetOverloadOwed(), 0);
+    CHECK_EQ(curPlayer->GetOverloadLocked(), 1);
+}
+
 // ---------------------------------------- SPELL - WARLOCK
 // [VAN_CS2_062] Hellfire - COST:4
 // - Set: VANILLA, Rarity: Free


### PR DESCRIPTION
This revision includes:
- Implement 10 VANILLA cards (#674)
  - Frost Nova (VAN_CS2_026)
  - Mirror Image (VAN_CS2_027)
  - Blizzard (VAN_CS2_028)
  - Ice Lance (VAN_CS2_031)
  - Flamestrike (VAN_CS2_032)
  - Water Elemental (VAN_CS2_033)
  - Lightning Bolt (VAN_EX1_238)
  - Ethereal Arcanist (VAN_EX1_274)
  - Cone of Cold (VAN_EX1_275)
  - Counterspell (VAN_EX1_287)
- Implement missing card 'Mirror Image' (CS2_mirror)
- Combine text to improve readability