### PR TITLE
Implement 10 ALTERAC_VALLEY cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -1080,7 +1080,7 @@ ALTERAC_VALLEY | AV_113 | Beaststalker Tavish |
 ALTERAC_VALLEY | AV_114 | Shivering Sorceress |  
 ALTERAC_VALLEY | AV_115 | Amplified Snowflurry |  
 ALTERAC_VALLEY | AV_116 | Arcane Brilliance |  
-ALTERAC_VALLEY | AV_118 | Battleworn Vanguard |  
+ALTERAC_VALLEY | AV_118 | Battleworn Vanguard | O
 ALTERAC_VALLEY | AV_119 | To the Front! |  
 ALTERAC_VALLEY | AV_121 | Gnome Private | O
 ALTERAC_VALLEY | AV_122 | Corporal | O
@@ -1088,13 +1088,13 @@ ALTERAC_VALLEY | AV_123 | Sneaky Scout | O
 ALTERAC_VALLEY | AV_124 | Direwolf Commander | O
 ALTERAC_VALLEY | AV_125 | Tower Sergeant | O
 ALTERAC_VALLEY | AV_126 | Bunker Sergeant | O
-ALTERAC_VALLEY | AV_127 | Ice Revenant |  
+ALTERAC_VALLEY | AV_127 | Ice Revenant | O
 ALTERAC_VALLEY | AV_128 | Frozen Mammoth |  
 ALTERAC_VALLEY | AV_129 | Blood Guard |  
-ALTERAC_VALLEY | AV_130 | Legionnaire |  
-ALTERAC_VALLEY | AV_131 | Knight-Captain |  
-ALTERAC_VALLEY | AV_132 | Troll Centurion |  
-ALTERAC_VALLEY | AV_133 | Icehoof Protector |  
+ALTERAC_VALLEY | AV_130 | Legionnaire | O
+ALTERAC_VALLEY | AV_131 | Knight-Captain | O
+ALTERAC_VALLEY | AV_132 | Troll Centurion | O
+ALTERAC_VALLEY | AV_133 | Icehoof Protector | O
 ALTERAC_VALLEY | AV_134 | Frostwolf Warmaster |  
 ALTERAC_VALLEY | AV_135 | Stormpike Marshal |  
 ALTERAC_VALLEY | AV_136 | Kobold Taskmaster |  
@@ -1121,7 +1121,7 @@ ALTERAC_VALLEY | AV_212 | Siphon Mana |
 ALTERAC_VALLEY | AV_213 | Vitality Surge |  
 ALTERAC_VALLEY | AV_215 | Frantic Hippogryph |  
 ALTERAC_VALLEY | AV_218 | Mass Polymorph | O
-ALTERAC_VALLEY | AV_219 | Ram Commander |  
+ALTERAC_VALLEY | AV_219 | Ram Commander | O
 ALTERAC_VALLEY | AV_222 | Spammy Arcanist |  
 ALTERAC_VALLEY | AV_223 | Vanndar Stormpike |  
 ALTERAC_VALLEY | AV_224 | Spring the Trap | O
@@ -1136,8 +1136,8 @@ ALTERAC_VALLEY | AV_257 | Bearon Gla'shear |
 ALTERAC_VALLEY | AV_258 | Bru'kan of the Elements |  
 ALTERAC_VALLEY | AV_259 | Frostbite |  
 ALTERAC_VALLEY | AV_260 | Sleetbreaker | O
-ALTERAC_VALLEY | AV_261 | Flag Runner |  
-ALTERAC_VALLEY | AV_262 | Warden of Chains |  
+ALTERAC_VALLEY | AV_261 | Flag Runner | O
+ALTERAC_VALLEY | AV_262 | Warden of Chains | O
 ALTERAC_VALLEY | AV_264 | Sigil of Reckoning |  
 ALTERAC_VALLEY | AV_265 | Ur'zul Giant |  
 ALTERAC_VALLEY | AV_266 | Windchill | O
