### PR TITLE
Implement 13 VANILLA cards

### DIFF
--- a/Documents/CardList - Classic.md
+++ b/Documents/CardList - Classic.md
@@ -189,14 +189,14 @@ VANILLA | VAN_EX1_126 | Betrayal | O
 VANILLA | VAN_EX1_128 | Conceal | O
 VANILLA | VAN_EX1_129 | Fan of Knives | O
 VANILLA | VAN_EX1_130 | Noble Sacrifice | O
-VANILLA | VAN_EX1_131 | Defias Ringleader |  
+VANILLA | VAN_EX1_131 | Defias Ringleader | O
 VANILLA | VAN_EX1_132 | Eye for an Eye | O
-VANILLA | VAN_EX1_133 | Perdition's Blade |  
-VANILLA | VAN_EX1_134 | SI:7 Agent |  
+VANILLA | VAN_EX1_133 | Perdition's Blade | O
+VANILLA | VAN_EX1_134 | SI:7 Agent | O
 VANILLA | VAN_EX1_136 | Redemption | O
-VANILLA | VAN_EX1_137 | Headcrack |  
-VANILLA | VAN_EX1_144 | Shadowstep |  
-VANILLA | VAN_EX1_145 | Preparation |  
+VANILLA | VAN_EX1_137 | Headcrack | O
+VANILLA | VAN_EX1_144 | Shadowstep | O
+VANILLA | VAN_EX1_145 | Preparation | O
 VANILLA | VAN_EX1_154 | Wrath | O
 VANILLA | VAN_EX1_155 | Mark of Nature | O
 VANILLA | VAN_EX1_158 | Soul of the Forest | O
@@ -226,7 +226,7 @@ VANILLA | VAN_EX1_259 | Lightning Storm |
 VANILLA | VAN_EX1_274 | Ethereal Arcanist | O
 VANILLA | VAN_EX1_275 | Cone of Cold | O
 VANILLA | VAN_EX1_277 | Arcane Missiles | O
-VANILLA | VAN_EX1_278 | Shiv |  
+VANILLA | VAN_EX1_278 | Shiv | O
 VANILLA | VAN_EX1_279 | Pyroblast | O
 VANILLA | VAN_EX1_283 | Frost Elemental |  
 VANILLA | VAN_EX1_284 | Azure Drake |  
@@ -292,7 +292,7 @@ VANILLA | VAN_EX1_506 | Murloc Tidehunter |
 VANILLA | VAN_EX1_507 | Murloc Warleader |  
 VANILLA | VAN_EX1_508 | Grimscale Oracle |  
 VANILLA | VAN_EX1_509 | Murloc Tidecaller |  
-VANILLA | VAN_EX1_522 | Patient Assassin |  
+VANILLA | VAN_EX1_522 | Patient Assassin | O
 VANILLA | VAN_EX1_531 | Scavenging Hyena | O
 VANILLA | VAN_EX1_533 | Misdirection | O
 VANILLA | VAN_EX1_534 | Savannah Highmane | O
@@ -322,7 +322,7 @@ VANILLA | VAN_EX1_573 | Cenarius | O
 VANILLA | VAN_EX1_575 | Mana Tide Totem |  
 VANILLA | VAN_EX1_577 | The Beast |  
 VANILLA | VAN_EX1_578 | Savagery | O
-VANILLA | VAN_EX1_581 | Sap |  
+VANILLA | VAN_EX1_581 | Sap | O
 VANILLA | VAN_EX1_582 | Dalaran Mage |  
 VANILLA | VAN_EX1_583 | Priestess of Elune |  
 VANILLA | VAN_EX1_584 | Ancient Mage |  
@@ -344,7 +344,7 @@ VANILLA | VAN_EX1_609 | Snipe | O
 VANILLA | VAN_EX1_610 | Explosive Trap | O
 VANILLA | VAN_EX1_611 | Freezing Trap | O
 VANILLA | VAN_EX1_612 | Kirin Tor Mage | O
