### PR TITLE
Implement 10 NAXX cards

### DIFF
--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -491,27 +491,27 @@ NAXX | FP1_009 | Deathlord | O
 NAXX | FP1_010 | Maexxna | O
 NAXX | FP1_011 | Webspinner | O
 NAXX | FP1_012 | Sludge Belcher | O
-NAXX | FP1_013 | Kel'Thuzad |  
-NAXX | FP1_014 | Stalagg |  
-NAXX | FP1_015 | Feugen |  
-NAXX | FP1_016 | Wailing Soul |  
-NAXX | FP1_017 | Nerub'ar Weblord |  
+NAXX | FP1_013 | Kel'Thuzad | O
+NAXX | FP1_014 | Stalagg | O
+NAXX | FP1_015 | Feugen | O
+NAXX | FP1_016 | Wailing Soul | O
+NAXX | FP1_017 | Nerub'ar Weblord | O
 NAXX | FP1_018 | Duplicate | O
 NAXX | FP1_019 | Poison Seeds | O
 NAXX | FP1_020 | Avenge | O
 NAXX | FP1_021 | Death's Bite | O
 NAXX | FP1_022 | Voidcaller | O
 NAXX | FP1_023 | Dark Cultist | O
-NAXX | FP1_024 | Unstable Ghoul |  
+NAXX | FP1_024 | Unstable Ghoul | O
 NAXX | FP1_025 | Reincarnate | O
 NAXX | FP1_026 | Anub'ar Ambusher | O
-NAXX | FP1_027 | Stoneskin Gargoyle |  
-NAXX | FP1_028 | Undertaker |  
-NAXX | FP1_029 | Dancing Swords |  
-NAXX | FP1_030 | Loatheb |  
+NAXX | FP1_027 | Stoneskin Gargoyle | O
+NAXX | FP1_028 | Undertaker | O
+NAXX | FP1_029 | Dancing Swords | O
+NAXX | FP1_030 | Loatheb | O
 NAXX | FP1_031 | Baron Rivendare | O
 
-- Progress: 66% (20 of 30 Cards)
+- Progress: 100% (30 of 30 Cards)
 
 ## Goblins vs Gnomes
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * **100% Legacy (167 of 167 Cards)**
   * **100% Expert1 (245 of 245 Cards)**
   * **100% Demon Hunter Initiate (20 of 20 Cards)**
-  * 66% Curse of Naxxramas (20 of 30 Cards)
+  * **100% Curse of Naxxramas (30 of 30 Cards)**
   * 5% Goblins vs Gnomes (7 of 123 Cards)
   * 3% Blackrock Mountain (1 of 31 Cards)
   * 6% The Grand Tournament (8 of 132 Cards)

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -675,6 +675,14 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::SUMMON));
+    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    power.GetTrigger()->conditions = { std::make_shared<SelfCondition>(
+        SelfCondition::IsDeathrattleCard()) };
+    power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "FP1_028e", EntityType::SOURCE) };
+    cards.emplace("FP1_028", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_029] Dancing Swords - COST:3 [ATK:4/HP:4]
@@ -789,6 +797,9 @@ void NaxxCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Increased stats.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddEnchant(std::make_shared<Enchant>(Effects::AttackN(1)));
+    cards.emplace("FP1_028e", CardDef(power));
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [FP1_030e] Necrotic Aura (*) - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -659,6 +659,11 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // Text: At the start of your turn,
     //       restore this minion to full Health.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_START));
