### PR TITLE
Implement 12 VANILLA cards

### DIFF
--- a/Documents/CardList - Classic.md
+++ b/Documents/CardList - Classic.md
@@ -8,12 +8,12 @@ Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
 VANILLA | VAN_CS1_042 | Goldshire Footman |  
 VANILLA | VAN_CS1_069 | Fen Creeper |  
-VANILLA | VAN_CS1_112 | Holy Nova |  
-VANILLA | VAN_CS1_113 | Mind Control |  
-VANILLA | VAN_CS1_129 | Inner Fire |  
-VANILLA | VAN_CS1_130 | Holy Smite |  
-VANILLA | VAN_CS2_003 | Mind Vision |  
-VANILLA | VAN_CS2_004 | Power Word: Shield |  
+VANILLA | VAN_CS1_112 | Holy Nova | O
+VANILLA | VAN_CS1_113 | Mind Control | O
+VANILLA | VAN_CS1_129 | Inner Fire | O
+VANILLA | VAN_CS1_130 | Holy Smite | O
+VANILLA | VAN_CS2_003 | Mind Vision | O
+VANILLA | VAN_CS2_004 | Power Word: Shield | O
 VANILLA | VAN_CS2_005 | Claw | O
 VANILLA | VAN_CS2_007 | Healing Touch | O
 VANILLA | VAN_CS2_008 | Moonfire | O
@@ -114,9 +114,9 @@ VANILLA | VAN_CS2_227 | Venture Co. Mercenary |
 VANILLA | VAN_CS2_231 | Wisp |  
 VANILLA | VAN_CS2_232 | Ironbark Protector | O
 VANILLA | VAN_CS2_233 | Blade Flurry |  
-VANILLA | VAN_CS2_234 | Shadow Word: Pain |  
-VANILLA | VAN_CS2_235 | Northshire Cleric |  
-VANILLA | VAN_CS2_236 | Divine Spirit |  
+VANILLA | VAN_CS2_234 | Shadow Word: Pain | O
+VANILLA | VAN_CS2_235 | Northshire Cleric | O
+VANILLA | VAN_CS2_236 | Divine Spirit | O
 VANILLA | VAN_CS2_237 | Starving Buzzard | O
 VANILLA | VAN_DS1_055 | Darkscale Healer |  
 VANILLA | VAN_DS1_070 | Houndmaster | O
@@ -126,7 +126,7 @@ VANILLA | VAN_DS1_183 | Multi-Shot | O
 VANILLA | VAN_DS1_184 | Tracking | O
 VANILLA | VAN_DS1_185 | Arcane Shot | O
 VANILLA | VAN_DS1_188 | Gladiator's Longbow | O
-VANILLA | VAN_DS1_233 | Mind Blast |  
+VANILLA | VAN_DS1_233 | Mind Blast | O
 VANILLA | VAN_EX1_001 | Lightwarden |  
 VANILLA | VAN_EX1_002 | The Black Knight |  
 VANILLA | VAN_EX1_004 | Young Priestess |  
@@ -136,7 +136,7 @@ VANILLA | VAN_EX1_007 | Acolyte of Pain |
 VANILLA | VAN_EX1_008 | Argent Squire |  
 VANILLA | VAN_EX1_009 | Angry Chicken |  
 VANILLA | VAN_EX1_010 | Worgen Infiltrator |  
-VANILLA | VAN_EX1_011 | Voodoo Doctor |  
+VANILLA | VAN_EX1_011 | Voodoo Doctor | O
 VANILLA | VAN_EX1_012 | Bloodmage Thalnos |  
 VANILLA | VAN_EX1_014 | King Mukla |  
 VANILLA | VAN_EX1_015 | Novice Engineer |  
@@ -172,7 +172,7 @@ VANILLA | VAN_EX1_083 | Tinkmaster Overspark |
 VANILLA | VAN_EX1_084 | Warsong Commander |  
 VANILLA | VAN_EX1_085 | Mind Control Tech |  
 VANILLA | VAN_EX1_089 | Arcane Golem |  
