### PR TITLE
Implement 10 ALTERAC_VALLEY cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -1084,10 +1084,10 @@ ALTERAC_VALLEY | AV_118 | Battleworn Vanguard |
 ALTERAC_VALLEY | AV_119 | To the Front! |  
 ALTERAC_VALLEY | AV_121 | Gnome Private | O
 ALTERAC_VALLEY | AV_122 | Corporal | O
-ALTERAC_VALLEY | AV_123 | Sneaky Scout |  
+ALTERAC_VALLEY | AV_123 | Sneaky Scout | O
 ALTERAC_VALLEY | AV_124 | Direwolf Commander | O
-ALTERAC_VALLEY | AV_125 | Tower Sergeant |  
-ALTERAC_VALLEY | AV_126 | Bunker Sergeant |  
+ALTERAC_VALLEY | AV_125 | Tower Sergeant | O
+ALTERAC_VALLEY | AV_126 | Bunker Sergeant | O
 ALTERAC_VALLEY | AV_127 | Ice Revenant |  
 ALTERAC_VALLEY | AV_128 | Frozen Mammoth |  
 ALTERAC_VALLEY | AV_129 | Blood Guard |  
@@ -1105,7 +1105,7 @@ ALTERAC_VALLEY | AV_141t | Lokholar the Ice Lord |
 ALTERAC_VALLEY | AV_142t | Ivus, the Forest Lord |  
 ALTERAC_VALLEY | AV_143 | Korrak the Bloodrager |  
 ALTERAC_VALLEY | AV_145 | Captain Galvangar |  
-ALTERAC_VALLEY | AV_147 | Dun Baldar Bunker |  
+ALTERAC_VALLEY | AV_147 | Dun Baldar Bunker | O
 ALTERAC_VALLEY | AV_200 | Magister Dawngrasp |  
 ALTERAC_VALLEY | AV_201 | Coldtooth Yeti | O
 ALTERAC_VALLEY | AV_202 | Rokara, the Valorous |  
@@ -1124,7 +1124,7 @@ ALTERAC_VALLEY | AV_218 | Mass Polymorph | O
 ALTERAC_VALLEY | AV_219 | Ram Commander |  
 ALTERAC_VALLEY | AV_222 | Spammy Arcanist |  
 ALTERAC_VALLEY | AV_223 | Vanndar Stormpike |  
-ALTERAC_VALLEY | AV_224 | Spring the Trap |  
+ALTERAC_VALLEY | AV_224 | Spring the Trap | O
 ALTERAC_VALLEY | AV_226 | Ice Trap |  
 ALTERAC_VALLEY | AV_238 | Gankster |  
 ALTERAC_VALLEY | AV_244 | Bloodseeker | O
@@ -1144,12 +1144,12 @@ ALTERAC_VALLEY | AV_266 | Windchill | O
 ALTERAC_VALLEY | AV_267 | Caria Felsoul |  
 ALTERAC_VALLEY | AV_268 | Wildpaw Cavern | O
 ALTERAC_VALLEY | AV_269 | Flanking Maneuver |  
-ALTERAC_VALLEY | AV_277 | Seeds of Destruction |  
-ALTERAC_VALLEY | AV_281 | Felfire in the Hole! |  
+ALTERAC_VALLEY | AV_277 | Seeds of Destruction | O
+ALTERAC_VALLEY | AV_281 | Felfire in the Hole! | O
 ALTERAC_VALLEY | AV_282 | Build a Snowman |  
 ALTERAC_VALLEY | AV_283 | Rune of the Archmage |  
 ALTERAC_VALLEY | AV_284 | Balinda Stonehearth |  
-ALTERAC_VALLEY | AV_285 | Full-Blown Evil |  
+ALTERAC_VALLEY | AV_285 | Full-Blown Evil | O
 ALTERAC_VALLEY | AV_286 | Felwalker |  
 ALTERAC_VALLEY | AV_290 | Iceblood Tower |  
 ALTERAC_VALLEY | AV_291 | Frostsaber Matriarch |  
@@ -1159,7 +1159,7 @@ ALTERAC_VALLEY | AV_294 | Clawfury Adept |
 ALTERAC_VALLEY | AV_295 | Capture Coldtooth Mine |  
 ALTERAC_VALLEY | AV_296 | Pride Seeker |  
 ALTERAC_VALLEY | AV_298 | Wildpaw Gnoll |  
