### PR TITLE
Implement new keyword 'Colossal'

### DIFF
--- a/Documents/AbilityList.md
+++ b/Documents/AbilityList.md
@@ -32,7 +32,7 @@
 * [x] Casts When Drawn
 * [x] Charge
 * [ ] Choose Twice
-* [ ] Colossal
+* [x] Colossal
 * [x] Corrupt
 * [x] Counter
 * [x] Dormant

--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -806,9 +806,9 @@ THE_SUNKEN_CITY | TSC_013 | Slimescale Diver |
 THE_SUNKEN_CITY | TSC_017 | Baba Naga | O
 THE_SUNKEN_CITY | TSC_020 | Barbaric Sorceress |  
 THE_SUNKEN_CITY | TSC_023 | Barbed Nets |  
-THE_SUNKEN_CITY | TSC_026 | Colaque |  
+THE_SUNKEN_CITY | TSC_026 | Colaque | O
 THE_SUNKEN_CITY | TSC_029 | Gaia, the Techtonic |  
-THE_SUNKEN_CITY | TSC_030 | The Leviathan |  
+THE_SUNKEN_CITY | TSC_030 | The Leviathan | O
 THE_SUNKEN_CITY | TSC_032 | Blademaster Okani |  
 THE_SUNKEN_CITY | TSC_034 | Gorloc Ravager |  
 THE_SUNKEN_CITY | TSC_039 | Azsharan Scavenger |  
@@ -934,4 +934,4 @@ THE_SUNKEN_CITY | TSC_960 | Twin-fin Fin Twin |
 THE_SUNKEN_CITY | TSC_962 | Gigafin |  
 THE_SUNKEN_CITY | TSC_963 | Filletfighter |  
 
-- Progress: 2% (4 of 135 Cards)
+- Progress: 4% (6 of 135 Cards)

--- a/Includes/Rosetta/Common/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/TaskEnums.hpp
@@ -80,16 +80,17 @@ enum class EntityType
 //! \brief An enumerator for identifying the side of summoned minion.
 enum class SummonSide
 {
-    DEFAULT,      //!< Summoning on the last position on the right side.
-    LEFT,         //!< Summoning left of the minion.
-    RIGHT,        //!< Summoning right of the minion.
-    DEATHRATTLE,  //!< Summoning at the last position of the source.
-    NUMBER,       //!< Summoning at a given position in the stack number.
-    SPELL,        //!< Summoning by spell, currently like default.
-    TARGET,       //!< Summoning right of the target.
-    ALTERNATE,    //!< Summoning on the right side and left side alternately.
-    ALTERNATE_ENEMY,  //!< Summoning on the right side and left side
-                      //!< alternately for opponent.
+    DEFAULT,             //!< Summoning on the last position on the right side.
+    LEFT,                //!< Summoning left of the minion.
+    RIGHT,               //!< Summoning right of the minion.
+    DEATHRATTLE,         //!< Summoning at the last position of the source.
+    NUMBER,              //!< Summoning at a given position in the stack number.
+    SPELL,               //!< Summoning by spell, currently like default.
+    TARGET,              //!< Summoning right of the target.
+    ALTERNATE_FRIENDLY,  //!< Summoning on the right side and left side
+                         //!< alternately for friendly.
+    ALTERNATE_ENEMY,     //!< Summoning on the right side and left side
+                         //!< alternately for opponent.
 };
 
 //! \brief An enumerator for evaluating the relation between primitive values

--- a/Includes/Rosetta/Common/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/TaskEnums.hpp
@@ -77,6 +77,21 @@ enum class EntityType
     EVENT_TARGET,
 };
 
