### PR TITLE
Implement new keyword 'Dredge'

### DIFF
--- a/Documents/AbilityList.md
+++ b/Documents/AbilityList.md
@@ -36,7 +36,7 @@
 * [x] Corrupt
 * [x] Counter
 * [x] Dormant
-* [ ] Dredge
+* [x] Dredge
 * [x] Echo
 * [ ] Frenzy
 * [x] Honorable Kill

--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -891,7 +891,7 @@ THE_SUNKEN_CITY | TSC_827 | Vicious Slitherspear |
 THE_SUNKEN_CITY | TSC_828 | Priestess Valishj |  
 THE_SUNKEN_CITY | TSC_829 | Naga Giant |  
 THE_SUNKEN_CITY | TSC_908 | Sir Finley, Sea Guide |  
-THE_SUNKEN_CITY | TSC_909 | Tuskarrrr Trawler |  
+THE_SUNKEN_CITY | TSC_909 | Tuskarrrr Trawler | O
 THE_SUNKEN_CITY | TSC_911 | Excavation Specialist |  
 THE_SUNKEN_CITY | TSC_912 | Azsharan Vessel |  
 THE_SUNKEN_CITY | TSC_913 | Azsharan Trident |  
@@ -934,4 +934,4 @@ THE_SUNKEN_CITY | TSC_960 | Twin-fin Fin Twin |
 THE_SUNKEN_CITY | TSC_962 | Gigafin |  
 THE_SUNKEN_CITY | TSC_963 | Filletfighter |  
 
-- Progress: 2% (3 of 135 Cards)
+- Progress: 2% (4 of 135 Cards)

--- a/Documents/TaskList.md
+++ b/Documents/TaskList.md
@@ -54,6 +54,7 @@
 * DrawStackTask
 * DrawTask
 * DrawWeaponTask
+* DredgeTask
 * EnqueueNumberTask
 * EnqueueTask
 * FilterStackTask

--- a/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
@@ -59,6 +59,7 @@ enum class ChoiceAction
     DRAW_FROM_DECK,      //!< Draw from deck.
     CAST_SPELL,          //!< Cast spell.
     SUMMON,              //!< Summon.
+    DREDGE,              //!< Dredge.
     STACK,               //!< Stack.
     ENVOY_OF_LAZUL,      //!< Envoy Of Lazul.
     SIGHTLESS_WATCHER,   //!< Sightless Watcher.

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks.hpp
@@ -48,6 +48,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawWeaponTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueNumberTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.hpp
@@ -1,0 +1,40 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_PLAYMODE_DREDGE_TASK_HPP
+#define ROSETTASTONE_PLAYMODE_DREDGE_TASK_HPP
+
+#include <Rosetta/PlayMode/Tasks/ITask.hpp>
+
+namespace RosettaStone::PlayMode::SimpleTasks
+{
+//!
+//! \brief DredgeTask class.
+//!
+//! This class represents the task for processing keyword 'Dredge'.
+//!
+class DredgeTask : public ITask
+{
+ public:
+    //! Constructs task with given \p addToStack.
+    //! \param addToStack The flag that indicates the dredged card
+    //! add to task stack.
+    explicit DredgeTask(bool addToStack = false);
+
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player* player) override;
+
+    //! Internal method of Clone().
+    //! \return The cloned task.
+    std::unique_ptr<ITask> CloneImpl() override;
+
+    bool m_addToStack = false;
+};
+}  // namespace RosettaStone::PlayMode::SimpleTasks
+
+#endif  // ROSETTASTONE_PLAYMODE_DREDGE_TASK_HPP

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.hpp
@@ -14,6 +14,10 @@ namespace RosettaStone::PlayMode::SimpleTasks
 //! \brief DredgeTask class.
 //!
 //! This class represents the task for processing keyword 'Dredge'.
