### PR TITLE
Implement 12 VANILLA cards

### DIFF
--- a/Documents/CardList - Classic.md
+++ b/Documents/CardList - Classic.md
@@ -278,16 +278,16 @@ VANILLA | VAN_EX1_393 | Amani Berserker |
 VANILLA | VAN_EX1_396 | Mogu'shan Warden |  
 VANILLA | VAN_EX1_398 | Arathi Weaponsmith | O
 VANILLA | VAN_EX1_399 | Gurubashi Berserker |  
-VANILLA | VAN_EX1_400 | Whirlwind |  
-VANILLA | VAN_EX1_402 | Armorsmith |  
+VANILLA | VAN_EX1_400 | Whirlwind | O
+VANILLA | VAN_EX1_402 | Armorsmith | O
 VANILLA | VAN_EX1_405 | Shieldbearer |  
-VANILLA | VAN_EX1_407 | Brawl |  
+VANILLA | VAN_EX1_407 | Brawl | O
 VANILLA | VAN_EX1_408 | Mortal Strike | O
 VANILLA | VAN_EX1_409 | Upgrade! | O
-VANILLA | VAN_EX1_410 | Shield Slam |  
-VANILLA | VAN_EX1_411 | Gorehowl |  
+VANILLA | VAN_EX1_410 | Shield Slam | O
+VANILLA | VAN_EX1_411 | Gorehowl | O
 VANILLA | VAN_EX1_412 | Raging Worgen |  
-VANILLA | VAN_EX1_414 | Grommash Hellscream |  
+VANILLA | VAN_EX1_414 | Grommash Hellscream | O
 VANILLA | VAN_EX1_506 | Murloc Tidehunter |  
 VANILLA | VAN_EX1_507 | Murloc Warleader |  
 VANILLA | VAN_EX1_508 | Grimscale Oracle |  
@@ -335,10 +335,10 @@ VANILLA | VAN_EX1_594 | Vaporize | O
 VANILLA | VAN_EX1_595 | Cult Master |  
 VANILLA | VAN_EX1_596 | Demonfire | O
 VANILLA | VAN_EX1_597 | Imp Master |  
-VANILLA | VAN_EX1_603 | Cruel Taskmaster |  
-VANILLA | VAN_EX1_604 | Frothing Berserker |  
-VANILLA | VAN_EX1_606 | Shield Block |  
-VANILLA | VAN_EX1_607 | Inner Rage |  
+VANILLA | VAN_EX1_603 | Cruel Taskmaster | O
+VANILLA | VAN_EX1_604 | Frothing Berserker | O
+VANILLA | VAN_EX1_606 | Shield Block | O
+VANILLA | VAN_EX1_607 | Inner Rage | O
 VANILLA | VAN_EX1_608 | Sorcerer's Apprentice | O
 VANILLA | VAN_EX1_609 | Snipe | O
 VANILLA | VAN_EX1_610 | Explosive Trap | O
@@ -362,7 +362,7 @@ VANILLA | VAN_NEW1_005 | Kidnapper | O
 VANILLA | VAN_NEW1_007 | Starfall | O
 VANILLA | VAN_NEW1_008 | Ancient of Lore | O
 VANILLA | VAN_NEW1_010 | Al'Akir the Windlord | O
-VANILLA | VAN_NEW1_011 | Kor'kron Elite |  
+VANILLA | VAN_NEW1_011 | Kor'kron Elite | O
 VANILLA | VAN_NEW1_012 | Mana Wyrm | O
 VANILLA | VAN_NEW1_014 | Master of Disguise | O
 VANILLA | VAN_NEW1_016 | Captain's Parrot |  
@@ -380,7 +380,7 @@ VANILLA | VAN_NEW1_027 | Southsea Captain |
 VANILLA | VAN_NEW1_029 | Millhouse Manastorm |  
 VANILLA | VAN_NEW1_030 | Deathwing |  
 VANILLA | VAN_NEW1_031 | Animal Companion | O
-VANILLA | VAN_NEW1_036 | Commanding Shout |  
+VANILLA | VAN_NEW1_036 | Commanding Shout | O
 VANILLA | VAN_NEW1_037 | Master Swordsmith |  
 VANILLA | VAN_NEW1_038 | Gruul |  
 VANILLA | VAN_NEW1_040 | Hogger |  
@@ -389,4 +389,4 @@ VANILLA | VAN_PRO_001 | Elite Tauren Chieftain |
 VANILLA | VAN_tt_004 | Flesheating Ghoul |  
 VANILLA | VAN_tt_010 | Spellbender | O
 