-VANILLA | VAN_EX1_613 | Edwin VanCleef |  
+VANILLA | VAN_EX1_613 | Edwin VanCleef | O
 VANILLA | VAN_EX1_614 | Illidan Stormrage |  
 VANILLA | VAN_EX1_616 | Mana Wraith |  
 VANILLA | VAN_EX1_617 | Deadly Shot | O
@@ -357,14 +357,14 @@ VANILLA | VAN_EX1_624 | Holy Fire | O
 VANILLA | VAN_EX1_625 | Shadowform | O
 VANILLA | VAN_EX1_626 | Mass Dispel | O
 VANILLA | VAN_NEW1_003 | Sacrificial Pact |  
-VANILLA | VAN_NEW1_004 | Vanish |  
-VANILLA | VAN_NEW1_005 | Kidnapper |  
+VANILLA | VAN_NEW1_004 | Vanish | O
+VANILLA | VAN_NEW1_005 | Kidnapper | O
 VANILLA | VAN_NEW1_007 | Starfall | O
 VANILLA | VAN_NEW1_008 | Ancient of Lore | O
 VANILLA | VAN_NEW1_010 | Al'Akir the Windlord |  
 VANILLA | VAN_NEW1_011 | Kor'kron Elite |  
 VANILLA | VAN_NEW1_012 | Mana Wyrm | O
-VANILLA | VAN_NEW1_014 | Master of Disguise |  
+VANILLA | VAN_NEW1_014 | Master of Disguise | O
 VANILLA | VAN_NEW1_016 | Captain's Parrot |  
 VANILLA | VAN_NEW1_017 | Hungry Crab |  
 VANILLA | VAN_NEW1_018 | Bloodsail Raider |  
@@ -389,4 +389,4 @@ VANILLA | VAN_PRO_001 | Elite Tauren Chieftain |
 VANILLA | VAN_tt_004 | Flesheating Ghoul |  
 VANILLA | VAN_tt_010 | Spellbender | O
 
-- Progress: 37% (144 of 382 Cards)
+- Progress: 40% (157 of 382 Cards)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Classic Format
 
-  * 37% Vanilla Set (144 of 382 Cards)
+  * 40% Vanilla Set (157 of 382 Cards)
 
 ## Implementation List
 

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -2729,7 +2729,8 @@ void Expert1CardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // [EX1_133] Perdition's Blade - COST:3 [ATK:2/HP:0]
     // - Faction: Neutral, Set: Expert1, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Deal 1 damage. <b>Combo:</b> Deal 2 instead.
+    // Text: <b>Battlecry:</b> Deal 1 damage.
+    //       <b>Combo:</b> Deal 2 instead.
     // --------------------------------------------------------
     // GameTag:
     // - DURABILITY = 2

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -2991,6 +2991,7 @@ void Expert1CardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
     // Text: The next spell you cast this turn costs (2) less.
     // --------------------------------------------------------
     // GameTag:
+    // - CANT_BE_SILENCED = 1
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
     power.ClearData();

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -3657,6 +3657,14 @@ void VanillaCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - COMBO = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddComboTask(std::make_shared<GetPlayerGameTagTask>(
+        GameTag::NUM_CARDS_PLAYED_THIS_TURN));
+    power.AddComboTask(std::make_shared<MathSubtractTask>(1));
+    power.AddComboTask(std::make_shared<MathMultiplyTask>(2));
+    power.AddComboTask(std::make_shared<AddEnchantmentTask>(
+        "EX1_613e", EntityType::SOURCE, true));
+    cards.emplace("VAN_EX1_613", CardDef(power));
 
     // ------------------------------------------ SPELL - ROGUE
     // [VAN_NEW1_004] Vanish - COST:6

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -3706,9 +3706,24 @@ void VanillaCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_NONSELF_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
     // RefTag:
     // - STEALTH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::TARGET,
+                                                        GameTag::STEALTH, 1));
+    cards.emplace(
+        "VAN_NEW1_014",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },
+                                 { PlayReq::REQ_NONSELF_TARGET, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_FRIENDLY_TARGET, 0 } }));
 }
 
 void VanillaCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -3686,6 +3686,16 @@ void VanillaCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - COMBO = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_FOR_COMBO = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddComboTask(std::make_shared<ReturnHandTask>(EntityType::TARGET));
