### PR TITLE
Implement 12 VANILLA cards

### DIFF
--- a/Documents/CardList - Classic.md
+++ b/Documents/CardList - Classic.md
@@ -92,19 +92,19 @@ VANILLA | VAN_CS2_162 | Lord of the Arena | O
 VANILLA | VAN_CS2_168 | Murloc Raider | O
 VANILLA | VAN_CS2_169 | Young Dragonhawk | O
 VANILLA | VAN_CS2_171 | Stonetusk Boar | O
-VANILLA | VAN_CS2_172 | Bloodfen Raptor |  
-VANILLA | VAN_CS2_173 | Bluegill Warrior |  
-VANILLA | VAN_CS2_179 | Sen'jin Shieldmasta |  
+VANILLA | VAN_CS2_172 | Bloodfen Raptor | O
+VANILLA | VAN_CS2_173 | Bluegill Warrior | O
+VANILLA | VAN_CS2_179 | Sen'jin Shieldmasta | O
 VANILLA | VAN_CS2_181 | Injured Blademaster | O
-VANILLA | VAN_CS2_182 | Chillwind Yeti |  
-VANILLA | VAN_CS2_186 | War Golem |  
-VANILLA | VAN_CS2_187 | Booty Bay Bodyguard |  
-VANILLA | VAN_CS2_188 | Abusive Sergeant |  
-VANILLA | VAN_CS2_189 | Elven Archer |  
-VANILLA | VAN_CS2_196 | Razorfen Hunter |  
-VANILLA | VAN_CS2_197 | Ogre Magi |  
-VANILLA | VAN_CS2_200 | Boulderfist Ogre |  
-VANILLA | VAN_CS2_201 | Core Hound |  
+VANILLA | VAN_CS2_182 | Chillwind Yeti | O
+VANILLA | VAN_CS2_186 | War Golem | O
+VANILLA | VAN_CS2_187 | Booty Bay Bodyguard | O
+VANILLA | VAN_CS2_188 | Abusive Sergeant | O
+VANILLA | VAN_CS2_189 | Elven Archer | O
+VANILLA | VAN_CS2_196 | Razorfen Hunter | O
+VANILLA | VAN_CS2_197 | Ogre Magi | O
+VANILLA | VAN_CS2_200 | Boulderfist Ogre | O
+VANILLA | VAN_CS2_201 | Core Hound | O
 VANILLA | VAN_CS2_203 | Ironbeak Owl |  
 VANILLA | VAN_CS2_213 | Reckless Rocketeer |  
 VANILLA | VAN_CS2_221 | Spiteful Smith |  
@@ -389,4 +389,4 @@ VANILLA | VAN_PRO_001 | Elite Tauren Chieftain |
 VANILLA | VAN_tt_004 | Flesheating Ghoul |  
 VANILLA | VAN_tt_010 | Spellbender | O
 
-- Progress: 65% (252 of 382 Cards)
+- Progress: 69% (264 of 382 Cards)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Classic Format
 