-- Progress: 56% (216 of 382 Cards)
+- Progress: 59% (228 of 382 Cards)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Classic Format
 
-  * 56% Vanilla Set (216 of 382 Cards)
+  * 59% Vanilla Set (228 of 382 Cards)
 
 ## Implementation List
 

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -4036,6 +4036,9 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Whenever a minion takes damage, gain +1 Attack.
     // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
     power.ClearData();
     power.AddTrigger(std::make_shared<Trigger>(TriggerType::TAKE_DAMAGE));
     power.GetTrigger()->triggerSource = TriggerSource::ALL_MINIONS;

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -3872,7 +3872,8 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // [EX1_402] Armorsmith - COST:2 [ATK:1/HP:4]
     // - Faction: Neutral, Set: Expert1, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Whenever a friendly minion takes damage, gain 1 Armor.
+    // Text: Whenever a friendly minion takes damage,
+    //       gain 1 Armor.
     // --------------------------------------------------------
     // GameTag:
     // - TRIGGER_VISUAL = 1

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -4984,6 +4984,11 @@ void VanillaCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TAKE_DAMAGE));
+    power.GetTrigger()->triggerSource = TriggerSource::MINIONS;
+    power.GetTrigger()->tasks = { std::make_shared<ArmorTask>(1) };
+    cards.emplace("VAN_EX1_402", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [VAN_EX1_407] Brawl - COST:5

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5172,6 +5172,19 @@ void VanillaCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 1 damage to a minion and give it +2 Attack.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 1, true));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("EX1_607e", EntityType::TARGET));
+    cards.emplace(
+        "VAN_EX1_607",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // --------------------------------------- MINION - WARRIOR
     // [VAN_NEW1_011] Kor'kron Elite - COST:4 [ATK:4/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5147,6 +5147,12 @@ void VanillaCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TAKE_DAMAGE));
+    power.GetTrigger()->triggerSource = TriggerSource::ALL_MINIONS;
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "EX1_604o", EntityType::SOURCE) };
+    cards.emplace("VAN_EX1_604", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [VAN_EX1_606] Shield Block - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5076,11 +5076,24 @@ void VanillaCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
                                  { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // --------------------------------------- WEAPON - WARRIOR
-    // [VAN_EX1_411] Gorehowl - COST:7
+    // [VAN_EX1_411] Gorehowl - COST:7 [ATK:7/HP:0]
     // - Set: VANILLA, Rarity: Epic
     // --------------------------------------------------------
     // Text: Attacking a minion costs 1 Attack instead of 1 Durability.
     // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 1
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TARGET));
+    power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsProposedDefender(CardType::MINION)) };
+    power.GetTrigger()->fastExecution = true;
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "EX1_411e", EntityType::SOURCE) };
+    cards.emplace("VAN_EX1_411", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [VAN_EX1_414] Grommash Hellscream - COST:8 [ATK:4/HP:9]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5061,6 +5061,19 @@ void VanillaCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - AFFECTED_BY_SPELL_POWER = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINION_TARGET = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<GetGameTagTask>(EntityType::HERO, GameTag::ARMOR));
+    power.AddPowerTask(
+        std::make_shared<DamageNumberTask>(EntityType::TARGET, true));
+    cards.emplace(
+        "VAN_EX1_410",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));
 
     // --------------------------------------- WEAPON - WARRIOR
     // [VAN_EX1_411] Gorehowl - COST:7

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5206,6 +5206,11 @@ void VanillaCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // Text: Your minions can't be reduced below 1 Health this turn.
     //       Draw a card.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("NEW1_036e2", EntityType::PLAYER));
+    power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cards.emplace("VAN_NEW1_036", CardDef(power));
 }
 
 void VanillaCardsGen::AddWarriorNonCollect(

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -4997,6 +4997,18 @@ void VanillaCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // Text: Destroy all minions except one.
     //       <i>(chosen randomly)</i>
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_MINIMUM_TOTAL_MINIONS = 2
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<RandomTask>(EntityType::ALL_MINIONS, 1));
+    power.AddPowerTask(std::make_shared<IncludeTask>(
+        EntityType::ALL_MINIONS, std::vector<EntityType>{ EntityType::STACK }));
+    power.AddPowerTask(std::make_shared<DestroyTask>(EntityType::STACK));
+    cards.emplace(
+        "VAN_EX1_407",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_MINIMUM_TOTAL_MINIONS, 2 } }));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [VAN_EX1_408] Mortal Strike - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5195,6 +5195,9 @@ void VanillaCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CHARGE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_NEW1_011", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [VAN_NEW1_036] Commanding Shout - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -4785,8 +4785,8 @@ void VanillaCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // - CHARGE = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddPowerTask(
-        std::make_shared<AddEnchantmentTask>("CS2_103e2", EntityType::TARGET));
+    power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
+        "VAN_CS2_103e2", EntityType::TARGET));
     cards.emplace(
         "VAN_CS2_103",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
@@ -5119,12 +5119,17 @@ void VanillaCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 void VanillaCardsGen::AddWarriorNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [VAN_CS2_103e2] Charge - COST:0
     // - Set: VANILLA
     // --------------------------------------------------------
     // Text: +2 Attack and <b>Charge</b>.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("VAN_CS2_103e2"));
+    cards.emplace("VAN_CS2_103e2", CardDef(power));
 }
 
 void VanillaCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5117,12 +5117,26 @@ void VanillaCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // [VAN_EX1_603] Cruel Taskmaster - COST:2 [ATK:2/HP:2]
     // - Set: VANILLA, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Deal 1 damage to a minion and