@@ -1160,7 +1160,7 @@ ALTERAC_VALLEY | AV_295 | Capture Coldtooth Mine |
 ALTERAC_VALLEY | AV_296 | Pride Seeker |  
 ALTERAC_VALLEY | AV_298 | Wildpaw Gnoll |  
 ALTERAC_VALLEY | AV_308 | Grave Defiler | O
-ALTERAC_VALLEY | AV_309 | Piggyback Imp |  
+ALTERAC_VALLEY | AV_309 | Piggyback Imp | O
 ALTERAC_VALLEY | AV_312 | Sacrificial Summoner |  
 ALTERAC_VALLEY | AV_313 | Hollow Abomination |  
 ALTERAC_VALLEY | AV_315 | Deliverance |  
@@ -1205,4 +1205,4 @@ ALTERAC_VALLEY | AV_704 | Humongous Owl |
 ALTERAC_VALLEY | AV_710 | Reconnaissance |  
 ALTERAC_VALLEY | AV_711 | Double Agent |  
 
-- Progress: 22% (31 of 135 Cards)
+- Progress: 30% (41 of 135 Cards)

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -538,6 +538,11 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition Has5MoreCostSpellInHand();
 
+    //! SelfCondition wrapper for checking the player has demon
+    //! that costs 5 or more in hand.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition Has5MoreCostDemonInHand();
+
     //! SelfCondition wrapper for checking the player casts a spell
     //! that costs (5) or more this turn.
     //! \return Generated SelfCondition for intended purpose.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
   * 80% Forged in the Barrens (136 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
-  * 22% Fractured in Alterac Valley (31 of 135 cards)
+  * 30% Fractured in Alterac Valley (41 of 135 cards)
 
 ### Wild Format
 

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2927,6 +2927,10 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("AV_309t", SummonSide::DEATHRATTLE));
+    cards.emplace("AV_309", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_401] Stormpike Quartermaster - COST:2 [ATK:2/HP:2]
@@ -3157,6 +3161,9 @@ void AlteracValleyCardsGen::AddNeutralNonCollect(
     // [AV_309t] Backpiggy Imp - COST:3 [ATK:4/HP:1]
     // - Race: Demon, Set: ALTERAC_VALLEY
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("AV_309t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [AV_401e] Quartered - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2684,6 +2684,16 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - HONORABLEKILL = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::TARGET, 3));
+    power.AddHonorableKillTask(
+        std::make_shared<AddEnchantmentTask>("AV_131e", EntityType::SOURCE));
+    cards.emplace(
+        "AV_131",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_132] Troll Centurion - COST:8 [ATK:8/HP:8]
@@ -3012,6 +3022,9 @@ void AlteracValleyCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +3/+3
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("AV_131e"));
+    cards.emplace("AV_131e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [AV_136e] Rusted Armor - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2628,6 +2628,15 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::CAST_SPELL));
+    power.GetTrigger()->triggerSource = TriggerSource::SPELLS;
+    power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsFrostSpell())
+    };
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "AV_127e", EntityType::SOURCE) };
+    cards.emplace("AV_127", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_128] Frozen Mammoth - COST:4 [ATK:6/HP:7]
@@ -2966,6 +2975,9 @@ void AlteracValleyCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("AV_127e"));
+    cards.emplace("AV_127e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [AV_128e] Unthawed - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2656,6 +2656,13 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(std::make_shared<IncludeTask>(EntityType::HAND));
+    power.AddDeathrattleTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsMinion()) }));
+    power.AddDeathrattleTask(
+        std::make_shared<AddEnchantmentTask>("AV_130e", EntityType::STACK));
+    cards.emplace("AV_130", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_131] Knight-Captain - COST:5 [ATK:3/HP:3]
@@ -2983,6 +2990,9 @@ void AlteracValleyCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("AV_130e"));
+    cards.emplace("AV_130e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [AV_131e] Armed to the Teeth - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2312,6 +2312,14 @@ void AlteracValleyCardsGen::AddDemonHunter(
     // - BATTLECRY = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::Has5MoreCostDemonInHand()) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<AddEnchantmentTask>(
+                  "AV_262e2", EntityType::SOURCE) }));
+    cards.emplace("AV_262", CardDef(power));
 
     // ------------------------------------ SPELL - DEMONHUNTER
     // [AV_264] Sigil of Reckoning - COST:5
