### PR TITLE
Implement 6 CORE cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -12,7 +12,7 @@ Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
 CORE | CORE_AT_021 | Tiny Knight of Evil | O
 CORE | CORE_AT_029 | Buccaneer |  
-CORE | CORE_AT_037 | Living Roots |  
+CORE | CORE_AT_037 | Living Roots | O
 CORE | CORE_AT_055 | Flash Heal | O
 CORE | CORE_AT_064 | Bash |  
 CORE | CORE_AT_075 | Warhorse Trainer | O
@@ -103,7 +103,7 @@ CORE | CORE_EX1_130 | Noble Sacrifice | O
 CORE | CORE_EX1_134 | SI:7 Agent | O
 CORE | CORE_EX1_144 | Shadowstep | O
 CORE | CORE_EX1_145 | Preparation | O
-CORE | CORE_EX1_154 | Wrath |  
+CORE | CORE_EX1_154 | Wrath | O
 CORE | CORE_EX1_158 | Soul of the Forest | O
 CORE | CORE_EX1_160 | Power of the Wild | O
 CORE | CORE_EX1_162 | Dire Wolf Alpha | O
@@ -190,7 +190,7 @@ CORE | CORE_LOE_003 | Ethereal Conjurer | O
 CORE | CORE_LOE_011 | Reno Jackson |  
 CORE | CORE_LOE_012 | Tomb Pillager | O
 CORE | CORE_LOE_039 | Gorillabot A-3 |  
-CORE | CORE_LOE_050 | Mounted Raptor |  
+CORE | CORE_LOE_050 | Mounted Raptor | O
 CORE | CORE_LOE_076 | Sir Finley Mrrgglton |  
 CORE | CORE_LOE_077 | Brann Bronzebeard |  
 CORE | CORE_LOE_079 | Elise Starseeker |  
@@ -201,7 +201,7 @@ CORE | CORE_LOOT_137 | Sleepy Dragon | O
 CORE | CORE_LOOT_222 | Candleshot |  
 CORE | CORE_LOOT_413 | Plated Beetle |  
 CORE | CORE_LOOT_516 | Zola the Gorgon |  
-CORE | CORE_NEW1_008 | Ancient of Lore |  
+CORE | CORE_NEW1_008 | Ancient of Lore | O
 CORE | CORE_NEW1_010 | Al'Akir the Windlord | O
 CORE | CORE_NEW1_018 | Bloodsail Raider | O
 CORE | CORE_NEW1_020 | Wild Pyromancer |  
@@ -210,7 +210,7 @@ CORE | CORE_NEW1_023 | Faerie Dragon |
 CORE | CORE_NEW1_026 | Violet Teacher | O
 CORE | CORE_NEW1_027 | Southsea Captain | O
 CORE | CORE_NEW1_031 | Animal Companion |  
-CORE | CORE_OG_044 | Fandral Staghelm |  
+CORE | CORE_OG_044 | Fandral Staghelm | O
 CORE | CORE_OG_047 | Feral Rage | O
 CORE | CORE_OG_109 | Darkshire Librarian |  
 CORE | CORE_OG_218 | Bloodhoof Brave |  
@@ -227,7 +227,7 @@ CORE | CORE_ULD_209 | Vulpera Scoundrel |
 CORE | CORE_ULD_271 | Injured Tol'vir |  
 CORE | CORE_UNG_020 | Arcanologist | O
 CORE | CORE_UNG_034 | Radiant Elemental |  
-CORE | CORE_UNG_108 | Earthen Scales |  
+CORE | CORE_UNG_108 | Earthen Scales | O
 CORE | CORE_UNG_813 | Stormwatcher | O
 CORE | CORE_UNG_817 | Tidal Surge | O
 CORE | CORE_UNG_833 | Lakkari Felhound | O
@@ -261,7 +261,7 @@ CORE | CS3_036 | Deathwing the Destroyer | O
 CORE | CS3_037 | Emerald Skytalon | O
 CORE | CS3_038 | Redgill Razorjaw | O
 
