### PR TITLE
Implement 9 ALTERAC_VALLEY cards

### DIFF
--- a/.github/workflows/ubuntu-sonarcloud.yml
+++ b/.github/workflows/ubuntu-sonarcloud.yml
@@ -31,7 +31,9 @@ jobs:
         unzip -q build-wrapper-linux-x86.zip
         echo "${PWD}/build-wrapper-linux-x86" >> $GITHUB_PATH
     - name: Install packages
-      run: sudo apt-get install -yq gcovr ggcov lcov curl
+      run: |
+        sudo apt-get update
+        sudo apt-get install -yq gcovr ggcov lcov curl
     - name: Configure Compiler
       run: |
         if [ "${{ matrix.compiler }}" = "gcc" ]; then

--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -1116,18 +1116,18 @@ ALTERAC_VALLEY | AV_206 | Lightforged Cariel |
 ALTERAC_VALLEY | AV_207 | Xyrella, the Devout |  
 ALTERAC_VALLEY | AV_209 | Dreadprison Glaive |  
 ALTERAC_VALLEY | AV_210 | Pathmaker |  
-ALTERAC_VALLEY | AV_211 | Dire Frostwolf |  
+ALTERAC_VALLEY | AV_211 | Dire Frostwolf | O
 ALTERAC_VALLEY | AV_212 | Siphon Mana |  
 ALTERAC_VALLEY | AV_213 | Vitality Surge |  
 ALTERAC_VALLEY | AV_215 | Frantic Hippogryph |  
-ALTERAC_VALLEY | AV_218 | Mass Polymorph |  
+ALTERAC_VALLEY | AV_218 | Mass Polymorph | O
 ALTERAC_VALLEY | AV_219 | Ram Commander |  
 ALTERAC_VALLEY | AV_222 | Spammy Arcanist |  
 ALTERAC_VALLEY | AV_223 | Vanndar Stormpike |  
 ALTERAC_VALLEY | AV_224 | Spring the Trap |  
 ALTERAC_VALLEY | AV_226 | Ice Trap |  
 ALTERAC_VALLEY | AV_238 | Gankster |  
-ALTERAC_VALLEY | AV_244 | Bloodseeker |  
+ALTERAC_VALLEY | AV_244 | Bloodseeker | O
 ALTERAC_VALLEY | AV_250 | Snowball Fight! |  
 ALTERAC_VALLEY | AV_251 | Cheaty Snobold |  
 ALTERAC_VALLEY | AV_255 | Snowfall Guardian |  
@@ -1167,8 +1167,8 @@ ALTERAC_VALLEY | AV_315 | Deliverance |
 ALTERAC_VALLEY | AV_316 | Dreadlich Tamsin |  
 ALTERAC_VALLEY | AV_317 | Tamsin's Phylactery |  
 ALTERAC_VALLEY | AV_321 | Glory Chaser | O
-ALTERAC_VALLEY | AV_322 | Snowed In |  
-ALTERAC_VALLEY | AV_323 | Scrapsmith |  
+ALTERAC_VALLEY | AV_322 | Snowed In | O
+ALTERAC_VALLEY | AV_323 | Scrapsmith | O
 ALTERAC_VALLEY | AV_324 | Shadow Word: Devour |  
 ALTERAC_VALLEY | AV_325 | Undying Disciple |  
 ALTERAC_VALLEY | AV_326 | Luminous Geode |  
@@ -1177,10 +1177,10 @@ ALTERAC_VALLEY | AV_329 | Bless |
 ALTERAC_VALLEY | AV_330 | Gift of the Naaru |  
 ALTERAC_VALLEY | AV_331 | Najak Hexxen |  
 ALTERAC_VALLEY | AV_333 | Revive Pet |  
-ALTERAC_VALLEY | AV_334 | Stormpike Battle Ram |  
-ALTERAC_VALLEY | AV_335 | Ram Tamer |  
+ALTERAC_VALLEY | AV_334 | Stormpike Battle Ram | O
+ALTERAC_VALLEY | AV_335 | Ram Tamer | O
 ALTERAC_VALLEY | AV_336 | Wing Commander Ichman |  
-ALTERAC_VALLEY | AV_337 | Mountain Bear |  
+ALTERAC_VALLEY | AV_337 | Mountain Bear | O
 ALTERAC_VALLEY | AV_338 | Hold the Bridge |  
 ALTERAC_VALLEY | AV_339 | Templar Captain |  
 ALTERAC_VALLEY | AV_340 | Brasswing |  
@@ -1195,7 +1195,7 @@ ALTERAC_VALLEY | AV_401 | Stormpike Quartermaster |
 ALTERAC_VALLEY | AV_402 | The Lobotomizer |  
 ALTERAC_VALLEY | AV_403 | Cera'thine Fleetrunner |  
 ALTERAC_VALLEY | AV_405 | Contraband Stash |  
-ALTERAC_VALLEY | AV_565 | Axe Berserker |  
+ALTERAC_VALLEY | AV_565 | Axe Berserker | O
 ALTERAC_VALLEY | AV_601 | Forsaken Lieutenant |  
 ALTERAC_VALLEY | AV_657 | Desecrated Graveyard |  
 ALTERAC_VALLEY | AV_660 | Iceblood Garrison |  
@@ -1205,4 +1205,4 @@ ALTERAC_VALLEY | AV_704 | Humongous Owl |
 ALTERAC_VALLEY | AV_710 | Reconnaissance |  
 ALTERAC_VALLEY | AV_711 | Double Agent |  
 
-- Progress: 8% (12 of 135 Cards)
+- Progress: 15% (21 of 135 Cards)

--- a/Documents/TaskList.md
+++ b/Documents/TaskList.md
@@ -58,6 +58,7 @@
 * EnqueueTask
 * FilterStackTask
 * FlagTask
+* FreezeTask
 * FuncNumberTask
 * FuncPlayableTask
 * GetEventNumberTask