+//! \brief An enumerator for identifying the side of summoned minion.
+enum class SummonSide
+{
+    DEFAULT,      //!< Summoning on the last position on the right side.
+    LEFT,         //!< Summoning left of the minion.
+    RIGHT,        //!< Summoning right of the minion.
+    DEATHRATTLE,  //!< Summoning at the last position of the source.
+    NUMBER,       //!< Summoning at a given position in the stack number.
+    SPELL,        //!< Summoning by spell, currently like default.
+    TARGET,       //!< Summoning right of the target.
+    ALTERNATE,    //!< Summoning on the right side and left side alternately.
+    ALTERNATE_ENEMY,  //!< Summoning on the right side and left side
+                      //!< alternately for opponent.
+};
+
 //! \brief An enumerator for evaluating the relation between primitive values
 //! during game simulation.
 enum class RelaSign

--- a/Includes/Rosetta/PlayMode/Actions/Summon.hpp
+++ b/Includes/Rosetta/PlayMode/Actions/Summon.hpp
@@ -19,6 +19,13 @@ void Summon(Minion* minion, int fieldPos, Entity* summoner);
 //! Summons an minion that has reborn on battlefield.
 //! \param minion An minion to summon.
 void SummonReborn(Minion* minion);
+
+//! Summons appendage minions for Colossal on battlefield.
+//! \param appendages Appendage minions to summon.
+//! \param fieldPos The position of minion to summon.
+//! \param summoner The summoner of minion.
+void SummonAppendages(const std::vector<std::string>& appendages,
+                      Entity* summoner);
 }  // namespace RosettaStone::PlayMode::Generic
 
 #endif  // ROSETTASTONE_PLAYMODE_SUMMON_HPP

--- a/Includes/Rosetta/PlayMode/Actions/Summon.hpp
+++ b/Includes/Rosetta/PlayMode/Actions/Summon.hpp
@@ -24,8 +24,9 @@ void SummonReborn(Minion* minion);
 //! \param appendages Appendage minions to summon.
 //! \param fieldPos The position of minion to summon.
 //! \param summoner The summoner of minion.
-void SummonAppendages(const std::vector<std::string>& appendages,
-                      Entity* summoner);
+void SummonAppendages(
+    const std::vector<std::tuple<std::string, SummonSide>>& appendages,
+    Entity* summoner);
 }  // namespace RosettaStone::PlayMode::Generic
 
 #endif  // ROSETTASTONE_PLAYMODE_SUMMON_HPP

--- a/Includes/Rosetta/PlayMode/Cards/Card.hpp
+++ b/Includes/Rosetta/PlayMode/Cards/Card.hpp
@@ -9,6 +9,7 @@
 
 #include <Rosetta/Common/Enums/CardEnums.hpp>
 #include <Rosetta/Common/Enums/TargetingEnums.hpp>
+#include <Rosetta/Common/Enums/TaskEnums.hpp>
 #include <Rosetta/PlayMode/Enchants/Power.hpp>
 #include <Rosetta/PlayMode/Loaders/TargetingPredicates.hpp>
 
@@ -170,7 +171,7 @@ class Card
     std::map<PlayReq, int> playRequirements;
     std::vector<std::string> chooseCardIDs;
     std::vector<std::string> entourages;
-    std::vector<std::string> appendages;
+    std::vector<std::tuple<std::string, SummonSide>> appendages;
 
     std::vector<TargetingPredicate> targetingPredicate;
     std::vector<AvailabilityPredicate> targetingAvailabilityPredicate;

--- a/Includes/Rosetta/PlayMode/Cards/Card.hpp
+++ b/Includes/Rosetta/PlayMode/Cards/Card.hpp
@@ -166,6 +166,7 @@ class Card
     std::map<PlayReq, int> playRequirements;
     std::vector<std::string> chooseCardIDs;
     std::vector<std::string> entourages;
+    std::vector<std::string> appendages;
 
     std::vector<TargetingPredicate> targetingPredicate;
     std::vector<AvailabilityPredicate> targetingAvailabilityPredicate;

