### PR TITLE
Implement 10 ALTERAC_VALLEY cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -1071,9 +1071,9 @@ Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
 ALTERAC_VALLEY | AV_100 | Drek'Thar |  
 ALTERAC_VALLEY | AV_101 | Herald of Lokholar | O
-ALTERAC_VALLEY | AV_102 | Popsicooler |  
+ALTERAC_VALLEY | AV_102 | Popsicooler | O
 ALTERAC_VALLEY | AV_107 | Glaciate |  
-ALTERAC_VALLEY | AV_108 | Shield Shatter |  
+ALTERAC_VALLEY | AV_108 | Shield Shatter | O
 ALTERAC_VALLEY | AV_109 | Frozen Buckler | O
 ALTERAC_VALLEY | AV_112 | Snowblind Harpy | O
 ALTERAC_VALLEY | AV_113 | Beaststalker Tavish |  
@@ -1095,11 +1095,11 @@ ALTERAC_VALLEY | AV_130 | Legionnaire | O
 ALTERAC_VALLEY | AV_131 | Knight-Captain | O
 ALTERAC_VALLEY | AV_132 | Troll Centurion | O
 ALTERAC_VALLEY | AV_133 | Icehoof Protector | O
-ALTERAC_VALLEY | AV_134 | Frostwolf Warmaster |  
+ALTERAC_VALLEY | AV_134 | Frostwolf Warmaster | O
 ALTERAC_VALLEY | AV_135 | Stormpike Marshal |  
 ALTERAC_VALLEY | AV_136 | Kobold Taskmaster |  
 ALTERAC_VALLEY | AV_137 | Irondeep Trogg |  
-ALTERAC_VALLEY | AV_138 | Grimtotem Bounty Hunter |  
+ALTERAC_VALLEY | AV_138 | Grimtotem Bounty Hunter | O
 ALTERAC_VALLEY | AV_139 | Abominable Lieutenant |  
 ALTERAC_VALLEY | AV_141t | Lokholar the Ice Lord |  
 ALTERAC_VALLEY | AV_142t | Ivus, the Forest Lord |  
@@ -1119,7 +1119,7 @@ ALTERAC_VALLEY | AV_210 | Pathmaker |
 ALTERAC_VALLEY | AV_211 | Dire Frostwolf | O
 ALTERAC_VALLEY | AV_212 | Siphon Mana |  
 ALTERAC_VALLEY | AV_213 | Vitality Surge |  
-ALTERAC_VALLEY | AV_215 | Frantic Hippogryph |  
+ALTERAC_VALLEY | AV_215 | Frantic Hippogryph | O
 ALTERAC_VALLEY | AV_218 | Mass Polymorph | O
 ALTERAC_VALLEY | AV_219 | Ram Commander | O
 ALTERAC_VALLEY | AV_222 | Spammy Arcanist |  
@@ -1146,14 +1146,14 @@ ALTERAC_VALLEY | AV_268 | Wildpaw Cavern | O
 ALTERAC_VALLEY | AV_269 | Flanking Maneuver |  
 ALTERAC_VALLEY | AV_277 | Seeds of Destruction | O
 ALTERAC_VALLEY | AV_281 | Felfire in the Hole! | O
-ALTERAC_VALLEY | AV_282 | Build a Snowman |  
+ALTERAC_VALLEY | AV_282 | Build a Snowman | O
 ALTERAC_VALLEY | AV_283 | Rune of the Archmage |  
 ALTERAC_VALLEY | AV_284 | Balinda Stonehearth |  
 ALTERAC_VALLEY | AV_285 | Full-Blown Evil | O
 ALTERAC_VALLEY | AV_286 | Felwalker |  
 ALTERAC_VALLEY | AV_290 | Iceblood Tower |  
 ALTERAC_VALLEY | AV_291 | Frostsaber Matriarch |  
-ALTERAC_VALLEY | AV_292 | Heart of the Wild |  
+ALTERAC_VALLEY | AV_292 | Heart of the Wild | O
 ALTERAC_VALLEY | AV_293 | Wing Commander Mulverick |  
 ALTERAC_VALLEY | AV_294 | Clawfury Adept |  
 ALTERAC_VALLEY | AV_295 | Capture Coldtooth Mine |  