+    cards.emplace(
+        "VAN_NEW1_005",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_TARGET_FOR_COMBO, 0 } }));
 
     // ----------------------------------------- MINION - ROGUE
     // [VAN_NEW1_014] Master of Disguise - COST:4 [ATK:4/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -3479,6 +3479,10 @@ void VanillaCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - COMBO = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddComboTask(
+        std::make_shared<SummonTask>("EX1_131t", SummonSide::RIGHT));
+    cards.emplace("VAN_EX1_131", CardDef(power));
 
     // ----------------------------------------- WEAPON - ROGUE
     // [VAN_EX1_133] Perdition's Blade - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -3534,6 +3534,34 @@ void VanillaCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - COMBO = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 2, true));
+    power.AddComboTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 2, true));
+    power.AddComboTask(std::make_shared<SetGameTagTask>(
+        EntityType::SOURCE, GameTag::HEADCRACK_COMBO, 1));
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->tasks = {
+        std::make_shared<ConditionTask>(
+            EntityType::SOURCE,
+            SelfCondList{ std::make_shared<SelfCondition>(
+                SelfCondition::IsTagValue(GameTag::HEADCRACK_COMBO, 1)) }),
+        std::make_shared<FlagTask>(
+            true,
+            TaskList{ std::make_shared<IncludeTask>(EntityType::SOURCE),
+                      std::make_shared<FuncPlayableTask>(
+                          [=](const std::vector<Playable*>& playables) {
+                              auto source = playables[0];
+                              source->zone->Remove(source);
+                              source->SetGameTag(GameTag::HEADCRACK_COMBO, 0);
+
+                              return std::vector<Playable*>{ source };
+                          }),
+                      std::make_shared<AddStackToTask>(EntityType::HAND) })
+    };
+    power.GetTrigger()->removeAfterTriggered = true;
+    cards.emplace("VAN_EX1_137", CardDef(power));
 
     // ------------------------------------------ SPELL - ROGUE
     // [VAN_EX1_144] Shadowstep - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -3485,16 +3485,26 @@ void VanillaCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     cards.emplace("VAN_EX1_131", CardDef(power));
 
     // ----------------------------------------- WEAPON - ROGUE
-    // [VAN_EX1_133] Perdition's Blade - COST:3
+    // [VAN_EX1_133] Perdition's Blade - COST:3 [ATK:2/HP:0]
     // - Set: VANILLA, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Deal 1 damage.
     //       <b>Combo:</b> Deal 2 instead.
     // --------------------------------------------------------
     // GameTag:
+    // - DURABILITY = 2
     // - BATTLECRY = 1
     // - COMBO = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::TARGET, 1));
+    power.AddComboTask(std::make_shared<DamageTask>(EntityType::TARGET, 2));
+    cards.emplace(
+        "VAN_EX1_133",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } }));
 
     // ----------------------------------------- MINION - ROGUE
     // [VAN_EX1_134] SI:7 Agent - COST:3 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -3672,6 +3672,10 @@ void VanillaCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Return all minions to their owner's hand.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<ReturnHandTask>(EntityType::ALL_MINIONS));
+    cards.emplace("VAN_NEW1_004", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
     // [VAN_NEW1_005] Kidnapper - COST:6 [ATK:5/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -3515,6 +3515,14 @@ void VanillaCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - COMBO = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_FOR_COMBO = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddComboTask(std::make_shared<DamageTask>(EntityType::TARGET, 2));
+    cards.emplace(
+        "VAN_EX1_134",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_FOR_COMBO, 0 } }));
 
     // ------------------------------------------ SPELL - ROGUE
     // [VAN_EX1_137] Headcrack - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -3622,7 +3622,11 @@ void VanillaCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // GameTag:
     // - STEALTH = 1
+    // - POISONOUS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_EX1_522", CardDef(power));
 
     // ------------------------------------------ SPELL - ROGUE
     // [VAN_EX1_581] Sap - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -3570,6 +3570,20 @@ void VanillaCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // Text: Return a friendly minion to your hand.
     //       It costs (2) less.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ReturnHandTask>(EntityType::TARGET));