-VANILLA | VAN_EX1_091 | Cabal Shadow Priest |  
+VANILLA | VAN_EX1_091 | Cabal Shadow Priest | O
 VANILLA | VAN_EX1_093 | Defender of Argus |  
 VANILLA | VAN_EX1_095 | Gadgetzan Auctioneer |  
 VANILLA | VAN_EX1_096 | Loot Hoarder |  
@@ -389,4 +389,4 @@ VANILLA | VAN_PRO_001 | Elite Tauren Chieftain |
 VANILLA | VAN_tt_004 | Flesheating Ghoul |  
 VANILLA | VAN_tt_010 | Spellbender | O
 
-- Progress: 27% (106 of 382 Cards)
+- Progress: 30% (118 of 382 Cards)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Classic Format
 
-  * 27% Vanilla Set (106 of 382 Cards)
+  * 30% Vanilla Set (118 of 382 Cards)
 
 ## Implementation List
 

--- a/Sources/Rosetta/PlayMode/CardSets/LegacyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LegacyCardsGen.cpp
@@ -1434,7 +1434,8 @@ void LegacyCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // - Faction: Neutral, Set: Legacy, Rarity: Free
     // - Spell School: Shadow
     // --------------------------------------------------------
-    // Text: Put a copy of a random card in your opponent's hand into your hand.
+    // Text: Put a copy of a random card in your opponent's
+    //       hand into your hand.
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(std::make_shared<RandomTask>(EntityType::ENEMY_HAND, 1));

