### PR TITLE
Implement 10 ALTERAC_VALLEY cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -1070,12 +1070,12 @@ STORMWIND | SW_463 | Imported Tarantula |
 Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
 ALTERAC_VALLEY | AV_100 | Drek'Thar |  
-ALTERAC_VALLEY | AV_101 | Herald of Lokholar |  
+ALTERAC_VALLEY | AV_101 | Herald of Lokholar | O
 ALTERAC_VALLEY | AV_102 | Popsicooler |  
 ALTERAC_VALLEY | AV_107 | Glaciate |  
 ALTERAC_VALLEY | AV_108 | Shield Shatter |  
-ALTERAC_VALLEY | AV_109 | Frozen Buckler |  
-ALTERAC_VALLEY | AV_112 | Snowblind Harpy |  
+ALTERAC_VALLEY | AV_109 | Frozen Buckler | O
+ALTERAC_VALLEY | AV_112 | Snowblind Harpy | O
 ALTERAC_VALLEY | AV_113 | Beaststalker Tavish |  
 ALTERAC_VALLEY | AV_114 | Shivering Sorceress |  
 ALTERAC_VALLEY | AV_115 | Amplified Snowflurry |  
@@ -1083,9 +1083,9 @@ ALTERAC_VALLEY | AV_116 | Arcane Brilliance |
 ALTERAC_VALLEY | AV_118 | Battleworn Vanguard |  
 ALTERAC_VALLEY | AV_119 | To the Front! |  
 ALTERAC_VALLEY | AV_121 | Gnome Private | O
-ALTERAC_VALLEY | AV_122 | Corporal |  
+ALTERAC_VALLEY | AV_122 | Corporal | O
 ALTERAC_VALLEY | AV_123 | Sneaky Scout |  
-ALTERAC_VALLEY | AV_124 | Direwolf Commander |  
+ALTERAC_VALLEY | AV_124 | Direwolf Commander | O
 ALTERAC_VALLEY | AV_125 | Tower Sergeant |  
 ALTERAC_VALLEY | AV_126 | Bunker Sergeant |  
 ALTERAC_VALLEY | AV_127 | Ice Revenant |  
@@ -1107,7 +1107,7 @@ ALTERAC_VALLEY | AV_143 | Korrak the Bloodrager |
 ALTERAC_VALLEY | AV_145 | Captain Galvangar |  
 ALTERAC_VALLEY | AV_147 | Dun Baldar Bunker |  
 ALTERAC_VALLEY | AV_200 | Magister Dawngrasp |  
-ALTERAC_VALLEY | AV_201 | Coldtooth Yeti |  
+ALTERAC_VALLEY | AV_201 | Coldtooth Yeti | O
 ALTERAC_VALLEY | AV_202 | Rokara, the Valorous |  
 ALTERAC_VALLEY | AV_203 | Shadowcrafter Scabbs |  
 ALTERAC_VALLEY | AV_204 | Kurtrus, Demon-Render |  
@@ -1135,14 +1135,14 @@ ALTERAC_VALLEY | AV_256 | Reflecto Engineer |
 ALTERAC_VALLEY | AV_257 | Bearon Gla'shear |  
 ALTERAC_VALLEY | AV_258 | Bru'kan of the Elements |  
 ALTERAC_VALLEY | AV_259 | Frostbite |  
-ALTERAC_VALLEY | AV_260 | Sleetbreaker |  
+ALTERAC_VALLEY | AV_260 | Sleetbreaker | O
 ALTERAC_VALLEY | AV_261 | Flag Runner |  
 ALTERAC_VALLEY | AV_262 | Warden of Chains |  
 ALTERAC_VALLEY | AV_264 | Sigil of Reckoning |  
 ALTERAC_VALLEY | AV_265 | Ur'zul Giant |  
-ALTERAC_VALLEY | AV_266 | Windchill |  
+ALTERAC_VALLEY | AV_266 | Windchill | O
 ALTERAC_VALLEY | AV_267 | Caria Felsoul |  
-ALTERAC_VALLEY | AV_268 | Wildpaw Cavern |  
+ALTERAC_VALLEY | AV_268 | Wildpaw Cavern | O
 ALTERAC_VALLEY | AV_269 | Flanking Maneuver |  
 ALTERAC_VALLEY | AV_277 | Seeds of Destruction |  
 ALTERAC_VALLEY | AV_281 | Felfire in the Hole! |  
@@ -1166,7 +1166,7 @@ ALTERAC_VALLEY | AV_313 | Hollow Abomination |
 ALTERAC_VALLEY | AV_315 | Deliverance |  
 ALTERAC_VALLEY | AV_316 | Dreadlich Tamsin |  
 ALTERAC_VALLEY | AV_317 | Tamsin's Phylactery |  