--- a/Includes/Rosetta/PlayMode/Cards/Card.hpp
+++ b/Includes/Rosetta/PlayMode/Cards/Card.hpp
@@ -110,6 +110,10 @@ class Card
     //! \return The flag that indicates whether it is Galakrond.
     bool IsGalakrond() const;
 
+    //! Returns the flag that indicates whether it is Colossal.
+    //! \return The flag that indicates whether it is Colossal.
+    bool IsColossal() const;
+
     //! Returns the flag that indicates whether it is untouchable.
     //! \return The flag that indicates whether it is untouchable.
     bool IsUntouchable() const;

--- a/Includes/Rosetta/PlayMode/Cards/CardProperty.hpp
+++ b/Includes/Rosetta/PlayMode/Cards/CardProperty.hpp
@@ -7,6 +7,7 @@
 #define ROSETTASTONE_PLAYMODE_CARD_PROPERTY_HPP
 
 #include <Rosetta/Common/Enums/CardEnums.hpp>
+#include <Rosetta/Common/Enums/TaskEnums.hpp>
 
 #include <map>
 #include <string>
@@ -36,7 +37,7 @@ struct CardProperty
     std::map<PlayReq, int> playReqs;
     std::vector<std::string> chooseCardIDs;
     std::vector<std::string> entourages;
-    std::vector<std::string> appendages;
+    std::vector<std::tuple<std::string, SummonSide>> appendages;
     std::string corruptCardID;
     int questProgressTotal = 0;
     int heroPowerDbfID = 0;

--- a/Includes/Rosetta/PlayMode/Cards/CardProperty.hpp
+++ b/Includes/Rosetta/PlayMode/Cards/CardProperty.hpp
@@ -27,6 +27,7 @@ struct CardProperty
         playReqs.clear();
         chooseCardIDs.clear();
         entourages.clear();
+        appendages.clear();
         corruptCardID.clear();
         questProgressTotal = 0;
         heroPowerDbfID = 0;
@@ -35,6 +36,7 @@ struct CardProperty
     std::map<PlayReq, int> playReqs;
     std::vector<std::string> chooseCardIDs;
     std::vector<std::string> entourages;
+    std::vector<std::string> appendages;
     std::string corruptCardID;
     int questProgressTotal = 0;
     int heroPowerDbfID = 0;

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -198,6 +198,11 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsControllingLackey();
 