--- a/Includes/Rosetta/PlayMode/Models/Character.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Character.hpp
@@ -105,6 +105,9 @@ class Character : public Playable
     //! \return The flag that indicates whether it is immune.
     bool IsImmune() const;
 
+    //! Freezes a character.
+    void Freeze();
+
     //! Returns the flag that indicates whether it is frozen.
     //! \return The flag that indicates whether it is frozen.
     bool IsFrozen() const;

--- a/Includes/Rosetta/PlayMode/Models/Hero.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Hero.hpp
@@ -79,6 +79,10 @@ class Hero : public Character
     //! \return The flag that indicates whether it has lifesteal.
     bool HasLifesteal() const override;
 
+    //! Returns the flag that indicates whether it has honorable kill.
+    //! \return The flag that indicates whether it has honorable kill.
+    bool HasHonorableKill() const override;
+
     HeroPower* heroPower = nullptr;
     Weapon* weapon = nullptr;
 

--- a/Includes/Rosetta/PlayMode/Models/Playable.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Playable.hpp
@@ -131,7 +131,7 @@ class Playable : public Entity
 
     //! Returns the flag that indicates whether it has honorable kill.
     //! \return The flag that indicates whether it has honorable kill.
-    bool HasHonorableKill() const;
+    virtual bool HasHonorableKill() const;
 
     //! Returns the flag that indicates it can activate 'Spellbrust'.
     //! \return The flag that indicates it can activate 'Spellbrust'.

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks.hpp
@@ -52,6 +52,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FlagTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/FreezeTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FuncNumberTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FuncPlayableTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/GetEventNumberTask.hpp>

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/FreezeTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/FreezeTask.hpp
@@ -1,0 +1,37 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_PLAYMODE_FREEZE_TASK_HPP
+#define ROSETTASTONE_PLAYMODE_FREEZE_TASK_HPP
+
+#include <Rosetta/PlayMode/Tasks/ITask.hpp>
+
+namespace RosettaStone::PlayMode::SimpleTasks
+{
+//!
+//! \brief FreezeTask class.
+//!
+//! This class represents the task for freezing character(s).
+//!
+class FreezeTask : public ITask
+{
+ public:
+    //! Constructs task with given \p entityType.
+    //! \param entityType The entity type of target to freeze.
+    explicit FreezeTask(EntityType entityType);
+
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player* player) override;
+
+    //! Internal method of Clone().
+    //! \return The cloned task.
+    std::unique_ptr<ITask> CloneImpl() override;
+};
+}  // namespace RosettaStone::PlayMode::SimpleTasks
+
+#endif  // ROSETTASTONE_PLAYMODE_FREEZE_TASK_HPP

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -215,6 +215,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FlagTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/FreezeTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FuncNumberTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FuncPlayableTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/GetEventNumberTask.hpp>

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
   * 80% Forged in the Barrens (136 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
-  * 8% Fractured in Alterac Valley (12 of 135 cards)
+  * 15% Fractured in Alterac Valley (21 of 135 cards)
 
 ### Wild Format
 

--- a/Sources/Rosetta/PlayMode/Actions/Attack.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Attack.cpp
@@ -64,6 +64,13 @@ void Attack(const Player* player, Character* source, Character* target,
     const int targetAttack = realTarget->GetAttack();
     const int sourceAttack = source->GetAttack();
 
+    // Remove durability from weapon if hero attack
+    if (hero && hero->HasWeapon() &&
+        hero->weapon->GetGameTag(GameTag::IMMUNE) == 0)
+    {
+        hero->weapon->RemoveDurability(1);
+    }
+
     // Take damage to target
     const int targetDamage = realTarget->TakeDamage(source, sourceAttack);
     const bool isTargetDamaged = targetDamage > 0;
@@ -120,13 +127,6 @@ void Attack(const Player* player, Character* source, Character* target,
     if (source->GetGameTag(GameTag::STEALTH) == 1)
     {
         source->SetGameTag(GameTag::STEALTH, 0);
-    }
-
-    // Remove durability from weapon if hero attack
-    if (hero && hero->HasWeapon() &&
-        hero->weapon->GetGameTag(GameTag::IMMUNE) == 0)
-    {
-        hero->weapon->RemoveDurability(1);
     }
 
     // Increase the number of attacked

--- a/Sources/Rosetta/PlayMode/Actions/Attack.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Attack.cpp
@@ -128,7 +128,7 @@ void Attack(const Player* player, Character* source, Character* target,
     {
         TaskList tasks;
 
-        if (hero->HasWeapon())
+        if (hero && hero->HasWeapon())
         {
             tasks = hero->weapon->card->power.GetHonorableKillTask();
         }
@@ -142,7 +142,14 @@ void Attack(const Player* player, Character* source, Character* target,
             std::unique_ptr<ITask> clonedTask = task->Clone();
 
             clonedTask->SetPlayer(source->player);
-            clonedTask->SetSource(source);
+            if (hero && hero->HasWeapon())
+            {
+                clonedTask->SetSource(hero->weapon);
+            }
+            else
+            {
+                clonedTask->SetSource(source);
+            }
             clonedTask->SetTarget(target);
 
             player->game->taskQueue.Enqueue(std::move(clonedTask));

--- a/Sources/Rosetta/PlayMode/Actions/Attack.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Attack.cpp
@@ -123,6 +123,8 @@ void Attack(const Player* player, Character* source, Character* target,
         }
     }
 
+    player->game->taskQueue.StartEvent();
+
     // Check if the source has Honorable Kill
     if (source->HasHonorableKill() && target->GetHealth() == 0)
     {
@@ -155,6 +157,9 @@ void Attack(const Player* player, Character* source, Character* target,
             player->game->taskQueue.Enqueue(std::move(clonedTask));
         }
     }
+
+    player->game->ProcessTasks();
+    player->game->taskQueue.EndEvent();
 
     // Remove stealth ability if attacker has it
     if (source->GetGameTag(GameTag::STEALTH) == 1)

--- a/Sources/Rosetta/PlayMode/Actions/Attack.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Attack.cpp
@@ -123,6 +123,32 @@ void Attack(const Player* player, Character* source, Character* target,
         }
     }
 
+    // Check if the source has Honorable Kill
+    if (source->HasHonorableKill() && target->GetHealth() == 0)
+    {
+        TaskList tasks;
+
+        if (hero->HasWeapon())
+        {
+            tasks = hero->weapon->card->power.GetHonorableKillTask();
+        }
+        else
+        {
+            tasks = source->card->power.GetHonorableKillTask();
+        }
+
+        for (auto& task : tasks)
+        {
+            std::unique_ptr<ITask> clonedTask = task->Clone();
+
+            clonedTask->SetPlayer(source->player);
+            clonedTask->SetSource(source);
+            clonedTask->SetTarget(target);
+
+            player->game->taskQueue.Enqueue(std::move(clonedTask));
+        }
+    }
+
     // Remove stealth ability if attacker has it
     if (source->GetGameTag(GameTag::STEALTH) == 1)
     {

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -1959,9 +1959,8 @@ void AlteracValleyCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(std::make_shared<ArmorTask>(10));
-    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
-    power.GetTrigger()->tasks = { std::make_shared<ArmorTask>(-5) };
-    power.GetTrigger()->removeAfterTriggered = true;
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("AV_109e", EntityType::SOURCE));
     cards.emplace("AV_109", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
@@ -2084,6 +2083,11 @@ void AlteracValleyCardsGen::AddWarriorNonCollect(
     // --------------------------------------------------------
     // Text: Lose 5 Armor next turn.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
+    power.GetTrigger()->tasks = { std::make_shared<ArmorTask>(-5) };
+    power.GetTrigger()->removeAfterTriggered = true;
+    cards.emplace("AV_109e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [AV_119e] Frontlined - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -612,6 +612,16 @@ void AlteracValleyCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // - SECRET = 1
     // - STEALTH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsControllingSecret()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<AddEnchantmentTask>(
+                            "AV_335e", EntityType::SOURCE),
+                        std::make_shared<SetGameTagTask>(
+                            EntityType::SOURCE, GameTag::STEALTH, 1) }));
+    cards.emplace("AV_335", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
     // [AV_336] Wing Commander Ichman - COST:9 [ATK:5/HP:4]
@@ -806,6 +816,9 @@ void AlteracValleyCardsGen::AddHunterNonCollect(
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("AV_335e"));
+    cards.emplace("AV_335e", CardDef(power));
 
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [AV_336e] Frightful Pack - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -1677,8 +1677,7 @@ void AlteracValleyCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // - FREEZE = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::TARGET,
-                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::TARGET));
     power.AddPowerTask(std::make_shared<DrawTask>(1));
     cards.emplace(
         "AV_266",

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -566,7 +566,7 @@ void AlteracValleyCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddHonorableKillTask(
-        std::make_shared<AddEnchantmentTask>("AV_244e", EntityType::SOURCE));
+        std::make_shared<AddEnchantmentTask>("AV_244e", EntityType::WEAPON));
     cards.emplace("AV_244", CardDef(power));
 
     // ----------------------------------------- SPELL - HUNTER
@@ -761,7 +761,9 @@ void AlteracValleyCardsGen::AddHunterNonCollect(
     // Text: +1/+1.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddEnchant(Enchants::GetEnchantFromText("AV_244e"));
+    power.AddEnchant(
+        std::make_shared<Enchant>(std::vector<std::shared_ptr<IEffect>>(
+            { Effects::AttackN(1), Effects::DurabilityN(1) })));
     cards.emplace("AV_244e", CardDef(power));
 
     // ----------------------------------- ENCHANTMENT - HUNTER

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -804,6 +804,8 @@ void AlteracValleyCardsGen::AddHunterNonCollect(
 
 void AlteracValleyCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------ MINION - MAGE
     // [AV_114] Shivering Sorceress - COST:1 [ATK:2/HP:2]
     // - Set: ALTERAC_VALLEY, Rarity: Common
@@ -857,6 +859,10 @@ void AlteracValleyCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Transform all minions into 1/1 Sheep.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<TransformTask>(EntityType::ALL_MINIONS, "CS2_tk1"));
+    cards.emplace("AV_218", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [AV_282] Build a Snowman - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -13,6 +13,7 @@ namespace RosettaStone::PlayMode
 {
 using PlayReqs = std::map<PlayReq, int>;
 using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
+using EffectList = std::vector<std::shared_ptr<IEffect>>;
 
 void AlteracValleyCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
@@ -592,6 +593,10 @@ void AlteracValleyCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // - DEATHRATTLE = 1
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<AddEnchantmentTask>("AV_334e2", EntityType::SOURCE));
+    cards.emplace("AV_334", CardDef(power));
 
     // ---------------------------------------- MINION - HUNTER
     // [AV_335] Ram Tamer - COST:3 [ATK:4/HP:3]
@@ -782,6 +787,18 @@ void AlteracValleyCardsGen::AddHunterNonCollect(
     // --------------------------------------------------------
     // Text: Costs (2) less.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<Aura>(AuraType::HAND,
+                                         EffectList{ Effects::ReduceCost(2) }));
+    {
+        const auto aura = dynamic_cast<Aura*>(power.GetAura());
+        aura->condition =
+            std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::BEAST));
+        aura->removeTrigger = { TriggerType::PLAY_MINION,
+                                std::make_shared<SelfCondition>(
+                                    SelfCondition::IsRace(Race::BEAST)) };
+    }
+    cards.emplace("AV_334e2", CardDef(power));
 
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [AV_335e] Sneaking Up - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2046,6 +2046,10 @@ void AlteracValleyCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::HAND, "AV_323t", 2));
+    cards.emplace("AV_323", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [AV_565] Axe Berserker - COST:4 [ATK:3/HP:5]
@@ -2072,6 +2076,8 @@ void AlteracValleyCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 void AlteracValleyCardsGen::AddWarriorNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [AV_109e] Chilly - COST:0
     // - Set: ALTERAC_VALLEY
@@ -2117,6 +2123,9 @@ void AlteracValleyCardsGen::AddWarriorNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("AV_323t", CardDef(power));
 }
 
 void AlteracValleyCardsGen::AddDemonHunter(

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -564,6 +564,10 @@ void AlteracValleyCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // - HONORABLEKILL = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddHonorableKillTask(
+        std::make_shared<AddEnchantmentTask>("AV_244e", EntityType::SOURCE));
+    cards.emplace("AV_244", CardDef(power));
 
     // ----------------------------------------- SPELL - HUNTER
     // [AV_333] Revive Pet - COST:3
