### PR TITLE
Implement new minion type 'Naga'

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -803,7 +803,7 @@ THE_SUNKEN_CITY | TSC_002 | Pufferfist |
 THE_SUNKEN_CITY | TSC_006 | Multi-Strike |  
 THE_SUNKEN_CITY | TSC_007 | Gangplank Diver |  
 THE_SUNKEN_CITY | TSC_013 | Slimescale Diver |  
-THE_SUNKEN_CITY | TSC_017 | Baba Naga |  
+THE_SUNKEN_CITY | TSC_017 | Baba Naga | O
 THE_SUNKEN_CITY | TSC_020 | Barbaric Sorceress |  
 THE_SUNKEN_CITY | TSC_023 | Barbed Nets |  
 THE_SUNKEN_CITY | TSC_026 | Colaque |  
@@ -818,7 +818,7 @@ THE_SUNKEN_CITY | TSC_054 | Mecha-Shark |
 THE_SUNKEN_CITY | TSC_055 | Seafloor Gateway |  
 THE_SUNKEN_CITY | TSC_056 | Volcanomancy |  
 THE_SUNKEN_CITY | TSC_057 | Azsharan Defector |  
-THE_SUNKEN_CITY | TSC_058 | Predation |  
+THE_SUNKEN_CITY | TSC_058 | Predation | O
 THE_SUNKEN_CITY | TSC_059 | Bubblebot |  
 THE_SUNKEN_CITY | TSC_060 | Shimmering Sunfish |  
 THE_SUNKEN_CITY | TSC_061 | The Garden's Grace |  
@@ -922,7 +922,7 @@ THE_SUNKEN_CITY | TSC_943 | Lady Ashvane |
 THE_SUNKEN_CITY | TSC_944 | The Fires of Zin-Azshari |  
 THE_SUNKEN_CITY | TSC_945 | Azsharan Saber |  
 THE_SUNKEN_CITY | TSC_946 | Urchin Spines |  
-THE_SUNKEN_CITY | TSC_947 | Naga's Pride |  
+THE_SUNKEN_CITY | TSC_947 | Naga's Pride | O
 THE_SUNKEN_CITY | TSC_948 | Gifts of Azshara |  
 THE_SUNKEN_CITY | TSC_950 | Hydralodon |  
 THE_SUNKEN_CITY | TSC_952 | Holy Maki Roll |  
@@ -934,4 +934,4 @@ THE_SUNKEN_CITY | TSC_960 | Twin-fin Fin Twin |
 THE_SUNKEN_CITY | TSC_962 | Gigafin |  
 THE_SUNKEN_CITY | TSC_963 | Filletfighter |  
 
-- Progress: 0% (0 of 135 Cards)
+- Progress: 2% (3 of 135 Cards)

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTrigger.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTrigger.hpp
@@ -36,6 +36,19 @@ class ComplexTrigger
                 EntityType::SOURCE, GameTag::TAG_SCRIPT_DATA_NUM_1, 1)
         };
     }
+
+    //! Adds a trigger for checking "If you cast a spell while holding this".
+    //! \param power A power to add the trigger.
+    static void CastSpellWhileHoldingThis(Power& power)
+    {
+        power.AddTrigger(std::make_shared<Trigger>(TriggerType::CAST_SPELL));
+        power.GetTrigger()->triggerActivation = TriggerActivation::HAND;
+        power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+        power.GetTrigger()->tasks = {
+            std::make_shared<SimpleTasks::SetGameTagTask>(
+                EntityType::SOURCE, GameTag::TAG_SCRIPT_DATA_NUM_1, 1)
+        };
+    }
 };
 }  // namespace RosettaStone::PlayMode
 

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTrigger.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTrigger.hpp
@@ -1,0 +1,23 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_PLAYMODE_COMPLEX_TRIGGER_HPP
+#define ROSETTASTONE_PLAYMODE_COMPLEX_TRIGGER_HPP
+
+namespace RosettaStone::PlayMode
+{
+//!
+//! \brief ComplexTrigger class.
+//!
+//! This class lists complex triggers such as "If you played a Naga
+//! while holding this.".
+//!
+class ComplexTrigger
+{
+ public:
+};
+}  // namespace RosettaStone::PlayMode
+
+#endif  // ROSETTASTONE_PLAYMODE_COMPLEX_TRIGGER_HPP

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTrigger.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTrigger.hpp
@@ -6,8 +6,12 @@
 #ifndef ROSETTASTONE_PLAYMODE_COMPLEX_TRIGGER_HPP
 #define ROSETTASTONE_PLAYMODE_COMPLEX_TRIGGER_HPP
 