-    //       give it +2 Attack.
+    // Text: <b>Battlecry:</b> Deal 1 damage to a minion
+    //       and give it +2 Attack.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_NONSELF_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::TARGET, 1));
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("EX1_603e", EntityType::TARGET));
+    cards.emplace(
+        "VAN_EX1_603",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 },
+                                 { PlayReq::REQ_NONSELF_TARGET, 0 } }));
 
     // --------------------------------------- MINION - WARRIOR
     // [VAN_EX1_604] Frothing Berserker - COST:3 [ATK:2/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5158,8 +5158,13 @@ void VanillaCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // [VAN_EX1_606] Shield Block - COST:3
     // - Set: VANILLA, Rarity: Free
     // --------------------------------------------------------
-    // Text: Gain 5 Armor. Draw a card.
+    // Text: Gain 5 Armor.
+    //       Draw a card.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ArmorTask>(5));
+    power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cards.emplace("VAN_EX1_606", CardDef(power));
 
     // ---------------------------------------- SPELL - WARRIOR
     // [VAN_EX1_607] Inner Rage - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5,6 +5,7 @@
 
 #include <Rosetta/PlayMode/Actions/Choose.hpp>
 #include <Rosetta/PlayMode/Auras/AdaptiveEffect.hpp>
+#include <Rosetta/PlayMode/Auras/EnrageEffect.hpp>
 #include <Rosetta/PlayMode/Auras/SummoningPortalAura.hpp>
 #include <Rosetta/PlayMode/CardSets/VanillaCardsGen.hpp>
 #include <Rosetta/PlayMode/Cards/Cards.hpp>
@@ -5108,6 +5109,9 @@ void VanillaCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - ENRAGED = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<EnrageEffect>(AuraType::SELF, "EX1_414e"));
+    cards.emplace("VAN_EX1_414", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [VAN_EX1_603] Cruel Taskmaster - COST:2 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -4969,6 +4969,10 @@ void VanillaCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 1 damage to all minions.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ALL_MINIONS, 1, true));
+    cards.emplace("VAN_EX1_400", CardDef(power));
 
     // --------------------------------------- MINION - WARRIOR
     // [VAN_EX1_402] Armorsmith - COST:2 [ATK:1/HP:4]

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -8216,7 +8216,8 @@ TEST_CASE("[Warrior : Minion] - EX1_398 : Arathi Weaponsmith")
 // [EX1_402] Armorsmith - COST:2 [ATK:1/HP:4]
 // - Faction: Neutral, Set: Expert1, Rarity: Rare
 // --------------------------------------------------------
-// Text: Whenever a friendly minion takes damage, gain 1 Armor.
+// Text: Whenever a friendly minion takes damage,
+//       gain 1 Armor.
 // --------------------------------------------------------
 // GameTag:
 // - TRIGGER_VISUAL = 1

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -8669,6 +8669,9 @@ TEST_CASE("[Warrior : Minion] - EX1_603 : Cruel Taskmaster")
 // --------------------------------------------------------
 // Text: Whenever a minion takes damage, gain +1 Attack.
 // --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
 TEST_CASE("[Warrior : Minion] - EX1_604 : Frothing Berserker")
 {
     GameConfig config;

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -8807,9 +8807,9 @@ TEST_CASE("[Warrior : Spell] - NEW1_036 : Commanding Shout")
     const auto card1 = Generic::DrawCard(
         curPlayer, Cards::FindCardByName("Gurubashi Berserker"));
     const auto card2 =
-        Generic::DrawCard(curPlayer, Cards::FindCardByID("NEW1_036"));
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Commanding Shout"));
     const auto card3 =
-        Generic::DrawCard(curPlayer, Cards::FindCardByID("NEW1_036"));
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Commanding Shout"));
     const auto card4 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
 

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -13936,6 +13936,20 @@ TEST_CASE("[Warrior : Spell] - VAN_EX1_607 : Inner Rage")
     CHECK_EQ(curField[0]->GetHealth(), 6);
 }
 