@@ -1191,7 +1191,7 @@ ALTERAC_VALLEY | AV_344 | Dun Baldar Bridge |
 ALTERAC_VALLEY | AV_345 | Saidan the Scarlet |  
 ALTERAC_VALLEY | AV_360 | Frostwolf Kennels | O
 ALTERAC_VALLEY | AV_400 | Snowfall Graveyard |  
-ALTERAC_VALLEY | AV_401 | Stormpike Quartermaster |  
+ALTERAC_VALLEY | AV_401 | Stormpike Quartermaster | O
 ALTERAC_VALLEY | AV_402 | The Lobotomizer |  
 ALTERAC_VALLEY | AV_403 | Cera'thine Fleetrunner |  
 ALTERAC_VALLEY | AV_405 | Contraband Stash |  
@@ -1199,10 +1199,10 @@ ALTERAC_VALLEY | AV_565 | Axe Berserker | O
 ALTERAC_VALLEY | AV_601 | Forsaken Lieutenant |  
 ALTERAC_VALLEY | AV_657 | Desecrated Graveyard |  
 ALTERAC_VALLEY | AV_660 | Iceblood Garrison | O
-ALTERAC_VALLEY | AV_661 | Field of Strife |  
+ALTERAC_VALLEY | AV_661 | Field of Strife | O
 ALTERAC_VALLEY | AV_664 | Stormpike Aid Station |  
-ALTERAC_VALLEY | AV_704 | Humongous Owl |  
+ALTERAC_VALLEY | AV_704 | Humongous Owl | O
 ALTERAC_VALLEY | AV_710 | Reconnaissance |  
 ALTERAC_VALLEY | AV_711 | Double Agent |  
 
-- Progress: 30% (41 of 135 Cards)
+- Progress: 37% (51 of 135 Cards)

--- a/Includes/Rosetta/PlayMode/Loaders/TargetingPredicates.hpp
+++ b/Includes/Rosetta/PlayMode/Loaders/TargetingPredicates.hpp
@@ -83,6 +83,11 @@ class TargetingPredicates
     static TargetingPredicate ReqTargetWithDeathrattle();
 
     //! Predicate wrapper for checking the target requires that