+    power.AddPowerTask(std::make_shared<AddAuraEffectTask>(
+        Effects::ReduceCost(2), EntityType::TARGET));
+    cards.emplace(
+        "VAN_EX1_144",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_FRIENDLY_TARGET, 0 } }));
 
     // ------------------------------------------ SPELL - ROGUE
     // [VAN_EX1_145] Preparation - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -3591,6 +3591,10 @@ void VanillaCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: The next spell you cast this turn costs (3) less.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
+        "VAN_EX1_145o", EntityType::PLAYER));
+    cards.emplace("VAN_EX1_145", CardDef(power));
 
     // ------------------------------------------ SPELL - ROGUE
     // [VAN_EX1_278] Shiv - COST:2
@@ -3682,6 +3686,16 @@ void VanillaCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
     // - CANT_BE_SILENCED = 1
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<Aura>(AuraType::HAND,
+                                         EffectList{ Effects::ReduceCost(3) }));
+    {
+        const auto aura = dynamic_cast<Aura*>(power.GetAura());
+        aura->condition =
+            std::make_shared<SelfCondition>(SelfCondition::IsSpell());
+        aura->removeTrigger = { TriggerType::CAST_SPELL, nullptr };
+    }
+    cards.emplace("VAN_EX1_145o", CardDef(power));
 }
 
 void VanillaCardsGen::AddShaman(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -3602,6 +3602,16 @@ void VanillaCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 1 damage. Draw a card.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 1, true));
+    power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cards.emplace(
+        "VAN_EX1_278",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ----------------------------------------- MINION - ROGUE
     // [VAN_EX1_522] Patient Assassin - COST:2 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -3634,6 +3634,17 @@ void VanillaCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Return an enemy minion to your opponent's hand.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_ENEMY_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ReturnHandTask>(EntityType::TARGET));
+    cards.emplace("VAN_EX1_581",
+                  CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                           { PlayReq::REQ_MINION_TARGET, 0 },
+                                           { PlayReq::REQ_ENEMY_TARGET, 0 } }));
 
     // ----------------------------------------- MINION - ROGUE
     // [VAN_EX1_613] Edwin VanCleef - COST:3 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
@@ -126,6 +126,7 @@ void CardLoader::Load(std::vector<Card*>& cards)
 
         // NOTE: Skyvateer (YOD_016), Cowardly Grunt (SW_021)
         //       doesn't have GameTag::DEATHRATTLE
+        // NOTE: Patient Assassin (VAN_EX1_522) doesn't have GameTag::POISONOUS
         // NOTE: Carousel Gryphon (DMF_064) doesn't have GameTag::DIVINE_SHIELD
         // NOTE: Healing Totem (AT_132_SHAMANa), Searing Totem (AT_132_SHAMANb),
         //       Stoneclaw Totem (AT_132_SHAMANc), Wrath of Air Totem
@@ -135,6 +136,10 @@ void CardLoader::Load(std::vector<Card*>& cards)
         if (dbfID == 56091 || dbfID == 64196)
         {
             gameTags.emplace(GameTag::DEATHRATTLE, 1);
+        }
+        else if (dbfID == 69961)
+        {
+            gameTags.emplace(GameTag::POISONOUS, 1);
         }
         else if (dbfID == 61581)
         {

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -5687,7 +5687,8 @@ TEST_CASE("[Rogue : Minion] - EX1_131 : Defias Ringleader")
 // [EX1_133] Perdition's Blade - COST:3 [ATK:2/HP:0]
 // - Faction: Neutral, Set: Expert1, Rarity: Rare
 // --------------------------------------------------------
-// Text: <b>Battlecry:</b> Deal 1 damage. <b>Combo:</b> Deal 2 instead.
+// Text: <b>Battlecry:</b> Deal 1 damage.
+//       <b>Combo:</b> Deal 2 instead.
 // --------------------------------------------------------
 // GameTag:
 // - DURABILITY = 2

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -9304,6 +9304,70 @@ TEST_CASE("[Rogue : Spell] - VAN_EX1_144 : Shadowstep")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 22);
 }
 
