### PR TITLE
Implement 5 ALTERAC_VALLEY cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -1210,20 +1210,20 @@ ALTERAC_VALLEY | ONY_003 | Whelp Bonker |
 ALTERAC_VALLEY | ONY_004 | Raid Boss Onyxia |  
 ALTERAC_VALLEY | ONY_005 | Kazakusan |  
 ALTERAC_VALLEY | ONY_006 | Deep Breath |  
-ALTERAC_VALLEY | ONY_007 | Haleh, Matron Protectorate |  
+ALTERAC_VALLEY | ONY_007 | Haleh, Matron Protectorate | O
 ALTERAC_VALLEY | ONY_008 | Furious Howl |  
-ALTERAC_VALLEY | ONY_009 | Pet Collector |  
-ALTERAC_VALLEY | ONY_010 | Dragonbane Shot |  
+ALTERAC_VALLEY | ONY_009 | Pet Collector | O
+ALTERAC_VALLEY | ONY_010 | Dragonbane Shot | O
 ALTERAC_VALLEY | ONY_011 | Don't Stand in the Fire! |  
 ALTERAC_VALLEY | ONY_012 | Spirit Mount |  
 ALTERAC_VALLEY | ONY_013 | Bracing Cold |  
 ALTERAC_VALLEY | ONY_014 | Keen Reflex |  
 ALTERAC_VALLEY | ONY_016 | Wings of Hate (Rank 1) |  
 ALTERAC_VALLEY | ONY_017 | Horn of Wrathion |  
-ALTERAC_VALLEY | ONY_018 | Boomkin |  
+ALTERAC_VALLEY | ONY_018 | Boomkin | O
 ALTERAC_VALLEY | ONY_019 | Raid Negotiator |  
 ALTERAC_VALLEY | ONY_020 | Stormwind Avenger |  
-ALTERAC_VALLEY | ONY_021 | Scale of Onyxia |  
+ALTERAC_VALLEY | ONY_021 | Scale of Onyxia | O
 ALTERAC_VALLEY | ONY_022 | Battle Vicar |  
 ALTERAC_VALLEY | ONY_023 | Hit It Very Hard |  
 ALTERAC_VALLEY | ONY_024 | Onyxian Drake |  
@@ -1240,4 +1240,4 @@ ALTERAC_VALLEY | ONY_034 | Curse of Agony |
 ALTERAC_VALLEY | ONY_035 | Spawn of Deathwing |  
 ALTERAC_VALLEY | ONY_036 | Razorglaive Sentinel |  
 
-- Progress: 30% (51 of 170 Cards)
+- Progress: 32% (56 of 170 Cards)

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -91,7 +91,7 @@ class SelfCondition
     //! SelfCondition wrapper for checking the count of field is satisfied
     //! according to \p value and \p relaSign.
     //! \param value The value to check condition.
-    //! \param relaSign The comparer to check condition..
+    //! \param relaSign The comparer to check condition.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsFieldCount(int value,
                                       RelaSign relaSign = RelaSign::EQ);
@@ -99,7 +99,7 @@ class SelfCondition
     //! SelfCondition wrapper for checking the count of opponent field
     //! is satisfied according to \p value and \p relaSign.
     //! \param value The value to check condition.
-    //! \param relaSign The comparer to check condition..
+    //! \param relaSign The comparer to check condition.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsOpFieldCount(int value,
                                         RelaSign relaSign = RelaSign::EQ);

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
@@ -83,6 +83,26 @@ class ComplexTask
         };
     }
 