@@ -756,6 +760,9 @@ void AlteracValleyCardsGen::AddHunterNonCollect(
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("AV_244e"));
+    cards.emplace("AV_244e", CardDef(power));
 
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [AV_334e] Ready for Battle - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -326,6 +326,10 @@ void AlteracValleyCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - DEATHRATTLE = 1
     // - STEALTH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("AV_211t", SummonSide::DEATHRATTLE));
+    cards.emplace("AV_211", CardDef(power));
 
     // ----------------------------------------- MINION - DRUID
     // [AV_291] Frostsaber Matriarch - COST:7 [ATK:4/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2019,6 +2019,20 @@ void AlteracValleyCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_DAMAGED_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DestroyTask>(EntityType::TARGET));
+    power.AddPowerTask(
+        std::make_shared<FreezeTask>(EntityType::ALL_MINIONS_NOTARGET));
+    cards.emplace(
+        "AV_322",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_DAMAGED_TARGET, 0 } }));
 
     // --------------------------------------- MINION - WARRIOR
     // [AV_323] Scrapsmith - COST:3 [ATK:2/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2062,6 +2062,9 @@ void AlteracValleyCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - HONORABLEKILL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddHonorableKillTask(std::make_shared<DrawWeaponTask>(1));
+    cards.emplace("AV_565", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [AV_660] Iceblood Garrison - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -513,6 +513,8 @@ void AlteracValleyCardsGen::AddDruidNonCollect(
 
 void AlteracValleyCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- SPELL - HUNTER
     // [AV_147] Dun Baldar Bunker - COST:2
     // - Set: ALTERAC_VALLEY, Rarity: Rare
@@ -625,11 +627,17 @@ void AlteracValleyCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // - DEATHRATTLE = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("AV_337t", 2, SummonSide::DEATHRATTLE));
+    cards.emplace("AV_337", CardDef(power));
 }
 
 void AlteracValleyCardsGen::AddHunterNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------------- SPELL - HUNTER
     // [AV_113t1] Improved Explosive Trap - COST:2
     // - Set: ALTERAC_VALLEY
@@ -789,6 +797,9 @@ void AlteracValleyCardsGen::AddHunterNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("AV_337t", CardDef(power));
 }
 
 void AlteracValleyCardsGen::AddMage(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -643,8 +643,7 @@ void BlackTempleCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - REQ_ENEMY_TARGET = 0
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::TARGET,
-                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::TARGET));
     power.AddPowerTask(std::make_shared<SummonTask>("CS2_033", 2));
     cards.emplace("BT_072",
                   CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
@@ -2567,8 +2566,7 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - FREEZE = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::TARGET,
-                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::TARGET));
     cards.emplace(
         "BT_714",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -759,8 +759,7 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddPowerTask(
         std::make_shared<IncludeAdjacentTask>(EntityType::TARGET, true));
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::STACK,
-                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::STACK));
     power.AddPowerTask(
         std::make_shared<DamageTask>(EntityType::STACK, 1, true));
     cards.emplace(
@@ -863,8 +862,7 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.AddPowerTask(std::make_shared<FlagTask>(
         true, TaskList{ std::make_shared<DestroyTask>(EntityType::TARGET) }));
     power.AddPowerTask(std::make_shared<FlagTask>(
-        false, TaskList{ std::make_shared<SetGameTagTask>(
-                   EntityType::TARGET, GameTag::FROZEN, 1) }));
+        false, TaskList{ std::make_shared<FreezeTask>(EntityType::TARGET) }));
     cards.emplace(
         "CORE_GIL_801",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },

