### PR TITLE
Implement 11 NAXX cards

### DIFF
--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -480,17 +480,17 @@ DEMON_HUNTER_INITIATE | BT_937 | Altruis the Outcast | O
 
 Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
-NAXX | FP1_001 | Zombie Chow |  
-NAXX | FP1_002 | Haunted Creeper |  
-NAXX | FP1_003 | Echoing Ooze |  
-NAXX | FP1_004 | Mad Scientist |  
-NAXX | FP1_005 | Shade of Naxxramas |  
+NAXX | FP1_001 | Zombie Chow | O
+NAXX | FP1_002 | Haunted Creeper | O
+NAXX | FP1_003 | Echoing Ooze | O
+NAXX | FP1_004 | Mad Scientist | O
+NAXX | FP1_005 | Shade of Naxxramas | O
 NAXX | FP1_007 | Nerubian Egg | O
-NAXX | FP1_008 | Spectral Knight |  
-NAXX | FP1_009 | Deathlord |  
-NAXX | FP1_010 | Maexxna |  
+NAXX | FP1_008 | Spectral Knight | O
+NAXX | FP1_009 | Deathlord | O
+NAXX | FP1_010 | Maexxna | O
 NAXX | FP1_011 | Webspinner | O
-NAXX | FP1_012 | Sludge Belcher |  
+NAXX | FP1_012 | Sludge Belcher | O
 NAXX | FP1_013 | Kel'Thuzad |  
 NAXX | FP1_014 | Stalagg |  
 NAXX | FP1_015 | Feugen |  
@@ -499,8 +499,8 @@ NAXX | FP1_017 | Nerub'ar Weblord |
 NAXX | FP1_018 | Duplicate | O
 NAXX | FP1_019 | Poison Seeds | O
 NAXX | FP1_020 | Avenge | O
-NAXX | FP1_021 | Death's Bite |  
-NAXX | FP1_022 | Voidcaller |  
+NAXX | FP1_021 | Death's Bite | O
+NAXX | FP1_022 | Voidcaller | O
 NAXX | FP1_023 | Dark Cultist | O
 NAXX | FP1_024 | Unstable Ghoul |  
 NAXX | FP1_025 | Reincarnate | O
@@ -511,7 +511,7 @@ NAXX | FP1_029 | Dancing Swords |
 NAXX | FP1_030 | Loatheb |  
 NAXX | FP1_031 | Baron Rivendare | O
 
-- Progress: 30% (9 of 30 Cards)
+- Progress: 66% (20 of 30 Cards)
 
 ## Goblins vs Gnomes
 

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -51,6 +51,10 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsDeckEmpty();
 
+    //! SelfCondition wrapper for checking the secret zone is full.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsSecretFull();
+
     //! SelfCondition wrapper for checking the hero is Galakrond.
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsGalakrondHero();

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
@@ -59,6 +59,18 @@ class ComplexTask
         };
     }
 
+    //! Returns a list of task for summoning a opponent minion from your deck.
+    static TaskList SummonOpMinionFromDeck()
+    {
+        return TaskList{
+            std::make_shared<SimpleTasks::IncludeTask>(EntityType::ENEMY_DECK),
+            std::make_shared<SimpleTasks::FilterStackTask>(SelfCondList{
+                std::make_shared<SelfCondition>(SelfCondition::IsMinion()) }),
+            std::make_shared<SimpleTasks::RandomTask>(EntityType::STACK, 1),
+            std::make_shared<SimpleTasks::SummonStackTask>(true)
+        };
+    }
+
     //! Returns a list of task for summoning a \p race minion from your deck.
     //! \param race The race of minion(s) to summon.
     static TaskList SummonRaceMinionFromDeck(Race race)

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
@@ -11,7 +11,6 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 #include <Rosetta/PlayMode/Zones/DeckZone.hpp>
 #include <Rosetta/PlayMode/Zones/HandZone.hpp>
-#include <Rosetta/PlayMode/Zones/SecretZone.hpp>
 
 #include <effolkronium/random.hpp>
 
@@ -45,64 +44,6 @@ class ComplexTask
             std::make_shared<SimpleTasks::RandomTask>(EntityType::STACK,
                                                       amount),
             std::make_shared<SimpleTasks::DrawStackTask>(addToStack)