+// --------------------------------------- MINION - WARRIOR
+// [VAN_NEW1_011] Kor'kron Elite - COST:4 [ATK:4/HP:3]
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Charge</b>
+// --------------------------------------------------------
+// GameTag:
+// - CHARGE = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - VAN_NEW1_011 : Kor'kron Elite")
+{
+    // Do nothing
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -13248,6 +13248,76 @@ TEST_CASE("[Warrior : Minion] - VAN_EX1_398 : Arathi Weaponsmith")
 }
 
 // ---------------------------------------- SPELL - WARRIOR
+// [VAN_EX1_400] Whirlwind - COST:1
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Deal 1 damage to all minions.
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Spell] - VAN_EX1_400 : Whirlwind")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Whirlwind", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Boulderfist Ogre", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+    const auto card4 = Generic::DrawCard(
+        opPlayer,
+        Cards::FindCardByName("Boulderfist Ogre", FormatType::CLASSIC));
+    const auto card5 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetHealth(), 7);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opField[0]->GetHealth(), 7);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(opField[1]->GetHealth(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 6);
+}
+
+// ---------------------------------------- SPELL - WARRIOR
 // [VAN_EX1_408] Mortal Strike - COST:4
 // - Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -13888,6 +13888,54 @@ TEST_CASE("[Warrior : Spell] - VAN_EX1_606 : Shield Block")
     CHECK_EQ(curPlayer->GetHero()->GetArmor(), 8);
 }
 
+// ---------------------------------------- SPELL - WARRIOR
+// [VAN_EX1_607] Inner Rage - COST:0
+// - Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: Deal 1 damage to a minion and give it +2 Attack.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Spell] - VAN_EX1_607 : Inner Rage")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Boulderfist Ogre", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Inner Rage", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 6);
+    CHECK_EQ(curField[0]->GetHealth(), 7);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField[0]->GetAttack(), 8);
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -13851,6 +13851,43 @@ TEST_CASE("[Warrior : Minion] - VAN_EX1_604 : Frothing Berserker")
     CHECK_EQ(curField[0]->GetAttack(), 7);
 }
 
+// ---------------------------------------- SPELL - WARRIOR
+// [VAN_EX1_606] Shield Block - COST:3
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Gain 5 Armor.
+//       Draw a card.
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Spell] - VAN_EX1_606 : Shield Block")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetArmor(3);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Shield Block", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 8);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -13784,6 +13784,73 @@ TEST_CASE("[Warrior : Minion] - VAN_EX1_603 : Cruel Taskmaster")
     CHECK_EQ(curField[1]->GetHealth(), 2);
 }
 
+// --------------------------------------- MINION - WARRIOR
+// [VAN_EX1_604] Frothing Berserker - COST:3 [ATK:2/HP:4]
+// - Set: VANILLA, Rarity: Rare
+// --------------------------------------------------------
+// Text: Whenever a minion takes damage, gain +1 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - VAN_EX1_604 : Frothing Berserker")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Frothing Berserker", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wisp", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wisp", FormatType::CLASSIC));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Stonetusk Boar", FormatType::CLASSIC));
+    const auto card5 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Stonetusk Boar", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+
+    game.Process(opPlayer, AttackTask(card4, card2));
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+
+    game.Process(opPlayer, AttackTask(card5, card3));
+    CHECK_EQ(curField[0]->GetAttack(), 7);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -13728,6 +13728,62 @@ TEST_CASE("[Warrior : Minion] - VAN_EX1_414 : Grommash Hellscream")
     CHECK_EQ(curField[0]->GetHealth(), 9);
 }
 
+// --------------------------------------- MINION - WARRIOR
+// [VAN_EX1_603] Cruel Taskmaster - COST:2 [ATK:2/HP:2]
+// - Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Deal 1 damage to a minion
+//       and give it +2 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// - REQ_MINION_TARGET = 0
+// - REQ_NONSELF_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - VAN_EX1_603 : Cruel Taskmaster")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Cruel Taskmaster", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Cruel Taskmaster", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -13612,6 +13612,66 @@ TEST_CASE("[Warrior : Spell] - VAN_EX1_410 : Shield Slam")
     CHECK_EQ(opField[0]->GetHealth(), 1);
 }
 