+// ------------------------------------------ SPELL - ROGUE
+// [VAN_EX1_145] Preparation - COST:0
+// - Set: VANILLA, Rarity: Epic
+// --------------------------------------------------------
+// Text: The next spell you cast this turn costs (3) less.
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Spell] - VAN_EX1_145 : Preparation")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Preparation", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Preparation", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Preparation", FormatType::CLASSIC));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Eviscerate", FormatType::CLASSIC));
+    const auto card5 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Vanish", FormatType::CLASSIC));
+
+    CHECK_EQ(card1->GetCost(), 0);
+    CHECK_EQ(card2->GetCost(), 0);
+    CHECK_EQ(card3->GetCost(), 0);
+    CHECK_EQ(card4->GetCost(), 2);
+    CHECK_EQ(card5->GetCost(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(card2->GetCost(), 0);
+    CHECK_EQ(card3->GetCost(), 0);
+    CHECK_EQ(card4->GetCost(), 0);
+    CHECK_EQ(card5->GetCost(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(card3->GetCost(), 0);
+    CHECK_EQ(card4->GetCost(), 0);
+    CHECK_EQ(card5->GetCost(), 3);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card4, opPlayer->GetHero()));
+    CHECK_EQ(card3->GetCost(), 0);
+    CHECK_EQ(card5->GetCost(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(card5->GetCost(), 3);
+}
+
 // ----------------------------------------- SPELL - SHAMAN
 // [VAN_EX1_238] Lightning Bolt - COST:1
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -9755,6 +9755,68 @@ TEST_CASE("[Rogue : Minion] - VAN_NEW1_005 : Kidnapper")
     CHECK_EQ(opPlayer->GetHandZone()->GetCount(), 7);
 }
 
+// ----------------------------------------- MINION - ROGUE
+// [VAN_NEW1_014] Master of Disguise - COST:4 [ATK:4/HP:4]
+// - Set: VANILLA, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give a friendly minion <b>Stealth</b>.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// - REQ_NONSELF_TARGET = 0
+// - REQ_MINION_TARGET = 0
+// - REQ_FRIENDLY_TARGET = 0
+// --------------------------------------------------------
+// RefTag:
+// - STEALTH = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - VAN_NEW1_014 : Master of Disguise")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Master of Disguise", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->HasStealth(), false);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card1, card2));
+    CHECK_EQ(curField[0]->HasStealth(), true);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->HasStealth(), true);
+}
+
 // ----------------------------------------- SPELL - SHAMAN
 // [VAN_EX1_238] Lightning Bolt - COST:1
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -8981,6 +8981,58 @@ TEST_CASE("[Rogue : Spell] - VAN_EX1_129 : Fan of Knives")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
 }
 
+// ----------------------------------------- MINION - ROGUE
+// [VAN_EX1_131] Defias Ringleader - COST:2 [ATK:2/HP:2]
+// - Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Combo:</b> Summon a 2/1 Defias Bandit.
+// --------------------------------------------------------
+// GameTag:
+// - COMBO = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - VAN_EX1_131 : Defias Ringleader")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Defias Ringleader", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Defias Ringleader", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+    CHECK_EQ(curField[2]->GetAttack(), 2);
+    CHECK_EQ(curField[2]->GetHealth(), 1);
+}
+
 // ----------------------------------------- SPELL - SHAMAN
 // [VAN_EX1_238] Lightning Bolt - COST:1
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -9620,6 +9620,64 @@ TEST_CASE("[Rogue : Minion] - VAN_EX1_613 : Edwin VanCleef")
     CHECK_EQ(curField[2]->GetHealth(), 6);
 }
 