+    //! it is Legendary.
+    //! \return Generated TargetingPredicate for intended purpose.
+    static TargetingPredicate ReqLegendaryTarget();
+
+    //! Predicate wrapper for checking the target requires that
     //! it is damaged.
     //! \return Generated TargetingPredicate for intended purpose.
     static TargetingPredicate ReqDamagedTarget();

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
   * 80% Forged in the Barrens (136 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
-  * 30% Fractured in Alterac Valley (41 of 135 cards)
+  * 37% Fractured in Alterac Valley (51 of 135 cards)
 
 ### Wild Format
 

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -350,6 +350,22 @@ void AlteracValleyCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Give a minion +2/+2, then give your Beasts +1/+1.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("AV_292e", EntityType::TARGET));
+    power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::MINIONS));
+    power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::BEAST)) }));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("AV_292e2", EntityType::STACK));
+    cards.emplace(
+        "AV_292",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // ----------------------------------------- MINION - DRUID
     // [AV_293] Wing Commander Mulverick - COST:4 [ATK:2/HP:5]
@@ -422,6 +438,8 @@ void AlteracValleyCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 void AlteracValleyCardsGen::AddDruidNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------------ SPELL - DRUID
     // [AV_205a] Ice Blossom - COST:2
     // - Set: ALTERAC_VALLEY
@@ -449,6 +467,9 @@ void AlteracValleyCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
     // Text: +2/+2.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("AV_292e"));
+    cards.emplace("AV_292e", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [AV_292e2] Pack Member - COST:0
@@ -456,6 +477,9 @@ void AlteracValleyCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("AV_292e2"));
+    cards.emplace("AV_292e2", CardDef(power));
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [AV_293e] Air Strike - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -943,9 +943,19 @@ void AlteracValleyCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // Text: Summon a 3/3 Snowman that <b>Freezes</b>.
     //       Add "Build a Snowbrute" to your hand.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
     // RefTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("AV_282t"));
+    power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::HAND, "AV_282t2"));
+    cards.emplace(
+        "AV_282",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ------------------------------------------- SPELL - MAGE
     // [AV_283] Rune of the Archmage - COST:9
@@ -978,6 +988,8 @@ void AlteracValleyCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 void AlteracValleyCardsGen::AddMageNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ------------------------------------- ENCHANTMENT - MAGE
     // [AV_114e] Shocking - COST:0
     // - Set: ALTERAC_VALLEY
@@ -1009,6 +1021,9 @@ void AlteracValleyCardsGen::AddMageNonCollect(
     // GameTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("AV_282t", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [AV_282t2] Build a Snowbrute - COST:6
@@ -1018,9 +1033,19 @@ void AlteracValleyCardsGen::AddMageNonCollect(
     // Text: Summon a 6/6 Snowbrute that <b>Freezes</b>.
     //       Add "Build a Snowgre" to your hand.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
     // RefTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("AV_282t3"));
+    power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::HAND, "AV_282t4"));
+    cards.emplace(
+        "AV_282t2",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ------------------------------------------ MINION - MAGE
     // [AV_282t3] Snowbrute - COST:6 [ATK:6/HP:6]
@@ -1031,6 +1056,9 @@ void AlteracValleyCardsGen::AddMageNonCollect(
     // GameTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("AV_282t3", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [AV_282t4] Build a Snowgre - COST:9
@@ -1039,9 +1067,17 @@ void AlteracValleyCardsGen::AddMageNonCollect(
     // --------------------------------------------------------
     // Text: Summon a 9/9 Snowgre that <b>Freezes</b>.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
     // RefTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SummonTask>("AV_282t5"));
+    cards.emplace(
+        "AV_282t4",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 
     // ------------------------------------------ MINION - MAGE
     // [AV_282t5] Snowgre - COST:9 [ATK:9/HP:9]
@@ -1052,6 +1088,9 @@ void AlteracValleyCardsGen::AddMageNonCollect(
     // GameTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("AV_282t5", CardDef(power));
 
     // ------------------------------------- ENCHANTMENT - MAGE
     // [AV_284e] Arcane Swap - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2374,6 +2374,12 @@ void AlteracValleyCardsGen::AddDemonHunter(
     // --------------------------------------------------------
     // Text: Your minions have +1 Attack. Lasts 3 turns.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "AV_661e2", EntityType::MINIONS) };
+    power.GetTrigger()->lastTurn = 3;
+    cards.emplace("AV_661", CardDef(power));
 }
 
 void AlteracValleyCardsGen::AddDemonHunterNonCollect(
@@ -2456,6 +2462,9 @@ void AlteracValleyCardsGen::AddDemonHunterNonCollect(
     // --------------------------------------------------------
     // Text: +1 Attack from {0}.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("AV_661e2"));
+    cards.emplace("AV_661e2", CardDef(power));
 }
 
 void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2894,6 +2894,10 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - WINDFURY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddHonorableKillTask(std::make_shared<SetGameTagTask>(
+        EntityType::SOURCE, GameTag::WINDFURY, 1));
+    cards.emplace("AV_215", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_219] Ram Commander - COST:2 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2997,6 +2997,12 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<RandomTask>(EntityType::ENEMIES, 1));
+    power.AddDeathrattleTask(
+        std::make_shared<DamageTask>(EntityType::STACK, 8));
+    cards.emplace("AV_704", CardDef(power));
 }
 
 void AlteracValleyCardsGen::AddNeutralNonCollect(

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2509,6 +2509,11 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<RandomTask>(EntityType::ENEMY_MINIONS, 2));
+    power.AddDeathrattleTask(std::make_shared<FreezeTask>(EntityType::STACK));
+    cards.emplace("AV_102", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_112] Snowblind Harpy - COST:3 [ATK:3/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2807,6 +2807,20 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_LEGENDARY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_ENEMY_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DestroyTask>(EntityType::TARGET));
+    cards.emplace(
+        "AV_138",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },
+                                 { PlayReq::REQ_LEGENDARY_TARGET, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_ENEMY_TARGET, 0 } }));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_139] Abominable Lieutenant - COST:8 [ATK:3/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2756,6 +2756,12 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Costs (1) less for each card you've played this turn.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<AdaptiveCostEffect>([](Playable* playable) {
+        return playable->player->GetGameTag(
+            GameTag::NUM_CARDS_PLAYED_THIS_TURN);
+    }));
+    cards.emplace("AV_134", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_135] Stormpike Marshal - COST:4 [ATK:2/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2987,6 +2987,12 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::CAST_SPELL));
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    power.GetTrigger()->tasks = { ComplexTask::GiveBuffToRandomMinionInHand(
+        "AV_401e") };
+    cards.emplace("AV_401", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [AV_704] Humongous Owl - COST:7 [ATK:8/HP:4]
@@ -3222,6 +3228,9 @@ void AlteracValleyCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("AV_401e"));
+    cards.emplace("AV_401e", CardDef(power));
 
     // ---------------------------------------- SPELL - NEUTRAL
     // [AV_COIN1] The Coin - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2060,6 +2060,13 @@ void AlteracValleyCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // Text: Deal 5 damage to all minions.
     //       Costs (1) less for each Armor you have.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ALL_MINIONS, 5, true));