+    power.GetTrigger()->tasks = { std::make_shared<HealFullTask>(
+        EntityType::SOURCE) };
+    cards.emplace("FP1_027", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_028] Undertaker - COST:1 [ATK:1/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -693,6 +693,9 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(std::make_shared<DrawOpTask>(1));
+    cards.emplace("FP1_029", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_030] Loatheb - COST:5 [ATK:5/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -559,6 +559,43 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<FuncNumberTask>([](Playable* playable) {
+            Player* player = playable->player;
+            bool isFeugenDead = false;
+
+            const auto curGraveyard = player->GetGraveyardZone();
+            const auto opGraveyard = player->opponent->GetGraveyardZone();
+
+            for (const auto& minion : curGraveyard->GetAll())
+            {
+                if (minion->card->id == "FP1_014" && minion->isDestroyed)
+                {
+                    isFeugenDead = true;
+                    break;
+                }
+            }
+
+            for (const auto& minion : opGraveyard->GetAll())
+            {
+                if (minion->card->id == "FP1_014" && minion->isDestroyed)
+                {
+                    isFeugenDead = true;
+                    break;
+                }
+            }
+
+            if (isFeugenDead && !player->GetFieldZone()->IsFull())
+            {
+                const auto thaddius = Entity::GetFromCard(
+                    player, Cards::FindCardByID("FP1_014t"));
+                Generic::Summon(dynamic_cast<Minion*>(thaddius), -1, playable);
+            }
+
+            return 0;
+        }));
+    cards.emplace("FP1_015", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_016] Wailing Soul - COST:4 [ATK:3/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -626,6 +626,15 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<Aura>(AuraType::HANDS,
+                                         EffectList{ Effects::AddCost(2) }));
+    {
+        const auto aura = dynamic_cast<Aura*>(power.GetAura());
+        aura->condition =
+            std::make_shared<SelfCondition>(SelfCondition::IsBattlecryCard());
+    }
+    cards.emplace("FP1_017", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_024] Unstable Ghoul - COST:2 [ATK:1/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -609,6 +609,10 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SILENCE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(
+        std::make_shared<SilenceTask>(EntityType::MINIONS_NOSOURCE));
+    cards.emplace("FP1_016", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_017] Nerub'ar Weblord - COST:2 [ATK:1/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -707,6 +707,10 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
+        "FP1_030e", EntityType::ENEMY_PLAYER));
+    cards.emplace("FP1_030", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_031] Baron Rivendare - COST:4 [ATK:1/HP:7]
@@ -810,6 +814,18 @@ void NaxxCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Your spells cost (5) more this turn.
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddAura(std::make_shared<Aura>(AuraType::ENEMY_HAND,
+                                         EffectList{ Effects::AddCost(5) }));
+    {
+        const auto aura = dynamic_cast<Aura*>(power.GetAura());
+        aura->condition =
+            std::make_shared<SelfCondition>(SelfCondition::IsSpell());
+        aura->removeTrigger = { TriggerType::TURN_END,
+                                std::make_shared<SelfCondition>(
+                                    SelfCondition::IsEnemyTurn()) };
+    }
+    cards.emplace("FP1_030e", CardDef(power));
 }
 
 void NaxxCardsGen::AddAll(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -489,6 +489,13 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - ELITE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    power.GetTrigger()->tasks = {
+        ComplexTask::SummonAllFriendlyDiedThisTurn()
+    };
+    power.GetTrigger()->eitherTurn = true;
+    cards.emplace("FP1_013", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_014] Stalagg - COST:5 [ATK:7/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/NaxxCardsGen.cpp
@@ -640,13 +640,17 @@ void NaxxCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [FP1_024] Unstable Ghoul - COST:2 [ATK:1/HP:3]
     // - Set: Naxx, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Taunt</b>. <b>Deathrattle:</b> Deal 1 damage
-    //       to all minions.
+    // Text: <b>Taunt</b>.
+    //       <b>Deathrattle:</b> Deal 1 damage to all minions.
     // --------------------------------------------------------
     // GameTag:
     // - TAUNT = 1
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddDeathrattleTask(
+        std::make_shared<DamageTask>(EntityType::ALL_MINIONS, 1));
+    cards.emplace("FP1_024", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [FP1_027] Stoneskin Gargoyle - COST:3 [ATK:1/HP:4]

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -1353,6 +1353,77 @@ TEST_CASE("[Neutral : Minion] - FP1_016 : Wailing Soul")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [FP1_017] Nerub'ar Weblord - COST:2 [ATK:1/HP:4]
+// - Set: Naxx, Rarity: Common
+// --------------------------------------------------------
+// Text: Minions with <b>Battlecry</b> cost (2) more.
+// --------------------------------------------------------
+// GameTag:
+// - AURA = 1
+// --------------------------------------------------------
+// RefTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_017 : Nerub'ar Weblord")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& opHand = *(opPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Nerub'ar Weblord"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Nerubian Egg"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Echoing Ooze"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Kel'Thuzad"));
+    const auto card6 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("SI:7 Infiltrator"));
+
+    CHECK_EQ(card2->GetCost(), 2);
+    CHECK_EQ(card3->GetCost(), 2);
+    CHECK_EQ(card4->GetCost(), 4);
+    CHECK_EQ(card5->GetCost(), 8);
+    CHECK_EQ(card6->GetCost(), 4);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(card2->GetCost(), 2);
+    CHECK_EQ(card3->GetCost(), 4);
+    CHECK_EQ(card4->GetCost(), 4);
+    CHECK_EQ(card5->GetCost(), 8);
+    CHECK_EQ(card6->GetCost(), 6);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card1));
+    CHECK_EQ(card2->GetCost(), 2);
+    CHECK_EQ(card3->GetCost(), 2);
+    CHECK_EQ(card5->GetCost(), 8);
+    CHECK_EQ(card6->GetCost(), 4);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [FP1_031] Baron Rivendare - COST:4 [ATK:1/HP:7]
 // - Set: Naxx, Rarity: Legendary
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -1531,6 +1531,58 @@ TEST_CASE("[Neutral : Minion] - FP1_027 : Stoneskin Gargoyle")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [FP1_028] Undertaker - COST:1 [ATK:1/HP:2]
+// - Set: Naxx, Rarity: Common
+// --------------------------------------------------------
+// Text: Whenever you summon a minion with <b>Deathrattle</b>,
+//       gain +1 Attack.
+// --------------------------------------------------------
+// RefTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_028 : Undertaker")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Undertaker"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Nerubian Egg"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Nerubian Egg"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [FP1_031] Baron Rivendare - COST:4 [ATK:1/HP:7]
 // - Set: Naxx, Rarity: Legendary
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -1125,6 +1125,90 @@ TEST_CASE("[Neutral : Minion] - FP1_013 : Kel'Thuzad")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [FP1_014] Stalagg - COST:5 [ATK:7/HP:4]
+// - Set: Naxx, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> If Feugen also died this game,
+//       summon Thaddius.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_014 : Stalagg")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Stalagg"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Stalagg"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Pyroblast"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Feugen"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Pyroblast"));
+    const auto card6 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Pyroblast"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card5, card1));
+    CHECK_EQ(curField.GetCount(), 0);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opField.GetCount(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card4));
+    CHECK_EQ(opField.GetCount(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card6, card2));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Thaddius");
+    CHECK_EQ(curField[0]->GetAttack(), 11);
+    CHECK_EQ(curField[0]->GetHealth(), 11);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [FP1_031] Baron Rivendare - COST:4 [ATK:1/HP:7]
 // - Set: Naxx, Rarity: Legendary
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -1583,6 +1583,53 @@ TEST_CASE("[Neutral : Minion] - FP1_028 : Undertaker")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [FP1_029] Dancing Swords - COST:3 [ATK:4/HP:4]
+// - Set: Naxx, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Your opponent draws a card.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_029 : Dancing Swords")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opHand = *(opPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Dancing Swords"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(opHand.GetCount(), 7);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(opHand.GetCount(), 7);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [FP1_031] Baron Rivendare - COST:4 [ATK:1/HP:7]
 // - Set: Naxx, Rarity: Legendary
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -1384,9 +1384,6 @@ TEST_CASE("[Neutral : Minion] - FP1_017 : Nerub'ar Weblord")
     opPlayer->SetTotalMana(10);
     opPlayer->SetUsedMana(0);
 