+// --------------------------------------- WEAPON - WARRIOR
+// [VAN_EX1_411] Gorehowl - COST:7 [ATK:7/HP:0]
+// - Set: VANILLA, Rarity: Epic
+// --------------------------------------------------------
+// Text: Attacking a minion costs 1 Attack instead of 1 Durability.
+// --------------------------------------------------------
+// GameTag:
+// - DURABILITY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Weapon] - VAN_EX1_411 : Gorehowl")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Gorehowl", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Weapon(card2));
+    CHECK_EQ(opPlayer->GetHero()->weapon->GetAttack(), 7);
+    CHECK_EQ(opPlayer->GetHero()->weapon->GetDurability(), 1);
+
+    game.Process(opPlayer, AttackTask(opPlayer->GetHero(), card1));
+    CHECK_EQ(opPlayer->GetHero()->weapon->GetAttack(), 6);
+    CHECK_EQ(opPlayer->GetHero()->weapon->GetDurability(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer,
+                 AttackTask(opPlayer->GetHero(), curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 24);
+    CHECK_EQ(opPlayer->GetHero()->HasWeapon(), false);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -13317,6 +13317,59 @@ TEST_CASE("[Warrior : Spell] - VAN_EX1_400 : Whirlwind")
     CHECK_EQ(opField[0]->GetHealth(), 6);
 }
 
+// --------------------------------------- MINION - WARRIOR
+// [VAN_EX1_402] Armorsmith - COST:2 [ATK:1/HP:4]
+// - Set: VANILLA, Rarity: Rare
+// --------------------------------------------------------
+// Text: Whenever a friendly minion takes damage,
+//       gain 1 Armor.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - VAN_EX1_402 : Armorsmith")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Armorsmith", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Amani Berserker", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Frostbolt", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card2));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 1);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 2);
+}
+
 // ---------------------------------------- SPELL - WARRIOR
 // [VAN_EX1_408] Mortal Strike - COST:4
 // - Set: VANILLA, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -13672,6 +13672,62 @@ TEST_CASE("[Warrior : Weapon] - VAN_EX1_411 : Gorehowl")
     CHECK_EQ(opPlayer->GetHero()->HasWeapon(), false);
 }
 
+// --------------------------------------- MINION - WARRIOR
+// [VAN_EX1_414] Grommash Hellscream - COST:8 [ATK:4/HP:9]
+// - Set: VANILLA, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Charge</b> <b>Enrage:</b> +6 Attack
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - CHARGE = 1
+// --------------------------------------------------------
+// RefTag:
+// - ENRAGED = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - VAN_EX1_414 : Grommash Hellscream")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Grommash Hellscream", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Circle of Healing", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 9);
+
+    game.Process(curPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 10);
+    CHECK_EQ(curField[0]->GetHealth(), 8);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 9);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -13371,6 +13371,74 @@ TEST_CASE("[Warrior : Minion] - VAN_EX1_402 : Armorsmith")
 }
 
 // ---------------------------------------- SPELL - WARRIOR
+// [VAN_EX1_407] Brawl - COST:5
+// - Set: VANILLA, Rarity: Epic
+// --------------------------------------------------------
+// Text: Destroy all minions except one.
+//       <i>(chosen randomly)</i>
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINIMUM_TOTAL_MINIONS = 2
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Spell] - VAN_EX1_407 : Brawl")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Brawl", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+    const auto card5 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curHand.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(opField.GetCount(), 3);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curHand.GetCount(), 0);
+    CHECK_EQ(curField.GetCount() + opField.GetCount(), 1);
+}
+
+// ---------------------------------------- SPELL - WARRIOR
 // [VAN_EX1_408] Mortal Strike - COST:4
 // - Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------


### PR DESCRIPTION
This revision includes:
- Implement 12 VANILLA cards (#674)
  - Whirlwind (VAN_EX1_400)
  - Armorsmith (VAN_EX1_402)
  - Brawl (VAN_EX1_407)
  - Shield Slam (VAN_EX1_410)
  - Gorehowl (VAN_EX1_411)
  - Grommash Hellscream (VAN_EX1_414)
  - Cruel Taskmaster (VAN_EX1_603)
  - Frothing Berserker (VAN_EX1_604)
  - Shield Block (VAN_EX1_606)
  - Inner Rage (VAN_EX1_607)
  - Kor'kron Elite (VAN_NEW1_011)
  - Commanding Shout (VAN_NEW1_036)
- Implement missing card 'Charge' (VAN_CS2_103e2)
- Add missing game tag 'TRIGGER_VISUAL'
- Replace code to call 'FindCardByID()' with 'FindCardByName()'
- Separate text to improve readability