-- Progress: 69% (174 of 250 Cards)
+- Progress: 72% (180 of 250 Cards)
 
 ## Forged in the Barrens
 

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -724,7 +724,7 @@ TGT | AT_033 | Burgle |
 TGT | AT_034 | Poisoned Blade |  
 TGT | AT_035 | Beneath the Grounds |  
 TGT | AT_036 | Anub'arak |  
-TGT | AT_037 | Living Roots |  
+TGT | AT_037 | Living Roots | O
 TGT | AT_038 | Darnassus Aspirant |  
 TGT | AT_039 | Savage Combatant |  
 TGT | AT_040 | Wildwalker |  
@@ -821,7 +821,7 @@ TGT | AT_131 | Eydis Darkbane |
 TGT | AT_132 | Justicar Trueheart |  
 TGT | AT_133 | Gadgetzan Jouster |  
 
-- Progress: 6% (8 of 132 Cards)
+- Progress: 6% (9 of 132 Cards)
 
 ## The League of Explorers
 
@@ -850,7 +850,7 @@ LOE | LOE_038 | Naga Sea Witch |
 LOE | LOE_039 | Gorillabot A-3 |  
 LOE | LOE_046 | Huge Toad |  
 LOE | LOE_047 | Tomb Spider |  
-LOE | LOE_050 | Mounted Raptor |  
+LOE | LOE_050 | Mounted Raptor | O
 LOE | LOE_051 | Jungle Moonkin |  
 LOE | LOE_053 | Djinni of Zephyrs |  
 LOE | LOE_061 | Anubisath Sentinel |  
@@ -873,7 +873,7 @@ LOE | LOE_118 | Cursed Blade |
 LOE | LOE_119 | Animated Armor |  
 LOE | LOEA10_3 | Murloc Tinyfin | O
 
-- Progress: 6% (3 of 45 Cards)
+- Progress: 8% (4 of 45 Cards)
 
 ## Whispers of the Old Gods
 
@@ -889,7 +889,7 @@ OG | OG_031 | Hammer of Twilight |
 OG | OG_033 | Tentacles for Arms |  
 OG | OG_034 | Silithid Swarmer |  
 OG | OG_042 | Y'Shaarj, Rage Unbound |  
-OG | OG_044 | Fandral Staghelm |  
+OG | OG_044 | Fandral Staghelm | O
 OG | OG_045 | Infest |  
 OG | OG_047 | Feral Rage | O
 OG | OG_048 | Mark of Y'Shaarj |  
@@ -1014,7 +1014,7 @@ OG | OG_338 | Nat, the Darkfisher |
 OG | OG_339 | Skeram Cultist |  
 OG | OG_340 | Soggoth the Slitherer |  
 
-- Progress: 2% (4 of 134 Cards)
+- Progress: 3% (5 of 134 Cards)
 
 ## One Night in Karazhan
 
@@ -1124,7 +1124,7 @@ UNGORO | UNG_099 | Charged Devilsaur |
 UNGORO | UNG_100 | Verdant Longneck |  
 UNGORO | UNG_101 | Shellshifter |  
 UNGORO | UNG_103 | Evolving Spores |  
-UNGORO | UNG_108 | Earthen Scales |  
+UNGORO | UNG_108 | Earthen Scales | O
 UNGORO | UNG_109 | Elder Longneck |  
 UNGORO | UNG_111 | Living Mana |  
 UNGORO | UNG_113 | Bright-Eyed Scout |  
@@ -1208,7 +1208,7 @@ UNGORO | UNG_961 | Adaptation |
 UNGORO | UNG_962 | Lightfused Stegodon |  
 UNGORO | UNG_963 | Lyra the Sunshard |  
 
-- Progress: 3% (5 of 135 Cards)
+- Progress: 4% (6 of 135 Cards)
 
 ## Knights of the Frozen Throne
 

--- a/Includes/Rosetta/PlayMode/Enchants/AuraEffects.hpp
+++ b/Includes/Rosetta/PlayMode/Enchants/AuraEffects.hpp
@@ -16,7 +16,7 @@ constexpr int AURA_EFFECT_CARD_SIZE = 0;
 constexpr int AURA_EFFECT_WEAPON_SIZE = AURA_EFFECT_CARD_SIZE + 2;
 constexpr int AURA_EFFECT_CHARACTER_SIZE = AURA_EFFECT_CARD_SIZE + 2;
 constexpr int AURA_EFFECT_HERO_SIZE = AURA_EFFECT_CHARACTER_SIZE + 3;
