### PR TITLE
Implement 12 VANILLA cards

### DIFF
--- a/Documents/CardList - Classic.md
+++ b/Documents/CardList - Classic.md
@@ -6,8 +6,8 @@
 
 Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
-VANILLA | VAN_CS1_042 | Goldshire Footman |  
-VANILLA | VAN_CS1_069 | Fen Creeper |  
+VANILLA | VAN_CS1_042 | Goldshire Footman | O
+VANILLA | VAN_CS1_069 | Fen Creeper | O
 VANILLA | VAN_CS1_112 | Holy Nova | O
 VANILLA | VAN_CS1_113 | Mind Control | O
 VANILLA | VAN_CS1_129 | Inner Fire | O
@@ -70,16 +70,16 @@ VANILLA | VAN_CS2_106 | Fiery War Axe | O
 VANILLA | VAN_CS2_108 | Execute | O
 VANILLA | VAN_CS2_112 | Arcanite Reaper | O
 VANILLA | VAN_CS2_114 | Cleave | O
-VANILLA | VAN_CS2_117 | Earthen Ring Farseer |  
-VANILLA | VAN_CS2_118 | Magma Rager |  
-VANILLA | VAN_CS2_119 | Oasis Snapjaw |  
-VANILLA | VAN_CS2_120 | River Crocolisk |  
-VANILLA | VAN_CS2_121 | Frostwolf Grunt |  
-VANILLA | VAN_CS2_122 | Raid Leader |  
-VANILLA | VAN_CS2_124 | Wolfrider |  
-VANILLA | VAN_CS2_125 | Ironfur Grizzly |  
-VANILLA | VAN_CS2_127 | Silverback Patriarch |  
-VANILLA | VAN_CS2_131 | Stormwind Knight |  
+VANILLA | VAN_CS2_117 | Earthen Ring Farseer | O
+VANILLA | VAN_CS2_118 | Magma Rager | O
+VANILLA | VAN_CS2_119 | Oasis Snapjaw | O
+VANILLA | VAN_CS2_120 | River Crocolisk | O
+VANILLA | VAN_CS2_121 | Frostwolf Grunt | O
+VANILLA | VAN_CS2_122 | Raid Leader | O
+VANILLA | VAN_CS2_124 | Wolfrider | O
+VANILLA | VAN_CS2_125 | Ironfur Grizzly | O
+VANILLA | VAN_CS2_127 | Silverback Patriarch | O
+VANILLA | VAN_CS2_131 | Stormwind Knight | O
 VANILLA | VAN_CS2_141 | Ironforge Rifleman |  
 VANILLA | VAN_CS2_142 | Kobold Geomancer |  
 VANILLA | VAN_CS2_146 | Southsea Deckhand |  
@@ -389,4 +389,4 @@ VANILLA | VAN_PRO_001 | Elite Tauren Chieftain |
 VANILLA | VAN_tt_004 | Flesheating Ghoul |  
 VANILLA | VAN_tt_010 | Spellbender | O
 
-- Progress: 59% (228 of 382 Cards)
+- Progress: 62% (240 of 382 Cards)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Classic Format
 
