### PR TITLE
Implement 12 VANILLA cards

### DIFF
--- a/Documents/CardList - Classic.md
+++ b/Documents/CardList - Classic.md
@@ -183,7 +183,7 @@ VANILLA | VAN_EX1_103 | Coldlight Seer | O
 VANILLA | VAN_EX1_105 | Mountain Giant | O
 VANILLA | VAN_EX1_110 | Cairne Bloodhoof | O
 VANILLA | VAN_EX1_112 | Gelbin Mekkatorque | O
-VANILLA | VAN_EX1_116 | Leeroy Jenkins |  
+VANILLA | VAN_EX1_116 | Leeroy Jenkins | O
 VANILLA | VAN_EX1_124 | Eviscerate | O
 VANILLA | VAN_EX1_126 | Betrayal | O
 VANILLA | VAN_EX1_128 | Conceal | O
@@ -202,12 +202,12 @@ VANILLA | VAN_EX1_155 | Mark of Nature | O
 VANILLA | VAN_EX1_158 | Soul of the Forest | O
 VANILLA | VAN_EX1_160 | Power of the Wild | O
 VANILLA | VAN_EX1_161 | Naturalize | O
-VANILLA | VAN_EX1_162 | Dire Wolf Alpha |  
+VANILLA | VAN_EX1_162 | Dire Wolf Alpha | O
 VANILLA | VAN_EX1_164 | Nourish | O
 VANILLA | VAN_EX1_165 | Druid of the Claw | O
 VANILLA | VAN_EX1_166 | Keeper of the Grove | O
 VANILLA | VAN_EX1_169 | Innervate | O
-VANILLA | VAN_EX1_170 | Emperor Cobra |  
+VANILLA | VAN_EX1_170 | Emperor Cobra | O
 VANILLA | VAN_EX1_173 | Starfire | O
 VANILLA | VAN_EX1_178 | Ancient of War | O
 VANILLA | VAN_EX1_238 | Lightning Bolt | O
@@ -218,7 +218,7 @@ VANILLA | VAN_EX1_245 | Earth Shock | O
 VANILLA | VAN_EX1_246 | Hex | O
 VANILLA | VAN_EX1_247 | Stormforged Axe | O
 VANILLA | VAN_EX1_248 | Feral Spirit | O
-VANILLA | VAN_EX1_249 | Baron Geddon |  
+VANILLA | VAN_EX1_249 | Baron Geddon | O
 VANILLA | VAN_EX1_250 | Earth Elemental | O
 VANILLA | VAN_EX1_251 | Forked Lightning | O
 VANILLA | VAN_EX1_258 | Unbound Elemental | O
@@ -228,13 +228,13 @@ VANILLA | VAN_EX1_275 | Cone of Cold | O
 VANILLA | VAN_EX1_277 | Arcane Missiles | O
 VANILLA | VAN_EX1_278 | Shiv | O
 VANILLA | VAN_EX1_279 | Pyroblast | O
-VANILLA | VAN_EX1_283 | Frost Elemental |  
-VANILLA | VAN_EX1_284 | Azure Drake |  
+VANILLA | VAN_EX1_283 | Frost Elemental | O
+VANILLA | VAN_EX1_284 | Azure Drake | O
 VANILLA | VAN_EX1_287 | Counterspell | O
 VANILLA | VAN_EX1_289 | Ice Barrier | O
 VANILLA | VAN_EX1_294 | Mirror Entity | O
 VANILLA | VAN_EX1_295 | Ice Block | O
-VANILLA | VAN_EX1_298 | Ragnaros the Firelord |  
+VANILLA | VAN_EX1_298 | Ragnaros the Firelord | O
 VANILLA | VAN_EX1_301 | Felguard | O
 VANILLA | VAN_EX1_302 | Mortal Coil | O
 VANILLA | VAN_EX1_303 | Shadowflame | O