-ALTERAC_VALLEY | AV_308 | Grave Defiler |  
+ALTERAC_VALLEY | AV_308 | Grave Defiler | O
 ALTERAC_VALLEY | AV_309 | Piggyback Imp |  
 ALTERAC_VALLEY | AV_312 | Sacrificial Summoner |  
 ALTERAC_VALLEY | AV_313 | Hollow Abomination |  
@@ -1198,11 +1198,11 @@ ALTERAC_VALLEY | AV_405 | Contraband Stash |
 ALTERAC_VALLEY | AV_565 | Axe Berserker | O
 ALTERAC_VALLEY | AV_601 | Forsaken Lieutenant |  
 ALTERAC_VALLEY | AV_657 | Desecrated Graveyard |  
-ALTERAC_VALLEY | AV_660 | Iceblood Garrison |  
+ALTERAC_VALLEY | AV_660 | Iceblood Garrison | O
 ALTERAC_VALLEY | AV_661 | Field of Strife |  
 ALTERAC_VALLEY | AV_664 | Stormpike Aid Station |  
 ALTERAC_VALLEY | AV_704 | Humongous Owl |  
 ALTERAC_VALLEY | AV_710 | Reconnaissance |  
 ALTERAC_VALLEY | AV_711 | Double Agent |  
 
-- Progress: 15% (21 of 135 Cards)
+- Progress: 22% (31 of 135 Cards)

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -96,6 +96,14 @@ class SelfCondition
     static SelfCondition IsFieldCount(int value,
                                       RelaSign relaSign = RelaSign::EQ);
 
+    //! SelfCondition wrapper for checking the count of opponent field
+    //! is satisfied according to \p value and \p relaSign.
+    //! \param value The value to check condition.
+    //! \param relaSign The comparer to check condition..
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsOpFieldCount(int value,
+                                        RelaSign relaSign = RelaSign::EQ);
+
     //! SelfCondition wrapper for checking the field is full.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsFieldFull();

--- a/Includes/Rosetta/PlayMode/Enchants/Power.hpp
+++ b/Includes/Rosetta/PlayMode/Enchants/Power.hpp
@@ -144,6 +144,10 @@ class Power
     //! \param task A pointer to honorable kill task.
     void AddHonorableKillTask(std::shared_ptr<ITask> task);
 
+    //! Adds a list of honorable kill task.
+    //! \param tasks A list of honorable kill task.
+    void AddHonorableKillTask(TaskList tasks);
+
  private:
     std::shared_ptr<IAura> m_aura;
     std::shared_ptr<Enchant> m_enchant;

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
@@ -26,14 +26,17 @@ class ComplexTask
     //! Returns a list of task for drawing card(s) from your deck.
     //! \param amount The amount to draw card.
     //! \param list A list of self conditions to filter card(s).
-    static TaskList DrawCardFromDeck(int amount, const SelfCondList& list)
+    //! \param addToStack A flag to store card to stack.
+    static TaskList DrawCardFromDeck(int amount, const SelfCondList& list,
+                                     bool addToStack = false)
     {
-        return TaskList{ std::make_shared<SimpleTasks::IncludeTask>(
-                             EntityType::DECK),
-                         std::make_shared<SimpleTasks::FilterStackTask>(list),
-                         std::make_shared<SimpleTasks::RandomTask>(
-                             EntityType::STACK, amount),
-                         std::make_shared<SimpleTasks::DrawStackTask>() };
+        return TaskList{
+            std::make_shared<SimpleTasks::IncludeTask>(EntityType::DECK),
+            std::make_shared<SimpleTasks::FilterStackTask>(list),
+            std::make_shared<SimpleTasks::RandomTask>(EntityType::STACK,
+                                                      amount),
+            std::make_shared<SimpleTasks::DrawStackTask>(addToStack)
+        };
     }
 
     //! Returns a list of task for summoning a minion from your deck.

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
@@ -219,6 +219,20 @@ class ComplexTask
 
         return ret;
     }