-        };
-    }
-
-    //! Returns a list of task for putting a secret from your deck.
-    static TaskList PutSecretFromDeck()
-    {
-        return TaskList{
-            std::make_shared<SimpleTasks::ConditionTask>(
-                EntityType::SOURCE,
-                SelfCondList{ std::make_shared<SelfCondition>(
-                    SelfCondition::IsSecretFull()) }),
-            std::make_shared<SimpleTasks::FlagTask>(
-                false,
-                TaskList{
-                    std::make_shared<SimpleTasks::IncludeTask>(
-                        EntityType::DECK),
-                    std::make_shared<SimpleTasks::FilterStackTask>(
-                        SelfCondList{ std::make_shared<SelfCondition>(
-                            SelfCondition::IsSecret()) }),
-                    std::make_shared<SimpleTasks::FuncPlayableTask>(
-                        [=](const std::vector<Playable*>& playables) {
-                            if (playables.empty())
-                            {
-                                return std::vector<Playable*>{};
-                            }
-
-                            auto secrets = playables;
-                            Random::shuffle(secrets);
-
-                            const Player* player = playables[0]->player;
-                            const auto activeSecrets =
-                                player->GetSecretZone()->GetAll();
-
-                            for (const auto& secret : secrets)
-                            {
-                                bool isExist = false;
-                                for (auto& activeSecret : activeSecrets)
-                                {
-                                    if (secret->card->id ==
-                                        activeSecret->card->id)
-                                    {
-                                        isExist = true;
-                                        break;
-                                    }
-                                }
-
-                                if (!isExist)
-                                {
-                                    Playable* playable =
-                                        player->GetDeckZone()->Remove(secret);
-                                    player->GetSecretZone()->Add(playable);
-
-                                    break;
-                                }
-                            }
-
-                            return std::vector<Playable*>{};
-                        }) })
         };
     }
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * **100% Legacy (167 of 167 Cards)**
   * **100% Expert1 (245 of 245 Cards)**
   * **100% Demon Hunter Initiate (20 of 20 Cards)**
-  * 30% Curse of Naxxramas (9 of 30 Cards)
+  * 66% Curse of Naxxramas (20 of 30 Cards)
   * 5% Goblins vs Gnomes (7 of 123 Cards)
   * 3% Blackrock Mountain (1 of 31 Cards)
   * 6% The Grand Tournament (8 of 132 Cards)

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -386,6 +386,9 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(ComplexTask::PutSecretFromDeck());
+    cards.emplace("FP1_004", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_005] Shade of Naxxramas - COST:3 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -259,6 +259,8 @@ void NaxxCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
 void NaxxCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- MINION - WARLOCK
     // [FP1_022] Voidcaller - COST:4 [ATK:3/HP:4]
     // - Race: Demon, Set: Naxx, Rarity: Common
@@ -269,6 +271,14 @@ void NaxxCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(std::make_shared<IncludeTask>(EntityType::HAND));
+    power.AddDeathrattleTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::DEMON)) }));
+    power.AddDeathrattleTask(
+        std::make_shared<RandomTask>(EntityType::STACK, 1));
+    power.AddDeathrattleTask(std::make_shared<SummonStackTask>(true));
+    cards.emplace("FP1_022", CardDef(power));
 }
 
 void NaxxCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -400,6 +400,11 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - STEALTH = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "FP1_005e", EntityType::SOURCE) };
+    cards.emplace("FP1_005", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_007] Nerubian Egg - COST:2 [ATK:0/HP:2]
@@ -613,6 +618,9 @@ void NaxxCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Increased stats.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(Enchants::GetEnchantFromText("FP1_005e"));
+    cards.emplace("FP1_005e", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_006] Deathcharger (*) - COST:1 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -387,7 +387,7 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - SECRET = 1
     // --------------------------------------------------------
     power.ClearData();