@@ -271,16 +271,16 @@ VANILLA | VAN_EX1_379 | Repentance | O
 VANILLA | VAN_EX1_382 | Aldor Peacekeeper | O
 VANILLA | VAN_EX1_383 | Tirion Fordring | O
 VANILLA | VAN_EX1_384 | Avenging Wrath | O
-VANILLA | VAN_EX1_390 | Tauren Warrior |  
+VANILLA | VAN_EX1_390 | Tauren Warrior | O
 VANILLA | VAN_EX1_391 | Slam | O
 VANILLA | VAN_EX1_392 | Battle Rage | O
-VANILLA | VAN_EX1_393 | Amani Berserker |  
-VANILLA | VAN_EX1_396 | Mogu'shan Warden |  
+VANILLA | VAN_EX1_393 | Amani Berserker | O
+VANILLA | VAN_EX1_396 | Mogu'shan Warden | O
 VANILLA | VAN_EX1_398 | Arathi Weaponsmith | O
-VANILLA | VAN_EX1_399 | Gurubashi Berserker |  
+VANILLA | VAN_EX1_399 | Gurubashi Berserker | O
 VANILLA | VAN_EX1_400 | Whirlwind | O
 VANILLA | VAN_EX1_402 | Armorsmith | O
-VANILLA | VAN_EX1_405 | Shieldbearer |  
+VANILLA | VAN_EX1_405 | Shieldbearer | O
 VANILLA | VAN_EX1_407 | Brawl | O
 VANILLA | VAN_EX1_408 | Mortal Strike | O
 VANILLA | VAN_EX1_409 | Upgrade! | O
@@ -389,4 +389,4 @@ VANILLA | VAN_PRO_001 | Elite Tauren Chieftain |
 VANILLA | VAN_tt_004 | Flesheating Ghoul |  
 VANILLA | VAN_tt_010 | Spellbender | O
 
-- Progress: 84% (324 of 382 Cards)
+- Progress: 87% (336 of 382 Cards)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Classic Format
 
-  * 84% Vanilla Set (324 of 382 Cards)
+  * 87% Vanilla Set (336 of 382 Cards)
 
 ## Implementation List
 

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -5277,8 +5277,8 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [EX1_116] Leeroy Jenkins - COST:5 [ATK:6/HP:2]
     // - Faction: Alliance, Set: Expert1, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Charge</b>. <b>Battlecry:</b> Summon two 1/1 Whelps
-    //       for your opponent.
+    // Text: <b>Charge</b>.
+    //       <b>Battlecry:</b> Summon two 1/1 Whelps for your opponent.
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -6917,6 +6917,14 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - FREEZE = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<FreezeTask>(EntityType::TARGET));
+    cards.emplace(
+        "VAN_EX1_283",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } }));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_EX1_284] Azure Drake - COST:5 [ATK:4/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -6901,6 +6901,11 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->tasks = { std::make_shared<DamageTask>(
+        EntityType::ALL_NOSOURCE, 2) };
+    cards.emplace("VAN_EX1_249", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_EX1_283] Frost Elemental - COST:6 [ATK:5/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -6885,6 +6885,10 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Destroy any minion damaged by this minion.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(EntityType::SOURCE,
+                                                        GameTag::POISONOUS, 1));
+    cards.emplace("VAN_EX1_170", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_EX1_249] Baron Geddon - COST:7 [ATK:7/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -6875,6 +6875,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - ADJACENT_BUFF = 1
     // - AURA = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<AdjacentAura>("EX1_162o"));
+    cards.emplace("VAN_EX1_162", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_EX1_170] Emperor Cobra - COST:3 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -6953,6 +6953,16 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - CANT_ATTACK = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->tasks = {
+        std::make_shared<IncludeTask>(EntityType::ENEMIES),
+        std::make_shared<FilterStackTask>(SelfCondList{
+            std::make_shared<SelfCondition>(SelfCondition::IsNotDead()) }),
+        std::make_shared<RandomTask>(EntityType::STACK, 1),
+        std::make_shared<DamageTask>(EntityType::STACK, 8)
+    };
+    cards.emplace("VAN_EX1_298", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_EX1_390] Tauren Warrior - COST:3 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -7005,6 +7005,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_EX1_396", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_EX1_399] Gurubashi Berserker - COST:5 [ATK:2/HP:7]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -6860,6 +6860,10 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - CHARGE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<EnqueueTask>(
+        TaskList{ std::make_shared<SummonOpTask>("EX1_116t") }, 2));
+    cards.emplace("VAN_EX1_116", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_EX1_162] Dire Wolf Alpha - COST:2 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -6991,6 +6991,10 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - ENRAGED = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(
+        std::make_shared<Trigger>(Triggers::EnrageTrigger("EX1_393e")));
+    cards.emplace("VAN_EX1_393", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_EX1_396] Mogu'shan Warden - COST:4 [ATK:1/HP:7]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -6968,7 +6968,8 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [VAN_EX1_390] Tauren Warrior - COST:3 [ATK:2/HP:3]
     // - Set: VANILLA, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>. <b>Enrage:</b> +3 Attack