+
+    //! Returns a list of task for copying a random card(s) in your hand.
+    //! \param amount The amount to copy card(s).
+    //! \param list A list of self conditions to filter card(s).
+    static TaskList CopyCardInHand(int amount, const SelfCondList& list)
+    {
+        return TaskList{ std::make_shared<SimpleTasks::IncludeTask>(
+                             EntityType::HAND),
+                         std::make_shared<SimpleTasks::FilterStackTask>(list),
+                         std::make_shared<SimpleTasks::RandomTask>(
+                             EntityType::STACK, amount),
+                         std::make_shared<SimpleTasks::CopyTask>(
+                             EntityType::STACK, ZoneType::HAND) };
+    }
 };
 }  // namespace RosettaStone::PlayMode
 

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
@@ -24,6 +24,8 @@ class ComplexTask
 {
  public:
     //! Returns a list of task for drawing card(s) from your deck.
+    //! \param amount The amount to draw card.
+    //! \param list A list of self conditions to filter card(s).
     static TaskList DrawCardFromDeck(int amount, const SelfCondList& list)
     {
         return TaskList{ std::make_shared<SimpleTasks::IncludeTask>(

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
   * 80% Forged in the Barrens (136 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
-  * 15% Fractured in Alterac Valley (21 of 135 cards)
+  * 22% Fractured in Alterac Valley (31 of 135 cards)
 
 ### Wild Format
 

--- a/Sources/Rosetta/PlayMode/Actions/Generic.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Generic.cpp
@@ -44,6 +44,28 @@ void TakeDamageToCharacter(Playable* source, Character* target, int amount,
     }
 
     target->TakeDamage(source, amount);
+
+    source->player->game->taskQueue.StartEvent();
+
+    // Check if the source has Honorable Kill
+    if (source->HasHonorableKill() && target->GetHealth() == 0)
+    {
+        TaskList tasks = source->card->power.GetHonorableKillTask();
+
+        for (auto& task : tasks)
+        {
+            std::unique_ptr<ITask> clonedTask = task->Clone();
+
+            clonedTask->SetPlayer(source->player);
+            clonedTask->SetSource(source);
+            clonedTask->SetTarget(target);
+
+            source->game->taskQueue.Enqueue(std::move(clonedTask));
+        }
+    }
+
+    source->player->game->ProcessTasks();
+    source->player->game->taskQueue.EndEvent();
 }
 
 bool AddCardToHand(const Player* player, Playable* entity)

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -1897,6 +1897,16 @@ void AlteracValleyCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - ImmuneToSpellpower = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<EnqueueTask>(
+        TaskList{
+            std::make_shared<FilterStackTask>(SelfCondList{
+                std::make_shared<SelfCondition>(SelfCondition::IsNotDead()) }),
+            std::make_shared<RandomTask>(EntityType::ENEMY_MINIONS, 1),
+            std::make_shared<DamageTask>(EntityType::STACK, 1) },
+        5, true));
+    power.AddPowerTask(ComplexTask::RepeatableThisTurn());
+    cards.emplace("AV_285", CardDef(power));
 
     // --------------------------------------- MINION - WARLOCK
     // [AV_286] Felwalker - COST:6 [ATK:3/HP:7]

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -1851,6 +1851,8 @@ void AlteracValleyCardsGen::AddShamanNonCollect(
 
 void AlteracValleyCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------------- SPELL - WARLOCK
     // [AV_277] Seeds of Destruction - COST:2
     // - Set: ALTERAC_VALLEY, Rarity: Rare
@@ -1868,6 +1870,17 @@ void AlteracValleyCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // Text: Draw a spell and deal 2 damage to all enemies.
     //       If it's a Fel spell, deal 1 more.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawSpellTask>(1, true));
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMIES, 2, true));
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::STACK, SelfCondList{ std::make_shared<SelfCondition>(
+                               SelfCondition::IsFelSpell()) }));
+    power.AddPowerTask(
+        std::make_shared<FlagTask>(true, TaskList{ std::make_shared<DamageTask>(
+                                             EntityType::ENEMIES, 1, true) }));
+    cards.emplace("AV_281", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [AV_285] Full-Blown Evil - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2533,6 +2533,15 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE,
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsOpFieldCount(2, RelaSign::GEQ)) }));
+    power.AddPowerTask(
+        std::make_shared<FlagTask>(true, TaskList{ std::make_shared<DamageTask>(
+                                             EntityType::ENEMY_MINIONS, 1) }));
+    cards.emplace("AV_126", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_127] Ice Revenant - COST:4 [ATK:4/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -5,6 +5,7 @@
 
 #include <Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
+#include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 
 using namespace RosettaStone::PlayMode::SimpleTasks;
@@ -530,6 +531,17 @@ void AlteracValleyCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->tasks = { ComplexTask::DrawCardFromDeck(
+        1,
+        SelfCondList{
+            std::make_shared<SelfCondition>(SelfCondition::IsSecret()) },
+        true) };
+    power.GetTrigger()->tasks.emplace_back(
+        std::make_shared<AddEnchantmentTask>("AV_147e", EntityType::STACK));
+    power.GetTrigger()->lastTurn = 3;
+    cards.emplace("AV_147", CardDef(power));
 
     // ----------------------------------------- SPELL - HUNTER
     // [AV_224] Spring the Trap - COST:4
@@ -761,6 +773,9 @@ void AlteracValleyCardsGen::AddHunterNonCollect(
     // --------------------------------------------------------
     // Text: Costs (1).
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(std::make_shared<Enchant>(Effects::SetCost(1)));
+    cards.emplace("AV_147e", CardDef(power));
 
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [AV_226e] Frosty - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -1861,6 +1861,10 @@ void AlteracValleyCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // Text: Shuffle four Rifts into your deck.
     //       They summon a 3/3 Dread Imp when drawn.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::DECK, "AV_316t4", 4));
+    cards.emplace("AV_277", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [AV_281] Felfire in the Hole! - COST:5
@@ -1969,6 +1973,8 @@ void AlteracValleyCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 void AlteracValleyCardsGen::AddWarlockNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------- ENCHANTMENT - WARLOCK
     // [AV_286e2] Felgorged - COST:0
     // - Set: ALTERAC_VALLEY
@@ -1987,6 +1993,9 @@ void AlteracValleyCardsGen::AddWarlockNonCollect(
     // [AV_316t] Dread Imp - COST:3 [ATK:3/HP:3]
     // - Race: Demon, Set: ALTERAC_VALLEY
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("AV_316t", CardDef(power));
 
     // ---------------------------------------- SPELL - WARLOCK
     // [AV_316t4] Fel Rift - COST:3
@@ -1999,6 +2008,10 @@ void AlteracValleyCardsGen::AddWarlockNonCollect(
     // GameTag:
     // - TOPDECK = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTopdeckTask(std::make_shared<SummonTask>("AV_316t"));
+    power.AddPowerTask(std::make_shared<SummonTask>("AV_316t"));
+    cards.emplace("AV_316t4", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - WARLOCK
     // [AV_317e] Lich Perfume - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2185,6 +2185,12 @@ void AlteracValleyCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // Text: At the end of your turn,
     //       deal 1 damage to all minions. Lasts 3 turns.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->tasks = { std::make_shared<DamageTask>(
+        EntityType::ALL_MINIONS, 1, true) };
+    power.GetTrigger()->lastTurn = 3;
+    cards.emplace("AV_660", CardDef(power));
 }
 
 void AlteracValleyCardsGen::AddWarriorNonCollect(

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2513,6 +2513,15 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE,
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsFieldCount(3, RelaSign::GEQ)) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<AddEnchantmentTask>(
+                  "AV_125e", EntityType::SOURCE) }));
+    cards.emplace("AV_125", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_126] Bunker Sergeant - COST:3 [ATK:2/HP:4]
@@ -2855,6 +2864,9 @@ void AlteracValleyCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("AV_125e"));
+    cards.emplace("AV_125e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [AV_127e] Frosty Spirit - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2480,6 +2480,10 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - HONORABLEKILL = 1
     // - STEALTH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddHonorableKillTask(
+        std::make_shared<AddEnchantmentTask>("AV_123e", EntityType::PLAYER));
+    cards.emplace("AV_123", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_124] Direwolf Commander - COST:3 [ATK:2/HP:5]
@@ -2836,6 +2840,14 @@ void AlteracValleyCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: Your Hero Power costs (0).
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<Aura>(AuraType::HERO_POWER,
+                                         EffectList{ Effects::SetCost(0) }));
+    {
+        const auto aura = dynamic_cast<Aura*>(power.GetAura());
+        aura->removeTrigger = { TriggerType::INSPIRE, nullptr };
+    }
+    cards.emplace("AV_123e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [AV_125e] Shielded - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -550,10 +550,23 @@ void AlteracValleyCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // Text: Deal 3 damage to a minion and cast a <b>Secret</b>
     //       from your deck. <b>Honorable Kill:</b> Cast 2.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
     // RefTag:
     // - HONORABLEKILL = 1
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
+    power.AddPowerTask(ComplexTask::CastSecretFromDeck());
+    power.AddHonorableKillTask(ComplexTask::CastSecretFromDeck());
+    cards.emplace(
+        "AV_224",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ----------------------------------------- SPELL - HUNTER
     // [AV_226] Ice Trap - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -1930,6 +1930,11 @@ void AlteracValleyCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(ComplexTask::CopyCardInHand(
+        1, SelfCondList{
+               std::make_shared<SelfCondition>(SelfCondition::IsFelSpell()) }));
+    cards.emplace("AV_308", CardDef(power));
 
     // --------------------------------------- MINION - WARLOCK
     // [AV_312] Sacrificial Summoner - COST:3 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