+    power.AddAura(std::make_shared<AdaptiveCostEffect>([](Playable* playable) {
+        return playable->player->GetHero()->GetArmor();
+    }));
+    cards.emplace("AV_108", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [AV_109] Frozen Buckler - COST:2

--- a/Sources/Rosetta/PlayMode/Cards/Card.cpp
+++ b/Sources/Rosetta/PlayMode/Cards/Card.cpp
@@ -51,6 +51,10 @@ void Card::Initialize()
             case PlayReq::REQ_MINION_OR_ENEMY_HERO:
                 characterType = CharacterType::CHARACTERS_EXCEPT_HERO;
                 break;
+            case PlayReq::REQ_LEGENDARY_TARGET:
+                targetingPredicate.emplace_back(
+                    TargetingPredicates::ReqLegendaryTarget());
+                break;
             case PlayReq::REQ_DAMAGED_TARGET:
                 targetingPredicate.emplace_back(
                     TargetingPredicates::ReqDamagedTarget());

--- a/Sources/Rosetta/PlayMode/Loaders/TargetingPredicates.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/TargetingPredicates.cpp
@@ -99,6 +99,13 @@ TargetingPredicate TargetingPredicates::ReqTargetWithDeathrattle()
     return [](Character* character) { return character->HasDeathrattle(); };
 }
 
+TargetingPredicate TargetingPredicates::ReqLegendaryTarget()
+{
+    return [](Character* character) {
+        return character->card->GetRarity() == Rarity::LEGENDARY;
+    };
+}
+
 TargetingPredicate TargetingPredicates::ReqDamagedTarget()
 {
     return [](Character* character) { return character->GetDamage() > 0; };

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -1845,6 +1845,82 @@ TEST_CASE("[Neutral : Minion] - AV_101 : Herald of Lokholar")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [AV_102] Popsicooler - COST:3 [ATK:3/HP:3]
+// - Race: Mechanical, Set: ALTERAC_VALLEY, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> <b>Freeze</b> two random
+//       enemy minions.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+// RefTag:
+// - FREEZE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - AV_102 : Popsicooler")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Popsicooler"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Frostbolt"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+
+    int numFrozenMinions = 0;
+
+    opField.ForEach([&](Playable* minion) {
+        if (dynamic_cast<Minion*>(minion)->IsFrozen())
+        {
+            ++numFrozenMinions;
+        }
+    });
+    CHECK_EQ(numFrozenMinions, 0);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+
+    opField.ForEach([&](Playable* minion) {
+        if (dynamic_cast<Minion*>(minion)->IsFrozen())
+        {
+            ++numFrozenMinions;
+        }
+    });
+    CHECK_EQ(numFrozenMinions, 2);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [AV_112] Snowblind Harpy - COST:3 [ATK:3/HP:4]
 // - Set: ALTERAC_VALLEY, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -2912,3 +2912,46 @@ TEST_CASE("[Neutral : Minion] - AV_309 : Piggyback Imp")
     CHECK_EQ(curField[0]->GetAttack(), 4);
     CHECK_EQ(curField[0]->GetHealth(), 1);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [AV_704] Humongous Owl - COST:7 [ATK:8/HP:4]
+// - Race: Beast, Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Deal 8 damage to a random enemy.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - AV_704 : Humongous Owl")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Humongous Owl"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 22);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -73,6 +73,59 @@ TEST_CASE("[Druid : Minion] - AV_211 : Dire Frostwolf")
 }
 
 // ------------------------------------------ SPELL - DRUID