+    // Text: <b>Taunt</b>.
+    //       <b>Enrage:</b> +3 Attack
     // --------------------------------------------------------
     // GameTag:
     // - TAUNT = 1
@@ -6976,6 +6977,10 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - ENRAGED = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(
+        std::make_shared<Trigger>(Triggers::EnrageTrigger("EX1_390e")));
+    cards.emplace("VAN_EX1_390", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_EX1_393] Amani Berserker - COST:2 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -7034,6 +7034,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("VAN_EX1_405", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_EX1_412] Raging Worgen - COST:3 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -7018,6 +7018,12 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TAKE_DAMAGE));
+    power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "EX1_399e", EntityType::SOURCE) };
+    cards.emplace("VAN_EX1_399", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_EX1_405] Shieldbearer - COST:1 [ATK:0/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/VanillaCardsGen.cpp
@@ -6937,6 +6937,9 @@ void VanillaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - SPELLPOWER = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cards.emplace("VAN_EX1_284", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [VAN_EX1_298] Ragnaros the Firelord - COST:8 [ATK:8/HP:8]

--- a/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
@@ -116,7 +116,8 @@ void CardLoader::Load(std::vector<Card*>& cards)
             GameTag gameTag = StrToEnum<GameTag>(mechanic.get<std::string>());
 
             // NOTE: Erase mechanics 'FREEZE' of Frost Elemental (EX1_283)
-            if (dbfID == 512 && gameTag == GameTag::FREEZE)
+            // NOTE: Erase mechanics 'FREEZE' of Frost Elemental (VAN_EX1_283)
+            if ((dbfID == 512 || dbfID == 69906) && gameTag == GameTag::FREEZE)
             {
                 continue;
             }

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -11541,8 +11541,8 @@ TEST_CASE("[Neutral : Minion] - EX1_110 : Cairne Bloodhoof")
 // [EX1_116] Leeroy Jenkins - COST:5 [ATK:6/HP:2]
 // - Faction: Alliance, Set: Expert1, Rarity: Legendary
 // --------------------------------------------------------
-// Text: <b>Charge</b>. <b>Battlecry:</b> Summon two 1/1 Whelps
-//       for your opponent.
+// Text: <b>Charge</b>.
+//       <b>Battlecry:</b> Summon two 1/1 Whelps for your opponent.
 // --------------------------------------------------------
 // GameTag:
 // - ELITE = 1

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -18522,3 +18522,17 @@ TEST_CASE("[Warrior : Minion] - VAN_EX1_393 : Amani Berserker")
     CHECK_EQ(curField[0]->GetAttack(), 5);
     CHECK_EQ(curField[0]->GetHealth(), 2);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [VAN_EX1_396] Mogu'shan Warden - COST:4 [ATK:1/HP:7]
+// - Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_EX1_396 : Mogu'shan Warden")
+{
+    // Do nothing
+}

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -18591,3 +18591,17 @@ TEST_CASE("[Neutral : Minion] - VAN_EX1_399 : Gurubashi Berserker")
     game.Process(opPlayer, HeroPowerTask(card1));
     CHECK_EQ(curField[0]->GetAttack(), 8);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [VAN_EX1_405] Shieldbearer - COST:1 [ATK:0/HP:4]
+// - Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_EX1_405 : Shieldbearer")
+{
+    // Do nothing
+}

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -18036,3 +18036,89 @@ TEST_CASE("[Neutral : Minion] - VAN_EX1_116 : Leeroy Jenkins")
     CHECK_EQ(opField[1]->GetHealth(), 1);
     CHECK_EQ(opField[1]->GetAttack(), 1);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [VAN_EX1_162] Dire Wolf Alpha - COST:2 [ATK:2/HP:2]
+// - Race: Beast, Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: Adjacent minions have +1 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - ADJACENT_BUFF = 1
+// - AURA = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_EX1_162 : Dire Wolf Alpha")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wisp", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wisp", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wisp", FormatType::CLASSIC));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wisp", FormatType::CLASSIC));
+    const auto card5 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Wisp", FormatType::CLASSIC));
+    const auto card6 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Dire Wolf Alpha", FormatType::CLASSIC));
+    const auto card7 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Fireball", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[2]->GetAttack(), 1);
+    CHECK_EQ(curField[3]->GetAttack(), 1);
+
+    game.Process(curPlayer, PlayCardTask(card6, nullptr, 2));
+    CHECK_EQ(curField[2]->card->name, "Dire Wolf Alpha");
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[3]->GetAttack(), 2);
+    CHECK_EQ(curField[4]->GetAttack(), 1);
+
+    game.Process(curPlayer, PlayCardTask(card5, nullptr, 3));
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[3]->GetAttack(), 2);
+    CHECK_EQ(curField[4]->GetAttack(), 1);
+    CHECK_EQ(card5, curField[3]);
+    CHECK_EQ(card3, curField[4]);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[3]->GetAttack(), 2);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card7, card6));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[2]->GetAttack(), 1);
+    CHECK_EQ(curField[3]->GetAttack(), 1);
+    CHECK_EQ(curField[4]->GetAttack(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -18305,3 +18305,61 @@ TEST_CASE("[Neutral : Minion] - VAN_EX1_283 : Frost Elemental")
     CHECK_EQ(curField[1]->GetGameTag(GameTag::DAMAGE), 5);
     CHECK_EQ(curField[1]->IsFrozen(), false);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [VAN_EX1_284] Azure Drake - COST:5 [ATK:4/HP:4]
+// - Race: Dragon, Set: VANILLA, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Spell Damage +1</b>
+//       <b>Battlecry:</b> Draw a card.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - SPELLPOWER = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_EX1_284 : Azure Drake")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Azure Drake", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Fireball", FormatType::CLASSIC));
+    const auto card3 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Archmage", FormatType::CLASSIC));
+
+    const auto curHandCount = curPlayer->GetHandZone()->GetCount();
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), curHandCount);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card3));
+
+    CHECK_EQ(curPlayer->GetFieldZone()->GetCount(), 1);
+    CHECK_EQ(opPlayer->GetFieldZone()->GetCount(), 0);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -18426,3 +18426,54 @@ TEST_CASE("[Neutral : Minion] - VAN_EX1_298 : Ragnaros the Firelord")
         opPlayer->GetHero()->GetHealth() == 14 || opField[0]->GetHealth() == 1;
     CHECK_EQ(check, true);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [VAN_EX1_390] Tauren Warrior - COST:3 [ATK:2/HP:3]
+// - Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>.
+//       <b>Enrage:</b> +3 Attack
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+// RefTag:
+// - ENRAGED = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_EX1_390 : Tauren Warrior")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Tauren Warrior", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAUNT), 1);
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField[0]->GetGameTag(GameTag::TAUNT), 1);
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -18122,3 +18122,50 @@ TEST_CASE("[Neutral : Minion] - VAN_EX1_162 : Dire Wolf Alpha")
     CHECK_EQ(curField[3]->GetAttack(), 1);
     CHECK_EQ(curField[4]->GetAttack(), 1);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [VAN_EX1_170] Emperor Cobra - COST:3 [ATK:2/HP:3]
+// - Race: Beast, Set: VANILLA, Rarity: Rare
+// --------------------------------------------------------
+// Text: Destroy any minion damaged by this minion.
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_EX1_170 : Emperor Cobra")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Emperor Cobra", FormatType::CLASSIC));
+    const auto card2 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Chillwind Yeti", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(card1, card2));
+
+    CHECK(card2->isDestroyed);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -17989,3 +17989,50 @@ TEST_CASE("[Neutral : Minion] - VAN_EX1_112 : Gelbin Mekkatorque")
                          curField[1]->card->name == "Poultryizer";
     CHECK(isMekka);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [VAN_EX1_116] Leeroy Jenkins - COST:4 [ATK:6/HP:2]