@@ -2402,6 +2410,9 @@ void AlteracValleyCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
     // Text: +1/+2.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("AV_262e2"));
+    cards.emplace("AV_262e2", CardDef(power));
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [AV_267e2] Demonic - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2725,6 +2725,9 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("AV_133", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_134] Frostwolf Warmaster - COST:4 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2867,6 +2867,10 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::HAND, "AV_219t", 2));
+    cards.emplace("AV_219", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_222] Spammy Arcanist - COST:5 [ATK:3/HP:4]
@@ -3110,6 +3114,9 @@ void AlteracValleyCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("AV_219t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [AV_223e] Occupy the Keep - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2256,6 +2256,8 @@ void AlteracValleyCardsGen::AddWarriorNonCollect(
 void AlteracValleyCardsGen::AddDemonHunter(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ----------------------------------- MINION - DEMONHUNTER
     // [AV_118] Battleworn Vanguard - COST:2 [ATK:2/HP:2]
     // - Set: ALTERAC_VALLEY, Rarity: Common
@@ -2265,6 +2267,11 @@ void AlteracValleyCardsGen::AddDemonHunter(
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->tasks = { std::make_shared<SummonTask>("BT_922t", 2) };
+    cards.emplace("AV_118", CardDef(power));
 
     // ----------------------------------- WEAPON - DEMONHUNTER
     // [AV_209] Dreadprison Glaive - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2706,6 +2706,10 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - HONORABLEKILL = 1
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddHonorableKillTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 8));
+    cards.emplace("AV_132", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_133] Icehoof Protector - COST:6 [ATK:2/HP:10]

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2293,6 +2293,12 @@ void AlteracValleyCardsGen::AddDemonHunter(
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::DEATH));
+    power.GetTrigger()->triggerSource = TriggerSource::MINIONS;
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "AV_261e", EntityType::SOURCE) };
+    cards.emplace("AV_261", CardDef(power));
 
     // ----------------------------------- MINION - DEMONHUNTER
     // [AV_262] Warden of Chains - COST:4 [ATK:2/HP:6]
@@ -2358,6 +2364,8 @@ void AlteracValleyCardsGen::AddDemonHunter(
 void AlteracValleyCardsGen::AddDemonHunterNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [AV_204e] Ashfallen's Power - COST:0
     // - Set: ALTERAC_VALLEY
@@ -2384,6 +2392,9 @@ void AlteracValleyCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
     // Text: +1 Attack
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("AV_261e"));
+    cards.emplace("AV_261e", CardDef(power));
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER
     // [AV_262e2] Terrifying - COST:0

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -1128,6 +1128,25 @@ SelfCondition SelfCondition::Has5MoreCostSpellInHand()
     });
 }
 