+#include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
+
 namespace RosettaStone::PlayMode
 {
+using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
+
 //!
 //! \brief ComplexTrigger class.
 //!
@@ -17,6 +21,21 @@ namespace RosettaStone::PlayMode
 class ComplexTrigger
 {
  public:
+    //! Adds a trigger for checking "If you played a Naga while holding this".
+    //! \param power A power to add the trigger.
+    static void PlayedNagaWhileHoldingThis(Power& power)
+    {
+        power.AddTrigger(std::make_shared<Trigger>(TriggerType::PLAY_CARD));
+        power.GetTrigger()->triggerActivation = TriggerActivation::HAND;
+        power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+        power.GetTrigger()->conditions = SelfCondList{
+            std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::NAGA))
+        };
+        power.GetTrigger()->tasks = {
+            std::make_shared<SimpleTasks::SetGameTagTask>(
+                EntityType::SOURCE, GameTag::TAG_SCRIPT_DATA_NUM_1, 1)
+        };
+    }
 };
 }  // namespace RosettaStone::PlayMode
 

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -161,6 +161,7 @@
 #include <Rosetta/PlayMode/Models/Spell.hpp>
 #include <Rosetta/PlayMode/Models/Weapon.hpp>
 #include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
+#include <Rosetta/PlayMode/Tasks/ComplexTrigger.hpp>
 #include <Rosetta/PlayMode/Tasks/EventMetaData.hpp>
 #include <Rosetta/PlayMode/Tasks/ITask.hpp>
 #include <Rosetta/PlayMode/Tasks/PlayerTasks.hpp>

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 81% Forged in the Barrens (139 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
-  * 0% Voyage to the Sunken City (0 of 135 cards)
+  * 2% Voyage to the Sunken City (3 of 135 cards)
 
 ### Wild Format
 

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -5,6 +5,7 @@
 
 #include <Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
+#include <Rosetta/PlayMode/Tasks/ComplexTrigger.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 #include <Rosetta/PlayMode/Zones/HandZone.hpp>
 
@@ -366,14 +367,7 @@ void TheSunkenCityCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     power.AddPowerTask(std::make_shared<FlagTask>(
         true, TaskList{ std::make_shared<AddEnchantmentTask>(
                   "TSC_947e", EntityType::STACK) }));
-    power.AddTrigger(std::make_shared<Trigger>(TriggerType::PLAY_CARD));
-    power.GetTrigger()->triggerActivation = TriggerActivation::HAND;
-    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->conditions = SelfCondList{
-        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::NAGA))
-    };
-    power.GetTrigger()->tasks = { std::make_shared<SetGameTagTask>(
-        EntityType::SOURCE, GameTag::TAG_SCRIPT_DATA_NUM_1, 1) };
+    ComplexTrigger::PlayedNagaWhileHoldingThis(power);
     cards.emplace(
         "TSC_947",
         CardDef(power, PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } }));
@@ -1942,14 +1936,7 @@ void TheSunkenCityCardsGen::AddDemonHunter(
 
         return 0;
     }));