--- a/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
@@ -848,8 +848,7 @@ void DalaranCardsGen::AddMage(std::map<std::string, CardDef>& cards)
         true,
         TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 2, true) }));
     power.AddPowerTask(std::make_shared<FlagTask>(
-        false, TaskList{ std::make_shared<SetGameTagTask>(
-                   EntityType::TARGET, GameTag::FROZEN, 1) }));
+        false, TaskList{ std::make_shared<FreezeTask>(EntityType::TARGET) }));
     cards.emplace(
         "DAL_577",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
@@ -1009,8 +1008,7 @@ void DalaranCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
         true,
         TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 2, true) }));
     power.AddPowerTask(std::make_shared<FlagTask>(
-        false, TaskList{ std::make_shared<SetGameTagTask>(
-                   EntityType::TARGET, GameTag::FROZEN, 1) }));
+        false, TaskList{ std::make_shared<FreezeTask>(EntityType::TARGET) }));
     cards.emplace(
         "DAL_577ts",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },

--- a/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
@@ -1394,8 +1394,7 @@ void DragonsCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(
-        EntityType::ENEMY_MINIONS, GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::ENEMY_MINIONS));
     cards.emplace("DRG_270t5", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
@@ -1462,8 +1461,7 @@ void DragonsCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddPowerTask(
         std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::TARGET,
-                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::TARGET));
     cards.emplace(
         "DRG_270t8",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
@@ -2695,8 +2693,7 @@ void DragonsCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // - REQ_ENEMY_TARGET = 0
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::TARGET,
-                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::TARGET));
     power.AddPowerTask(std::make_shared<InvokeTask>());
     cards.emplace("DRG_248",
                   CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -1284,8 +1284,7 @@ void Expert1CardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddPowerTask(
         std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 2, true));
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(
-        EntityType::ENEMY_MINIONS, GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::ENEMY_MINIONS));
     cards.emplace("CS2_028", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
@@ -1310,8 +1309,7 @@ void Expert1CardsGen::AddMage(std::map<std::string, CardDef>& cards)
         true,
         TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 4, true) }));
     power.AddPowerTask(std::make_shared<FlagTask>(
-        false, TaskList{ std::make_shared<SetGameTagTask>(
-                   EntityType::TARGET, GameTag::FROZEN, 1) }));
+        false, TaskList{ std::make_shared<FreezeTask>(EntityType::TARGET) }));
     cards.emplace(
         "CS2_031",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
@@ -1397,8 +1395,7 @@ void Expert1CardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddPowerTask(
         std::make_shared<IncludeAdjacentTask>(EntityType::TARGET, true));
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::STACK,
-                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::STACK));
     power.AddPowerTask(
         std::make_shared<DamageTask>(EntityType::STACK, 1, true));
     cards.emplace(
@@ -5451,8 +5448,7 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - REQ_TARGET_IF_AVAILABLE = 0
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::TARGET,
-                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::TARGET));
     cards.emplace(
         "EX1_283",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } }));