+SelfCondition SelfCondition::Has5MoreCostDemonInHand()
+{
+    return SelfCondition([](Playable* playable) {
+        for (auto& handCard : playable->player->GetHandZone()->GetAll())
+        {
+            if (auto minion = dynamic_cast<Minion*>(handCard); minion)
+            {
+                if (minion->card->GetRace() == Race::DEMON &&
+                    minion->GetCost() >= 5)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    });
+}
+
 SelfCondition SelfCondition::Cast5MoreCostSpellInThisTurn()
 {
     return SelfCondition([](Playable* playable) {

--- a/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
@@ -126,6 +126,7 @@ void CardLoader::Load(std::vector<Card*>& cards)
 
         // NOTE: Skyvateer (YOD_016), Cowardly Grunt (SW_021)
         //       doesn't have GameTag::DEATHRATTLE
+        // NOTE: Icehoof Protector (AV_133) doesn't have GameTag::FREEZE
         // NOTE: Patient Assassin (VAN_EX1_522) doesn't have GameTag::POISONOUS
         // NOTE: Carousel Gryphon (DMF_064) doesn't have GameTag::DIVINE_SHIELD
         // NOTE: Healing Totem (AT_132_SHAMANa), Searing Totem (AT_132_SHAMANb),
@@ -138,6 +139,10 @@ void CardLoader::Load(std::vector<Card*>& cards)
         if (dbfID == 56091 || dbfID == 64196)
         {
             gameTags.emplace(GameTag::DEATHRATTLE, 1);
+        }
+        else if (dbfID == 70236)
+        {
+            gameTags.emplace(GameTag::FREEZE, 1);
         }
         else if (dbfID == 69961)
         {

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -1533,6 +1533,62 @@ TEST_CASE("[Demon Hunter : Minion] - AV_118 : Battleworn Vanguard")
     CHECK_EQ(curField[4]->GetHealth(), 1);
 }
 
+// ----------------------------------- MINION - DEMONHUNTER
+// [AV_261] Flag Runner - COST:3 [ATK:1/HP:6]
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: Whenever a friendly minion dies, gain +1 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - AV_261 : Flag Runner")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flag Runner"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Blizzard"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Spell(card4));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [AV_101] Herald of Lokholar - COST:4 [ATK:3/HP:5]
 // - Set: ALTERAC_VALLEY, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -2143,6 +2143,65 @@ TEST_CASE("[Neutral : Minion] - AV_126 : Bunker Sergeant")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [AV_127] Ice Revenant - COST:4 [ATK:4/HP:5]
+// - Race: Elemental, Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: Whenever you cast a Frost spell, gain +2/+2.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - AV_127 : Ice Revenant")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ice Revenant"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Frostbolt"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(curField[0]->GetAttack(), 6);
+    CHECK_EQ(curField[0]->GetHealth(), 7);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
+    CHECK_EQ(curField[0]->GetAttack(), 6);
+    CHECK_EQ(curField[0]->GetHealth(), 7);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [AV_130] Legionnaire - COST:6 [ATK:9/HP:3]
 // - Set: ALTERAC_VALLEY, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -1468,6 +1468,71 @@ TEST_CASE("[Warrior : Spell] - AV_660 : Iceblood Garrison")
     CHECK_EQ(opField[0]->GetHealth(), 4);
 }
 
+// ----------------------------------- MINION - DEMONHUNTER
+// [AV_118] Battleworn Vanguard - COST:2 [ATK:2/HP:2]
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: After your hero attacks, summon two 1/1 Felwings.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - AV_118 : Battleworn Vanguard")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Battleworn Vanguard"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, HeroPowerTask());
+    game.Process(curPlayer,
+                 AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[1]->card->name, "Felwing");
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+    CHECK_EQ(curField[2]->card->name, "Felwing");
+    CHECK_EQ(curField[2]->GetAttack(), 1);
+    CHECK_EQ(curField[2]->GetHealth(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, HeroPowerTask());
+    game.Process(curPlayer,
+                 AttackTask(curPlayer->GetHero(), opPlayer->GetHero()));
+    CHECK_EQ(curField.GetCount(), 5);
+    CHECK_EQ(curField[3]->card->name, "Felwing");
+    CHECK_EQ(curField[3]->GetAttack(), 1);
+    CHECK_EQ(curField[3]->GetHealth(), 1);
+    CHECK_EQ(curField[4]->card->name, "Felwing");
+    CHECK_EQ(curField[4]->GetAttack(), 1);
+    CHECK_EQ(curField[4]->GetHealth(), 1);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [AV_101] Herald of Lokholar - COST:4 [ATK:3/HP:5]
 // - Set: ALTERAC_VALLEY, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -2471,3 +2471,49 @@ TEST_CASE("[Neutral : Minion] - AV_219 : Ram Commander")
     CHECK_EQ(dynamic_cast<Minion*>(curHand[1])->GetHealth(), 1);
     CHECK_EQ(dynamic_cast<Minion*>(curHand[1])->HasRush(), true);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [AV_309] Piggyback Imp - COST:3 [ATK:4/HP:1]
+// - Race: Demon, Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Summon a 4/1 Imp.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - AV_309 : Piggyback Imp")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Piggyback Imp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Backpiggy Imp");
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -2369,3 +2369,55 @@ TEST_CASE("[Neutral : Minion] - AV_132 : Troll Centurion")
     game.Process(curPlayer, AttackTask(card1, card2));
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 22);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [AV_133] Icehoof Protector - COST:6 [ATK:2/HP:10]
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Freeze</b> any character damaged by this minion.
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+// RefTag:
+// - FREEZE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - AV_133 : Icehoof Protector")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::DEMONHUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Icehoof Protector"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Troll Centurion"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    game.Process(opPlayer, AttackTask(card2, card1));
+    CHECK_EQ(opField[0]->GetHealth(), 6);
+    CHECK_EQ(opField[0]->IsFrozen(), true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -1589,6 +1589,64 @@ TEST_CASE("[Demon Hunter : Minion] - AV_261 : Flag Runner")
     game.ProcessUntil(Step::MAIN_ACTION);
 }
 
+// ----------------------------------- MINION - DEMONHUNTER
+// [AV_262] Warden of Chains - COST:4 [ATK:2/HP:6]
+// - Set: ALTERAC_VALLEY, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Battlecry:</b> If you're holding a Demon that
+//       costs (5) or more, gain +1/+2.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Minion] - AV_262 : Warden of Chains")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Warden of Chains"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Warden of Chains"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Dread Infernal"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 8);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[2]->GetAttack(), 2);
+    CHECK_EQ(curField[2]->GetHealth(), 6);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [AV_101] Herald of Lokholar - COST:4 [ATK:3/HP:5]
 // - Set: ALTERAC_VALLEY, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -2320,3 +2320,52 @@ TEST_CASE("[Neutral : Minion] - AV_131 : Knight-Captain")
     CHECK_EQ(curField[0]->GetAttack(), 9);
     CHECK_EQ(curField[0]->GetHealth(), 5);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [AV_132] Troll Centurion - COST:8 [ATK:8/HP:8]
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Rush</b>. <b>Honorable Kill:</b>
+//       Deal 8 damage to the enemy hero.
+// --------------------------------------------------------
+// GameTag:
+// - HONORABLEKILL = 1
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - AV_132 : Troll Centurion")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Troll Centurion"));
+    const auto card2 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Gurubashi Berserker"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, AttackTask(card1, card2));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 22);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -2421,3 +2421,53 @@ TEST_CASE("[Neutral : Minion] - AV_133 : Icehoof Protector")
     CHECK_EQ(opField[0]->GetHealth(), 6);
     CHECK_EQ(opField[0]->IsFrozen(), true);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [AV_219] Ram Commander - COST:2 [ATK:2/HP:2]
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Add two 1/1 Rams with <b>Rush</b>
+//       to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - AV_219 : Ram Commander")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::DEMONHUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ram Commander"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 2);
+    CHECK_EQ(curHand[0]->card->name, "Battle Ram");
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[0])->GetAttack(), 1);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[0])->GetHealth(), 1);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[0])->HasRush(), true);
+    CHECK_EQ(curHand[1]->card->name, "Battle Ram");
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[1])->GetAttack(), 1);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[1])->GetHealth(), 1);
+    CHECK_EQ(dynamic_cast<Minion*>(curHand[1])->HasRush(), true);
+}


### PR DESCRIPTION
This revision includes:
- Implement 10 ALTERAC_VALLEY cards
  - Battleworn Vanguard (AV_118)
  - Ice Revenant (AV_127)
  - Legionnaire (AV_130)
  - Knight-Captain (AV_131)
  - Troll Centurion (AV_132)
  - Icehoof Protector (AV_133)
  - Ram Commander (AV_219)
  - Flag Runner (AV_261)
  - Warden of Chains (AV_262)
  - Piggyback Imp (AV_309)
- Add self condition method 'Has5MoreCostDemonInHand()'
  - SelfCondition wrapper for checking the player has demon that costs 5 or more in hand
- Add code to emplace missing game tag 'FREEZE'