@@ -2076,19 +2076,7 @@ void DalaranCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     power.ClearData();
     power.AddPowerTask(std::make_shared<HealTask>(EntityType::TARGET, 4));
-    power.AddPowerTask(std::make_shared<CustomTask>(
-        [](Player* player, Entity* source, [[maybe_unused]] Playable* target) {
-            std::map<GameTag, int> tags;
-            tags.emplace(GameTag::GHOSTLY, 1);
-
-            Playable* playable = Entity::GetFromCard(player, source->card, tags,
-                                                     player->GetHandZone());
-            Generic::AddCardToHand(player, playable);
-
-            player->game->UpdateAura();
-            player->game->ghostlyCards.emplace_back(
-                playable->GetGameTag(GameTag::ENTITY_ID));
-        }));
+    power.AddPowerTask(ComplexTask::RepeatableThisTurn());
     cards.emplace(
         "DAL_432",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));

--- a/Sources/Rosetta/PlayMode/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UldumCardsGen.cpp
@@ -517,12 +517,9 @@ void UldumCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::HAND));
-    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
-        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::BEAST)) }));
-    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
-    power.AddPowerTask(
-        std::make_shared<CopyTask>(EntityType::STACK, ZoneType::HAND));
+    power.AddPowerTask(ComplexTask::CopyCardInHand(
+        1, SelfCondList{ std::make_shared<SelfCondition>(
+               SelfCondition::IsRace(Race::BEAST)) }));
     cards.emplace("ULD_151", CardDef(power));
 
     // ----------------------------------------- SPELL - HUNTER