--- a/Sources/Rosetta/PlayMode/CardSets/LegacyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LegacyCardsGen.cpp
@@ -1489,6 +1489,9 @@ void LegacyCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Whenever a minion is healed, draw a card.
     // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TAKE_HEAL));
     power.GetTrigger()->triggerSource = TriggerSource::ALL_MINIONS;

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -2862,6 +2862,18 @@ void VanillaCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Give a minion +2 Health. Draw a card.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("CS2_004e", EntityType::TARGET));
+    power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cards.emplace(
+        "VAN_CS2_004",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ----------------------------------------- SPELL - PRIEST
     // [VAN_CS2_234] Shadow Word: Pain - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -2939,6 +2939,10 @@ void VanillaCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 5 damage to the enemy hero.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 5, true));
+    cards.emplace("VAN_DS1_233", CardDef(power));
 
     // ---------------------------------------- MINION - PRIEST
     // [VAN_EX1_091] Cabal Shadow Priest - COST:6 [ATK:4/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -2881,6 +2881,18 @@ void VanillaCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Destroy a minion with 3 or less Attack.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_TARGET_MAX_ATTACK = 3
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DestroyTask>(EntityType::TARGET));
+    cards.emplace(
+        "VAN_CS2_234",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_TARGET_MAX_ATTACK, 3 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ---------------------------------------- MINION - PRIEST
     // [VAN_CS2_235] Northshire Cleric - COST:1 [ATK:1/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -2903,6 +2903,11 @@ void VanillaCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TAKE_HEAL));
+    power.GetTrigger()->triggerSource = TriggerSource::ALL_MINIONS;
+    power.GetTrigger()->tasks = { std::make_shared<DrawTask>(1) };
+    cards.emplace("VAN_CS2_235", CardDef(power));
 
     // ----------------------------------------- SPELL - PRIEST
     // [VAN_CS2_236] Divine Spirit - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -2243,8 +2243,8 @@ void VanillaCardsGen::AddMage(std::map<std::string, CardDef>& cards)
                     SelfCondition::IsTagValue(GameTag::CANT_PLAY, 0)) }),
         std::make_shared<FlagTask>(
             true, ComplexTask::ActivateSecret(TaskList{
-                      std::make_shared<SummonTask>("VAN_tt_010a", SummonSide::SPELL,
-                                                   true),
+                      std::make_shared<SummonTask>("VAN_tt_010a",
+                                                   SummonSide::SPELL, true),
                       std::make_shared<IncludeTask>(
                           EntityType::SOURCE, std::vector<EntityType>(), true),
                       std::make_shared<IncludeTask>(
@@ -2833,6 +2833,15 @@ void VanillaCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 2 damage.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 2, true));
+    cards.emplace(
+        "VAN_CS1_130",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ----------------------------------------- SPELL - PRIEST
     // [VAN_CS2_003] Mind Vision - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -2776,6 +2776,11 @@ void VanillaCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // Text: Deal 2 damage to all enemies.
     //       Restore 2 Health to all friendly characters.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 2, true));
+    power.AddPowerTask(std::make_shared<HealTask>(EntityType::FRIENDS, 2));
+    cards.emplace("VAN_CS1_112", CardDef(power));
 
     // ----------------------------------------- SPELL - PRIEST
     // [VAN_CS1_113] Mind Control - COST:10

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -4761,6 +4761,14 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<HealTask>(EntityType::TARGET, 2));
+    cards.emplace(
+        "VAN_EX1_011",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } }));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_EX1_012] Bloodmage Thalnos - COST:2 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -2954,6 +2954,20 @@ void VanillaCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_TARGET_MAX_ATTACK = 2
+    // - REQ_MINION_TARGET = 0
+    // - REQ_ENEMY_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ControlTask>(EntityType::TARGET));
+    cards.emplace(
+        "VAN_EX1_091",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },
+                                 { PlayReq::REQ_TARGET_MAX_ATTACK, 2 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_ENEMY_TARGET, 0 } }));
 
     // ----------------------------------------- SPELL - PRIEST
     // [VAN_EX1_332] Silence - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -2788,6 +2788,20 @@ void VanillaCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Take control of an enemy minion.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_ENEMY_TARGET = 0
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ControlTask>(EntityType::TARGET));
+    cards.emplace(
+        "VAN_CS1_113",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_ENEMY_TARGET, 0 },
+                                 { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ----------------------------------------- SPELL - PRIEST
     // [VAN_CS1_129] Inner Fire - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -2809,6 +2809,23 @@ void VanillaCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Change a minion's Attack to be equal to its Health.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<GetGameTagTask>(EntityType::TARGET, GameTag::HEALTH));
+    power.AddPowerTask(std::make_shared<GetGameTagTask>(EntityType::TARGET,
+                                                        GameTag::DAMAGE, 0, 1));
+    power.AddPowerTask(
+        std::make_shared<MathNumberIndexTask>(0, 1, MathOperation::SUB));
+    power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
+        "CS1_129e", EntityType::TARGET, true));
+    cards.emplace(
+        "VAN_CS1_129",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ----------------------------------------- SPELL - PRIEST
     // [VAN_CS1_130] Holy Smite - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -2850,6 +2850,11 @@ void VanillaCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // Text: Put a copy of a random card in your opponent's
     //       hand into your hand.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::ENEMY_HAND, 1));
+    power.AddPowerTask(
+        std::make_shared<CopyTask>(EntityType::STACK, ZoneType::HAND));
+    cards.emplace("VAN_CS2_003", CardDef(power));
 
     // ----------------------------------------- SPELL - PRIEST
     // [VAN_CS2_004] Power Word: Shield - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -2872,6 +2872,23 @@ void VanillaCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Double a minion's Health.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<GetGameTagTask>(EntityType::TARGET, GameTag::HEALTH));
+    power.AddPowerTask(std::make_shared<GetGameTagTask>(EntityType::TARGET,
+                                                        GameTag::DAMAGE, 0, 1));
+    power.AddPowerTask(
+        std::make_shared<MathNumberIndexTask>(0, 1, MathOperation::SUB));
+    power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
+        "CS2_236e", EntityType::TARGET, true));
+    cards.emplace(
+        "VAN_CS2_236",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ----------------------------------------- SPELL - PRIEST
     // [VAN_DS1_233] Mind Blast - COST:2

--- a/Tests/UnitTests/PlayMode/CardSets/LegacyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LegacyCardsGenTests.cpp
@@ -3061,6 +3061,9 @@ TEST_CASE("[Priest : Spell] - CS2_234 : Shadow Word: Pain")
 // --------------------------------------------------------
 // Text: Whenever a minion is healed, draw a card.
 // --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
 TEST_CASE("[Priest : Minion] - CS2_235 : Northshire Cleric")
 {
     GameConfig config;

--- a/Tests/UnitTests/PlayMode/CardSets/LegacyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LegacyCardsGenTests.cpp
@@ -2895,7 +2895,8 @@ TEST_CASE("[Priest : Spell] - CS1_130 : Holy Smite")
 // - Faction: Neutral, Set: Legacy, Rarity: Free
 // - Spell School: Shadow
 // --------------------------------------------------------
-// Text: Put a copy of a random card in your opponent's hand into your hand.
+// Text: Put a copy of a random card in your opponent's
+//       hand into your hand.
 // --------------------------------------------------------
 TEST_CASE("[Priest : Spell] - CS2_003 : Mind Vision")
 {

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -7278,6 +7278,40 @@ TEST_CASE("[Priest : Spell] - VAN_CS2_236 : Divine Spirit")
 }
 
 // ----------------------------------------- SPELL - PRIEST
+// [VAN_DS1_233] Mind Blast - COST:2
+// - Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: Deal 5 damage to the enemy hero.
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - VAN_DS1_233 : Mind Blast")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Mind Blast", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 25);
+}
+
+// ----------------------------------------- SPELL - PRIEST
 // [VAN_EX1_332] Silence - COST:0
 // - Set: VANILLA, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -7311,6 +7311,79 @@ TEST_CASE("[Priest : Spell] - VAN_DS1_233 : Mind Blast")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 25);
 }
 