--- a/Sources/Rosetta/PlayMode/CardSets/GilneasCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/GilneasCardsGen.cpp
@@ -493,8 +493,7 @@ void GilneasCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.AddPowerTask(std::make_shared<FlagTask>(
         true, TaskList{ std::make_shared<DestroyTask>(EntityType::TARGET) }));
     power.AddPowerTask(std::make_shared<FlagTask>(
-        false, TaskList{ std::make_shared<SetGameTagTask>(
-                   EntityType::TARGET, GameTag::FROZEN, 1) }));
+        false, TaskList{ std::make_shared<FreezeTask>(EntityType::TARGET) }));
     cards.emplace(
         "GIL_801",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },

--- a/Sources/Rosetta/PlayMode/CardSets/LegacyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LegacyCardsGen.cpp
@@ -1029,8 +1029,7 @@ void LegacyCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddPowerTask(
         std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::TARGET,
-                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::TARGET));
     cards.emplace(
         "CS2_024",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
@@ -1057,8 +1056,7 @@ void LegacyCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - FREEZE = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(
-        EntityType::ENEMY_MINIONS, GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::ENEMY_MINIONS));
     cards.emplace("CS2_026", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
@@ -1864,8 +1862,7 @@ void LegacyCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddPowerTask(
         std::make_shared<DamageTask>(EntityType::TARGET, 1, true));
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::TARGET,
-                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::TARGET));
     cards.emplace("CS2_037",
                   CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
                                            { PlayReq::REQ_ENEMY_TARGET, 0 } }));

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -2689,10 +2689,8 @@ void ScholomanceCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - REQ_MINION_TARGET = 0
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::TARGET,
-                                                        GameTag::FROZEN, 1));
-    power.AddComboTask(std::make_shared<SetGameTagTask>(EntityType::TARGET,
-                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::TARGET));
+    power.AddComboTask(std::make_shared<FreezeTask>(EntityType::TARGET));
     power.AddComboTask(
         std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
     cards.emplace(

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -842,8 +842,7 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddPowerTask(
         std::make_shared<RandomTask>(EntityType::ENEMY_MINIONS, 1));
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::STACK,
-                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::STACK));
     power.AddTrigger(
         std::make_shared<Trigger>(Triggers::RankSpellTrigger(5, "BAR_305t")));
     cards.emplace(
@@ -949,7 +948,7 @@ void TheBarrensCardsGen::AddMage(std::map<std::string, CardDef>& cards)
                 }
                 else
                 {
-                    minion->SetGameTag(GameTag::FROZEN, 1);
+                    minion->Freeze();
                 }
             }
         }));
@@ -1120,8 +1119,7 @@ void TheBarrensCardsGen::AddMageNonCollect(
     power.ClearData();
     power.AddPowerTask(
         std::make_shared<RandomTask>(EntityType::ENEMY_MINIONS, 2));
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::STACK,
-                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::STACK));
     power.AddTrigger(
         std::make_shared<Trigger>(Triggers::RankSpellTrigger(10, "BAR_305t2")));
     cards.emplace(
@@ -1144,8 +1142,7 @@ void TheBarrensCardsGen::AddMageNonCollect(
     power.ClearData();
     power.AddPowerTask(
         std::make_shared<RandomTask>(EntityType::ENEMY_MINIONS, 3));
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::STACK,
-                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::STACK));
     cards.emplace(
         "BAR_305t2",
         CardDef(power, PlayReqs{ { PlayReq::REQ_MINIMUM_ENEMY_MINIONS, 1 } }));