-constexpr int AURA_EFFECT_MINION_SIZE = AURA_EFFECT_CHARACTER_SIZE + 5;
+constexpr int AURA_EFFECT_MINION_SIZE = AURA_EFFECT_CHARACTER_SIZE + 7;
 
 //!
 //! \brief AuraEffects class.
@@ -148,6 +148,14 @@ class AuraEffects
     //! \param value The value of GameTag::CANT_ATTACK to set.
     void SetCantAttack(int value);
 
+    //! Returns the value of GameTag::CHOOSE_BOTH.
+    //! \return The value of GameTag::CHOOSE_BOTH.
+    int GetChooseBoth() const;
+
+    //! Sets the value of GameTag::CHOOSE_BOTH.
+    //! \param value The value of GameTag::CHOOSE_BOTH to set.
+    void SetChooseBoth(int value);
+
  private:
     CardType m_type = CardType::INVALID;
 
@@ -171,6 +179,7 @@ class AuraEffects
     // 5 : CHARGE
     // 6 : LIFESTEAL
     // 7 : CANT_ATTACK
+    // 8 : CHOOSE_BOTH
     int* m_data = nullptr;
 };
 }  // namespace RosettaStone::PlayMode

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 69% Core Set (174 of 235 cards)
+  * 72% Core Set (180 of 235 cards)
   * 81% Forged in the Barrens (139 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
@@ -57,12 +57,12 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * **100% Curse of Naxxramas (30 of 30 Cards)**
   * 5% Goblins vs Gnomes (7 of 123 Cards)
   * 3% Blackrock Mountain (1 of 31 Cards)
-  * 6% The Grand Tournament (8 of 132 Cards)
-  * 6% The League of Explorers (3 of 45 Cards)
-  * 2% Whispers of the Old Gods (4 of 134 Cards)
+  * 6% The Grand Tournament (9 of 132 Cards)
+  * 8% The League of Explorers (4 of 45 Cards)
+  * 3% Whispers of the Old Gods (5 of 134 Cards)
   * 11% One Night in Karazhan (5 of 45 Cards)
   * 0% Mean Streets of Gadgetzan (0 of 132 Cards)
-  * 3% Journey to Un'Goro (5 of 135 Cards)
+  * 4% Journey to Un'Goro (6 of 135 Cards)
   * 3% Knights of the Frozen Throne (5 of 135 Cards)
   * 2% Kobolds & Catacombs (3 of 135 Cards)
   * 2% The Witchwood (3 of 135 Cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -292,6 +292,11 @@ void CoreCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - AURA = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(std::make_shared<Aura>(
+        AuraType::PLAYER, EffectList{ std::make_shared<Effect>(
+                              GameTag::CHOOSE_BOTH, EffectOperator::SET, 1) }));
+    cards.emplace("CORE_OG_044", cardDef);
 
     // ------------------------------------------ SPELL - DRUID
     // [CORE_OG_047] Feral Rage - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -271,6 +271,15 @@ void CoreCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CHOOSE_ONE = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cardDef.property.playReqs =
+        PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } };
+    cardDef.property.chooseCardIDs = ChooseCardIDs{ "NEW1_008a", "NEW1_008b" };
+    cards.emplace("CORE_NEW1_008", cardDef);
 
     // ----------------------------------------- MINION - DRUID
     // [CORE_OG_044] Fandral Staghelm - COST:4 [ATK:3/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -332,6 +332,21 @@ void CoreCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // Text: Give a friendly minion +1/+1,
     //       then gain Armor equal to its Attack.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("UNG_108e", EntityType::TARGET));