+    //! Returns a list of task for summoning a \p race and \p cost minion
+    //! from your deck according to \p relaSign.
+    //! \param race The race of minion(s) to summon.
+    //! \param cost The cost of minion(s) to summon.
+    //! \param relaSign The comparer to check condition.
+    static TaskList SummonRaceCostMinionFromDeck(Race race, int cost,
+                                                 RelaSign relaSign)
+    {
+        return TaskList{
+            std::make_shared<SimpleTasks::IncludeTask>(EntityType::DECK),
+            std::make_shared<SimpleTasks::FilterStackTask>(SelfCondList{
+                std::make_shared<SelfCondition>(SelfCondition::IsMinion()),
+                std::make_shared<SelfCondition>(SelfCondition::IsRace(race)),
+                std::make_shared<SelfCondition>(
+                    SelfCondition::IsCost(cost, relaSign)) }),
+            std::make_shared<SimpleTasks::RandomTask>(EntityType::STACK, 1),
+            std::make_shared<SimpleTasks::SummonStackTask>(true)
+        };
+    }
+
     //! Returns a list of task for casting a secret from your deck.
     static TaskList CastSecretFromDeck()
     {

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)
   * 81% Forged in the Barrens (139 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
-  * 30% Fractured in Alterac Valley (51 of 170 cards)
+  * 32% Fractured in Alterac Valley (56 of 170 cards)
 
 ### Wild Format
 

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -824,6 +824,17 @@ void AlteracValleyCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - HONORABLEKILL = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 2, true));
+    power.AddHonorableKillTask(
+        std::make_shared<AddCardTask>(EntityType::HAND, "ONY_010"));
+    cards.emplace(
+        "ONY_010",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 }
 
 void AlteracValleyCardsGen::AddHunterNonCollect(

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -1167,6 +1167,17 @@ void AlteracValleyCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::CAST_SPELL));
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    power.GetTrigger()->tasks = { std::make_shared<EnqueueTask>(
+        TaskList{
+            std::make_shared<FilterStackTask>(SelfCondList{
+                std::make_shared<SelfCondition>(SelfCondition::IsNotDead()) }),
+            std::make_shared<RandomTask>(EntityType::ENEMIES, 1),
+            std::make_shared<DamageTask>(EntityType::STACK, 1) },
+        4, false) };
+    cards.emplace("ONY_007", CardDef(power));
 
     // ------------------------------------------- SPELL - MAGE
     // [ONY_029] Drakefire Amulet - COST:10

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -477,6 +477,15 @@ void AlteracValleyCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("ONY_001t", 7, SummonSide::SPELL));
+    cards.emplace(
+        "ONY_021",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
 }
 
 void AlteracValleyCardsGen::AddDruidNonCollect(
@@ -3862,6 +3871,9 @@ void AlteracValleyCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("ONY_001t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [ONY_002e] More Loot! - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -13,6 +13,7 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 namespace RosettaStone::PlayMode
 {
 using PlayReqs = std::map<PlayReq, int>;
+using ChooseCardIDs = std::vector<std::string>;
 using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
 using EffectList = std::vector<std::shared_ptr<IEffect>>;
 
@@ -438,12 +439,21 @@ void AlteracValleyCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // [ONY_018] Boomkin - COST:5 [ATK:4/HP:5]
     // - Set: ALTERAC_VALLEY, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Choose One - </b>Restore
-    //       8 Health to your hero; or Deal 4 damage.
+    // Text: <b>Choose One - </b>Restore 8 Health to your hero;
+    //       or Deal 4 damage.
     // --------------------------------------------------------
     // GameTag:
     // - CHOOSE_ONE = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace(
+        "ONY_018",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } },
+                ChooseCardIDs{ "ONY_018t", "ONY_018t2" }));
 
     // ----------------------------------------- MINION - DRUID
     // [ONY_019] Raid Negotiator - COST:4 [ATK:3/HP:4]
@@ -580,6 +590,9 @@ void AlteracValleyCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
     // Text: Restore 8 Health to your hero.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<HealTask>(EntityType::HERO, 8));
+    cards.emplace("ONY_018t", CardDef(power));
 
     // ------------------------------------------ SPELL - DRUID
     // [ONY_018t2] Heart of the Sun - COST:5
@@ -587,6 +600,15 @@ void AlteracValleyCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
     // Text: Deal 4 damage.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 4, true));
+    cards.emplace(
+        "ONY_018t2",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [ONY_019e] Decisive - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -808,6 +808,10 @@ void AlteracValleyCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(ComplexTask::SummonRaceCostMinionFromDeck(
+        Race::BEAST, 5, RelaSign::LEQ));
+    cards.emplace("ONY_009", CardDef(power));
 
     // ----------------------------------------- SPELL - HUNTER
     // [ONY_010] Dragonbane Shot - COST:2

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -260,6 +260,77 @@ TEST_CASE("[Druid : Minion] - ONY_018 : Boomkin")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 16);
 }
 