+// [AV_292] Heart of the Wild - COST:3
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: Give a minion +2/+2, then give your Beasts +1/+1.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - AV_292 : Heart of the Wild")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Heart of the Wild"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Enchanted Raven"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+}
+
+// ------------------------------------------ SPELL - DRUID
 // [AV_360] Frostwolf Kennels - COST:3
 // - Set: ALTERAC_VALLEY, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -635,6 +635,79 @@ TEST_CASE("[Mage : Spell] - AV_218 : Mass Polymorph")
     CHECK_EQ(opField[1]->GetHealth(), 1);
 }
 
+// ------------------------------------------- SPELL - MAGE
+// [AV_282] Build a Snowman - COST:3
+// - Set: ALTERAC_VALLEY, Rarity: Rare
+// - Spell School: Frost
+// --------------------------------------------------------
+// Text: Summon a 3/3 Snowman that <b>Freezes</b>.
+//       Add "Build a Snowbrute" to your hand.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+// RefTag:
+// - FREEZE = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - AV_282 : Build a Snowman")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::DEMONHUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Build a Snowman"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Snowman");
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+    CHECK_EQ(curField[0]->HasFreeze(), true);
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->name, "Build a Snowbrute");
+
+    game.Process(curPlayer, PlayCardTask::Spell(curHand[0]));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[1]->card->name, "Snowbrute");
+    CHECK_EQ(curField[1]->GetAttack(), 6);
+    CHECK_EQ(curField[1]->GetHealth(), 6);
+    CHECK_EQ(curField[1]->HasFreeze(), true);
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->name, "Build a Snowgre");
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(curHand[0]));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[2]->card->name, "Snowgre");
+    CHECK_EQ(curField[2]->GetAttack(), 9);
+    CHECK_EQ(curField[2]->GetHealth(), 9);
+    CHECK_EQ(curField[2]->HasFreeze(), true);
+    CHECK_EQ(curHand.GetCount(), 0);
+}
+
 // ----------------------------------------- MINION - ROGUE
 // [AV_201] Coldtooth Yeti - COST:3 [ATK:1/HP:5]
 // - Set: ALTERAC_VALLEY, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -2914,6 +2914,54 @@ TEST_CASE("[Neutral : Minion] - AV_309 : Piggyback Imp")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [AV_401] Stormpike Quartermaster - COST:2 [ATK:2/HP:2]
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: After you cast a spell,
+//       give a random minion in your hand +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Netural : Minion] - AV_401 : Stormpike Quartermaster")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Stormpike Quartermaster"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(dynamic_cast<Minion*>(card2)->GetAttack(), 1);
+    CHECK_EQ(dynamic_cast<Minion*>(card2)->GetHealth(), 1);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
+    CHECK_EQ(dynamic_cast<Minion*>(card2)->GetAttack(), 2);
+    CHECK_EQ(dynamic_cast<Minion*>(card2)->GetHealth(), 2);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [AV_704] Humongous Owl - COST:7 [ATK:8/HP:4]
 // - Race: Beast, Set: ALTERAC_VALLEY, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -2700,6 +2700,68 @@ TEST_CASE("[Neutral : Minion] - AV_134 : Frostwolf Warmaster")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [AV_138] Grimtotem Bounty Hunter - COST:3 [ATK:4/HP:2]
+// - Set: ALTERAC_VALLEY, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Destroy an enemy
+//       <b>Legendary</b> minion.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// - REQ_LEGENDARY_TARGET = 0
+// - REQ_MINION_TARGET = 0
+// - REQ_ENEMY_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - AV_138 : Grimtotem Bounty Hunter")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Grimtotem Bounty Hunter"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card1, card3));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card1, card2));
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->card->name, "Wisp");
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [AV_219] Ram Commander - COST:2 [ATK:2/HP:2]
 // - Set: ALTERAC_VALLEY, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -2762,6 +2762,62 @@ TEST_CASE("[Neutral : Minion] - AV_138 : Grimtotem Bounty Hunter")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [AV_215] Frantic Hippogryph - COST:5 [ATK:3/HP:7]