--- a/Sources/Rosetta/PlayMode/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UldumCardsGen.cpp
@@ -950,13 +950,13 @@ void UldumCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - SECRET = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::DECK));
-    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
-        std::make_shared<SelfCondition>(SelfCondition::IsSecret()) }));
-    power.AddPowerTask(std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddPowerTask(ComplexTask::DrawCardFromDeck(
+        1,
+        SelfCondList{
+            std::make_shared<SelfCondition>(SelfCondition::IsSecret()) },
+        true));
     power.AddPowerTask(
         std::make_shared<AddEnchantmentTask>("ULD_726e", EntityType::STACK));
-    power.AddPowerTask(std::make_shared<DrawStackTask>());
     cards.emplace("ULD_726", CardDef(power));
 }
 

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -152,6 +152,18 @@ SelfCondition SelfCondition::IsFieldCount(int value, RelaSign relaSign)
     });
 }
 
+SelfCondition SelfCondition::IsOpFieldCount(int value, RelaSign relaSign)
+{
+    return SelfCondition([value, relaSign](Playable* playable) {
+        const int val = playable->player->opponent->GetFieldZone()
+                            ->GetCountExceptUntouchables();
+
+        return (relaSign == RelaSign::EQ && val == value) ||
+               (relaSign == RelaSign::GEQ && val >= value) ||
+               (relaSign == RelaSign::LEQ && val <= value);
+    });
+}
+
 SelfCondition SelfCondition::IsFieldFull()
 {
     return SelfCondition([](Playable* playable) {

--- a/Sources/Rosetta/PlayMode/Enchants/Power.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/Power.cpp
@@ -167,4 +167,10 @@ void Power::AddHonorableKillTask(std::shared_ptr<ITask> task)
 {
     m_honorableKillTask.emplace_back(task);
 }
+
+void Power::AddHonorableKillTask(TaskList tasks)
+{
+    m_honorableKillTask.insert(m_honorableKillTask.end(), tasks.begin(),
+                               tasks.end());
+}
 }  // namespace RosettaStone::PlayMode

--- a/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
@@ -133,7 +133,8 @@ void CardLoader::Load(std::vector<Card*>& cards)
         //       (AT_132_SHAMANd), Strength Totem (AT_132_SHAMANe)
         //       doesn't have Race::TOTEM
         // NOTE: Wailing Demon (WC_003t) doesn't have GameTag::TAUNT
-        // NOTE: Axe Berserker (AV_565) doesn't have GameTag::HONORABLEKILL
+        // NOTE: Spring the Trap(AV_224), Axe Berserker (AV_565)
+        //       doesn't have GameTag::HONORABLEKILL
         if (dbfID == 56091 || dbfID == 64196)
         {
             gameTags.emplace(GameTag::DEATHRATTLE, 1);
@@ -155,7 +156,7 @@ void CardLoader::Load(std::vector<Card*>& cards)
         {
             gameTags.emplace(GameTag::TAUNT, 1);
         }
-        else if (dbfID == 73459)
+        else if (dbfID == 67241 || dbfID == 73459)
         {
             gameTags.emplace(GameTag::HONORABLEKILL, 1);
         }

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/ConditionTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/ConditionTask.cpp
@@ -44,6 +44,7 @@ TaskStatus ConditionTask::Impl(Player* player)
         IncludeTask::GetEntities(m_entityType, player, m_source, m_target);
     if (playables.empty())
     {
+        player->game->taskStack.flag = false;
         return TaskStatus::STOP;
     }
 

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -1399,6 +1399,63 @@ TEST_CASE("[Neutral : Minion] - AV_122 : Corporal")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [AV_123] Sneaky Scout - COST:2 [ATK:3/HP:2]
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Stealth</b>
+//       <b>Honorable Kill:</b> Your next Hero Power costs (0).
+// --------------------------------------------------------
+// GameTag:
+// - HONORABLEKILL = 1
+// - STEALTH = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - AV_123 : Sneaky Scout")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Sneaky Scout"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("River Crocolisk"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHero()->heroPower->GetCost(), 2);
+
+    game.Process(curPlayer, AttackTask(card1, card2));
+    CHECK_EQ(curPlayer->GetHero()->heroPower->GetCost(), 0);
+
+    game.Process(curPlayer, HeroPowerTask());
+    CHECK_EQ(curPlayer->GetHero()->heroPower->GetCost(), 2);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [AV_124] Direwolf Commander - COST:3 [ATK:2/HP:5]
 // - Set: ALTERAC_VALLEY, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -1382,6 +1382,92 @@ TEST_CASE("[Warrior : Minion] - AV_565 : Axe Berserker")
     CHECK_EQ(curHand[5]->card->name, "Fiery War Axe");
 }
 
+// ---------------------------------------- SPELL - WARRIOR
+// [AV_660] Iceblood Garrison - COST:2
+// - Set: ALTERAC_VALLEY, Rarity: Rare
+// --------------------------------------------------------
+// Text: At the end of your turn,
+//       deal 1 damage to all minions. Lasts 3 turns.
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Spell] - AV_660 : Iceblood Garrison")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Iceblood Garrison"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Strongman"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Strongman"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField[0]->GetHealth(), 6);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+    CHECK_EQ(opField[0]->GetHealth(), 6);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(opField[0]->GetHealth(), 5);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(opField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+    CHECK_EQ(opField[0]->GetHealth(), 4);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+    CHECK_EQ(opField[0]->GetHealth(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+    CHECK_EQ(opField[0]->GetHealth(), 4);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [AV_101] Herald of Lokholar - COST:4 [ATK:3/HP:5]
 // - Set: ALTERAC_VALLEY, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -11,6 +11,7 @@
 
 #include <Rosetta/PlayMode/Actions/Draw.hpp>
 #include <Rosetta/PlayMode/Cards/Cards.hpp>
+#include <Rosetta/PlayMode/Zones/DeckZone.hpp>
 #include <Rosetta/PlayMode/Zones/FieldZone.hpp>
 #include <Rosetta/PlayMode/Zones/HandZone.hpp>
 
@@ -154,6 +155,102 @@ TEST_CASE("[Druid : Spell] - AV_360 : Frostwolf Kennels")
     game.ProcessUntil(Step::MAIN_ACTION);
 
     CHECK_EQ(curField.GetCount(), 3);
+}
+
+// ----------------------------------------- SPELL - HUNTER
+// [AV_147] Dun Baldar Bunker - COST:2
+// - Set: ALTERAC_VALLEY, Rarity: Rare
+// --------------------------------------------------------
+// Text: At the end of your turn, draw a <b>Secret</b>
+//       and set its Cost to (1). Lasts 3 turns.
+// --------------------------------------------------------
+// RefTag:
+// - SECRET = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Spell] - AV_147 : Dun Baldar Bunker")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Snake Trap");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Holy Light");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Wisp");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curDeck = *(curPlayer->GetDeckZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Dun Baldar Bunker"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curDeck.GetCount(), 26);
+    CHECK_EQ(curHand.GetCount(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curDeck.GetCount(), 25);
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curHand[4]->card->IsSecret(), true);
+    CHECK_EQ(curHand[4]->GetCost(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curDeck.GetCount(), 24);
+    CHECK_EQ(curHand.GetCount(), 6);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curDeck.GetCount(), 23);
+    CHECK_EQ(curHand.GetCount(), 7);
+    CHECK_EQ(curHand[6]->card->IsSecret(), true);
+    CHECK_EQ(curHand[6]->GetCost(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curDeck.GetCount(), 22);
+    CHECK_EQ(curHand.GetCount(), 8);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curDeck.GetCount(), 21);
+    CHECK_EQ(curHand.GetCount(), 9);
+    CHECK_EQ(curHand[8]->card->IsSecret(), true);
+    CHECK_EQ(curHand[8]->GetCost(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curDeck.GetCount(), 20);
+    CHECK_EQ(curHand.GetCount(), 10);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curDeck.GetCount(), 20);
+    CHECK_EQ(curHand.GetCount(), 10);
 }
 
 // ---------------------------------------- WEAPON - HUNTER

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -1091,7 +1091,7 @@ TEST_CASE("[Warlock : Minion] - AV_308 : Grave Defiler")
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     CHECK_EQ(curHand.GetCount(), 4);
-    const bool check = curHand[3]->card->name == "River Felosophy" ||
+    const bool check = curHand[3]->card->name == "Felosophy" ||
                        curHand[3]->card->name == "Unstable Felbolt";
     CHECK_EQ(check, true);
 }

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -1525,3 +1525,55 @@ TEST_CASE("[Neutral : Minion] - AV_124 : Direwolf Commander")
     CHECK_EQ(curField[1]->GetHealth(), 2);
     CHECK_EQ(curField[1]->HasStealth(), true);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [AV_125] Tower Sergeant - COST:4 [ATK:4/HP:4]
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you control at least
+//       2 other minions, gain +2/+2.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - AV_124 : Direwolf Commander")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Tower Sergeant"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Tower Sergeant"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[1]->GetAttack(), 4);
+    CHECK_EQ(curField[1]->GetHealth(), 4);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[3]->GetAttack(), 6);
+    CHECK_EQ(curField[3]->GetHealth(), 6);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -1047,6 +1047,55 @@ TEST_CASE("[Warlock : Spell] - AV_285 : Full-Blown Evil")
     CHECK_EQ(curHand.GetCount(), 0);
 }
 