-ALTERAC_VALLEY | AV_321 | Glory Chaser |  
+ALTERAC_VALLEY | AV_321 | Glory Chaser | O
 ALTERAC_VALLEY | AV_322 | Snowed In |  
 ALTERAC_VALLEY | AV_323 | Scrapsmith |  
 ALTERAC_VALLEY | AV_324 | Shadow Word: Devour |  
@@ -1205,4 +1205,4 @@ ALTERAC_VALLEY | AV_704 | Humongous Owl |
 ALTERAC_VALLEY | AV_710 | Reconnaissance |  
 ALTERAC_VALLEY | AV_711 | Double Agent |  
 
-- Progress: 1% (2 of 135 Cards)
+- Progress: 8% (12 of 135 Cards)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
   * 80% Forged in the Barrens (136 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
-  * 1% Fractured in Alterac Valley (2 of 135 cards)
+  * 8% Fractured in Alterac Valley (12 of 135 cards)
 
 ### Wild Format
 

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2377,6 +2377,10 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - STEALTH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddHonorableKillTask(
+        std::make_shared<SummonTask>("AV_211t", SummonSide::RIGHT));
+    cards.emplace("AV_124", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_125] Tower Sergeant - COST:4 [ATK:4/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2311,6 +2311,14 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE,
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsHoldingSpell(SpellSchool::FROST)) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<ArmorTask>(5) }));
+    cards.emplace("AV_112", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_121] Gnome Private - COST:1 [ATK:1/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2347,6 +2347,10 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - DIVINE_SHIELD = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddHonorableKillTask(std::make_shared<SetGameTagTask>(
+        EntityType::MINIONS_NOSOURCE, GameTag::DIVINE_SHIELD, 1));
+    cards.emplace("AV_122", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_123] Sneaky Scout - COST:2 [ATK:3/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -1677,11 +1677,19 @@ void AlteracValleyCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->tasks = { std::make_shared<SummonTask>(
+        "AV_257t", SummonSide::SPELL) };
+    power.GetTrigger()->lastTurn = 3;
+    cards.emplace("AV_268", CardDef(power));
 }
 
 void AlteracValleyCardsGen::AddShamanNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------- ENCHANTMENT - SHAMAN
     // [AV_255e] Chilled - COST:0
     // - Set: ALTERAC_VALLEY
@@ -1698,6 +1706,9 @@ void AlteracValleyCardsGen::AddShamanNonCollect(
     // GameTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("AV_257t", CardDef(power));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [AV_258t] Earth Invocation - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -1354,6 +1354,8 @@ void AlteracValleyCardsGen::AddPriestNonCollect(
 
 void AlteracValleyCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- MINION - ROGUE
     // [AV_201] Coldtooth Yeti - COST:3 [ATK:1/HP:5]
     // - Set: ALTERAC_VALLEY, Rarity: Common
@@ -1363,6 +1365,10 @@ void AlteracValleyCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - COMBO = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddComboTask(
+        std::make_shared<AddEnchantmentTask>("AV_201e", EntityType::SOURCE));
+    cards.emplace("AV_201", CardDef(power));
 
     // ----------------------------------------- MINION - ROGUE
     // [AV_298] Wildpaw Gnoll - COST:5 [ATK:4/HP:5]
@@ -1465,12 +1471,17 @@ void AlteracValleyCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 void AlteracValleyCardsGen::AddRogueNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------ ENCHANTMENT - ROGUE
     // [AV_201e] Yeti Rage - COST:0
     // - Set: ALTERAC_VALLEY
     // --------------------------------------------------------
     // Text: +3 Attack.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("AV_201e"));
+    cards.emplace("AV_201e", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - ROGUE
     // [AV_203pe] Sleight of Hand - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -1921,6 +1921,8 @@ void AlteracValleyCardsGen::AddWarlockNonCollect(
 
 void AlteracValleyCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- SPELL - WARRIOR
     // [AV_108] Shield Shatter - COST:10
     // - Set: ALTERAC_VALLEY, Rarity: Rare
@@ -1938,6 +1940,12 @@ void AlteracValleyCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // Text: Gain 10 Armor.
     //       At the start of your next turn, lose 5 Armor.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ArmorTask>(10));
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
+    power.GetTrigger()->tasks = { std::make_shared<ArmorTask>(-5) };
+    power.GetTrigger()->removeAfterTriggered = true;
+    cards.emplace("AV_109", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [AV_119] To the Front! - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2283,6 +2283,9 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawSpellTask>(SpellSchool::FROST, 1));
+    cards.emplace("AV_101", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_102] Popsicooler - COST:3 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -11,6 +11,8 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 
 namespace RosettaStone::PlayMode
 {
+using PlayReqs = std::map<PlayReq, int>;
+
 void AlteracValleyCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
     // ------------------------------------------ HERO - HUNTER
@@ -1649,9 +1651,21 @@ void AlteracValleyCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Freeze</b> a minion. Draw a card.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
     // RefTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::TARGET,
+                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cards.emplace(
+        "AV_266",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [AV_268] Wildpaw Cavern - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -1541,6 +1541,8 @@ void AlteracValleyCardsGen::AddRogueNonCollect(
 
 void AlteracValleyCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- SPELL - SHAMAN
     // [AV_107] Glaciate - COST:6
     // - Set: ALTERAC_VALLEY, Rarity: Rare
@@ -1635,6 +1637,10 @@ void AlteracValleyCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::HAND, "AV_266"));
+    cards.emplace("AV_260", CardDef(power));
 
     // ----------------------------------------- SPELL - SHAMAN
     // [AV_266] Windchill - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -12,6 +12,7 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 namespace RosettaStone::PlayMode
 {
 using PlayReqs = std::map<PlayReq, int>;
+using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
 
 void AlteracValleyCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
@@ -1983,6 +1984,13 @@ void AlteracValleyCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_PLAY_MINION));
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::HasTaunt())
+    };
+    power.GetTrigger()->tasks = { std::make_shared<DrawTask>(1) };
+    cards.emplace("AV_321", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [AV_322] Snowed In - COST:3

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -385,6 +385,57 @@ TEST_CASE("[Warrior : Spell] - AV_109 : Frozen Buckler")
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 2);
 }
 