+// ------------------------------------------ SPELL - ROGUE
+// [VAN_NEW1_004] Vanish - COST:6
+// - Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: Return all minions to their owner's hand.
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Spell] - VAN_NEW1_004 : Vanish")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Vanish", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Voidwalker", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opPlayer->GetHandZone()->GetCount(), 6);
+    CHECK_EQ(opField.GetCount(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+    CHECK_EQ(curField.GetCount(), 0);
+    CHECK_EQ(opPlayer->GetHandZone()->GetCount(), 7);
+    CHECK_EQ(opField.GetCount(), 0);
+}
+
 // ----------------------------------------- SPELL - SHAMAN
 // [VAN_EX1_238] Lightning Bolt - COST:1
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -9142,6 +9142,63 @@ TEST_CASE("[Rogue : Minion] - VAN_EX1_134 : SI:7 Agent")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
 }
 
+// ------------------------------------------ SPELL - ROGUE
+// [VAN_EX1_137] Headcrack - COST:3
+// - Set: VANILLA, Rarity: Rare
+// --------------------------------------------------------
+// Text: Deal 2 damage to the enemy hero.
+//       <b>Combo:</b> Return this to your hand next turn.
+// --------------------------------------------------------
+// GameTag:
+// - COMBO = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Spell] - VAN_EX1_137 : Headcrack")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto opHero = opPlayer->GetHero();
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Headcrack", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Headcrack", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Bloodmage Thalnos", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(opHero->GetHealth(), 28);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 25);
+    CHECK_EQ(curHand.GetCount(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->card->name, "Headcrack");
+}
+
 // ----------------------------------------- SPELL - SHAMAN
 // [VAN_EX1_238] Lightning Bolt - COST:1
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -9033,6 +9033,69 @@ TEST_CASE("[Rogue : Minion] - VAN_EX1_131 : Defias Ringleader")
     CHECK_EQ(curField[2]->GetHealth(), 1);
 }
 
+// ----------------------------------------- WEAPON - ROGUE
+// [VAN_EX1_133] Perdition's Blade - COST:3 [ATK:2/HP:0]
+// - Set: VANILLA, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Deal 1 damage.
+//       <b>Combo:</b> Deal 2 instead.
+// --------------------------------------------------------
+// GameTag:
+// - DURABILITY = 2
+// - BATTLECRY = 1
+// - COMBO = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Weapon] - VAN_EX1_133 : Perdition's Blade")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::ROGUE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Perdition's Blade", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Perdition's Blade", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("SI:7 Agent", FormatType::CLASSIC));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::WeaponTarget(card1, card3));
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::WeaponTarget(card2, card3));
+    CHECK_EQ(opField.GetCount(), 0);
+}
+
 // ----------------------------------------- SPELL - SHAMAN
 // [VAN_EX1_238] Lightning Bolt - COST:1
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -9561,6 +9561,65 @@ TEST_CASE("[Rogue : Spell] - VAN_EX1_581 : Sap")
     CHECK_EQ(opField[0]->GetHealth(), 1);
 }
 
+// ----------------------------------------- MINION - ROGUE
+// [VAN_EX1_613] Edwin VanCleef - COST:3 [ATK:2/HP:2]
+// - Set: VANILLA, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Combo:</b> Gain +2/+2 for each card
+//       played earlier this turn.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - COMBO = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - VAN_EX1_613 : Edwin VanCleef")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Edwin VanCleef", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Edwin VanCleef", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Edwin VanCleef", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 4);
+    CHECK_EQ(curField[1]->GetHealth(), 4);
+
+    curPlayer->SetUsedMana(0);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[2]->GetAttack(), 6);
+    CHECK_EQ(curField[2]->GetHealth(), 6);
+}
+
 // ----------------------------------------- SPELL - SHAMAN
 // [VAN_EX1_238] Lightning Bolt - COST:1
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -9433,6 +9433,59 @@ TEST_CASE("[Rogue : Spell] - VAN_EX1_278 : Shiv")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
 }
 
+// ----------------------------------------- MINION - ROGUE
+// [VAN_EX1_522] Patient Assassin - COST:2 [ATK:1/HP:1]
+// - Set: VANILLA, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Stealth</b>.
+//       Destroy any minion damaged by this minion.
+// --------------------------------------------------------
+// GameTag:
+// - STEALTH = 1
+// - POISONOUS = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - VAN_EX1_522 : Patient Assassin")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Patient Assassin", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Chillwind Yeti", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(card1, card2));
+
+    CHECK(card2->isDestroyed);
+}
+
 // ----------------------------------------- SPELL - SHAMAN
 // [VAN_EX1_238] Lightning Bolt - COST:1
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -9096,6 +9096,52 @@ TEST_CASE("[Rogue : Weapon] - VAN_EX1_133 : Perdition's Blade")
     CHECK_EQ(opField.GetCount(), 0);
 }
 