+// --------------------------------------- MINION - WARLOCK
+// [AV_308] Grave Defiler - COST:1 [ATK:2/HP:1]
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Copy a Fel spell in your hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - AV_308 : Grave Defiler")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Grave Defiler"));
+    [[maybe_unused]] const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    [[maybe_unused]] const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Felosophy"));
+    [[maybe_unused]] const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Unstable Felbolt"));
+
+    CHECK_EQ(curHand.GetCount(), 4);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 4);
+    const bool check = curHand[3]->card->name == "River Felosophy" ||
+                       curHand[3]->card->name == "Unstable Felbolt";
+    CHECK_EQ(check, true);
+}
+
 // ---------------------------------------- SPELL - WARRIOR
 // [AV_109] Frozen Buckler - COST:2
 // - Set: ALTERAC_VALLEY, Rarity: Epic

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -863,6 +863,59 @@ TEST_CASE("[Shaman : Spell] - AV_268 : Wildpaw Cavern")
     CHECK_EQ(curField.GetCount(), 3);
 }
 
+// ---------------------------------------- SPELL - WARLOCK
+// [AV_281] Felfire in the Hole! - COST:5
+// - Set: ALTERAC_VALLEY, Rarity: Epic
+// - Spell School: Fel
+// --------------------------------------------------------
+// Text: Draw a spell and deal 2 damage to all enemies.
+//       If it's a Fel spell, deal 1 more.
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Spell] - AV_281 : Felfire in the Hole!")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 5; ++i)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Felfire in the Hole!");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Felfire in the Hole!"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Felfire in the Hole!"));
+
+    opPlayer->GetHero()->SetDamage(0);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curHand.GetCount(), 6);
+    CHECK_EQ(curHand[5]->card->GetSpellSchool(), SpellSchool::FEL);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 25);
+}
+
 // ---------------------------------------- SPELL - WARRIOR
 // [AV_109] Frozen Buckler - COST:2
 // - Set: ALTERAC_VALLEY, Rarity: Epic

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -864,6 +864,65 @@ TEST_CASE("[Shaman : Spell] - AV_268 : Wildpaw Cavern")
 }
 
 // ---------------------------------------- SPELL - WARLOCK