+// - Race: Beast, Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Rush</b>. <b>Honorable Kill</b>:
+//        Gain <b>Windfury</b>.
+// --------------------------------------------------------
+// GameTag:
+// - HONORABLEKILL = 1
+// - RUSH = 1
+// --------------------------------------------------------
+// RefTag:
+// - WINDFURY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - AV_215 : Frantic Hippogryph")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Frantic Hippogryph"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("River Crocolisk"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasWindfury(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(card1, card2));
+    CHECK_EQ(curField[0]->HasWindfury(), true);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [AV_219] Ram Commander - COST:2 [ATK:2/HP:2]
 // - Set: ALTERAC_VALLEY, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -2650,6 +2650,56 @@ TEST_CASE("[Neutral : Minion] - AV_133 : Icehoof Protector")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [AV_134] Frostwolf Warmaster - COST:4 [ATK:3/HP:3]
+// - Set: ALTERAC_VALLEY, Rarity: Rare
+// --------------------------------------------------------
+// Text: Costs (1) less for each card you've played this turn.
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - AV_134 : Frostwolf Warmaster")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::DEMONHUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Frostwolf Warmaster"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    CHECK_EQ(card1->GetCost(), 4);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(card1->GetCost(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(card1->GetCost(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card1->GetCost(), 4);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [AV_219] Ram Commander - COST:2 [ATK:2/HP:2]
 // - Set: ALTERAC_VALLEY, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -1458,7 +1458,7 @@ TEST_CASE("[Warrior : Minion] - AV_565 : Axe Berserker")
 TEST_CASE("[Warrior : Spell] - AV_660 : Iceblood Garrison")
 {
     GameConfig config;
-    config.player1Class = CardClass::DRUID;
+    config.player1Class = CardClass::WARRIOR;
     config.player2Class = CardClass::MAGE;
     config.startPlayer = PlayerType::PLAYER1;
     config.doFillDecks = false;
@@ -1711,6 +1711,91 @@ TEST_CASE("[Demon Hunter : Minion] - AV_262 : Warden of Chains")
     game.Process(curPlayer, PlayCardTask::Minion(card2));
     CHECK_EQ(curField[2]->GetAttack(), 2);
     CHECK_EQ(curField[2]->GetHealth(), 6);
+}
+
+// ------------------------------------ SPELL - DEMONHUNTER
+// [AV_661] Field of Strife - COST:2
+// - Set: ALTERAC_VALLEY, Rarity: Rare
+// --------------------------------------------------------
+// Text: Your minions have +1 Attack. Lasts 3 turns.
+// --------------------------------------------------------
+TEST_CASE("[Demon Hunter : Spell] - AV_661 : Field of Strife")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Field of Strife"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Strongman"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 6);
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetAttack(), 7);
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetAttack(), 7);
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetAttack(), 8);
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetAttack(), 8);
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetAttack(), 9);
+    CHECK_EQ(curField[1]->GetAttack(), 4);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetAttack(), 9);
+    CHECK_EQ(curField[1]->GetAttack(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetAttack(), 9);
+    CHECK_EQ(curField[1]->GetAttack(), 4);
 }
 
 // --------------------------------------- MINION - NEUTRAL


### PR DESCRIPTION
This revision includes:
- Implement 10 ALTERAC_VALLEY cards
  - Popsicooler (AV_102)
  - Shield Shatter (AV_108)
  - Frostwolf Warmaster (AV_134)
  - Grimtotem Bounty Hunter (AV_138)
  - Frantic Hippogryph (AV_215)
  - Build a Snowman (AV_282)
  - Heart of the Wild (AV_292)
  - Stormpike Quartermaster (AV_401)
  - Field of Strife (AV_661)
  - Humongous Owl (AV_704)
- Add predicate function 'ReqLegendaryTarget()': Predicate wrapper for checking the target requires that it is Legendary
- Add code to process 'PlayReq::REQ_LEGENDARY_TARGET'