-  * 59% Vanilla Set (228 of 382 Cards)
+  * 62% Vanilla Set (240 of 382 Cards)
 
 ## Implementation List
 

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5326,6 +5326,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [VAN_CS2_119] Oasis Snapjaw - COST:4 [ATK:2/HP:7]
     // - Race: Beast, Set: VANILLA, Rarity: Free
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_119", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_120] River Crocolisk - COST:2 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5374,6 +5374,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CHARGE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_124", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_125] Ironfur Grizzly - COST:3 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5279,6 +5279,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS1_042", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS1_069] Fen Creeper - COST:5 [ATK:3/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5305,6 +5305,14 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<HealTask>(EntityType::TARGET, 3));
+    cards.emplace(
+        "VAN_CS2_117",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } }));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_118] Magma Rager - COST:3 [ATK:5/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5347,6 +5347,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_121", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_122] Raid Leader - COST:3 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5360,6 +5360,10 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - AURA = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(
+        std::make_shared<Aura>(AuraType::FIELD_EXCEPT_SOURCE, "CS2_122e"));
+    cards.emplace("VAN_CS2_122", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_124] Wolfrider - COST:3 [ATK:3/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5292,6 +5292,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS1_069", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_117] Earthen Ring Farseer - COST:3 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5318,6 +5318,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [VAN_CS2_118] Magma Rager - COST:3 [ATK:5/HP:1]
     // - Set: VANILLA, Rarity: Free
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_118", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_119] Oasis Snapjaw - COST:4 [ATK:2/HP:7]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5413,6 +5413,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CHARGE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_131", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_141] Ironforge Rifleman - COST:3 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5334,6 +5334,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [VAN_CS2_120] River Crocolisk - COST:2 [ATK:2/HP:3]
     // - Race: Beast, Set: VANILLA, Rarity: Free
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_120", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_121] Frostwolf Grunt - COST:2 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5387,6 +5387,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_125", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_127] Silverback Patriarch - COST:3 [ATK:1/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5400,6 +5400,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_127", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_131] Stormwind Knight - COST:4 [ATK:2/HP:5]

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14132,6 +14132,15 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_118 : Magma Rager")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_119] Oasis Snapjaw - COST:4 [ATK:2/HP:7]
+// - Race: Beast, Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_119 : Oasis Snapjaw")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14123,6 +14123,15 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_117 : Earthen Ring Farseer")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_118] Magma Rager - COST:3 [ATK:5/HP:1]
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_118 : Magma Rager")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14046,6 +14046,20 @@ TEST_CASE("[Neutral : Minion] - VAN_CS1_042 : Goldshire Footman")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS1_069] Fen Creeper - COST:5 [ATK:3/HP:6]
+// - Faction: Alliance, Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS1_069 : Fen Creeper")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14218,6 +14218,20 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_122 : Raid Leader")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_124] Wolfrider - COST:3 [ATK:3/HP:1]
+// - Faction: Horde, Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Charge</b>
+// --------------------------------------------------------
+// GameTag:
+// - CHARGE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_124 : Wolfrider")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14141,6 +14141,15 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_119 : Oasis Snapjaw")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_120] River Crocolisk - COST:2 [ATK:2/HP:3]
+// - Race: Beast, Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_120 : River Crocolisk")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14060,6 +14060,69 @@ TEST_CASE("[Neutral : Minion] - VAN_CS1_069 : Fen Creeper")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_117] Earthen Ring Farseer - COST:3 [ATK:3/HP:3]
+// - Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Restore 3 Health.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_117 : Earthen Ring Farseer")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(10);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Earthen Ring Farseer", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Earthen Ring Farseer", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        opPlayer,
+        Cards::FindCardByName("Acidic Swamp Ooze", FormatType::CLASSIC));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    opField[0]->SetDamage(1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card1, curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 23);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card3));
+    CHECK_EQ(opField[0]->GetHealth(), 2);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14232,6 +14232,20 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_124 : Wolfrider")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_125] Ironfur Grizzly - COST:3 [ATK:3/HP:3]
+// - Race: Beast, Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_125 : Ironfur Grizzly")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14150,6 +14150,20 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_120 : River Crocolisk")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_121] Frostwolf Grunt - COST:2 [ATK:2/HP:2]
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_121 : Frostwolf Grunt")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14246,6 +14246,20 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_125 : Ironfur Grizzly")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_127] Silverback Patriarch - COST:3 [ATK:1/HP:4]
+// - Race: Beast, Faction: Horde, Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_127 : Silverback Patriarch")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14032,6 +14032,20 @@ TEST_CASE("[Warrior : Spell] - VAN_NEW1_036 : Commanding Shout")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS1_042] Goldshire Footman - COST:1 [ATK:1/HP:2]
+// - Faction: Alliance, Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS1_042 : Goldshire Footman")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14260,6 +14260,20 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_127 : Silverback Patriarch")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_131] Stormwind Knight - COST:4 [ATK:2/HP:5]
+// - Faction: Alliance, Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Charge</b>
+// --------------------------------------------------------
+// GameTag:
+// - CHARGE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_131 : Stormwind Knight")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14164,6 +14164,60 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_121 : Frostwolf Grunt")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_122] Raid Leader - COST:3 [ATK:2/HP:2]
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Your other minions have +1 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - AURA = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_122 : Raid Leader")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Raid Leader", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Boulderfist Ogre", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetAttack(), 6);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 7);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    game.Process(opPlayer, AttackTask(card3, card1));
+    CHECK_EQ(curField[0]->GetAttack(), 6);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------


### PR DESCRIPTION
This revision includes:
- Implement 12 VANILLA cards (#674)
  - Goldshire Footman (VAN_CS1_042)
  - Fen Creeper (VAN_CS1_069)
  - Earthen Ring Farseer (VAN_CS2_117)
  - Magma Rager (VAN_CS2_118)
  - Oasis Snapjaw (VAN_CS2_119)
  - River Crocolisk (VAN_CS2_120)
  - Frostwolf Grunt (VAN_CS2_121)
  - Raid Leader (VAN_CS2_122)
  - Wolfrider (VAN_CS2_124)
  - Ironfur Grizzly (VAN_CS2_125)
  - Silverback Patriarch (VAN_CS2_127)
  - Stormwind Knight (VAN_CS2_131)