-    auto& curHand = *(curPlayer->GetHandZone());
-    auto& opHand = *(opPlayer->GetHandZone());
-
     const auto card1 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Nerub'ar Weblord"));
     const auto card2 =
@@ -1421,6 +1418,64 @@ TEST_CASE("[Neutral : Minion] - FP1_017 : Nerub'ar Weblord")
     CHECK_EQ(card3->GetCost(), 2);
     CHECK_EQ(card5->GetCost(), 8);
     CHECK_EQ(card6->GetCost(), 4);
+}
+
+// --------------------------------------- MINION - NEUTRAL
+// [FP1_024] Unstable Ghoul - COST:2 [ATK:1/HP:3]
+// - Set: Naxx, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>.
+//       <b>Deathrattle:</b> Deal 1 damage to all minions.
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_024 : Unstable Ghoul")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Unstable Ghoul"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Frostbolt"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opField.GetCount(), 1);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
+    CHECK_EQ(curField.GetCount(), 0);
+    CHECK_EQ(opField.GetCount(), 0);
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -1479,6 +1479,58 @@ TEST_CASE("[Neutral : Minion] - FP1_024 : Unstable Ghoul")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [FP1_027] Stoneskin Gargoyle - COST:3 [ATK:1/HP:4]
+// - Set: Naxx, Rarity: Common
+// --------------------------------------------------------
+// Text: At the start of your turn,
+//       restore this minion to full Health.
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_027 : Stoneskin Gargoyle")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Stoneskin Gargoyle"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Power Word: Shield"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card1));
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [FP1_031] Baron Rivendare - COST:4 [ATK:1/HP:7]
 // - Set: Naxx, Rarity: Legendary
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -1048,6 +1048,83 @@ TEST_CASE("[Neutral : Minion] - FP1_012 : Sludge Belcher")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [FP1_013] Kel'Thuzad - COST:8 [ATK:6/HP:8]
+// - Set: Naxx, Rarity: Legendary
+// --------------------------------------------------------
+// Text: At the end of each turn,
+//       summon all friendly minions that died this turn.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_013 : Kel'Thuzad")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Kel'Thuzad"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(curField.GetCount(), 4);
+
+    game.Process(curPlayer, AttackTask(card2, card5));
+    game.Process(curPlayer, AttackTask(card3, card5));
+    game.Process(curPlayer, AttackTask(card4, card5));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 4);
+
+    game.Process(opPlayer, AttackTask(card5, curField[1]));
+    CHECK_EQ(curField.GetCount(), 3);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 4);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [FP1_031] Baron Rivendare - COST:4 [ATK:1/HP:7]
 // - Set: Naxx, Rarity: Legendary
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -1299,6 +1299,60 @@ TEST_CASE("[Neutral : Minion] - FP1_015 : Feugen")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [FP1_016] Wailing Soul - COST:4 [ATK:3/HP:5]
+// - Set: Naxx, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry: Silence</b> your other minions.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// RefTag:
+// - SILENCE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_016 : Wailing Soul")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wailing Soul"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Nerubian Egg"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->HasDeathrattle(), true);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasDeathrattle(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card2));
+    CHECK_EQ(curField.GetCount(), 1);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [FP1_031] Baron Rivendare - COST:4 [ATK:1/HP:7]
 // - Set: Naxx, Rarity: Legendary
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -1196,7 +1196,97 @@ TEST_CASE("[Neutral : Minion] - FP1_014 : Stalagg")
     game.ProcessUntil(Step::MAIN_ACTION);
 
     game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card4));