+// ---------------------------------------- MINION - PRIEST
+// [VAN_EX1_091] Cabal Shadow Priest - COST:6 [ATK:4/HP:5]
+// - Set: VANILLA, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Take control of an enemy minion
+//       that has 2 or less Attack.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// - REQ_TARGET_MAX_ATTACK = 2
+// - REQ_MINION_TARGET = 0
+// - REQ_ENEMY_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - VAN_EX1_091 : Cabal Shadow Priest")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Cabal Shadow Priest", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Cabal Shadow Priest", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Stonetusk Boar", FormatType::CLASSIC));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card4));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card3));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(opField.GetCount(), 1);
+}
+
 // ----------------------------------------- SPELL - PRIEST
 // [VAN_EX1_332] Silence - COST:0
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -6708,6 +6708,85 @@ TEST_CASE("[Paladin : Spell] - VAN_EX1_619 : Equality")
 }
 
 // ----------------------------------------- SPELL - PRIEST
+// [VAN_CS1_112] Holy Nova - COST:5
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Deal 2 damage to all enemies.
+//       Restore 2 Health to all friendly characters.
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - VAN_CS1_112 : Holy Nova")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(4);
+    opPlayer->GetHero()->SetDamage(4);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Windfury Harpy", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Boulderfist Ogre", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Holy Nova", FormatType::CLASSIC));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Argent Squire", FormatType::CLASSIC));
+    const auto card5 = Generic::DrawCard(
+        opPlayer,
+        Cards::FindCardByName("Worgen Infiltrator", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(card1, card4));
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(opField[0]->GetGameTag(GameTag::DIVINE_SHIELD), 0);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 28);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 26);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+    CHECK_EQ(curField[1]->GetHealth(), 7);
+    CHECK_EQ(opField.GetCount(), 0);
+}
+
+// ----------------------------------------- SPELL - PRIEST
 // [VAN_EX1_332] Silence - COST:0
 // - Set: VANILLA, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -6922,6 +6922,64 @@ TEST_CASE("[Priest : Spell] - VAN_CS1_129 : Inner Fire")
 }
 
 // ----------------------------------------- SPELL - PRIEST
