### PR TITLE
Update Hearthstone Patch 23.0.3

### DIFF
--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -142,10 +142,10 @@ constexpr int NUM_TIER1_MINIONS = 17;
 constexpr int NUM_TIER2_MINIONS = 26;
 
 //! The number of tier 3 minions in Battlegrounds.
-constexpr int NUM_TIER3_MINIONS = 29;
+constexpr int NUM_TIER3_MINIONS = 28;
 
 //! The number of tier 4 minions in Battlegrounds.
-constexpr int NUM_TIER4_MINIONS = 31;
+constexpr int NUM_TIER4_MINIONS = 32;
 
 //! The number of tier 5 minions in Battlegrounds.
 constexpr int NUM_TIER5_MINIONS = 24;

--- a/Resources/cards.collectible.json
+++ b/Resources/cards.collectible.json
@@ -12503,7 +12503,7 @@
         "name": "Kael'thas Sunstrider",
         "rarity": "LEGENDARY",
         "set": "BLACK_TEMPLE",
-        "text": "Every third spell you cast each turn costs (0).",
+        "text": "Every third spell you cast each turn costs (1).",
         "type": "MINION"
     },
     {
@@ -35187,7 +35187,7 @@
         "race": "MURLOC",
         "rarity": "RARE",
         "set": "EXPERT1",
-        "techLevel": 3,
+        "techLevel": 4,
         "text": "<b>Battlecry:</b> Give your other Murlocs +2 Health.",
         "type": "MINION"
     },
@@ -53350,7 +53350,7 @@
         "rarity": "EPIC",
         "set": "LOOTAPALOOZA",
         "spellSchool": "NATURE",