-    power.AddTrigger(std::make_shared<Trigger>(TriggerType::PLAY_CARD));
-    power.GetTrigger()->triggerActivation = TriggerActivation::HAND;
-    power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
-    power.GetTrigger()->conditions = SelfCondList{
-        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::NAGA))
-    };
-    power.GetTrigger()->tasks = { std::make_shared<SetGameTagTask>(
-        EntityType::SOURCE, GameTag::TAG_SCRIPT_DATA_NUM_1, 1) };
+    ComplexTrigger::PlayedNagaWhileHoldingThis(power);
     cards.emplace(
         "TSC_058",
         CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } }));

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -2134,6 +2134,8 @@ void TheSunkenCityCardsGen::AddDemonHunterNonCollect(
 
 void TheSunkenCityCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 {
+    Power power;
+    
     // --------------------------------------- MINION - NEUTRAL
     // [TSC_001] Naval Mine - COST:2 [ATK:0/HP:2]
     // - Race: Mechanical, Set: THE_SUNKEN_CITY, Rarity: Common
@@ -2190,6 +2192,20 @@ void TheSunkenCityCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE,
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsTagValue(GameTag::TAG_SCRIPT_DATA_NUM_1, 1)) }));
+    power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<DamageTask>(EntityType::TARGET, 3) }));
+    ComplexTrigger::CastSpellWhileHoldingThis(power);
+    cards.emplace(
+        "TSC_017",
+        CardDef(power, PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } }));
 
     // --------------------------------------- MINION - NEUTRAL
     // [TSC_020] Barbaric Sorceress - COST:6 [ATK:3/HP:7]

--- a/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
@@ -136,3 +136,57 @@ TEST_CASE("[Demon Hunter : Spell] - TSC_058 : Predation")
     CHECK_EQ(curPlayer->GetRemainingMana(), 5);
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 23);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [TSC_017] Baba Naga - COST:4 [ATK:4/HP:4]
+// - Race: Naga, Set: THE_SUNKEN_CITY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you've cast
+//       a spell while holding this, deal 3 damage.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - TSC_017 : Baba Naga")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Baba Naga"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Baba Naga"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card1, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 24);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
@@ -4,9 +4,78 @@
 // personal capacity and are not conveying any rights to any intellectual
 // property of any third parties.
 
-#include <Utils/CardSetUtils.hpp>
+#include "doctest_proxy.hpp"
 
-TEST_CASE("[TheSunkenCityCardsGen] - Temp")
+#include <Utils/CardSetUtils.hpp>
+#include <Utils/TestUtils.hpp>
+
+#include <Rosetta/PlayMode/Actions/Draw.hpp>
+#include <Rosetta/PlayMode/Cards/Cards.hpp>
+#include <Rosetta/PlayMode/Zones/FieldZone.hpp>
+#include <Rosetta/PlayMode/Zones/SecretZone.hpp>
+
+using namespace RosettaStone;
+using namespace PlayMode;
+using namespace PlayerTasks;
+using namespace SimpleTasks;
+
+// ----------------------------------------- SPELL - HUNTER
+// [TSC_947] Naga's Pride - COST:3
+// - Set: THE_SUNKEN_CITY, Rarity: Rare
+// --------------------------------------------------------
+// Text: Summon two 2/2 Lionfish.
+//       If you played a Naga while holding this,
+//       give them +1/+1.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Spell] - TSC_947 : Naga's Pride")
 {
-    CHECK(true);
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Naga's Pride"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Naga's Pride"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Rainbow Glowscale"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Lionfish");
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[1]->card->name, "Lionfish");
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curField.GetCount(), 5);
+    CHECK_EQ(curField[3]->card->name, "Lionfish");
+    CHECK_EQ(curField[3]->GetAttack(), 3);
+    CHECK_EQ(curField[3]->GetHealth(), 3);
+    CHECK_EQ(curField[4]->card->name, "Lionfish");
+    CHECK_EQ(curField[4]->GetAttack(), 3);
+    CHECK_EQ(curField[4]->GetHealth(), 3);
 }


### PR DESCRIPTION
This revision includes:
- Implement new minion type 'Naga'
  - Implement 3 'THE_SUNKEN_CITY' cards (Resolves #741)
    - Baba Naga (TSC_017)
    - Predation (TSC_058)
    - Naga's Pride (TSC_947)
  - Create class 'ComplexTrigger'
    - This class lists complex triggers such as "If you played a Naga while holding this."
  - Add two complex trigger functions
    - 'PlayedNagaWhileHoldingThis()': Adds a trigger for checking "If you played a Naga while holding this"
    - 'CastSpellWhileHoldingThis()': Adds a trigger for checking "If you cast a spell while holding this"