+// --------------------------------------- MINION - WARRIOR
+// [AV_321] Glory Chaser - COST:3 [ATK:4/HP:3]
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: After you play a <b>Taunt</b> minion, draw a card.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - AV_321 : Glory Chaser")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Glory Chaser"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Sen'jin Shieldmasta"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curHand.GetCount(), 5);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [AV_121] Gnome Private - COST:1 [ATK:1/HP:3]
 // - Set: ALTERAC_VALLEY, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -162,7 +162,7 @@ TEST_CASE("[Rogue : Minion] - AV_201 : Coldtooth Yeti")
 TEST_CASE("[Shaman : Minion] - AV_260 : Sleetbreaker")
 {
     GameConfig config;
-    config.player1Class = CardClass::ROGUE;
+    config.player1Class = CardClass::SHAMAN;
     config.player2Class = CardClass::WARRIOR;
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = false;
@@ -187,6 +187,64 @@ TEST_CASE("[Shaman : Minion] - AV_260 : Sleetbreaker")
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     CHECK_EQ(curHand.GetCount(), 1);
     CHECK_EQ(curHand[0]->card->name, "Windchill");
+}
+
+// ----------------------------------------- SPELL - SHAMAN
+// [AV_266] Windchill - COST:1
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// - Spell School: Frost
+// --------------------------------------------------------
+// Text: <b>Freeze</b> a minion. Draw a card.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+// RefTag:
+// - FREEZE = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - AV_266 : Windchill")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Windchill"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(opField[0]->IsFrozen(), false);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curHand.GetCount(), 6);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(opField[0]->IsFrozen(), true);
+    CHECK_EQ(curHand.GetCount(), 6);
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -483,6 +483,51 @@ TEST_CASE("[Neutral : Minion] - AV_101 : Herald of Lokholar")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [AV_112] Snowblind Harpy - COST:3 [ATK:3/HP:4]
+// - Set: ALTERAC_VALLEY, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you're holding a Frost spell,
+//       gain 5 Armor.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - AV_112 : Snowblind Harpy")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Snowblind Harpy"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Snowblind Harpy"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ice Barrier"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [AV_121] Gnome Private - COST:1 [ATK:1/HP:3]
 // - Set: ALTERAC_VALLEY, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -247,6 +247,92 @@ TEST_CASE("[Shaman : Spell] - AV_266 : Windchill")
     CHECK_EQ(curHand.GetCount(), 6);
 }
 