+    cardDef.power.AddPowerTask(
+        std::make_shared<GetGameTagTask>(EntityType::TARGET, GameTag::ATK));
+    cardDef.power.AddPowerTask(std::make_shared<ArmorTask>(0, false, true));
+    cardDef.property.playReqs = PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                          { PlayReq::REQ_MINION_TARGET, 0 },
+                                          { PlayReq::REQ_FRIENDLY_TARGET, 0 } };
+    cards.emplace("CORE_UNG_108", cardDef);
 }
 
 void CoreCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -255,6 +255,11 @@ void CoreCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddDeathrattleTask(std::make_shared<RandomMinionTask>(
+        TagValues{ { GameTag::COST, 1, RelaSign::EQ } }));
+    cardDef.power.AddDeathrattleTask(std::make_shared<SummonStackTask>());
+    cards.emplace("CORE_LOE_050", cardDef);
 
     // ----------------------------------------- MINION - DRUID
     // [CORE_NEW1_008] Ancient of Lore - COST:7 [ATK:5/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -122,6 +122,16 @@ void CoreCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CHOOSE_ONE = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cardDef.property.playReqs = PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                          { PlayReq::REQ_MINION_TARGET, 0 } };
+    cardDef.property.chooseCardIDs = ChooseCardIDs{ "EX1_154a", "EX1_154b" };
+    cards.emplace("CORE_EX1_154", cardDef);
 
     // ------------------------------------------ SPELL - DRUID
     // [CORE_EX1_158] Soul of the Forest - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -68,6 +68,15 @@ void CoreCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CHOOSE_ONE = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cardDef.property.playReqs =
+        PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } };
+    cardDef.property.chooseCardIDs = ChooseCardIDs{ "AT_037a", "AT_037b" };
+    cards.emplace("CORE_AT_037", cardDef);
 
     // ------------------------------------------ SPELL - DRUID
     // [CORE_CS2_009] Mark of the Wild - COST:2

--- a/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
@@ -10,6 +10,8 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 
 namespace RosettaStone::PlayMode
 {
+using TagValues = std::vector<TagValue>;
+
 void LoECardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
     // Do nothing
@@ -22,6 +24,8 @@ void LoECardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
 void LoECardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ----------------------------------------- MINION - DRUID
     // [LOE_050] Mounted Raptor - COST:3 [ATK:3/HP:2]
     // - Race: Beast, Set: LoE, Rarity: Common
@@ -31,6 +35,11 @@ void LoECardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddDeathrattleTask(std::make_shared<RandomMinionTask>(
+        TagValues{ { GameTag::COST, 1, RelaSign::EQ } }));
+    cardDef.power.AddDeathrattleTask(std::make_shared<SummonStackTask>());
+    cards.emplace("LOE_050", cardDef);
 
     // ----------------------------------------- MINION - DRUID
     // [LOE_051] Jungle Moonkin - COST:4 [ATK:4/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/OgCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/OgCardsGen.cpp
@@ -13,6 +13,7 @@ namespace RosettaStone::PlayMode
 {
 using PlayReqs = std::map<PlayReq, int>;
 using ChooseCardIDs = std::vector<std::string>;
+using EffectList = std::vector<std::shared_ptr<IEffect>>;
 
 void OgCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
@@ -38,7 +39,7 @@ void OgCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     CardDef cardDef;
 
     // ----------------------------------------- MINION - DRUID
-    // [OG_044] Fandral Staghelmh - COST:4 [ATK:3/HP:5]
+    // [OG_044] Fandral Staghelm - COST:4 [ATK:3/HP:5]
     // - Set: Og, Rarity: Legendary
     // --------------------------------------------------------
     // Text: Your <b>Choose One</b> cards and powers
@@ -48,6 +49,11 @@ void OgCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - AURA = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(std::make_shared<Aura>(
+        AuraType::PLAYER, EffectList{ std::make_shared<Effect>(
+                              GameTag::CHOOSE_BOTH, EffectOperator::SET, 1) }));
+    cards.emplace("OG_044", cardDef);
 
     // ------------------------------------------ SPELL - DRUID
     // [OG_047] Feral Rage - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/TgtCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TgtCardsGen.cpp
@@ -13,6 +13,7 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 namespace RosettaStone::PlayMode
 {
 using PlayReqs = std::map<PlayReq, int>;
+using ChooseCardIDs = std::vector<std::string>;
 using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
 using EffectList = std::vector<std::shared_ptr<IEffect>>;
 
@@ -125,6 +126,8 @@ void TgtCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
 void TgtCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ------------------------------------------ SPELL - DRUID
     // [AT_037] Living Roots - COST:1
     // - Set: Tgt, Rarity: Common
@@ -136,8 +139,14 @@ void TgtCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - CHOOSE_ONE = 1
     // --------------------------------------------------------
     // PlayReq:
-    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_TARGET_IF_AVAILABLE = 0
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cardDef.property.playReqs =
+        PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } };
+    cardDef.property.chooseCardIDs = ChooseCardIDs{ "AT_037a", "AT_037b" };
+    cards.emplace("AT_037", cardDef);
 
     // ----------------------------------------- MINION - DRUID
     // [AT_038] Darnassus Aspirant - COST:2 [ATK:2/HP:3]
@@ -247,6 +256,11 @@ void TgtCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // PlayReq:
     // - REQ_TARGET_TO_PLAY = 0
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 2, true));
+    cardDef.property.playReqs = PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } };
+    cards.emplace("AT_037a", cardDef);
 
     // ------------------------------------------ SPELL - DRUID
     // [AT_037b] Living Roots (*) - COST:0