+// - Faction: Alliance, Set: VANILLA, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Charge</b>.
+//       <b>Battlecry:</b> Summon two 1/1 Whelps for your opponent.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// - CHARGE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_EX1_116 : Leeroy Jenkins")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Leeroy Jenkins", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(opField.GetCount(), 2);
+    CHECK_EQ(opField[0]->GetHealth(), 1);
+    CHECK_EQ(opField[0]->GetAttack(), 1);
+    CHECK_EQ(opField[1]->GetHealth(), 1);
+    CHECK_EQ(opField[1]->GetAttack(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -18477,3 +18477,48 @@ TEST_CASE("[Neutral : Minion] - VAN_EX1_390 : Tauren Warrior")
     CHECK_EQ(curField[0]->GetAttack(), 5);
     CHECK_EQ(curField[0]->GetHealth(), 2);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [VAN_EX1_393] Amani Berserker - COST:2 [ATK:2/HP:3]
+// - Set: VANILLA, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Enrage:</b> +3 Attack
+// --------------------------------------------------------
+// RefTag:
+// - ENRAGED = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - VAN_EX1_393 : Amani Berserker")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Amani Berserker", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/VanillaCardsGenTests.cpp
@@ -18536,3 +18536,58 @@ TEST_CASE("[Neutral : Minion] - VAN_EX1_396 : Mogu'shan Warden")
 {
     // Do nothing
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [VAN_EX1_399] Gurubashi Berserker - COST:5 [ATK:2/HP:7]
+// - Set: VANILLA, Rarity: Free
+// --------------------------------------------------------
+// Text: Whenever this minion takes damage, gain +3 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - VAN_EX1_399 : Gurubashi Berserker")
+{
+    GameConfig config;
+    config.formatType = FormatType::CLASSIC;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer,
+        Cards::FindCardByName("Gurubashi Berserker", FormatType::CLASSIC));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 8);
+}


### PR DESCRIPTION
This revision includes:
- Implement 12 VANILLA cards (#674)
  - Leeroy Jenkins (VAN_EX1_116)
  - Dire Wolf Alpha (VAN_EX1_162)
  - Emperor Cobra (VAN_EX1_170)
  - Baron Geddon (VAN_EX1_249)
  - Frost Elemental (VAN_EX1_283)
  - Azure Drake (VAN_EX1_284)
  - Ragnaros the Firelord (VAN_EX1_298)
  - Tauren Warrior (VAN_EX1_390)
  - Amani Berserker (VAN_EX1_393)
  - Mogu'shan Warden (VAN_EX1_396)
  - Gurubashi Berserker (VAN_EX1_399)
  - Shieldbearer (VAN_EX1_405)
- Separate text to improve readability
- Add code to erase mechanics 'FREEZE' of 'Frost Elemental'