-    power.AddDeathrattleTask(ComplexTask::PutSecretFromDeck());
+    power.AddDeathrattleTask(ComplexTask::CastSecretFromDeck());
     cards.emplace("FP1_004", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -622,7 +622,7 @@ void NaxxCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
     // Text: Increased stats.
     // --------------------------------------------------------
     power.ClearData();
-    power.AddEnchant(Enchants::GetEnchantFromText("FP1_005e"));
+    power.AddEnchant(std::make_shared<Enchant>(Effects::AttackHealthN(1)));
     cards.emplace("FP1_005e", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -338,6 +338,10 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("FP1_002t", 2, SummonSide::DEATHRATTLE));
+    cards.emplace("FP1_002", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_003] Echoing Ooze - COST:2 [ATK:1/HP:2]
@@ -577,6 +581,9 @@ void NaxxCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
     // [FP1_002t] Spectral Spider (*) - COST:1 [ATK:1/HP:1]
     // - Set: Naxx
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("FP1_002t", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [FP1_005e] Consume (*) - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -474,6 +474,10 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - TAUNT = 1
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("FP1_012t", SummonSide::DEATHRATTLE));
+    cards.emplace("FP1_012", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_013] Kel'Thuzad - COST:8 [ATK:6/HP:8]
@@ -651,7 +655,7 @@ void NaxxCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
     cards.emplace("FP1_007t", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
-    // [FP1_012t] Slime (*) - COST:1 [ATK:1/HP:2]
+    // [FP1_012t] Putrid Slime (*) - COST:1 [ATK:1/HP:2]
     // - Set: Naxx
     // --------------------------------------------------------
     // Text: <b>Taunt</b>
@@ -659,6 +663,9 @@ void NaxxCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("FP1_012t", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_014t] Thaddius (*) - COST:10 [ATK:11/HP:11]

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -430,6 +430,9 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - CANT_BE_TARGETED_BY_SPELLS = 1
     // - CANT_BE_TARGETED_BY_HERO_POWERS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("FP1_008", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_009] Deathlord - COST:3 [ATK:2/HP:8]

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -459,6 +459,9 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - POISONOUS = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(nullptr);
+    cards.emplace("FP1_010", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_012] Sludge Belcher - COST:5 [ATK:3/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -324,6 +324,10 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<HealTask>(EntityType::ENEMY_HERO, 5));
+    cards.emplace("FP1_001", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_002] Haunted Creeper - COST:2 [ATK:1/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -353,6 +353,25 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(
+        EntityType::SOURCE, GameTag::CUSTOM_KEYWORD_EFFECT, 1));
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(
+        EntityType::SOURCE, GameTag::TAG_SCRIPT_DATA_NUM_1, 1));
+    power.AddPowerTask(std::make_shared<SetGameTagTask>(
+        EntityType::SOURCE, GameTag::MULTIPLY_BUFF_VALUE, 1));
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsTagValue(GameTag::CUSTOM_KEYWORD_EFFECT, 1)) };
+    power.GetTrigger()->tasks = {
+        std::make_shared<SetGameTagTask>(EntityType::SOURCE,
+                                         GameTag::CUSTOM_KEYWORD_EFFECT, 0),
+        std::make_shared<SummonCopyTask>(EntityType::SOURCE, false, false,
+                                         SummonSide::RIGHT)
+    };
+    power.GetTrigger()->removeAfterTriggered = true;
+    cards.emplace("FP1_003", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_004] Mad Scientist - COST:2 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -445,6 +445,9 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - TAUNT = 1
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(ComplexTask::SummonOpMinionFromDeck());
+    cards.emplace("FP1_009", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_010] Maexxna - COST:6 [ATK:2/HP:8]

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -288,6 +288,8 @@ void NaxxCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
 
 void NaxxCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+
     // --------------------------------------- WEAPON - WARRIOR
     // [FP1_021] Death's Bite - COST:4 [ATK:4/HP:0]
     // - Set: Naxx, Rarity: Common
@@ -298,6 +300,10 @@ void NaxxCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // - DURABILITY = 2
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<DamageTask>(EntityType::ALL_MINIONS, 1));
+    cards.emplace("FP1_021", CardDef(power));
 }
 
 void NaxxCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -70,6 +70,13 @@ SelfCondition SelfCondition::IsDeckEmpty()
     });
 }
 