+// ----------------------------------------- SPELL - SHAMAN
+// [AV_268] Wildpaw Cavern - COST:4
+// - Set: ALTERAC_VALLEY, Rarity: Rare
+// --------------------------------------------------------
+// Text: At the end of your turn, summon a 3/4 Elemental
+//       that <b>Freezes</b>. Lasts 3 turns.
+// --------------------------------------------------------
+// RefTag:
+// - FREEZE = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - AV_268 : Wildpaw Cavern")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wildpaw Cavern"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Frozen Stagguard");
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(curField[0]->HasFreeze(), true);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[1]->card->name, "Frozen Stagguard");
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->GetHealth(), 4);
+    CHECK_EQ(curField[1]->HasFreeze(), true);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[2]->card->name, "Frozen Stagguard");
+    CHECK_EQ(curField[2]->GetAttack(), 3);
+    CHECK_EQ(curField[2]->GetHealth(), 4);
+    CHECK_EQ(curField[2]->HasFreeze(), true);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 3);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [AV_121] Gnome Private - COST:1 [ATK:1/HP:3]
 // - Set: ALTERAC_VALLEY, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -12,6 +12,7 @@
 #include <Rosetta/PlayMode/Actions/Draw.hpp>
 #include <Rosetta/PlayMode/Cards/Cards.hpp>
 #include <Rosetta/PlayMode/Zones/FieldZone.hpp>
+#include <Rosetta/PlayMode/Zones/HandZone.hpp>
 
 using namespace RosettaStone;
 using namespace PlayMode;
@@ -147,6 +148,45 @@ TEST_CASE("[Rogue : Minion] - AV_201 : Coldtooth Yeti")
     game.Process(curPlayer, PlayCardTask::Minion(card2));
     CHECK_EQ(curField[1]->GetAttack(), 4);
     CHECK_EQ(curField[1]->GetHealth(), 5);
+}
+
+// ---------------------------------------- MINION - SHAMAN
+// [AV_260] Sleetbreaker - COST:2 [ATK:3/HP:2]
+// - Race: Elemental, Set: ALTERAC_VALLEY, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Add a Windchill to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Minion] - AV_260 : Sleetbreaker")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Sleetbreaker"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->name, "Windchill");
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -104,6 +104,51 @@ TEST_CASE("[Druid : Spell] - AV_360 : Frostwolf Kennels")
     CHECK_EQ(curField.GetCount(), 3);
 }
 
+// ----------------------------------------- MINION - ROGUE
+// [AV_201] Coldtooth Yeti - COST:3 [ATK:1/HP:5]
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Combo:</b> Gain +3 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - COMBO = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Minion] - AV_201 : Coldtooth Yeti")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Coldtooth Yeti"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Coldtooth Yeti"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 4);
+    CHECK_EQ(curField[1]->GetHealth(), 5);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [AV_121] Gnome Private - COST:1 [ATK:1/HP:3]
 // - Set: ALTERAC_VALLEY, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -333,6 +333,58 @@ TEST_CASE("[Shaman : Spell] - AV_268 : Wildpaw Cavern")
     CHECK_EQ(curField.GetCount(), 3);
 }
 
+// ---------------------------------------- SPELL - WARRIOR
+// [AV_109] Frozen Buckler - COST:2
+// - Set: ALTERAC_VALLEY, Rarity: Epic
+// - Spell School: Frost
+// --------------------------------------------------------
+// Text: Gain 10 Armor.
+//       At the start of your next turn, lose 5 Armor.
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Spell] - AV_109 : Frozen Buckler")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Frozen Buckler"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 10);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer,
+                 PlayCardTask::SpellTarget(card2, curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 4);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 2);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [AV_121] Gnome Private - COST:1 [ATK:1/HP:3]
 // - Set: ALTERAC_VALLEY, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -437,6 +437,52 @@ TEST_CASE("[Warrior : Minion] - AV_321 : Glory Chaser")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [AV_101] Herald of Lokholar - COST:4 [ATK:3/HP:5]
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Draw a Frost spell.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - AV_101 : Herald of Lokholar")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Ice Barrier");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Holy Light");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Wisp");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Herald of Lokholar"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->card->name, "Ice Barrier");
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [AV_121] Gnome Private - COST:1 [ATK:1/HP:3]
 // - Set: ALTERAC_VALLEY, Rarity: Common
 // --------------------------------------------------------


### PR DESCRIPTION
This revision includes:
- Implement 10 ALTERAC_VALLEY cards
  - Herald of Lokholar (AV_101)
  - Frozen Buckler (AV_109)
  - Snowblind Harpy (AV_112)
  - Corporal (AV_122)
  - Direwolf Commander (AV_124)
  - Coldtooth Yeti (AV_201)
  - Sleetbreaker (AV_260)
  - Windchill (AV_266)
  - Wildpaw Cavern (AV_268)
  - Glory Chaser (AV_321)