+// [AV_277] Seeds of Destruction - COST:2
+// - Set: ALTERAC_VALLEY, Rarity: Rare
+// - Spell School: Fel
+// --------------------------------------------------------
+// Text: Shuffle four Rifts into your deck.
+//       They summon a 3/3 Dread Imp when drawn.
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Spell] - AV_277 : Seeds of Destruction")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curDeck = *(curPlayer->GetDeckZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Seeds of Destruction"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 0);
+    CHECK_EQ(curDeck.GetCount(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 4);
+    CHECK_EQ(curField[0]->card->name, "Dread Imp");
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+    CHECK_EQ(curField[1]->card->name, "Dread Imp");
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+    CHECK_EQ(curField[2]->card->name, "Dread Imp");
+    CHECK_EQ(curField[2]->GetAttack(), 3);
+    CHECK_EQ(curField[2]->GetHealth(), 3);
+    CHECK_EQ(curField[3]->card->name, "Dread Imp");
+    CHECK_EQ(curField[3]->GetAttack(), 3);
+    CHECK_EQ(curField[3]->GetHealth(), 3);
+}
+
+// ---------------------------------------- SPELL - WARLOCK
 // [AV_281] Felfire in the Hole! - COST:5
 // - Set: ALTERAC_VALLEY, Rarity: Epic
 // - Spell School: Fel