+//! Dredge is a mechanic introduced in Voyage to the Sunken City. Dredge allows
+//! the player to look at the bottom 3 cards from their deck, then choose one to
+//! put them on the top of their deck. Dredge can also be considered a Putting
+//! on deck mechanic.
 //!
 class DredgeTask : public ITask
 {

--- a/Includes/Rosetta/PlayMode/Zones/DeckZone.hpp
+++ b/Includes/Rosetta/PlayMode/Zones/DeckZone.hpp
@@ -36,6 +36,10 @@ class DeckZone : public LimitedZone<Playable>
     //! \return The n-th top card of deck.
     Playable* GetNthTopCard(int rank) const;
 
+    //! Returns the bottom card from deck.
+    //! \return The bottom card of deck.
+    Playable* GetBottomCard() const;
+
     //! Adds the specified entity into this zone, at the given position.
     //! \param entity The entity.
     //! \param zonePos The zone position.

--- a/Includes/Rosetta/PlayMode/Zones/DeckZone.hpp
+++ b/Includes/Rosetta/PlayMode/Zones/DeckZone.hpp
@@ -27,22 +27,22 @@ class DeckZone : public LimitedZone<Playable>
     //! \param player The player.
     explicit DeckZone(Player* player);
 
-    //! Returns the top card from deck.
-    //! \return The top card of deck.
+    //! Returns the top card from the deck.
+    //! \return The top card of the deck.
     Playable* GetTopCard() const;
 
-    //! Returns the n-th top card from deck.
-    //! \param rank The rank of entity from deck.
-    //! \return The n-th top card of deck.
+    //! Returns the n-th top card from the deck.
+    //! \param rank The rank of entity from the deck.
+    //! \return The n-th top card of the deck.
     Playable* GetNthTopCard(int rank) const;
 
-    //! Returns the bottom card from deck.
-    //! \return The bottom card of deck.
+    //! Returns the bottom card from the deck.
+    //! \return The bottom card of the deck.
     Playable* GetBottomCard() const;
 
-    //! Returns the n-th bottom card from deck.
-    //! \param rank The rank of entity from deck.
-    //! \return The n-th bottom card of deck.
+    //! Returns the n-th bottom card from the deck.
+    //! \param rank The rank of entity from the deck.
+    //! \return The n-th bottom card of the deck.
     Playable* GetNthBottomCard(int rank) const;
 
     //! Adds the specified entity into this zone, at the given position.

--- a/Includes/Rosetta/PlayMode/Zones/DeckZone.hpp
+++ b/Includes/Rosetta/PlayMode/Zones/DeckZone.hpp
@@ -40,6 +40,11 @@ class DeckZone : public LimitedZone<Playable>
     //! \return The bottom card of deck.
     Playable* GetBottomCard() const;
 
+    //! Returns the n-th bottom card from deck.
+    //! \param rank The rank of entity from deck.
+    //! \return The n-th bottom card of deck.
+    Playable* GetNthBottomCard(int rank) const;
+
     //! Adds the specified entity into this zone, at the given position.
     //! \param entity The entity.
     //! \param zonePos The zone position.

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -214,6 +214,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawStackTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DrawWeaponTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueNumberTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/EnqueueTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.hpp>

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 81% Forged in the Barrens (139 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
-  * 2% Voyage to the Sunken City (3 of 135 cards)
+  * 2% Voyage to the Sunken City (4 of 135 cards)
 
 ### Wild Format
 

--- a/Sources/Rosetta/PlayMode/Actions/Choose.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Choose.cpp
@@ -178,6 +178,12 @@ bool ChoicePick(Player* player, int choice)
             }
             break;
         }