+// ----------------------------------------- MINION - ROGUE
+// [VAN_EX1_134] SI:7 Agent - COST:3 [ATK:3/HP:3]
+// - Set: VANILLA, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Combo:</b> Deal 2 damage.
+// --------------------------------------------------------
+// GameTag:
+// - COMBO = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_FOR_COMBO = 0
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - VAN_EX1_134 : SI:7 Agent")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("SI:7 Agent", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("SI:7 Agent", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+}
+
 // ----------------------------------------- SPELL - SHAMAN
 // [VAN_EX1_238] Lightning Bolt - COST:1
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -9368,6 +9368,71 @@ TEST_CASE("[Rogue : Spell] - VAN_EX1_145 : Preparation")
     CHECK_EQ(card5->GetCost(), 3);
 }
 
+// ------------------------------------------ SPELL - ROGUE
+// [VAN_EX1_278] Shiv - COST:2
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Deal 1 damage. Draw a card.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Spell] - VAN_EX1_278 : Shiv")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Shiv", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Shiv", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Kobold Geomancer", FormatType::CLASSIC));
+    const auto card4 = Generic::DrawCard(
+        opPlayer,
+        Cards::FindCardByName("Acidic Swamp Ooze", FormatType::CLASSIC));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opField[0]->GetHealth(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card4));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 8);
+    CHECK_EQ(opField[0]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curPlayer->GetCurrentSpellPower(), 1);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 7);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+}
+
 // ----------------------------------------- SPELL - SHAMAN
 // [VAN_EX1_238] Lightning Bolt - COST:1
 // - Set: VANILLA, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -9678,6 +9678,83 @@ TEST_CASE("[Rogue : Spell] - VAN_NEW1_004 : Vanish")
     CHECK_EQ(opField.GetCount(), 0);
 }
 
+// ----------------------------------------- MINION - ROGUE
+// [VAN_NEW1_005] Kidnapper - COST:6 [ATK:5/HP:3]
+// - Set: VANILLA, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Combo:</b> Return a minion to its owner's hand.
+// --------------------------------------------------------
+// GameTag:
+// - COMBO = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINION_TARGET = 0
+// - REQ_TARGET_FOR_COMBO = 0
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - VAN_NEW1_005 : Kidnapper")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Acidic Swamp Ooze", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Kidnapper", FormatType::CLASSIC));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Kidnapper", FormatType::CLASSIC));
+    const auto card5 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 7);
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card3, card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 7);
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opPlayer->GetHandZone()->GetCount(), 6);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card4, card5));
+    CHECK_EQ(opField.GetCount(), 0);
+    CHECK_EQ(opPlayer->GetHandZone()->GetCount(), 7);
+}
+
 // ----------------------------------------- SPELL - SHAMAN
 // [VAN_EX1_238] Lightning Bolt - COST:1
 // - Set: VANILLA, Rarity: Common


### PR DESCRIPTION
This revision includes:
- Implement 13 VANILLA cards (#674)
  - Defias Ringleader (VAN_EX1_131)
  - Perdition's Blade (VAN_EX1_133)
  - SI:7 Agent (VAN_EX1_134)
  - Headcrack (VAN_EX1_137)
  - Shadowstep (VAN_EX1_144)
  - Preparation (VAN_EX1_145)
  - Shiv (VAN_EX1_278)
  - Patient Assassin (VAN_EX1_522)
  - Sap (VAN_EX1_581)
  - Edwin VanCleef (VAN_EX1_613)
  - Vanish (VAN_NEW1_004)
  - Kidnapper (VAN_NEW1_005)
  - Master of Disguise (VAN_NEW1_014)
- Separate text to improve readability
- Add code to emplace missing game tag 'POISONOUS'