+SelfCondition SelfCondition::IsSecretFull()
+{
+    return SelfCondition([](Playable* playable) {
+        return playable->player->GetSecretZone()->IsFull();
+    });
+}
+
 SelfCondition SelfCondition::IsHeroPowerCard(const std::string& cardID)
 {
     return SelfCondition([cardID](Playable* playable) {

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -593,6 +593,55 @@ TEST_CASE("[Warrior : Weapon] - FP1_021 : Death's Bite")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [FP1_001] Zombie Chow - COST:1 [ATK:2/HP:3]
+// - Set: Naxx, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Restore 5 Health to the enemy hero.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_001 : Zombie Chow")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Zombie Chow"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 15);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField.GetCount(), 0);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 20);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [FP1_007] Nerubian Egg - COST:2 [ATK:0/HP:2]
 // - Set: Naxx, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -928,6 +928,59 @@ TEST_CASE("[Neutral : Minion] - FP1_008 : Spectral Knight")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [FP1_009] Deathlord - COST:3 [ATK:2/HP:8]
+// - Set: Naxx, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Taunt. Deathrattle:</b> Your opponent
+//       puts a minion from their deck into the battlefield.
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_009 : Deathlord")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; ++i)
+    {
+        config.player2Deck[i] = Cards::FindCardByName("Malygos");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Deathlord"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Pyroblast"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->card->name, "Malygos");
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [FP1_031] Baron Rivendare - COST:4 [ATK:1/HP:7]
 // - Set: Naxx, Rarity: Legendary
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -981,6 +981,21 @@ TEST_CASE("[Neutral : Minion] - FP1_009 : Deathlord")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [FP1_010] Maexxna - COST:6 [ATK:2/HP:8]
+// - Race: Beast, Set: Naxx, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Poisonous</b>
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - POISONOUS = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_010 : Maexxna")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [FP1_031] Baron Rivendare - COST:4 [ATK:1/HP:7]
 // - Set: Naxx, Rarity: Legendary
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -813,6 +813,57 @@ TEST_CASE("[Neutral : Minion] - FP1_004 : Mad Scientist")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [FP1_005] Shade of Naxxramas - COST:3 [ATK:2/HP:2]
+// - Set: Naxx, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Stealth.</b>
+//       At the start of your turn, gain +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - STEALTH = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_005 : Shade of Naxxramas")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Shade of Naxxramas"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasStealth(), true);
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->HasStealth(), true);
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [FP1_007] Nerubian Egg - COST:2 [ATK:0/HP:2]
 // - Set: Naxx, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -913,6 +913,21 @@ TEST_CASE("[Neutral : Minion] - FP1_007 : Nerubian Egg")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [FP1_008] Spectral Knight - COST:5 [ATK:4/HP:6]
+// - Set: Naxx, Rarity: Common
+// --------------------------------------------------------
+// Text: Can't be targeted by spells or Hero Powers.
+// --------------------------------------------------------
+// GameTag:
+// - CANT_BE_TARGETED_BY_SPELLS = 1
+// - CANT_BE_TARGETED_BY_HERO_POWERS = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_008 : Spectral Knight")
+{
+    // Do nothing
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [FP1_031] Baron Rivendare - COST:4 [ATK:1/HP:7]
 // - Set: Naxx, Rarity: Legendary
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -694,6 +694,59 @@ TEST_CASE("[Neutral : Minion] - FP1_002 : Haunted Creeper")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [FP1_003] Echoing Ooze - COST:2 [ATK:1/HP:2]
+// - Set: Naxx, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Summon an exact copy
+//       of this minion at the end of the turn.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_003 : Echoing Ooze")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Echoing Ooze"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[1]->card->name, "Echoing Ooze");
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 2);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [FP1_007] Nerubian Egg - COST:2 [ATK:0/HP:2]
 // - Set: Naxx, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -642,6 +642,58 @@ TEST_CASE("[Neutral : Minion] - FP1_001 : Zombie Chow")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [FP1_002] Haunted Creeper - COST:2 [ATK:1/HP:2]
+// - Race: Beast, Set: Naxx, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Summon two 1/1 Spectral Spiders.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_002 : Haunted Creeper")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Haunted Creeper"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Spectral Spider");
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->card->name, "Spectral Spider");
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [FP1_007] Nerubian Egg - COST:2 [ATK:0/HP:2]
 // - Set: Naxx, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -471,6 +471,60 @@ TEST_CASE("[Shaman : Spell] - FP1_025 : Reincarnate")
     CHECK_EQ(curField[0]->GetHealth(), 12);
 }
 
+// --------------------------------------- MINION - WARLOCK
+// [FP1_022] Voidcaller - COST:4 [ATK:3/HP:4]
+// - Race: Demon, Set: Naxx, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Put a random Demon
+//       from your hand into the battlefield.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - FP1_022 : Voidcaller")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Voidcaller"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flame Imp"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card1));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Flame Imp");
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [FP1_007] Nerubian Egg - COST:2 [ATK:0/HP:2]
 // - Set: Naxx, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -996,6 +996,58 @@ TEST_CASE("[Neutral : Minion] - FP1_010 : Maexxna")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [FP1_012] Sludge Belcher - COST:5 [ATK:3/HP:5]
+// - Set: Naxx, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Taunt Deathrattle:</b> Summon a 1/2 Slime
+//       with <b>Taunt</b>.
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_012 : Sludge Belcher")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Sludge Belcher"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Putrid Slime");
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [FP1_031] Baron Rivendare - COST:4 [ATK:1/HP:7]
 // - Set: Naxx, Rarity: Legendary
 // --------------------------------------------------------


### PR DESCRIPTION
This revision includes:
- Implement 11 NAXX cards
  - Zombie Chow (FP1_001)
  - Haunted Creeper (FP1_002)
  - Echoing Ooze (FP1_003)
  - Mad Scientist (FP1_004)
  - Shade of Naxxramas (FP1_005)
  - Spectral Knight (FP1_008)
  - Deathlord (FP1_009)
  - Maexxna (FP1_010)
  - Sludge Belcher (FP1_012)
  - Death's Bite (FP1_021)
  - Voidcaller (FP1_022)
- Add self condition 'IsSecretFull()': SelfCondition wrapper for checking the secret zone is full
- Add complex task 'SummonOpMinionFromDeck()': Returns a list of task for summoning a opponent minion from your deck