-  * 65% Vanilla Set (252 of 382 Cards)
+  * 69% Vanilla Set (264 of 382 Cards)
 
 ## Implementation List
 

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5671,6 +5671,17 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("CS2_188o", EntityType::TARGET));
+    cards.emplace(
+        "VAN_CS2_188",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                 { PlayReq::REQ_MINION_TARGET, 0 } }));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_189] Elven Archer - COST:1 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5726,6 +5726,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - SPELLPOWER = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_197", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_200] Boulderfist Ogre - COST:6 [ATK:6/HP:7]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5734,6 +5734,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [VAN_CS2_200] Boulderfist Ogre - COST:6 [ATK:6/HP:7]
     // - Set: VANILLA, Rarity: Free
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_200", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_201] Core Hound - COST:7 [ATK:9/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5712,6 +5712,10 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SummonTask>("VAN_CS2_boar", SummonSide::RIGHT));
+    cards.emplace("VAN_CS2_196", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_197] Ogre Magi - COST:4 [ATK:4/HP:4]
@@ -7063,6 +7067,9 @@ void VanillaCardsGen::AddNeutralNonCollect(
     // [VAN_CS2_boar] Boar - COST:1 [ATK:1/HP:1]
     // - Race: Beast, Set: VANILLA, Rarity: Common
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_boar", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_tk1] Sheep - COST:0 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5658,6 +5658,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_187", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_188] Abusive Sergeant - COST:1 [ATK:2/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5742,6 +5742,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [VAN_CS2_201] Core Hound - COST:7 [ATK:9/HP:5]
     // - Race: Beast, Set: VANILLA, Rarity: Free
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_201", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_203] Ironbeak Owl - COST:2 [ATK:2/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5615,6 +5615,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_179", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5589,6 +5589,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [VAN_CS2_172] Bloodfen Raptor - COST:2 [ATK:3/HP:2]
     // - Race: Beast, Faction: Horde, Set: VANILLA, Rarity: Free
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_172", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_173] Bluegill Warrior - COST:2 [ATK:2/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5602,6 +5602,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CHARGE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_173", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_179] Sen'jin Shieldmasta - COST:4 [ATK:3/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5692,6 +5692,16 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_NONSELF_TARGET = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DamageTask>(EntityType::TARGET, 1));
+    cards.emplace(
+        "VAN_CS2_189",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },
+                                 { PlayReq::REQ_NONSELF_TARGET, 0 } }));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_196] Razorfen Hunter - COST:3 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5637,6 +5637,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [VAN_CS2_182] Chillwind Yeti - COST:4 [ATK:4/HP:5]
     // - Set: VANILLA, Rarity: Free
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_182", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_186] War Golem - COST:7 [ATK:7/HP:7]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -5645,6 +5645,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [VAN_CS2_186] War Golem - COST:7 [ATK:7/HP:7]
     // - Set: VANILLA, Rarity: Free
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_CS2_186", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_CS2_187] Booty Bay Bodyguard - COST:5 [ATK:5/HP:4]

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14917,6 +14917,15 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_197 : Ogre Magi")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_200] Boulderfist Ogre - COST:6 [ATK:6/HP:7]
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_200 : Boulderfist Ogre")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_EX1_011] Voodoo Doctor - COST:1 [ATK:2/HP:1]
 // - Faction: Horde, Set: VANILLA, Rarity: Free
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14647,6 +14647,20 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_173 : Bluegill Warrior")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_179] Sen'jin Shieldmasta - COST:4 [ATK:3/HP:5]
+// - Faction: Horde, Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_179 : Sen'jin Shieldmasta")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14926,6 +14926,15 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_200 : Boulderfist Ogre")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_201] Core Hound - COST:7 [ATK:9/HP:5]
+// - Race: Beast, Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_201 : Core Hound")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_EX1_011] Voodoo Doctor - COST:1 [ATK:2/HP:1]
 // - Faction: Horde, Set: VANILLA, Rarity: Free
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14719,6 +14719,20 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_186 : War Golem")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_187] Booty Bay Bodyguard - COST:5 [ATK:5/HP:4]
+// - Faction: Horde, Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_187 : Booty Bay Bodyguard")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_EX1_011] Voodoo Doctor - COST:1 [ATK:2/HP:1]
 // - Faction: Horde, Set: VANILLA, Rarity: Free
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14860,6 +14860,49 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_189 : Elven Archer")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_196] Razorfen Hunter - COST:3 [ATK:2/HP:3]
+// - Faction: Horde, Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Summon a 1/1 Boar.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_196 : Razorfen Hunter")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Razorfen Hunter", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_EX1_011] Voodoo Doctor - COST:1 [ATK:2/HP:1]
 // - Faction: Horde, Set: VANILLA, Rarity: Free
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14701,6 +14701,15 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_181 : Injured Blademaster")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_182] Chillwind Yeti - COST:4 [ATK:4/HP:5]
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_182 : Chillwind Yeti")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_EX1_011] Voodoo Doctor - COST:1 [ATK:2/HP:1]
 // - Faction: Horde, Set: VANILLA, Rarity: Free
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14624,6 +14624,15 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_171 : Stonetusk Boar")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_172] Bloodfen Raptor - COST:2 [ATK:3/HP:2]
+// - Race: Beast, Faction: Horde, Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_172 : Bloodfen Raptor")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14903,6 +14903,20 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_196 : Razorfen Hunter")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_197] Ogre Magi - COST:4 [ATK:4/HP:4]
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Spell Damage +1</b>
+// --------------------------------------------------------
+// GameTag:
+// - SPELLPOWER = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_197 : Ogre Magi")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_EX1_011] Voodoo Doctor - COST:1 [ATK:2/HP:1]
 // - Faction: Horde, Set: VANILLA, Rarity: Free
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14633,6 +14633,20 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_172 : Bloodfen Raptor")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_173] Bluegill Warrior - COST:2 [ATK:2/HP:1]
+// - Race: Murloc, Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Charge</b>
+// --------------------------------------------------------
+// GameTag:
+// - CHARGE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_173 : Bluegill Warrior")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_CS2_181] Injured Blademaster - COST:3 [ATK:4/HP:7]
 // - Faction: Horde, Set: VANILLA, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14710,6 +14710,15 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_182 : Chillwind Yeti")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_186] War Golem - COST:7 [ATK:7/HP:7]
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_186 : War Golem")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_EX1_011] Voodoo Doctor - COST:1 [ATK:2/HP:1]
 // - Faction: Horde, Set: VANILLA, Rarity: Free
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14733,6 +14733,78 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_187 : Booty Bay Bodyguard")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_188] Abusive Sergeant - COST:1 [ATK:2/HP:1]
+// - Faction: Alliance, Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give a minion +2 Attack this turn.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_188 : Abusive Sergeant")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Abusive Sergeant", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Abusive Sergeant", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wolfrider", FormatType::CLASSIC));
+    const auto card4 = Generic::DrawCard(
+        opPlayer,
+        Cards::FindCardByName("Acidic Swamp Ooze", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card1, card3));
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card4));
+    CHECK_EQ(opField[0]->GetAttack(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(opField[0]->GetAttack(), 3);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_EX1_011] Voodoo Doctor - COST:1 [ATK:2/HP:1]
 // - Faction: Horde, Set: VANILLA, Rarity: Free
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -14805,6 +14805,61 @@ TEST_CASE("[Neutral : Minion] - VAN_CS2_188 : Abusive Sergeant")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [VAN_CS2_189] Elven Archer - COST:1 [ATK:1/HP:1]
+// - Faction: Horde, Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Deal 1 damage.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// - REQ_NONSELF_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_CS2_189 : Elven Archer")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Elven Archer", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        opPlayer,
+        Cards::FindCardByName("Acidic Swamp Ooze", FormatType::CLASSIC));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(opField[0]->GetHealth(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card1, card2));
+    CHECK_EQ(opField[0]->GetHealth(), 1);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [VAN_EX1_011] Voodoo Doctor - COST:1 [ATK:2/HP:1]
 // - Faction: Horde, Set: VANILLA, Rarity: Free
 // --------------------------------------------------------


### PR DESCRIPTION
This revision includes:
- Implement 12 VANILLA cards (#674)
  - Bloodfen Raptor (VAN_CS2_172)
  - Bluegill Warrior (VAN_CS2_173)
  - Sen'jin Shieldmasta (VAN_CS2_179)
  - Chillwind Yeti (VAN_CS2_182)
  - War Golem (VAN_CS2_186)
  - Booty Bay Bodyguard (VAN_CS2_187)
  - Abusive Sergeant (VAN_CS2_188)
  - Elven Archer (VAN_CS2_189)
  - Razorfen Hunter (VAN_CS2_196)
  - Ogre Magi (VAN_CS2_197)
  - Boulderfist Ogre (VAN_CS2_200)
  - Core Hound (VAN_CS2_201)