@@ -2692,9 +2689,8 @@ void TheBarrensCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
                 const int remainDamage = realDamage - targetHealth;
                 if (remainDamage > 0)
                 {
-                    Generic::TakeDamageToCharacter(realSource,
-                                                   player->GetHero(),
-                                                   remainDamage, false);
+                    Generic::TakeDamageToCharacter(
+                        realSource, player->GetHero(), remainDamage, false);
                 }
             }
         }));

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -1818,8 +1818,7 @@ void VanillaCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddPowerTask(
         std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::TARGET,
-                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::TARGET));
     cards.emplace(
         "VAN_CS2_024",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
@@ -1845,8 +1844,7 @@ void VanillaCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - FREEZE = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(
-        EntityType::ENEMY_MINIONS, GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::ENEMY_MINIONS));
     cards.emplace("VAN_CS2_026", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
@@ -1879,8 +1877,7 @@ void VanillaCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddPowerTask(
         std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 2, true));
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(
-        EntityType::ENEMY_MINIONS, GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::ENEMY_MINIONS));
     cards.emplace("VAN_CS2_028", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
@@ -1920,8 +1917,7 @@ void VanillaCardsGen::AddMage(std::map<std::string, CardDef>& cards)
         true,
         TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 4, true) }));
     power.AddPowerTask(std::make_shared<FlagTask>(
-        false, TaskList{ std::make_shared<SetGameTagTask>(
-                   EntityType::TARGET, GameTag::FROZEN, 1) }));
+        false, TaskList{ std::make_shared<FreezeTask>(EntityType::TARGET) }));
     cards.emplace(
         "VAN_CS2_031",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
@@ -1989,8 +1985,7 @@ void VanillaCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddPowerTask(
         std::make_shared<IncludeAdjacentTask>(EntityType::TARGET, true));
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::STACK,
-                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::STACK));
     power.AddPowerTask(
         std::make_shared<DamageTask>(EntityType::STACK, 1, true));
     cards.emplace(
@@ -3781,8 +3776,7 @@ void VanillaCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     power.ClearData();
     power.AddPowerTask(
         std::make_shared<DamageTask>(EntityType::TARGET, 1, true));
-    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::TARGET,
-                                                        GameTag::FROZEN, 1));
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::TARGET));
     cards.emplace("VAN_CS2_037",
                   CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
                                            { PlayReq::REQ_ENEMY_TARGET, 0 } }));

--- a/Sources/Rosetta/PlayMode/Enchants/Effect.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/Effect.cpp
@@ -31,6 +31,15 @@ void Effect::ApplyTo(Entity* entity, bool isOneTurnEffect) const
     {
         case EffectOperator::ADD:
             entity->SetNativeGameTag(m_gameTag, prevValue + m_value);
+
+            if (auto weapon = dynamic_cast<Weapon*>(entity); weapon)
+            {
+                if (m_gameTag == GameTag::DURABILITY && prevValue + m_value > 0)
+                {
+                    weapon->isDestroyed = false;
+                }
+            }
+
             break;
         case EffectOperator::SUB:
             entity->SetNativeGameTag(m_gameTag, prevValue - m_value);

--- a/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
@@ -133,6 +133,7 @@ void CardLoader::Load(std::vector<Card*>& cards)
         //       (AT_132_SHAMANd), Strength Totem (AT_132_SHAMANe)
         //       doesn't have Race::TOTEM
         // NOTE: Wailing Demon (WC_003t) doesn't have GameTag::TAUNT
+        // NOTE: Axe Berserker (AV_565) doesn't have GameTag::HONORABLEKILL
         if (dbfID == 56091 || dbfID == 64196)
         {
             gameTags.emplace(GameTag::DEATHRATTLE, 1);
@@ -153,6 +154,10 @@ void CardLoader::Load(std::vector<Card*>& cards)
         else if (dbfID == 63500)
         {
             gameTags.emplace(GameTag::TAUNT, 1);
+        }
+        else if (dbfID == 73459)
+        {
+            gameTags.emplace(GameTag::HONORABLEKILL, 1);
         }
 
         Card* card = new Card();

--- a/Sources/Rosetta/PlayMode/Models/Character.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Character.cpp
@@ -109,6 +109,11 @@ bool Character::IsImmune() const
     return static_cast<bool>(GetGameTag(GameTag::IMMUNE));
 }
 
+void Character::Freeze()
+{
+    SetGameTag(GameTag::FROZEN, 1);
+}
+
 bool Character::IsFrozen() const
 {
     return static_cast<bool>(GetGameTag(GameTag::FROZEN));

--- a/Sources/Rosetta/PlayMode/Models/Character.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Character.cpp
@@ -327,10 +327,17 @@ int Character::TakeDamage(Playable* source, int damage)
     if (source->HasHonorableKill() &&
         source->player == game->GetCurrentPlayer() && GetHealth() == 0)
     {
-        const TaskList tasks =
-            (hero && hero->HasWeapon())
-                ? hero->weapon->card->power.GetHonorableKillTask()
-                : source->card->power.GetHonorableKillTask();
+        TaskList tasks;
+
+        if (auto sourceHero = dynamic_cast<Hero*>(source);
+            sourceHero && sourceHero->HasWeapon())
+        {
+            tasks = sourceHero->weapon->card->power.GetHonorableKillTask();
+        }
+        else
+        {
+            tasks = source->card->power.GetHonorableKillTask();
+        }
 
         for (auto& task : tasks)
         {

--- a/Sources/Rosetta/PlayMode/Models/Character.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Character.cpp
@@ -323,34 +323,6 @@ int Character::TakeDamage(Playable* source, int damage)
     game->triggerManager.OnTakeDamageTrigger(this);
     game->triggerManager.OnDealDamageTrigger(source);
 
-    // Check if the source has Honorable Kill
-    if (source->HasHonorableKill() &&
-        source->player == game->GetCurrentPlayer() && GetHealth() == 0)
-    {
-        TaskList tasks;
-
-        if (auto sourceHero = dynamic_cast<Hero*>(source);
-            sourceHero && sourceHero->HasWeapon())
-        {
-            tasks = sourceHero->weapon->card->power.GetHonorableKillTask();
-        }
-        else
-        {
-            tasks = source->card->power.GetHonorableKillTask();
-        }
-
-        for (auto& task : tasks)
-        {
-            std::unique_ptr<ITask> clonedTask = task->Clone();
-
-            clonedTask->SetPlayer(source->player);
-            clonedTask->SetSource(source);
-            clonedTask->SetTarget(nullptr);
-
-            player->game->taskQueue.Enqueue(std::move(clonedTask));
-        }
-    }
-
     game->ProcessTasks();
     game->taskQueue.EndEvent();
     game->currentEventData.reset();

--- a/Sources/Rosetta/PlayMode/Models/Hero.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Hero.cpp
@@ -112,4 +112,14 @@ bool Hero::HasLifesteal() const
 
     return false;
 }
+
+bool Hero::HasHonorableKill() const
+{
+    if (HasWeapon())
+    {
+        return weapon->HasHonorableKill();
+    }
+
+    return false;
+}
 }  // namespace RosettaStone::PlayMode

--- a/Sources/Rosetta/PlayMode/Models/Weapon.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Weapon.cpp
@@ -41,11 +41,16 @@ void Weapon::SetDurability(int durability)
 {
     SetGameTag(GameTag::DURABILITY, durability);
 
-    // Destroy weapon if durability is 0
-    if (GetDurability() <= 0)
+    if (durability <= 0)
     {
         Destroy();
-        player->GetHero()->RemoveWeapon();
+    }
+    else
+    {
+        if (isDestroyed)
+        {
+            isDestroyed = false;
+        }
     }
 }
 

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/FreezeTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/FreezeTask.cpp
@@ -1,0 +1,37 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2021 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2017-2021 Chris Ohk
+
+#include <Rosetta/PlayMode/Games/Game.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/FreezeTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/IncludeTask.hpp>
+
+namespace RosettaStone::PlayMode::SimpleTasks
+{
+FreezeTask::FreezeTask(EntityType entityType) : ITask(entityType)
+{
+    // Do nothing
+}
+
+TaskStatus FreezeTask::Impl(Player* player)
+{
+    auto playables =
+        IncludeTask::GetEntities(m_entityType, player, m_source, m_target);
+
+    for (auto& playable : playables)
+    {
+        if (auto character = dynamic_cast<Character*>(playable); character)
+        {
+            character->Freeze();
+        }
+    }
+
+    return TaskStatus::COMPLETE;
+}
+
+std::unique_ptr<ITask> FreezeTask::CloneImpl()
+{
+    return std::make_unique<FreezeTask>(m_entityType);
+}
+}  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -19,6 +19,57 @@ using namespace PlayMode;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ----------------------------------------- MINION - DRUID
+// [AV_211] Dire Frostwolf - COST:4 [ATK:4/HP:4]
+// - Race: Beast, Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Stealth</b>
+//       <b>Deathrattle:</b> Summon a 2/2 Wolf with <b>Stealth</b>.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// - STEALTH = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - AV_211 : Dire Frostwolf")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Dire Frostwolf"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Flamestrike"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Frostwolf Cub");
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->HasStealth(), true);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [AV_360] Frostwolf Kennels - COST:3
 // - Set: ALTERAC_VALLEY, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -223,6 +223,74 @@ TEST_CASE("[Hunter : Weapon] - AV_244 : Bloodseeker")
 }
 
 // ---------------------------------------- MINION - HUNTER