-    CHECK_EQ(opField.GetCount(), 0);
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->card->name, "Thaddius");
+    CHECK_EQ(opField[0]->GetAttack(), 11);
+    CHECK_EQ(opField[0]->GetHealth(), 11);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card6, card2));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Thaddius");
+    CHECK_EQ(curField[0]->GetAttack(), 11);
+    CHECK_EQ(curField[0]->GetHealth(), 11);
+}
+
+// --------------------------------------- MINION - NEUTRAL
+// [FP1_015] Feugen - COST:5 [ATK:4/HP:7]
+// - Set: Naxx, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> If Stalagg also died this game,
+//       summon Thaddius.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_015 : Feugen")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Feugen"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Feugen"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Pyroblast"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Stalagg"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Pyroblast"));
+    const auto card6 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Pyroblast"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card5, card1));
+    CHECK_EQ(curField.GetCount(), 0);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opField.GetCount(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card4));
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->card->name, "Thaddius");
+    CHECK_EQ(opField[0]->GetAttack(), 11);
+    CHECK_EQ(opField[0]->GetHealth(), 11);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);

--- a/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/NaxxCardsGenTests.cpp
@@ -1630,6 +1630,60 @@ TEST_CASE("[Neutral : Minion] - FP1_029 : Dancing Swords")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [FP1_030] Loatheb - COST:5 [ATK:5/HP:5]
+// - Set: Naxx, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Enemy spells cost (5) more next turn.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - FP1_030 : Loatheb")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Loatheb"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(card2->GetCost(), 9);
+    CHECK_EQ(card3->GetCost(), 9);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card2->GetCost(), 9);
+    CHECK_EQ(card3->GetCost(), 9);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card2->GetCost(), 4);
+    CHECK_EQ(card3->GetCost(), 9);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [FP1_031] Baron Rivendare - COST:4 [ATK:1/HP:7]
 // - Set: Naxx, Rarity: Legendary
 // --------------------------------------------------------


### PR DESCRIPTION
This revision includes:
- Implement 10 NAXX cards
  - Kel'Thuzad (FP1_013)
  - Stalagg (FP1_014)
  - Feugen (FP1_015)
  - Wailing Soul (FP1_016)
  - Nerub'ar Weblord (FP1_017)
  - Unstable Ghoul (FP1_024)
  - Stoneskin Gargoyle (FP1_027)
  - Undertaker (FP1_028)
  - Dancing Swords (FP1_029)
  - Loatheb (FP1_030)
- Add complex task 'SummonAllFriendlyDiedThisTurn()': Returns a list of task for summoning friendly minions that died this turn