+// [VAN_CS2_236] Divine Spirit - COST:2
+// - Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: Double a minion's Health.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - VAN_CS2_236 : Divine Spirit")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Divine Spirit", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Boulderfist Ogre", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetHealth(), 7);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    game.Process(opPlayer, AttackTask(card3, card2));
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curField[0]->GetHealth(), 8);
+}
+
+// ----------------------------------------- SPELL - PRIEST
 // [VAN_EX1_332] Silence - COST:0
 // - Set: VANILLA, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -7163,6 +7163,62 @@ TEST_CASE("[Priest : Spell] - VAN_CS2_234 : Shadow Word: Pain")
     CHECK_EQ(opField.GetCount(), 1);
 }
 
+// ---------------------------------------- MINION - PRIEST
+// [VAN_CS2_235] Northshire Cleric - COST:1 [ATK:1/HP:3]
+// - Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: Whenever a minion is healed, draw a card.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - VAN_CS2_235 : Northshire Cleric")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(6);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Northshire Cleric", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Voodoo Doctor", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Voodoo Doctor", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card2, curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 26);
+
+    curField[0]->SetDamage(2);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card3, card1));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+}
+
 // ----------------------------------------- SPELL - PRIEST
 // [VAN_CS2_236] Divine Spirit - COST:2
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -6995,6 +6995,55 @@ TEST_CASE("[Priest : Spell] - VAN_CS1_130 : Holy Smite")
 }
 
 // ----------------------------------------- SPELL - PRIEST
+// [VAN_CS2_003] Mind Vision - COST:1
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Put a copy of a random card in your opponent's
+//       hand into your hand.
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - VAN_CS2_003 : Mind Vision")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Mind Vision", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    const auto gainedCard = curHand[4];
+
+    bool flag = false;
+    for (auto& handCard : opPlayer->GetHandZone()->GetAll())
+    {
+        if (handCard->card->id == gainedCard->card->id)
+        {
+            flag = true;
+            break;
+        }
+    }
+
+    CHECK(flag);
+}
+
+// ----------------------------------------- SPELL - PRIEST
 // [VAN_CS2_236] Divine Spirit - COST:2
 // - Set: VANILLA, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -6922,6 +6922,79 @@ TEST_CASE("[Priest : Spell] - VAN_CS1_129 : Inner Fire")
 }
 
 // ----------------------------------------- SPELL - PRIEST
+// [VAN_CS1_130] Holy Smite - COST:1
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Deal 2 damage.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - VAN_CS1_130 : Holy Smite")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Holy Smite", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Holy Smite", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Holy Smite", FormatType::CLASSIC));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Holy Smite", FormatType::CLASSIC));
+    const auto card5 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Acidic Swamp Ooze", FormatType::CLASSIC));
+    const auto card6 = Generic::DrawCard(
+        opPlayer,
+        Cards::FindCardByName("Boulderfist Ogre", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card6));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card6));
+    CHECK_EQ(opField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card5));
+    CHECK_EQ(curField.GetCount(), 0);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card4, curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 28);
+}
+
+// ----------------------------------------- SPELL - PRIEST
 // [VAN_CS2_236] Divine Spirit - COST:2
 // - Set: VANILLA, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -7096,6 +7096,74 @@ TEST_CASE("[Priest : Spell] - VAN_CS2_004 : Power Word: Shield")
 }
 
 // ----------------------------------------- SPELL - PRIEST