--- a/Tests/UnitTests/PlayMode/CardSets/DalaranCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DalaranCardsGenTests.cpp
@@ -4119,7 +4119,7 @@ TEST_CASE("[Shaman : Minion] - DAL_431t : Drustvar Horror")
 // PlayReq:
 // - REQ_TARGET_TO_PLAY = 0
 // --------------------------------------------------------
-TEST_CASE("[Shaman : Minion] - DAL_432 : Witch's Brew")
+TEST_CASE("[Shaman : Spell] - DAL_432 : Witch's Brew")
 {
     GameConfig config;
     config.player1Class = CardClass::SHAMAN;

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -3734,16 +3734,21 @@ TEST_CASE("[Shaman : Minion] - BAR_040 : South Coast Chieftain")
     opPlayer->SetTotalMana(10);
     opPlayer->SetUsedMana(0);
 
+    auto& curHand = *(curPlayer->GetHandZone());
+
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::FindCardByName("South Coast Chieftain"));
     const auto card2 = Generic::DrawCard(
         curPlayer, Cards::FindCardByName("South Coast Chieftain"));
 
-    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card1, opPlayer->GetHero()));
+    CHECK_EQ(curHand.GetCount(), 5);
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
 
     game.Process(curPlayer,
                  PlayCardTask::MinionTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(curHand.GetCount(), 4);
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
 }
 


### PR DESCRIPTION
This revision includes:
- Implement 10 ALTERAC_VALLEY cards
  - Sneaky Scout (AV_123)
  - Direwolf Commander (AV_124)
  - Bunker Sergeant (AV_126)
  - Dun Baldar Bunker (AV_147)
  - Spring the Trap (AV_224)
  - Seeds of Destruction (AV_277)
  - Felfire in the Hole! (AV_281)
  - Full-Blown Evil (AV_285)
  - Grave Defiler (AV_308)
  - Iceblood Garrison (AV_660)
- Add some complex task
  - Add function 'RepeatableThisTurn()': Returns a list of task for processing the text "Repeatable this turn"
    - Replace code to process "Repeatable This Turn" with function
  - Add function 'CopyCardInHand()': Returns a list of task for copying a random card(s) in your hand
    - Replace code to process "Copy Card in Hand" with function
- Fix incorrect logic
  - Add code to reset the value of 'flag' when 'playables' is empty
  - Correct unit test code of card 'South Coast Chieftain' (BAR_040)
- Add parameter 'addToStack' to function 'DrawCardFromDeck()' 
- Add method 'AddHonorableKillTask()': Adds a list of honorable kill task
  - Add code to process a list of honorable kill tasks
- Add self condition method 'IsOpFieldCount()': SelfCondition wrapper for checking the count of opponent field is satisfied according to value and relaSign
- Change the logic of card 'Ancient Mysteries' (ULD_726)
- Add code to emplace missing game tag 'HONORABLEKILL'