+// ------------------------------------------ SPELL - DRUID
+// [ONY_021] Scale of Onyxia - COST:7
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: Fill your board with 2/1 Whelps with <b>Rush</b>.
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - ONY_021 : Scale of Onyxia")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Scale of Onyxia"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Scale of Onyxia"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1, 1));
+    CHECK_EQ(curField.GetCount(), 7);
+    CHECK_EQ(curField[0]->card->name, "Onyxian Whelp");
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[0]->HasRush(), true);
+    CHECK_EQ(curField[1]->card->name, "Onyxian Whelp");
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->HasRush(), true);
+    CHECK_EQ(curField[2]->card->name, "Onyxian Whelp");
+    CHECK_EQ(curField[2]->GetAttack(), 2);
+    CHECK_EQ(curField[2]->GetHealth(), 1);
+    CHECK_EQ(curField[2]->HasRush(), true);
+    CHECK_EQ(curField[3]->card->name, "Onyxian Whelp");
+    CHECK_EQ(curField[3]->GetAttack(), 2);
+    CHECK_EQ(curField[3]->GetHealth(), 1);
+    CHECK_EQ(curField[3]->HasRush(), true);
+    CHECK_EQ(curField[4]->card->name, "Onyxian Whelp");
+    CHECK_EQ(curField[4]->GetAttack(), 2);
+    CHECK_EQ(curField[4]->GetHealth(), 1);
+    CHECK_EQ(curField[4]->HasRush(), true);
+    CHECK_EQ(curField[5]->card->name, "Onyxian Whelp");
+    CHECK_EQ(curField[5]->GetAttack(), 2);
+    CHECK_EQ(curField[5]->GetHealth(), 1);
+    CHECK_EQ(curField[5]->HasRush(), true);
+    CHECK_EQ(curField[6]->card->name, "Onyxian Whelp");
+    CHECK_EQ(curField[6]->GetAttack(), 2);
+    CHECK_EQ(curField[6]->GetHealth(), 1);
+    CHECK_EQ(curField[6]->HasRush(), true);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [AV_147] Dun Baldar Bunker - COST:2
 // - Set: ALTERAC_VALLEY, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -211,6 +211,55 @@ TEST_CASE("[Druid : Spell] - AV_360 : Frostwolf Kennels")
     CHECK_EQ(curField.GetCount(), 3);
 }
 
+// ----------------------------------------- MINION - DRUID
+// [ONY_018] Boomkin - COST:5 [ATK:4/HP:5]
+// - Set: ALTERAC_VALLEY, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Choose One - </b>Restore 8 Health to your hero;
+//       or Deal 4 damage.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - ONY_018 : Boomkin")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Boomkin"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Boomkin"));
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1, 1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 28);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero(), 2));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 16);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [AV_147] Dun Baldar Bunker - COST:2
 // - Set: ALTERAC_VALLEY, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -794,6 +794,64 @@ TEST_CASE("[Hunter : Minion] - ONY_009 : Pet Collector")
     CHECK_EQ(curDeck.GetCount(), 25);
 }
 
+// ----------------------------------------- SPELL - HUNTER
+// [ONY_010] Dragonbane Shot - COST:2
+// - Set: ALTERAC_VALLEY, Rarity: Rare
+// --------------------------------------------------------
+// Text: Deal 2 damage.
+//       <b>Honorable Kill:</b> Add a Dragonbane Shot
+//       to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - HONORABLEKILL = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Spell] - ONY_010 : Dragonbane Shot")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Dragonbane Shot"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Intrepid Initiate"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->name, "Dragonbane Shot");
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(curHand[0], opPlayer->GetHero()));
+    CHECK_EQ(curHand.GetCount(), 0);
+}
+
 // ------------------------------------------- SPELL - MAGE
 // [AV_218] Mass Polymorph - COST:7
 // - Set: ALTERAC_VALLEY, Rarity: Epic

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -744,6 +744,56 @@ TEST_CASE("[Hunter : Minion] - AV_337 : Mountain Bear")
     CHECK_EQ(curField[1]->HasTaunt(), true);
 }
 
+// ---------------------------------------- MINION - HUNTER
+// [ONY_009] Pet Collector - COST:5 [ATK:3/HP:3]
+// - Set: ALTERAC_VALLEY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Summon a Beast from your deck
+//       that costs (5) or less.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - ONY_009 : Pet Collector")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Razorboar");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Humongous Owl");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Malygos");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curDeck = *(curPlayer->GetDeckZone());
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Pet Collector"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[1]->card->GetRace(), Race::BEAST);
+    CHECK(curField[1]->GetCost() <= 5);
+    CHECK_EQ(curDeck.GetCount(), 25);
+}
+
 // ------------------------------------------- SPELL - MAGE
 // [AV_218] Mass Polymorph - COST:7
 // - Set: ALTERAC_VALLEY, Rarity: Epic


### PR DESCRIPTION
This revision includes:
- Implement 5 ALTERAC_VALLEY cards
  - Haleh, Matron Protectorate (ONY_007)
  - Pet Collector (ONY_009)
  - Dragonbane Shot (ONY_010)
  - Boomkin (ONY_018)
  - Scale of Onyxia (ONY_021)
- Add method 'SummonRaceCostMinionFromDeck()': Returns a list of task for summoning a race and cost minion from your deck according to relaSign
- Correct minor typos