@@ -254,11 +268,23 @@ void TgtCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Summon two 1/1 Saplings.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<SummonTask>("AT_037t", 2, SummonSide::SPELL));
+    cardDef.property.playReqs =
+        PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } };
+    cards.emplace("AT_037b", cardDef);
 
     // ----------------------------------------- MINION - DRUID
     // [AT_037t] Sapling (*) - COST:1 [ATK:1/HP:1]
     // - Set: Tgt
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("AT_037t", cardDef);
 
     // ------------------------------------ ENCHANTMENT - DRUID
     // [AT_039e] Savage (*) - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
@@ -4,6 +4,7 @@
 // Copyright (c) 2017-2021 Chris Ohk
 
 #include <Rosetta/PlayMode/CardSets/UngoroCardsGen.hpp>
+#include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 
@@ -43,6 +44,8 @@ void UngoroCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
 void UngoroCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ----------------------------------------- MINION - DRUID
     // [UNG_078] Tortollan Forager - COST:2 [ATK:2/HP:2]
     // - Set: Ungoro, Rarity: Common
@@ -115,6 +118,16 @@ void UngoroCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - REQ_MINION_TARGET = 0
     // - REQ_FRIENDLY_TARGET = 0
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("UNG_108e", EntityType::TARGET));
+    cardDef.power.AddPowerTask(
+        std::make_shared<GetGameTagTask>(EntityType::TARGET, GameTag::ATK));
+    cardDef.power.AddPowerTask(std::make_shared<ArmorTask>(0, false, true));
+    cardDef.property.playReqs = PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                          { PlayReq::REQ_MINION_TARGET, 0 },
+                                          { PlayReq::REQ_FRIENDLY_TARGET, 0 } };
+    cards.emplace("UNG_108", cardDef);
 
     // ----------------------------------------- MINION - DRUID
     // [UNG_109] Elder Longneck - COST:3 [ATK:5/HP:1]
@@ -171,6 +184,8 @@ void UngoroCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 
 void UngoroCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ------------------------------------------ SPELL - DRUID
     // [UNG_101a] Raptor Form (*) - COST:0
     // - Set: Ungoro
@@ -223,6 +238,9 @@ void UngoroCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddEnchant(Enchants::GetEnchantFromText("UNG_108e"));
+    cards.emplace("UNG_108e", cardDef);
 
     // ----------------------------------------- MINION - DRUID
     // [UNG_111t1] Mana Treant (*) - COST:2 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
@@ -242,4 +242,14 @@ void AuraEffects::SetCantAttack(int value)
 {
     m_data[7] = value;
 }
+
+int AuraEffects::GetChooseBoth() const
+{
+    return m_data[8];
+}
+
+void AuraEffects::SetChooseBoth(int value)
+{
+    m_data[8] = value;
+}
 }  // namespace RosettaStone::PlayMode

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -742,6 +742,54 @@ TEST_CASE("[Druid : Minion] - CORE_EX1_573 : Cenarius")
     CHECK_EQ(curField[3]->HasTaunt(), false);
 }
 