+        case ChoiceAction::DREDGE:
+        {
+            const auto deckZone = player->GetDeckZone();
+            deckZone->Add(deckZone->Remove(playable));
+            break;
+        }
         case ChoiceAction::STACK:
         {
             player->choice->AddToStack(choice);

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -2485,6 +2485,9 @@ void TheSunkenCityCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - DREDGE = 1
     // --------------------------------------------------------
+    power.ClearData();
+    power.AddPowerTask(std::make_shared<DredgeTask>());
+    cards.emplace("TSC_909", CardDef(power));
 
     // --------------------------------------- MINION - NEUTRAL
     // [TSC_911] Excavation Specialist - COST:4 [ATK:3/HP:6]

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.cpp
@@ -15,11 +15,25 @@ DredgeTask::DredgeTask(bool addToStack) : m_addToStack(addToStack)
 
 TaskStatus DredgeTask::Impl(Player* player)
 {
-    auto deck = player->GetDeckZone();
+    const auto deck = player->GetDeckZone();
 
     if (deck->IsEmpty())
     {
         return TaskStatus::STOP;
+    }
+
+    std::vector<int> cardList;
+    cardList.reserve(3);
+
+    for (int i = 0; i < 3; ++i)
+    {
+        const auto card = deck->GetNthBottomCard(i);
+        if (!card)
+        {
+            break;
+        }
+
+        cardList.emplace_back(card->GetGameTag(GameTag::ENTITY_ID));
     }
 
     return TaskStatus::COMPLETE;

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.cpp
@@ -26,7 +26,7 @@ TaskStatus DredgeTask::Impl(Player* player)
     std::vector<int> cardList;
     cardList.reserve(3);
 
-    for (int i = 0; i < 3; ++i)
+    for (int i = 1; i <= 3; ++i)
     {
         const auto card = deck->GetNthBottomCard(i);
         if (!card)

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.cpp
@@ -1,0 +1,24 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2021 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2017-2021 Chris Ohk
+
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.hpp>
+
+namespace RosettaStone::PlayMode::SimpleTasks
+{
+DredgeTask::DredgeTask(bool addToStack) : m_addToStack(addToStack)
+{
+    // Do nothing
+}
+
+TaskStatus DredgeTask::Impl(Player* player)
+{
+    return TaskStatus::COMPLETE;
+}
+
+std::unique_ptr<ITask> DredgeTask::CloneImpl()
+{
+    return std::make_unique<DredgeTask>(m_addToStack);
+}
+}  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.cpp
@@ -4,6 +4,7 @@
 // Copyright (c) 2017-2021 Chris Ohk
 
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.hpp>
+#include <Rosetta/PlayMode/Zones/DeckZone.hpp>
 
 namespace RosettaStone::PlayMode::SimpleTasks
 {
@@ -14,6 +15,13 @@ DredgeTask::DredgeTask(bool addToStack) : m_addToStack(addToStack)
 
 TaskStatus DredgeTask::Impl(Player* player)
 {
+    auto deck = player->GetDeckZone();
+
+    if (deck->IsEmpty())
+    {
+        return TaskStatus::STOP;
+    }
+
     return TaskStatus::COMPLETE;
 }
 

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.cpp
@@ -3,6 +3,7 @@
 // RosettaStone is hearthstone simulator using C++ with reinforcement learning.
 // Copyright (c) 2017-2021 Chris Ohk
 
+#include <Rosetta/PlayMode/Actions/Choose.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/DredgeTask.hpp>
 #include <Rosetta/PlayMode/Zones/DeckZone.hpp>
 
@@ -35,6 +36,9 @@ TaskStatus DredgeTask::Impl(Player* player)
 
         cardList.emplace_back(card->GetGameTag(GameTag::ENTITY_ID));
     }
+
+    Generic::CreateChoice(player, m_source, ChoiceType::GENERAL,
+                          ChoiceAction::DREDGE, cardList);
 
     return TaskStatus::COMPLETE;
 }

--- a/Sources/Rosetta/PlayMode/Zones/DeckZone.cpp
+++ b/Sources/Rosetta/PlayMode/Zones/DeckZone.cpp
@@ -21,22 +21,42 @@ DeckZone::DeckZone(Player* player) : LimitedZone(ZoneType::DECK, MAX_DECK_SIZE)
 
 Playable* DeckZone::GetTopCard() const
 {
+    if (IsEmpty())
+    {
+        return nullptr;
+    }
+
     return m_entities[m_count - 1];
 }
 
 Playable* DeckZone::GetNthTopCard(int rank) const
 {
+    if (IsEmpty() || rank < 0 || rank > m_count)
+    {
+        return nullptr;
+    }
+
     return m_entities[m_count - rank];
 }
 
 Playable* DeckZone::GetBottomCard() const
 {
+    if (IsEmpty())
+    {
+        return nullptr;
+    }
+
     return m_entities[0];
 }
 
 Playable* DeckZone::GetNthBottomCard(int rank) const
 {
-    return m_entities[rank];
+    if (IsEmpty() || rank < 0 || rank > m_count)
+    {
+        return nullptr;
+    }
+
+    return m_entities[rank - 1];
 }
 
 void DeckZone::Add(Playable* entity, int zonePos)

--- a/Sources/Rosetta/PlayMode/Zones/DeckZone.cpp
+++ b/Sources/Rosetta/PlayMode/Zones/DeckZone.cpp
@@ -34,6 +34,11 @@ Playable* DeckZone::GetBottomCard() const
     return m_entities[0];
 }
 
+Playable* DeckZone::GetNthBottomCard(int rank) const
+{
+    return m_entities[rank];
+}
+
 void DeckZone::Add(Playable* entity, int zonePos)
 {
     LimitedZone::Add(entity, zonePos);

--- a/Sources/Rosetta/PlayMode/Zones/DeckZone.cpp
+++ b/Sources/Rosetta/PlayMode/Zones/DeckZone.cpp
@@ -29,6 +29,11 @@ Playable* DeckZone::GetNthTopCard(int rank) const
     return m_entities[m_count - rank];
 }
 
+Playable* DeckZone::GetBottomCard() const
+{
+    return m_entities[0];
+}
+
 void DeckZone::Add(Playable* entity, int zonePos)
 {
     LimitedZone::Add(entity, zonePos);

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -3110,7 +3110,7 @@ TEST_CASE("[Neutral : Weapon] - SCH_259 : Sphere of Sapience")
 
     CHECK_EQ(curHero->weapon->GetDurability(), 3);
     CHECK_EQ(curHand.GetAll().back()->card->id, secondCardID);
-    CHECK_EQ(curDeck.GetNthTopCard(curDeck.GetCount())->card->id, topCardID);
+    CHECK_EQ(curDeck.GetBottomCard()->card->id, topCardID);
 }
 
 // ---------------------------------------- SPELL - NEUTRAL


### PR DESCRIPTION
This revision includes:
- Implement new keyword 'Dredge' (Resolves #743)
  - Create class 'DredgeTask': This class represents the task for processing keyword 'Dredge'
    - Add enum value 'ChoiceAction::DREDGE'
    - Add code to process 'ChoiceAction::DREDGE'
  - Add methods for processing keyword 'Dredge'
    - 'GetBottomCard()': Returns the bottom card from deck
    - 'GetNthBottomCard()': Returns the n-th bottom card from deck
  - Implement card 'Tuskarrrr Trawler' (TSC_909)
- Refactor code to check an error 'out of bound' in an array
  - Correct unit test code of card 'Sphere of Sapience' (SCH_259)