+// [VAN_CS2_234] Shadow Word: Pain - COST:2
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Destroy a minion with 3 or less Attack.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_TARGET_MAX_ATTACK = 3
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - VAN_CS2_234 : Shadow Word: Pain")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Shadow Word: Pain", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        opPlayer,
+        Cards::FindCardByName("Boulderfist Ogre", FormatType::CLASSIC));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(opField.GetCount(), 1);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card1, opPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+    CHECK_EQ(opField.GetCount(), 1);
+}
+
+// ----------------------------------------- SPELL - PRIEST
 // [VAN_CS2_236] Divine Spirit - COST:2
 // - Set: VANILLA, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -7044,6 +7044,58 @@ TEST_CASE("[Priest : Spell] - VAN_CS2_003 : Mind Vision")
 }
 
 // ----------------------------------------- SPELL - PRIEST
+// [VAN_CS2_004] Power Word: Shield - COST:1
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Give a minion +2 Health. Draw a card.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - VAN_CS2_004 : Power Word: Shield")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Power Word: Shield", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Boulderfist Ogre", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 4);
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 7);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 3);
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 9);
+}
+
+// ----------------------------------------- SPELL - PRIEST
 // [VAN_CS2_236] Divine Spirit - COST:2
 // - Set: VANILLA, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -6858,6 +6858,70 @@ TEST_CASE("[Priest : Spell] - VAN_CS1_113 : Mind Control")
 }
 
 // ----------------------------------------- SPELL - PRIEST
+// [VAN_CS1_129] Inner Fire - COST:1
+// - Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: Change a minion's Attack to be equal to its Health.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - VAN_CS1_129 : Inner Fire")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Inner Fire", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Divine Spirit", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Inner Fire", FormatType::CLASSIC));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Inner Fire", FormatType::CLASSIC));
+    const auto card5 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Northshire Cleric", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, curField[0]));
+    CHECK_EQ(curField[0]->GetHealth(), curField[0]->GetAttack());
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, curField[0]));
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, curField[0]));
+    CHECK_EQ(curField[0]->GetHealth(), curField[0]->GetAttack());
+
+    curField[0]->SetDamage(1);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card4, curField[0]));
+    CHECK_EQ(curField[0]->GetHealth(), curField[0]->GetAttack());
+}
+
+// ----------------------------------------- SPELL - PRIEST
 // [VAN_EX1_332] Silence - COST:0
 // - Set: VANILLA, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -6787,6 +6787,77 @@ TEST_CASE("[Priest : Spell] - VAN_CS1_112 : Holy Nova")
 }
 
 // ----------------------------------------- SPELL - PRIEST
+// [VAN_CS1_113] Mind Control - COST:10
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Take control of an enemy minion.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// - REQ_ENEMY_TARGET = 0
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - VAN_CS1_113 : Mind Control")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto& curField = *(curPlayer->GetFieldZone());
+    const auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Windfury Harpy", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        opPlayer,
+        Cards::FindCardByName("Boulderfist Ogre", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Mind Control", FormatType::CLASSIC));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Mind Control", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(opField.GetCount(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card2));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(opField.GetCount(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer,
+                 PlayCardTask::SpellTarget(card4, curPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHandZone()->GetCount(), 8);
+}
+
+// ----------------------------------------- SPELL - PRIEST
 // [VAN_EX1_332] Silence - COST:0
 // - Set: VANILLA, Rarity: Common
 // --------------------------------------------------------


### PR DESCRIPTION
This revision includes:
- Implement 12 VANILLA cards (#674)
  - Holy Nova' (VAN_CS1_112)
  - Mind Control (VAN_CS1_113)
  - Inner Fire (VAN_CS1_129)
  - Holy Smite (VAN_CS1_130)
  - Mind Vision (VAN_CS2_003)
  - Power Word: Shield (VAN_CS2_004)
  - Shadow Word: Pain (VAN_CS2_234)
  - Northshire Cleric (VAN_CS2_235)
  - Divine Spirit (VAN_CS2_236)
  - Mind Blast (VAN_DS1_233)
  - Voodoo Doctor (VAN_EX1_011)
  - Cabal Shadow Priest (VAN_EX1_091)
- Separate text to improve readability
- Add missing game tag 'TRIGGER_VISUAL'