+// ----------------------------------------- MINION - DRUID
+// [CORE_LOE_050] Mounted Raptor - COST:3 [ATK:3/HP:2]
+// - Race: Beast, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Summon a random 1-Cost minion.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - CORE_LOE_050 : Mounted Raptor")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mounted Raptor"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->GetCost(), 1);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [CORE_OG_047] Feral Rage - COST:3
 // - Set: CORE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -790,6 +790,61 @@ TEST_CASE("[Druid : Minion] - CORE_LOE_050 : Mounted Raptor")
     CHECK_EQ(curField[0]->card->GetCost(), 1);
 }
 
+// ----------------------------------------- MINION - DRUID
+// [CORE_NEW1_008] Ancient of Lore - COST:7 [ATK:5/HP:5]
+// - Set: CORE, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Choose One -</b> Draw 2 cards;
+//       or Restore 5 Health.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - CORE_NEW1_008 : Ancient of Lore")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(15);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ancient of Lore"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ancient of Lore"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1, 1));
+    CHECK_EQ(card1->GetZoneType(), ZoneType::PLAY);
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 7);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card2, curPlayer->GetHero(), 2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [CORE_OG_047] Feral Rage - COST:3
 // - Set: CORE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -986,6 +986,57 @@ TEST_CASE("[Druid : Spell] - CORE_TRL_243 : Pounce")
     CHECK_EQ(curPlayer->GetHero()->GetAttack(), 0);
 }
 
+// ------------------------------------------ SPELL - DRUID
+// [CORE_UNG_108] Earthen Scales - COST:1
+// - Set: CORE, Rarity: Rare
+// - Spell School: Nature
+// --------------------------------------------------------
+// Text: Give a friendly minion +1/+1,
+//       then gain Armor equal to its Attack.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// - REQ_FRIENDLY_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - CORE_UNG_108 : Earthen Scales")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Earthen Scales"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 12);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 13);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [CORE_BRM_013] Quick Shot - COST:2
 // - Set: CORE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -228,6 +228,69 @@ TEST_CASE("[Druid : Spell] - CORE_CS2_013 : Wild Growth")
 }
 
 // ------------------------------------------ SPELL - DRUID
+// [CORE_EX1_154] Wrath - COST:2
+// - Set: CORE, Rarity: Common
+// - Spell School: Nature
+// --------------------------------------------------------
+// Text: <b>Choose One -</b> Deal 3 damage to a minion;
+//       or 1 damage and draw a card.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - CORE_EX1_154 : Wrath")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wrath"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wrath"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField[0]->GetHealth(), 7);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card3, 1));
+    CHECK_EQ(opField[0]->GetHealth(), 4);
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card3, 2));
+    CHECK_EQ(opField[0]->GetHealth(), 3);
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+}
+
+// ------------------------------------------ SPELL - DRUID
 // [CORE_EX1_158] Soul of the Forest - COST:4
 // - Set: CORE, Rarity: Common
 // - Spell School: Nature

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -76,6 +76,62 @@ TEST_CASE("[Warlock : Hero] - CORE_EX1_323 : Lord Jaraxxus")
 }
 
 // ------------------------------------------ SPELL - DRUID
+// [CORE_AT_037] Living Roots - COST:1
+// - Set: CORE, Rarity: Common
+// - Spell School: Nature
+// --------------------------------------------------------
+// Text: <b>Choose One -</b> Deal 2 damage;
+//       or Summon two 1/1 Saplings.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - CORE_AT_037 : Living Roots")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Living Roots"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Living Roots"));
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card1, opPlayer->GetHero(), 1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2, 2));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Sapling");
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->card->name, "Sapling");
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+}
+
+// ------------------------------------------ SPELL - DRUID
 // [CORE_CS2_009] Mark of the Wild - COST:2
 // - Set: CORE, Rarity: Rare
 // - Spell School: Nature

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -845,6 +845,60 @@ TEST_CASE("[Druid : Minion] - CORE_NEW1_008 : Ancient of Lore")
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
 }
 