+// [AV_334] Stormpike Battle Ram - COST:4 [ATK:4/HP:3]
+// - Race: Beast, Set: ALTERAC_VALLEY, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Rush</b>
+//       <b>Deathrattle:</b> Your next Beast costs (2) less.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - AV_334 : Stormpike Battle Ram")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Stormpike Battle Ram"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Unbound Elemental"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Stranglethorn Tiger"));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Stranglethorn Tiger"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    CHECK_EQ(card2->GetCost(), 3);
+    CHECK_EQ(card3->GetCost(), 5);
+    CHECK_EQ(card4->GetCost(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(card2->GetCost(), 3);
+    CHECK_EQ(card3->GetCost(), 5);
+    CHECK_EQ(card4->GetCost(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card5, card1));
+    CHECK_EQ(card2->GetCost(), 3);
+    CHECK_EQ(card3->GetCost(), 3);
+    CHECK_EQ(card4->GetCost(), 3);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 7);
+    CHECK_EQ(card2->GetCost(), 3);
+    CHECK_EQ(card4->GetCost(), 5);
+}
+
+// ---------------------------------------- MINION - HUNTER
 // [AV_337] Mountain Bear - COST:7 [ATK:5/HP:6]
 // - Race: Beast, Set: ALTERAC_VALLEY, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -626,6 +626,55 @@ TEST_CASE("[Warrior : Spell] - AV_322 : Snowed In")
     CHECK_EQ(opField[0]->IsFrozen(), true);
 }
 
+// --------------------------------------- MINION - WARRIOR
+// [AV_323] Scrapsmith - COST:3 [ATK:2/HP:4]
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Battlecry:</b> Add two 2/4 Grunts
+//       with <b>Taunt</b> to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - AV_323 : Scrapsmith")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::DEMONHUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Scrapsmith"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 2);
+    CHECK_EQ(curHand[0]->card->name, "Scrappy Grunt");
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[0])->GetAttack(), 2);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[0])->GetHealth(), 4);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[0])->HasTaunt(), true);
+    CHECK_EQ(curHand[1]->card->name, "Scrappy Grunt");
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[1])->GetAttack(), 2);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[1])->GetHealth(), 4);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[1])->HasTaunt(), true);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [AV_101] Herald of Lokholar - COST:4 [ATK:3/HP:5]
 // - Set: ALTERAC_VALLEY, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -105,6 +105,61 @@ TEST_CASE("[Druid : Spell] - AV_360 : Frostwolf Kennels")
     CHECK_EQ(curField.GetCount(), 3);
 }
 