-        "text": "Transform a friendly minion into\none that costs (1) more. Repeatable this turn.",
+        "text": "<b>Echo</b>\nTransform a friendly minion into one that costs (1) more.",
         "type": "SPELL"
     },
     {
@@ -56993,6 +56993,7 @@
         "attack": 8,
         "cardClass": "NEUTRAL",
         "collectible": true,
+        "collectionText": "[x]<b>Battlecry:</b> If you played 4\nother Dragons this game,\ncraft a custom deck\nof Treasures.",
         "cost": 8,
         "dbfId": 71684,
         "elite": true,
@@ -57007,7 +57008,7 @@
         "race": "DRAGON",
         "rarity": "LEGENDARY",
         "set": "ALTERAC_VALLEY",
-        "text": "[x]<b>Battlecry:</b> If all minions\nin your deck are Dragons,\ncraft a custom deck\nof Treasures.",
+        "text": "[x]<b>Battlecry:</b> If you played 4\nother Dragons this game,\ncraft a custom deck\nof Treasures.@ <i>({0} left!)</i>@ <i>(Ready!)</i>",
         "type": "MINION"
     },
     {
@@ -61197,13 +61198,13 @@
     },
     {
         "artist": "Samche Chen",
-        "attack": 1,
+        "attack": 2,
         "cardClass": "NEUTRAL",
         "collectible": true,
-        "cost": 2,
+        "cost": 3,
         "dbfId": 64713,
         "flavor": "She carries everything you didn't want and more!",
-        "health": 3,
+        "health": 4,
         "howToEarnGolden": "Unlocked with \"Forgot This At Home\" Achievement.",
         "id": "SW_065",
         "mechanics": [
@@ -65565,7 +65566,7 @@
         "cost": 3,
         "dbfId": 71690,
         "flavor": "\"...and then I'll hit 'em with the ol' puffercut!\"",
-        "health": 4,
+        "health": 3,
         "id": "TSC_002",
         "mechanics": [
             "TRIGGER_VISUAL"
@@ -67080,7 +67081,7 @@
         "artist": "Tanamaes Leejiarasaes",
         "cardClass": "DRUID",
         "collectible": true,
-        "cost": 7,
+        "cost": 8,
         "dbfId": 73471,
         "flavor": "I’ve got NO idea what’s in that fertilizer.",
         "id": "TSC_656",
@@ -67189,7 +67190,7 @@
         "name": "Switcheroo",
         "rarity": "COMMON",
         "set": "THE_SUNKEN_CITY",
-        "text": "Draw 2 minions.\nSwap their stats.",
+        "text": "Draw 2 minions.\nSwap their Health.",
         "type": "SPELL"
     },
     {

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -3715,7 +3715,7 @@ void AlteracValleyCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - Race: Dragon, Set: ALTERAC_VALLEY, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b>
-    //       If all minions in your deck are Dragons,
+    //       If you played 4 other Dragons this game,
     //       craft a custom deck of Treasures.
     // --------------------------------------------------------
     // GameTag:

--- a/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BlackTempleCardsGen.cpp
@@ -2561,10 +2561,10 @@ void BlackTempleCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [BT_255] Kael'thas Sunstrider - COST:7 [ATK:4/HP:7]
+    // [BT_255] Kael'thas Sunstrider - COST:6 [ATK:4/HP:7]
     // - Set: BLACK_TEMPLE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: Every third spell you cast each turn costs (0).
+    // Text: Every third spell you cast each turn costs (1).
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -2787,7 +2787,7 @@ void StormwindCardsGen::AddWarriorNonCollect(
     // [SW_028t2] Secure the Supplies - COST:1
     // - Set: STORMWIND, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Questline:</b> Play 2 Pirates.
+    // Text: <b>Questline:</b> Play 3 Pirates.
     //       <b>Reward:</b> Cap'n Rokara.
     // --------------------------------------------------------
     // GameTag:

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -106,7 +106,7 @@ void TheSunkenCityCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [TSC_656] Miracle Growth - COST:7
+    // [TSC_656] Miracle Growth - COST:8
     // - Set: THE_SUNKEN_CITY, Rarity: Common
     // - Spell School: Nature
     // --------------------------------------------------------
@@ -959,7 +959,7 @@ void TheSunkenCityCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // [TSC_702] Switcheroo - COST:3
     // - Set: THE_SUNKEN_CITY, Rarity: Common
     // --------------------------------------------------------
-    // Text: Draw 2 minions. Swap their stats.
+    // Text: Draw 2 minions. Swap their Health.
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - PRIEST
@@ -2147,7 +2147,7 @@ void TheSunkenCityCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [TSC_002] Pufferfist - COST:3 [ATK:3/HP:4]
+    // [TSC_002] Pufferfist - COST:3 [ATK:3/HP:3]
     // - Race: Pirate, Set: THE_SUNKEN_CITY, Rarity: Common
     // --------------------------------------------------------
     // Text: After your hero attacks, deal 1 damage to all enemies.


### PR DESCRIPTION
This revision includes:
- Update Hearthstone Patch 23.0.3 (Resolves #763)
  - Hearthstone Card Changes
    - Kazakusan: Old: Battlecry: If all minions in your deck are Dragons, craft a custom deck of treasures. → New: Battlecry: If you played 4 other Dragons this game, craft a custom deck of treasures.
    - Miracle Growth: Old: [Costs 7] → New: [Costs 8]
    - Secure the Supplies (the third portion of the Warrior Questline, Raid the Docks): Old: Play 2 Pirates. → New: Play 3 Pirates.
    - Pufferfist: Old: 3 Attack, 4 Health → New: 3 Attack, 3 Health
    - Switcheroo: Old: Draw 2 minions. Swap their stats. → New: Draw 2 minions. Swap their Health, Banned in Wild.
    - Kael’thas Sunstrider: Old: Every third spell you cast each turn costs (0). → New: Every third spell you cast each turn costs (1).
  - Battlegrounds Changes
    - MechGyver (Ini Stormcoil’s Hero Power): Old: Passive: After 9 friendly minions die, get a random Mech. → New: Passive: After 12 friendly minions die, get a random Mech.
    - Aquarrior (Varden Dawngrasp’s Buddy): Old: [Tavern Tier 2] 3 Attack, 5 Health. → New: [Tavern Tier 3] 3 Attack, 6 Health.
    - SI:Sefin: Old: Avenge (3): Give a friendly Murloc Poisonous permanently. → New: Avenge (4): Give a friendly Murloc Poisonous permanently.
    - Coldlight Seer: Old: [Tavern Tier 3] → New: [Tavern Tier 4]
    - Baby Krush: Old: 7 Attack, 7 Health. Whenever this attacks, summon a 9/9 Devilsaur to attack the target first. → New: 6 Attack, 6 Health. Whenever this attacks, summon an 8/8 Devilsaur to attack the target first.