+// ----------------------------------------- MINION - DRUID
+// [CORE_OG_044] Fandral Staghelm - COST:4 [ATK:3/HP:5]
+// - Set: CORE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: Your <b>Choose One</b> cards and powers
+//       have both effects combined.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - AURA = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - CORE_OG_044 : Fandral Staghelmh")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fandral Staghelm"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Living Roots"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Druid of the Claw"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+    CHECK_EQ(curField.GetCount(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[3]->GetAttack(), 5);
+    CHECK_EQ(curField[3]->GetHealth(), 6);
+    CHECK_EQ(curField[3]->HasRush(), true);
+    CHECK_EQ(curField[3]->HasTaunt(), true);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [CORE_OG_047] Feral Rage - COST:3
 // - Set: CORE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/OgCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/OgCardsGenTests.cpp
@@ -17,6 +17,59 @@ using namespace PlayMode;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ----------------------------------------- MINION - DRUID
+// [OG_044] Fandral Staghelm - COST:4 [ATK:3/HP:5]
+// - Set: Og, Rarity: Legendary
+// --------------------------------------------------------
+// Text: Your <b>Choose One</b> cards and powers
+//       have both effects combined.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - AURA = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - OG_044 : Fandral Staghelmh")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fandral Staghelm"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Living Roots"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Druid of the Claw"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+    CHECK_EQ(curField.GetCount(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[3]->GetAttack(), 5);
+    CHECK_EQ(curField[3]->GetHealth(), 6);
+    CHECK_EQ(curField[3]->HasRush(), true);
+    CHECK_EQ(curField[3]->HasTaunt(), true);
+}
+
 // ------------------------------------------ SPELL - DRUID
 // [OG_047] Feral Rage - COST:3
 // - Set: Og, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/TgtCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TgtCardsGenTests.cpp
@@ -18,6 +18,60 @@ using namespace PlayMode;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ------------------------------------------ SPELL - DRUID
+// [AT_037] Living Roots - COST:1
+// - Set: Tgt, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Choose One -</b> Deal 2 damage;
+//       or Summon two 1/1 Saplings.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - AT_037 : Living Roots")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Living Roots"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Living Roots"));
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card1, opPlayer->GetHero(), 1));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2, 2));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Sapling");
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->card->name, "Sapling");
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [AT_061] Lock and Load - COST:2
 // - Set: Tgt, Rarity: Epic

--- a/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
@@ -18,6 +18,55 @@ using namespace PlayMode;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ------------------------------------------ SPELL - DRUID
+// [UNG_108] Earthen Scales - COST:1
+// - Faction: Neutral, Set: Ungoro, Rarity: Rare
+// --------------------------------------------------------
+// Text: Give a friendly minion +1/+1,
+//       then gain Armor equal to its Attack.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// - REQ_FRIENDLY_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Druid : Spell] - UNG_108 : Earthen Scales")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Earthen Scales"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 12);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 13);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+}
+
 // ------------------------------------------ MINION - MAGE
 // [UNG_020] Arcanologist - COST:2 [ATK:2/HP:3]
 // - Set: Ungoro, Rarity: Common


### PR DESCRIPTION
This revision includes:
- Implement 6 CORE cards (#755)
  - Living Roots (CORE_AT_037)
  - Wrath (CORE_EX1_154)
  - Mounted Raptor (CORE_LOE_050)
  - Ancient of Lore (CORE_NEW1_008)
  - Fandral Staghelm (CORE_OG_044)
  - Earthen Scales (CORE_UNG_108)
- Implement 1 TGT card
  - Living Roots (AT_037)
- Implement 1 LOE card
  - Mounted Raptor (LOE_050)
- Implement 1 OG card
  - Fandral Staghelm (OG_044)
- Implement 1 UNG card
  - Earthen Scales (UNG_108)
- Add getter/setter for 'GameTag::CHOOSE_BOTH'
  - GetChooseBoth(): Returns the value of GameTag::CHOOSE_BOTH
  - SetChooseBoth(): Sets the value of GameTag::CHOOSE_BOTH