+// ---------------------------------------- MINION - HUNTER
+// [AV_337] Mountain Bear - COST:7 [ATK:5/HP:6]
+// - Race: Beast, Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Deathrattle:</b> Summon two 2/4 Cubs with <b>Taunt</b>.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - AV_337 : Mountain Bear")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mountain Bear"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Mountain Cub");
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+    CHECK_EQ(curField[1]->card->name, "Mountain Cub");
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 4);
+    CHECK_EQ(curField[1]->HasTaunt(), true);
+}
+
 // ----------------------------------------- MINION - ROGUE
 // [AV_201] Coldtooth Yeti - COST:3 [ATK:1/HP:5]
 // - Set: ALTERAC_VALLEY, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -675,6 +675,69 @@ TEST_CASE("[Warrior : Minion] - AV_323 : Scrapsmith")
     CHECK_EQ(dynamic_cast<Minion*>(curHand[1])->HasTaunt(), true);
 }
 
+// --------------------------------------- MINION - WARRIOR
+// [AV_565] Axe Berserker - COST:4 [ATK:3/HP:5]
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Rush</b>. <b>Honorable Kill:</b> Draw a weapon.
+// --------------------------------------------------------
+// GameTag:
+// - RUSH = 1
+// --------------------------------------------------------
+// RefTag:
+// - HONORABLEKILL = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - AV_565 : Axe Berserker")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 30; ++i)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Fiery War Axe");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Axe Berserker"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("River Crocolisk"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, AttackTask(card1, card2));
+
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(curHand[5]->card->name, "Fiery War Axe");
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [AV_101] Herald of Lokholar - COST:4 [ATK:3/HP:5]
 // - Set: ALTERAC_VALLEY, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -160,6 +160,70 @@ TEST_CASE("[Hunter : Minion] - AV_337 : Mountain Bear")
     CHECK_EQ(curField[1]->HasTaunt(), true);
 }
 
+// ------------------------------------------- SPELL - MAGE
+// [AV_218] Mass Polymorph - COST:7
+// - Set: ALTERAC_VALLEY, Rarity: Epic
+// - Spell School: Arcane
+// --------------------------------------------------------
+// Text: Transform all minions into 1/1 Sheep.
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - AV_218 : Mass Polymorph")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::DEMONHUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mass Polymorph"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Sheep");
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(opField.GetCount(), 2);
+    CHECK_EQ(opField[0]->card->name, "Sheep");
+    CHECK_EQ(opField[0]->GetAttack(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 1);
+    CHECK_EQ(opField[1]->card->name, "Sheep");
+    CHECK_EQ(opField[1]->GetAttack(), 1);
+    CHECK_EQ(opField[1]->GetHealth(), 1);
+}
+
 // ----------------------------------------- MINION - ROGUE
 // [AV_201] Coldtooth Yeti - COST:3 [ATK:1/HP:5]
 // - Set: ALTERAC_VALLEY, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -291,6 +291,62 @@ TEST_CASE("[Hunter : Minion] - AV_334 : Stormpike Battle Ram")
 }
 
 // ---------------------------------------- MINION - HUNTER
+// [AV_335] Ram Tamer - COST:3 [ATK:4/HP:3]
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you control a <b>Secret</b>,
+//       gain +1/+1 and <b>Stealth</b>.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - SECRET = 1
+// - STEALTH = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - AV_335 : Ram Tamer")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ram Tamer"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ram Tamer"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Snake Trap"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+    CHECK_EQ(curField[0]->HasStealth(), false);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 5);
+    CHECK_EQ(curField[1]->GetHealth(), 4);
+    CHECK_EQ(curField[1]->HasStealth(), true);
+}
+
+// ---------------------------------------- MINION - HUNTER
 // [AV_337] Mountain Bear - COST:7 [ATK:5/HP:6]
 // - Race: Beast, Set: ALTERAC_VALLEY, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -156,6 +156,72 @@ TEST_CASE("[Druid : Spell] - AV_360 : Frostwolf Kennels")
     CHECK_EQ(curField.GetCount(), 3);
 }
 
+// ---------------------------------------- WEAPON - HUNTER
+// [AV_244] Bloodseeker - COST:2
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Honorable Kill:</b> Gain +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - HONORABLEKILL = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Weapon] - AV_244 : Bloodseeker")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bloodseeker"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Intrepid Initiate"));
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetAttack(), 2);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(curPlayer->GetHero(), card2));
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetAttack(), 2);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(curPlayer->GetHero(), card3));
+    CHECK_EQ(curPlayer->GetHero()->HasWeapon(), true);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetAttack(), 3);
+    CHECK_EQ(curPlayer->GetHero()->weapon->GetDurability(), 1);
+}
+
 // ---------------------------------------- MINION - HUNTER
 // [AV_337] Mountain Bear - COST:7 [ATK:5/HP:6]
 // - Race: Beast, Set: ALTERAC_VALLEY, Rarity: Common


### PR DESCRIPTION
This revision includes:
- Implement 9 ALTERAC_VALLEY cards
  - Diire Frostwolf (AV_211)
  - Mass Polymorph (AV_218)
  - Bloodseeker (AV_244)
  - Snowed In (AV_322)
  - Scrapsmith (AV_323)
  - Stormpike Battle Ram (AV_334)
  - Ram Tamer (AV_335)
  - Mountain Bear (AV_337)
  - Axe Berserker (AV_565)
- Create class 'FreezeTask': This class represents the task for freezing character(s)
  - Add method 'Freeze()': Freezes a character
  - Refactor code to use 'FreezeTask'
  - Change the logic of card 'Frozen Buckler' (AV_109)
- Add code to emplace missing game tag 'HONORABLEKILL'
- Change method 'HasHonorableKill()' to 'virtual'
- Fix the logic when the durability of the weapon decreases to 0 and increases to 1 according to effect
  - Correct code to assign tasks when source is a hero
  - Move code to remove durability from weapon if hero attack
  - Move code to check if the source has 'Honorable Kill'
  - Remove code to destroy weapon if durability is 0
  - Add code to check a hero is not 'nullptr' and has a weapon
  - Add code to call method 'ProcessTasks()' and start/end event
  - Add code to cancel logic to destroy weapon when it gains durability