+    //! SelfCondition wrapper for checking there is a Colaque's Shell
+    //! in field zone.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsControllingColaqueShell();
+
     //! SelfCondition wrapper for checking the player has
     //! a secret card in hand zone.
     //! \return Generated SelfCondition for intended purpose.

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp
@@ -10,21 +10,6 @@
 
 namespace RosettaStone::PlayMode::SimpleTasks
 {
-//! The side of summoned minion.
-enum class SummonSide
-{
-    DEFAULT,      //!< Summoning on the last position on the right side.
-    LEFT,         //!< Summoning left of the minion.
-    RIGHT,        //!< Summoning right of the minion.
-    DEATHRATTLE,  //!< Summoning at the last position of the source.
-    NUMBER,       //!< Summoning at a given position in the stack number.
-    SPELL,        //!< Summoning by spell, currently like default.
-    TARGET,       //!< Summoning right of the target.
-    ALTERNATE,    //!< Summoning on the right side and left side alternately.
-    ALTERNATE_ENEMY,  //!< Summoning on the right side and left side
-                      //!< alternately for opponent.
-};
-
 //!
 //! \brief SummonTask class.
 //!

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 81% Forged in the Barrens (139 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
-  * 2% Voyage to the Sunken City (4 of 135 cards)
+  * 4% Voyage to the Sunken City (6 of 135 cards)
 
 ### Wild Format
 

--- a/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
@@ -6,8 +6,10 @@
 #include <Rosetta/PlayMode/Actions/CastSpell.hpp>
 #include <Rosetta/PlayMode/Actions/Generic.hpp>
 #include <Rosetta/PlayMode/Actions/PlayCard.hpp>
+#include <Rosetta/PlayMode/Actions/Summon.hpp>
 #include <Rosetta/PlayMode/Cards/Cards.hpp>
 #include <Rosetta/PlayMode/Games/Game.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
 #include <Rosetta/PlayMode/Zones/DeckZone.hpp>
 #include <Rosetta/PlayMode/Zones/FieldZone.hpp>
 #include <Rosetta/PlayMode/Zones/GraveyardZone.hpp>
@@ -284,6 +286,24 @@ void PlayMinion(Player* player, Minion* minion, Character* target, int fieldPos,
     for (const auto& tags : minion->GetGameTags())
     {
         minion->SetGameTag(tags.first, tags.second);
+    }
+
+    // Check 'Colossal'
+    if (minion->card->IsColossal())
+    {
+        for (auto& appendage : minion->card->appendages)
+        {
+            using namespace SimpleTasks;
+
+            const auto appendageMinion = dynamic_cast<Minion*>(
+                Entity::GetFromCard(player, Cards::FindCardByID(appendage),
+                                    std::nullopt, player->GetFieldZone()));
+            int alternateCount = 0;
+            const int summonPos = SummonTask::GetPosition(
+                minion, SummonSide::RIGHT, appendageMinion, alternateCount);
+
+            Summon(appendageMinion, summonPos, minion);
+        }
     }
 
     // Process play card trigger

--- a/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
@@ -9,7 +9,6 @@
 #include <Rosetta/PlayMode/Actions/Summon.hpp>
 #include <Rosetta/PlayMode/Cards/Cards.hpp>
 #include <Rosetta/PlayMode/Games/Game.hpp>
-#include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
 #include <Rosetta/PlayMode/Zones/DeckZone.hpp>
 #include <Rosetta/PlayMode/Zones/FieldZone.hpp>
 #include <Rosetta/PlayMode/Zones/GraveyardZone.hpp>
@@ -291,19 +290,7 @@ void PlayMinion(Player* player, Minion* minion, Character* target, int fieldPos,
     // Check 'Colossal'
     if (minion->card->IsColossal())
     {
-        for (auto& appendage : minion->card->appendages)
-        {
-            using namespace SimpleTasks;
-
-            const auto appendageMinion = dynamic_cast<Minion*>(
-                Entity::GetFromCard(player, Cards::FindCardByID(appendage),
-                                    std::nullopt, player->GetFieldZone()));
-            int alternateCount = 0;
-            const int summonPos = SummonTask::GetPosition(
-                minion, SummonSide::RIGHT, appendageMinion, alternateCount);
-
-            Summon(appendageMinion, summonPos, minion);
-        }
+        SummonAppendages(minion->card->appendages, minion);
     }
 
     // Process play card trigger

--- a/Sources/Rosetta/PlayMode/Actions/Summon.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Summon.cpp
@@ -4,6 +4,7 @@
 // Copyright (c) 2017-2021 Chris Ohk
 
 #include <Rosetta/PlayMode/Actions/Summon.hpp>
+#include <Rosetta/PlayMode/Cards/Cards.hpp>
 #include <Rosetta/PlayMode/Games/Game.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.hpp>
 #include <Rosetta/PlayMode/Zones/FieldZone.hpp>
@@ -74,5 +75,21 @@ void SummonReborn(Minion* minion)
     copy->SetGameTag(GameTag::REBORN, 0);
 
     Summon(copy, zonePos, minion);
+}
+
+void SummonAppendages(const std::vector<std::string>& appendages,
+                      Entity* summoner)
+{
+    for (auto& appendage : appendages)
+    {
+        const auto appendageMinion = dynamic_cast<Minion*>(Entity::GetFromCard(
+            summoner->player, Cards::FindCardByID(appendage), std::nullopt,
+            summoner->player->GetFieldZone()));
+        int alternateCount = 0;
+        const int summonPos = SummonTask::GetPosition(
+            summoner, SummonSide::RIGHT, appendageMinion, alternateCount);
+
+        Summon(appendageMinion, summonPos, summoner);
+    }
 }
 }  // namespace RosettaStone::PlayMode::Generic

--- a/Sources/Rosetta/PlayMode/Actions/Summon.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Summon.cpp
@@ -77,14 +77,15 @@ void SummonReborn(Minion* minion)
     Summon(copy, zonePos, minion);
 }
 
-void SummonAppendages(const std::vector<std::string>& appendages,
-                      Entity* summoner)
+void SummonAppendages(
+    const std::vector<std::tuple<std::string, SummonSide>>& appendages,
+    Entity* summoner)
 {
     for (auto& appendage : appendages)
     {
         const auto appendageMinion = dynamic_cast<Minion*>(Entity::GetFromCard(
-            summoner->player, Cards::FindCardByID(appendage), std::nullopt,
-            summoner->player->GetFieldZone()));
+            summoner->player, Cards::FindCardByID(std::get<0>(appendage)),
+            std::nullopt, summoner->player->GetFieldZone()));
         int alternateCount = 0;
         const int summonPos = SummonTask::GetPosition(
             summoner, SummonSide::RIGHT, appendageMinion, alternateCount);

--- a/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
@@ -2543,8 +2543,9 @@ void DalaranCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     cardDef.power.AddPowerTask(std::make_shared<FlagTask>(
         true, TaskList{ std::make_shared<FuncNumberTask>(
                   []([[maybe_unused]] Playable* playable) { return 3; }) }));
-    cardDef.power.AddPowerTask(std::make_shared<EnqueueNumberTask>(TaskList{
-        std::make_shared<SummonTask>("GVG_110t", 2, SummonSide::ALTERNATE) }));
+    cardDef.power.AddPowerTask(std::make_shared<EnqueueNumberTask>(
+        TaskList{ std::make_shared<SummonTask>(
+            "GVG_110t", 2, SummonSide::ALTERNATE_FRIENDLY) }));
     cards.emplace("DAL_064", cardDef);
 
     // --------------------------------------- MINION - WARRIOR
@@ -2824,8 +2825,8 @@ void DalaranCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // --------------------------------------------------------
     cardDef.ClearData();
-    cardDef.power.AddPowerTask(
-        std::make_shared<SummonTask>("DAL_087t", 2, SummonSide::ALTERNATE));
+    cardDef.power.AddPowerTask(std::make_shared<SummonTask>(
+        "DAL_087t", 2, SummonSide::ALTERNATE_FRIENDLY));
     cards.emplace("DAL_087", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
@@ -3110,8 +3111,8 @@ void DalaranCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
         EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
                                 SelfCondition::IsDeckEmpty()) }));
     cardDef.power.AddPowerTask(std::make_shared<FlagTask>(
-        true, TaskList{ std::make_shared<SummonTask>("DAL_554t", 6,
-                                                     SummonSide::ALTERNATE) }));
+        true, TaskList{ std::make_shared<SummonTask>(
+                  "DAL_554t", 6, SummonSide::ALTERNATE_FRIENDLY) }));
     cards.emplace("DAL_554", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
@@ -3452,7 +3453,7 @@ void DalaranCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     cardDef.power.AddPowerTask(
         std::make_shared<CountTask>(ZoneType::PLAY, true, false));
     cardDef.power.AddPowerTask(std::make_shared<SummonNumberTask>(
-        "DAL_751t", false, SummonSide::ALTERNATE));
+        "DAL_751t", false, SummonSide::ALTERNATE_FRIENDLY));
     cardDef.power.AddPowerTask(
         std::make_shared<CountTask>(ZoneType::PLAY, true, true));
     cardDef.power.AddPowerTask(std::make_shared<SummonNumberTask>(

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -684,7 +684,7 @@ void TheSunkenCityCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
         std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
     cardDef.power.GetTrigger()->triggerSource = TriggerSource::SELF;
     cardDef.power.GetTrigger()->tasks = { std::make_shared<DredgeTask>() };
-    cardDef.property.appendages = { "TSC_030t2" };
+    cardDef.property.appendages = { { "TSC_030t2", SummonSide::RIGHT } };
     cards.emplace("TSC_030", cardDef);
 
     // --------------------------------------- MINION - PALADIN

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -3,6 +3,7 @@
 // Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
 // Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
 
+#include <Rosetta/PlayMode/Auras/AdaptiveEffect.hpp>
 #include <Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/ComplexTrigger.hpp>
@@ -28,6 +29,8 @@ void TheSunkenCityCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
 void TheSunkenCityCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ----------------------------------------- MINION - DRUID
     // [TSC_026] Colaque - COST:7 [ATK:6/HP:5]
     // - Race: Beast, Set: THE_SUNKEN_CITY, Rarity: Legendary
@@ -42,6 +45,13 @@ void TheSunkenCityCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - IMMUNE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(std::make_shared<AdaptiveEffect>(
+        std::make_shared<SelfCondition>(
+            SelfCondition::IsControllingColaqueShell()),
+        GameTag::IMMUNE));
+    cardDef.property.appendages = { { "TSC_026t", SummonSide::RIGHT } };
+    cards.emplace("TSC_026", cardDef);
 
     // ------------------------------------------ SPELL - DRUID
     // [TSC_650] Flipper Friends - COST:5
@@ -154,6 +164,8 @@ void TheSunkenCityCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 void TheSunkenCityCardsGen::AddDruidNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ----------------------------------------- MINION - DRUID
     // [TSC_026t] Colaque's Shell - COST:5 [ATK:0/HP:8]
     // - Race: Beast, Set: THE_SUNKEN_CITY
@@ -166,6 +178,9 @@ void TheSunkenCityCardsGen::AddDruidNonCollect(
     // - DEATHRATTLE = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddDeathrattleTask(std::make_shared<ArmorTask>(8));
+    cards.emplace("TSC_026t", cardDef);
 
     // ------------------------------------------ SPELL - DRUID
     // [TSC_650a] Order the Orca - COST:5

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -661,6 +661,8 @@ void TheSunkenCityCardsGen::AddMageNonCollect(
 
 void TheSunkenCityCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // --------------------------------------- MINION - PALADIN
     // [TSC_030] The Leviathan - COST:7 [ATK:4/HP:5]
     // - Race: Mechanical, Set: THE_SUNKEN_CITY, Rarity: Legendary
@@ -677,6 +679,13 @@ void TheSunkenCityCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // - RUSH = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<DredgeTask>() };
+    cardDef.property.appendages = { "TSC_030t2" };
+    cards.emplace("TSC_030", cardDef);
 
     // --------------------------------------- MINION - PALADIN
     // [TSC_059] Bubblebot - COST:4 [ATK:4/HP:4]
@@ -789,6 +798,8 @@ void TheSunkenCityCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 void TheSunkenCityCardsGen::AddPaladinNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // --------------------------------------- MINION - PALADIN
     // [TSC_030t2] The Leviathan's Claw - COST:3 [ATK:4/HP:2]
     // - Race: Mechanical, Set: THE_SUNKEN_CITY
@@ -802,6 +813,12 @@ void TheSunkenCityCardsGen::AddPaladinNonCollect(
     // - RUSH = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<DrawTask>(1) };
+    cards.emplace("TSC_030t2", cardDef);
 
     // ---------------------------------- ENCHANTMENT - PALADIN
     // [TSC_032e3] Blade Counter - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/UldumCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UldumCardsGen.cpp
@@ -320,8 +320,8 @@ void UldumCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
         EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
                                 SelfCondition::Has5MoreCostSpellInHand()) }));
     cardDef.power.AddPowerTask(std::make_shared<FlagTask>(
-        true, TaskList{ std::make_shared<SummonTask>("ULD_137t", 2,
-                                                     SummonSide::ALTERNATE) }));
+        true, TaskList{ std::make_shared<SummonTask>(
+                  "ULD_137t", 2, SummonSide::ALTERNATE_FRIENDLY) }));
     cards.emplace("ULD_137", cardDef);
 
     // ----------------------------------------- MINION - DRUID

--- a/Sources/Rosetta/PlayMode/Cards/Card.cpp
+++ b/Sources/Rosetta/PlayMode/Cards/Card.cpp
@@ -384,6 +384,11 @@ bool Card::IsGalakrond() const
     return false;
 }
 
+bool Card::IsColossal() const
+{
+    return HasGameTag(GameTag::COLOSSAL);
+}
+
 bool Card::IsUntouchable() const
 {
     return HasGameTag(GameTag::UNTOUCHABLE) &&

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -352,6 +352,21 @@ SelfCondition SelfCondition::IsControllingLackey()
     });
 }
 
+SelfCondition SelfCondition::IsControllingColaqueShell()
+{
+    return SelfCondition([](Playable* playable) {
+        for (auto& minion : playable->player->GetFieldZone()->GetAll())
+        {
+            if (minion->card->id == "TSC_026t")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    });
+}
+
 SelfCondition SelfCondition::IsHoldingSecret()
 {
     return SelfCondition([](Playable* playable) {

--- a/Sources/Rosetta/PlayMode/Loaders/InternalCardLoader.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/InternalCardLoader.cpp
@@ -20,6 +20,7 @@ void InternalCardLoader::Load(std::vector<Card*>& cards)
         card->playRequirements = cardDef.property.playReqs;
         card->chooseCardIDs = cardDef.property.chooseCardIDs;
         card->entourages = cardDef.property.entourages;
+        card->appendages = cardDef.property.appendages;
         card->gameTags[GameTag::QUEST_PROGRESS_TOTAL] =
             cardDef.property.questProgressTotal;
         card->gameTags[GameTag::HERO_POWER] = cardDef.property.heroPowerDbfID;

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/SummonTask.cpp
@@ -129,7 +129,7 @@ int SummonTask::GetPosition(Entity* source, SummonSide side, Entity* target,
             }
             break;
         }
-        case SummonSide::ALTERNATE:
+        case SummonSide::ALTERNATE_FRIENDLY:
         {
             const auto src = dynamic_cast<Playable*>(source);
             if (alternateCount % 2 == 0)

--- a/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
@@ -168,7 +168,7 @@ TEST_CASE("[Paladin : Minion] - TSC_030 : The Leviathan")
     game.Process(curPlayer, AttackTask(curField[1], card2));
     CHECK_EQ(opField[0]->GetHealth(), 4);
     CHECK_EQ(curHand.GetCount(), 6);
-    CHECK_EQ(curHand[6]->card->name, "Pyroblast");
+    CHECK_EQ(curHand[5]->card->name, "Pyroblast");
 }
 
 // ------------------------------------ SPELL - DEMONHUNTER


### PR DESCRIPTION
This revision includes:
- Implement new keyword 'Colossal' (Resolves #742)
  - Add card property 'appendages' and code to clear it
  - Add variable 'appendages' and code to assign the value of it
  - Add code to check 'Colossal' to summon appendages
  - Add method 'IsColossal()': Returns the flag that indicates whether it is Colossal
  - Add method 'SummonAppendages()': Summons appendage minions for Colossal on battlefield
- Add self condition 'IsControllingColaqueShell()': SelfCondition wrapper for checking there is a Colaque's Shell in field zone
- Implement 2 THE_SUNKEN_CITY cards
  - The Leviathan (TSC_030)
  - Colaque (TSC_026)
- Rename 'ALTERNATE' to 'ALTERNATE_FRIENDLY'