### PR TITLE
Implement 6 CORE cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -73,7 +73,7 @@ CORE | CORE_CS2_203 | Ironbeak Owl | O
 CORE | CORE_CS2_222 | Stormwind Champion | O
 CORE | CORE_CS2_235 | Northshire Cleric |  
 CORE | CORE_DAL_086 | Sunreaver Spy | O
-CORE | CORE_DAL_371 | Marked Shot |  
+CORE | CORE_DAL_371 | Marked Shot | O
 CORE | CORE_DAL_416 | Hench-Clan Burglar |  
 CORE | CORE_DAL_609 | Kalecgos |  
 CORE | CORE_DRG_090 | Murozond the Infinite |  
@@ -170,7 +170,7 @@ CORE | CORE_GIL_191 | Fiendish Circle | O
 CORE | CORE_GIL_547 | Darius Crowley |  
 CORE | CORE_GIL_598 | Tess Greymane |  
 CORE | CORE_GIL_622 | Lifedrinker |  
-CORE | CORE_GIL_650 | Houndmaster Shaw |  
+CORE | CORE_GIL_650 | Houndmaster Shaw | O
 CORE | CORE_GIL_801 | Snap Freeze | O
 CORE | CORE_GIL_828 | Dire Frenzy | O
 CORE | CORE_GVG_008 | Lightbomb |  
@@ -182,7 +182,7 @@ CORE | CORE_ICC_029 | Cobalt Scalebane |
 CORE | CORE_ICC_038 | Righteous Protector | O
 CORE | CORE_ICC_055 | Drain Soul | O
 CORE | CORE_ICC_809 | Plague Scientist | O
-CORE | CORE_KAR_006 | Cloaked Huntress |  
+CORE | CORE_KAR_006 | Cloaked Huntress | O
 CORE | CORE_KAR_009 | Babbling Book | O
 CORE | CORE_KAR_069 | Swashburglar | O
 CORE | CORE_KAR_073 | Maelstrom Portal |  
@@ -198,7 +198,7 @@ CORE | CORE_LOEA10_3 | Murloc Tinyfin | O
 CORE | CORE_LOOT_101 | Explosive Runes |  
 CORE | CORE_LOOT_124 | Lone Champion | O
 CORE | CORE_LOOT_137 | Sleepy Dragon | O
-CORE | CORE_LOOT_222 | Candleshot |  
+CORE | CORE_LOOT_222 | Candleshot | O
 CORE | CORE_LOOT_413 | Plated Beetle |  
 CORE | CORE_LOOT_516 | Zola the Gorgon |  
 CORE | CORE_NEW1_008 | Ancient of Lore | O
@@ -209,7 +209,7 @@ CORE | CORE_NEW1_021 | Doomsayer |
 CORE | CORE_NEW1_023 | Faerie Dragon |  
 CORE | CORE_NEW1_026 | Violet Teacher | O
 CORE | CORE_NEW1_027 | Southsea Captain | O
-CORE | CORE_NEW1_031 | Animal Companion |  
+CORE | CORE_NEW1_031 | Animal Companion | O
 CORE | CORE_OG_044 | Fandral Staghelm | O
 CORE | CORE_OG_047 | Feral Rage | O
 CORE | CORE_OG_109 | Darkshire Librarian |  
@@ -221,7 +221,7 @@ CORE | CORE_TRL_252 | High Priestess Jeklik |
 CORE | CORE_TRL_307 | Flash of Light |  
 CORE | CORE_TRL_315 | Pyromaniac |  
 CORE | CORE_TRL_345 | Krag'wa, the Frog |  
-CORE | CORE_TRL_348 | Springpaw |  
+CORE | CORE_TRL_348 | Springpaw | O
 CORE | CORE_ULD_191 | Beaming Sidekick |  
 CORE | CORE_ULD_209 | Vulpera Scoundrel |  
 CORE | CORE_ULD_271 | Injured Tol'vir |  
@@ -261,7 +261,7 @@ CORE | CS3_036 | Deathwing the Destroyer | O
 CORE | CS3_037 | Emerald Skytalon | O
 CORE | CS3_038 | Redgill Razorjaw | O
 
-- Progress: 72% (180 of 250 Cards)
+- Progress: 74% (186 of 250 Cards)
 
 ## Forged in the Barrens
 

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -1022,7 +1022,7 @@ Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
 KARA | KAR_004 | Cat Trick |  
 KARA | KAR_005 | Kindly Grandmother |  
-KARA | KAR_006 | Cloaked Huntress |  
+KARA | KAR_006 | Cloaked Huntress | O
 KARA | KAR_009 | Babbling Book | O
 KARA | KAR_010 | Nightbane Templar |  
 KARA | KAR_011 | Pompous Thespian |  
@@ -1066,7 +1066,7 @@ KARA | KAR_710 | Arcanosmith |
 KARA | KAR_711 | Arcane Giant |  
 KARA | KAR_712 | Violet Illusionist |  
 
-- Progress: 11% (5 of 45 Cards)
+- Progress: 13% (6 of 45 Cards)
 
 ## Journey to Un'Goro
 
@@ -1423,7 +1423,7 @@ LOOTAPALOOZA | LOOT_214 | Evasion |
 LOOTAPALOOZA | LOOT_216 | Lynessa Sunsorrow |  
 LOOTAPALOOZA | LOOT_217 | To My Side! |  
 LOOTAPALOOZA | LOOT_218 | Feral Gibberer |  
-LOOTAPALOOZA | LOOT_222 | Candleshot |  
+LOOTAPALOOZA | LOOT_222 | Candleshot | O
 LOOTAPALOOZA | LOOT_231 | Arcane Artificer |  
 LOOTAPALOOZA | LOOT_233 | Cursed Disciple |  
 LOOTAPALOOZA | LOOT_258 | Dire Mole |  
@@ -1492,7 +1492,7 @@ LOOTAPALOOZA | LOOT_540 | Dragonhatcher |
 LOOTAPALOOZA | LOOT_541 | King Togwaggle |  
 LOOTAPALOOZA | LOOT_542 | Kingsbane |  
 
-- Progress: 2% (3 of 135 Cards)
+- Progress: 2% (4 of 135 Cards)
 
 ## The Witchwood
 
@@ -1584,7 +1584,7 @@ GILNEAS | GIL_640 | Curio Collector |
 GILNEAS | GIL_645 | Bonfire Elemental |  
 GILNEAS | GIL_646 | Clockwork Automaton |  
 GILNEAS | GIL_648 | Chief Inspector |  
-GILNEAS | GIL_650 | Houndmaster Shaw |  
+GILNEAS | GIL_650 | Houndmaster Shaw | O
 GILNEAS | GIL_653 | Woodcutter's Axe |  
 GILNEAS | GIL_654 | Warpath |  
 GILNEAS | GIL_655 | Festeroot Hulk |  
@@ -1634,7 +1634,7 @@ GILNEAS | GIL_902 | Cutthroat Buccaneer |
 GILNEAS | GIL_903 | Hidden Wisdom |  
 GILNEAS | GIL_905 | Carrion Drake |  
 
-- Progress: 2% (3 of 135 Cards)
+- Progress: 2% (4 of 135 Cards)
 
 ## The Boomsday Project
 
@@ -1859,7 +1859,7 @@ TROLL | TRL_341 | Treespeaker |
 TROLL | TRL_343 | Wardruid Loti |  
 TROLL | TRL_345 | Krag'wa, the Frog |  
 TROLL | TRL_347 | Baited Arrow |  
-TROLL | TRL_348 | Springpaw |  
+TROLL | TRL_348 | Springpaw | O
 TROLL | TRL_349 | Bloodscalp Strategist |  
 TROLL | TRL_351 | Rain of Toads |  
 TROLL | TRL_352 | Likkim |  
@@ -1919,7 +1919,7 @@ TROLL | TRL_570 | Soup Vendor |
 TROLL | TRL_900 | Halazzi, the Lynx |  
 TROLL | TRL_901 | Spirit of the Lynx |  
 
-- Progress: 1% (2 of 135 Cards)
+- Progress: 2% (3 of 135 Cards)
 
 ## Rise of Shadows
 

--- a/Includes/Rosetta/PlayMode/Enchants/AuraEffects.hpp
+++ b/Includes/Rosetta/PlayMode/Enchants/AuraEffects.hpp
@@ -16,7 +16,7 @@ constexpr int AURA_EFFECT_CARD_SIZE = 0;
 constexpr int AURA_EFFECT_WEAPON_SIZE = AURA_EFFECT_CARD_SIZE + 2;
 constexpr int AURA_EFFECT_CHARACTER_SIZE = AURA_EFFECT_CARD_SIZE + 2;
 constexpr int AURA_EFFECT_HERO_SIZE = AURA_EFFECT_CHARACTER_SIZE + 3;
-constexpr int AURA_EFFECT_MINION_SIZE = AURA_EFFECT_CHARACTER_SIZE + 6;
+constexpr int AURA_EFFECT_MINION_SIZE = AURA_EFFECT_CHARACTER_SIZE + 7;
 
 //!
 //! \brief AuraEffects class.
@@ -132,6 +132,14 @@ class AuraEffects
     //! \param value The value of GameTag::CHARGE to set.
     void SetCharge(int value);
 
+    //! Returns the value of GameTag::RUSH.
+    //! \return The value of GameTag::RUSH.
+    int GetRush() const;
+
+    //! Sets the value of GameTag::RUSH.
+    //! \param value The value of GameTag::RUSH to set.
+    void SetRush(int value);
+
     //! Returns the value of GameTag::LIFESTEAL.
     //! \return The value of GameTag::LIFESTEAL.
     int GetLifesteal() const;
@@ -169,8 +177,9 @@ class AuraEffects
     // 3 : WINDFURY
     // 4 : TAUNT
     // 5 : CHARGE
-    // 6 : LIFESTEAL
-    // 7 : CANT_ATTACK
+    // 6 : RUSH
+    // 7 : LIFESTEAL
+    // 8 : CANT_ATTACK
     int* m_data = nullptr;
 };
 }  // namespace RosettaStone::PlayMode

--- a/Includes/Rosetta/PlayMode/Enchants/AuraEffects.hpp
+++ b/Includes/Rosetta/PlayMode/Enchants/AuraEffects.hpp
@@ -16,7 +16,7 @@ constexpr int AURA_EFFECT_CARD_SIZE = 0;
 constexpr int AURA_EFFECT_WEAPON_SIZE = AURA_EFFECT_CARD_SIZE + 2;
 constexpr int AURA_EFFECT_CHARACTER_SIZE = AURA_EFFECT_CARD_SIZE + 2;
 constexpr int AURA_EFFECT_HERO_SIZE = AURA_EFFECT_CHARACTER_SIZE + 3;
-constexpr int AURA_EFFECT_MINION_SIZE = AURA_EFFECT_CHARACTER_SIZE + 7;
+constexpr int AURA_EFFECT_MINION_SIZE = AURA_EFFECT_CHARACTER_SIZE + 6;
 
 //!
 //! \brief AuraEffects class.
@@ -148,14 +148,6 @@ class AuraEffects
     //! \param value The value of GameTag::CANT_ATTACK to set.
     void SetCantAttack(int value);
 
-    //! Returns the value of GameTag::CHOOSE_BOTH.
-    //! \return The value of GameTag::CHOOSE_BOTH.
-    int GetChooseBoth() const;
-
-    //! Sets the value of GameTag::CHOOSE_BOTH.
-    //! \param value The value of GameTag::CHOOSE_BOTH to set.
-    void SetChooseBoth(int value);
-
  private:
     CardType m_type = CardType::INVALID;
 
@@ -179,7 +171,6 @@ class AuraEffects
     // 5 : CHARGE
     // 6 : LIFESTEAL
     // 7 : CANT_ATTACK
-    // 8 : CHOOSE_BOTH
     int* m_data = nullptr;
 };
 }  // namespace RosettaStone::PlayMode

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 72% Core Set (180 of 235 cards)
+  * 74% Core Set (186 of 235 cards)
   * 81% Forged in the Barrens (139 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
@@ -60,14 +60,14 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 6% The Grand Tournament (9 of 132 Cards)
   * 8% The League of Explorers (4 of 45 Cards)
   * 3% Whispers of the Old Gods (5 of 134 Cards)
-  * 11% One Night in Karazhan (5 of 45 Cards)
+  * 13% One Night in Karazhan (6 of 45 Cards)
   * 0% Mean Streets of Gadgetzan (0 of 132 Cards)
   * 4% Journey to Un'Goro (6 of 135 Cards)
   * 3% Knights of the Frozen Throne (5 of 135 Cards)
-  * 2% Kobolds & Catacombs (3 of 135 Cards)
-  * 2% The Witchwood (3 of 135 Cards)
+  * 2% Kobolds & Catacombs (4 of 135 Cards)
+  * 2% The Witchwood (4 of 135 Cards)
   * 2% The Boomsday Project (4 of 136 Cards)
-  * 1% Rastakhan's Rumble (2 of 135 Cards)
+  * 2% Rastakhan's Rumble (3 of 135 Cards)
   * **100% Rise of Shadows (136 of 136 cards)**
   * **99% Saviors of Uldum (134 of 135 cards)**
     * Except 'Zephrys the Great' (ULD_003)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -599,6 +599,15 @@ void CoreCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(std::make_shared<Aura>(
+        AuraType::HAND, EffectList{ Effects::SetCost(0) }));
+    {
+        const auto aura = dynamic_cast<Aura*>(cardDef.power.GetAura());
+        aura->condition =
+            std::make_shared<SelfCondition>(SelfCondition::IsSecret());
+    }
+    cards.emplace("CORE_KAR_006", cardDef);
 
     // ---------------------------------------- WEAPON - HUNTER
     // [CORE_LOOT_222] Candleshot - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -615,9 +615,18 @@ void CoreCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Your hero is <b>Immune</b> while attacking.
     // --------------------------------------------------------
+    // GameTag:
+    // - DURABILITY = 3
+    // --------------------------------------------------------
     // RefTag:
     // - IMMUNE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(std::make_shared<Trigger>(TriggerType::TARGET));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "DS1_188e", EntityType::HERO) };
+    cards.emplace("CORE_LOOT_222", cardDef);
 
     // ----------------------------------------- SPELL - HUNTER
     // [CORE_NEW1_031] Animal Companion - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -560,6 +560,10 @@ void CoreCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(
+        std::make_shared<Aura>(AuraType::FIELD_EXCEPT_SOURCE, "GIL_650e"));
+    cards.emplace("CORE_GIL_650", cardDef);
 
     // ----------------------------------------- SPELL - HUNTER
     // [CORE_GIL_828] Dire Frenzy - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -660,6 +660,10 @@ void CoreCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - RUSH = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::HAND, "TRL_348t", 1));
+    cards.emplace("CORE_TRL_348", cardDef);
 
     // ---------------------------------------- MINION - HUNTER
     // [CS3_015] Selective Breeder - COST:2 [ATK:1/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -24,6 +24,7 @@ namespace RosettaStone::PlayMode
 using TagValues = std::vector<TagValue>;
 using PlayReqs = std::map<PlayReq, int>;
 using ChooseCardIDs = std::vector<std::string>;
+using Entourages = std::vector<std::string>;
 using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
 using RelaCondList = std::vector<std::shared_ptr<RelaCondition>>;
 using EffectList = std::vector<std::shared_ptr<IEffect>>;
@@ -634,6 +635,19 @@ void CoreCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Summon a random Beast Companion.
     // --------------------------------------------------------
+    // Entourage: NEW1_032, NEW1_033, NEW1_034
+    // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<RandomEntourageTask>());
+    cardDef.power.AddPowerTask(std::make_shared<SummonTask>());
+    cardDef.property.playReqs =
+        PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } };
+    cardDef.property.entourages =
+        Entourages{ "NEW1_032", "NEW1_033", "NEW1_034" };
+    cards.emplace("CORE_NEW1_031", cardDef);
 
     // ---------------------------------------- MINION - HUNTER
     // [CORE_TRL_348] Springpaw - COST:1 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -385,11 +385,27 @@ void CoreCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // [CORE_DAL_371] Marked Shot - COST:4
     // - Set: CORE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Deal 4 damage to a minion. <b>Discover</b> a spell.
+    // Text: Deal 4 damage to a minion. <b>Discover</b> a spell.
     // --------------------------------------------------------
     // GameTag:
     // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    // RefTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 4, true));
+    cardDef.power.AddPowerTask(
+        std::make_shared<DiscoverTask>(DiscoverType::SPELL));
+    cardDef.property.playReqs = PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                          { PlayReq::REQ_MINION_TARGET, 0 } };
+    cards.emplace("CORE_DAL_371", cardDef);
 
     // ----------------------------------------- SPELL - HUNTER
     // [CORE_DS1_184] Tracking - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/GilneasCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/GilneasCardsGen.cpp
@@ -301,6 +301,10 @@ void GilneasCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(
+        std::make_shared<Aura>(AuraType::FIELD_EXCEPT_SOURCE, "GIL_650e"));
+    cards.emplace("GIL_650", cardDef);
 
     // ----------------------------------------- SPELL - HUNTER
     // [GIL_828] Dire Frenzy - COST:4
@@ -2060,6 +2064,9 @@ void GilneasCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: Houndmaster Shaw grants <b>Rush</b>.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddEnchant(Enchants::GetEnchantFromText("GIL_650e"));
+    cards.emplace("GIL_650e", cardDef);
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [GIL_653e] Woodcutter (*) - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
@@ -81,6 +81,8 @@ void KaraCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
 
 void KaraCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ----------------------------------------- SPELL - HUNTER
     // [KAR_004] Cat Trick - COST:2
     // - Set: Kara, Rarity: Rare
@@ -114,6 +116,15 @@ void KaraCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(std::make_shared<Aura>(
+        AuraType::HAND, EffectList{ Effects::SetCost(0) }));
+    {
+        const auto aura = dynamic_cast<Aura*>(cardDef.power.GetAura());
+        aura->condition =
+            std::make_shared<SelfCondition>(SelfCondition::IsSecret());
+    }
+    cards.emplace("KAR_006", cardDef);
 }
 
 void KaraCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/LootapaloozaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LootapaloozaCardsGen.cpp
@@ -209,6 +209,8 @@ void LootapaloozaCardsGen::AddDruidNonCollect(
 
 void LootapaloozaCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ----------------------------------------- SPELL - HUNTER
     // [LOOT_077] Flanking Strike - COST:4
     // - Set: Lootapalooza, Rarity: Common
@@ -286,6 +288,15 @@ void LootapaloozaCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DURABILITY = 3
     // --------------------------------------------------------
+    // RefTag:
+    // - IMMUNE = 1
+    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(std::make_shared<Trigger>(TriggerType::TARGET));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "DS1_188e", EntityType::HERO) };
+    cards.emplace("LOOT_222", cardDef);
 
     // ---------------------------------------- MINION - HUNTER
     // [LOOT_511] Kathrena Winterwisp - COST:8 [ATK:6/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/TrollCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TrollCardsGen.cpp
@@ -387,14 +387,17 @@ void TrollCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // [TRL_348] Springpaw - COST:1 [ATK:1/HP:1]
     // - Race: Beast, Set: Troll, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Rush</b>
-    //       <b>Battlecry:</b> Add a 1/1 Lynx with <b>Rush</b>
-    //       to your hand.
+    // Text: <b>Rush</b> <b>Battlecry:</b> Add a 1/1 Lynx
+    //       with <b>Rush</b> to your hand.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
     // - RUSH = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::HAND, "TRL_348t", 1));
+    cards.emplace("TRL_348", cardDef);
 
     // ---------------------------------------- MINION - HUNTER
     // [TRL_349] Bloodscalp Strategist - COST:3 [ATK:2/HP:4]
@@ -450,6 +453,8 @@ void TrollCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 
 void TrollCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ---------------------------------------- MINION - HUNTER
     // [TRL_347t] Devilsaur (*) - COST:5 [ATK:5/HP:5]
     // - Race: Beast, Set: Troll
@@ -464,6 +469,9 @@ void TrollCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("TRL_348t", cardDef);
 }
 
 void TrollCardsGen::AddMage(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
@@ -223,23 +223,33 @@ void AuraEffects::SetCharge(int value)
     m_data[5] = value;
 }
 
-int AuraEffects::GetLifesteal() const
+int AuraEffects::GetRush() const
 {
     return m_data[6];
 }
 
-void AuraEffects::SetLifesteal(int value)
+void AuraEffects::SetRush(int value)
 {
     m_data[6] = value;
 }
 
-int AuraEffects::GetCantAttack() const
+int AuraEffects::GetLifesteal() const
 {
     return m_data[7];
 }
 
-void AuraEffects::SetCantAttack(int value)
+void AuraEffects::SetLifesteal(int value)
 {
     m_data[7] = value;
+}
+
+int AuraEffects::GetCantAttack() const
+{
+    return m_data[8];
+}
+
+void AuraEffects::SetCantAttack(int value)
+{
+    m_data[8] = value;
 }
 }  // namespace RosettaStone::PlayMode

--- a/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
@@ -59,6 +59,8 @@ int AuraEffects::GetGameTag(GameTag tag) const
             return GetTaunt();
         case GameTag::CHARGE:
             return GetCharge();
+        case GameTag::RUSH:
+            return GetRush();
         case GameTag::LIFESTEAL:
             return GetLifesteal();
         case GameTag::CANT_ATTACK:
@@ -99,6 +101,9 @@ void AuraEffects::SetGameTag(GameTag tag, int value)
             break;
         case GameTag::CHARGE:
             SetCharge(value);
+            break;
+        case GameTag::RUSH:
+            SetRush(value);
             break;
         case GameTag::LIFESTEAL:
             SetLifesteal(value);

--- a/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
@@ -242,14 +242,4 @@ void AuraEffects::SetCantAttack(int value)
 {
     m_data[7] = value;
 }
-
-int AuraEffects::GetChooseBoth() const
-{
-    return m_data[8];
-}
-
-void AuraEffects::SetChooseBoth(int value)
-{
-    m_data[8] = value;
-}
 }  // namespace RosettaStone::PlayMode

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -1987,6 +1987,55 @@ TEST_CASE("[Hunter : Spell] - CORE_NEW1_031 : Animal Companion")
 }
 
 // ---------------------------------------- MINION - HUNTER
+// [CORE_TRL_348] Springpaw - COST:1 [ATK:1/HP:1]
+// - Race: Beast, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Rush</b> <b>Battlecry:</b> Add a 1/1 Lynx
+//       with <b>Rush</b> to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - CORE_TRL_348 : Springpaw")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Springpaw"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasRush(), true);
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->name, "Lynx");
+
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[0]));
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->HasRush(), true);
+}
+
+// ---------------------------------------- MINION - HUNTER
 // [CS3_015] Selective Breeder - COST:2 [ATK:1/HP:3]
 // - Set: CORE, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -1772,6 +1772,66 @@ TEST_CASE("[Hunter : Spell] - CORE_GIL_828 : Dire Frenzy")
 }
 
 // ---------------------------------------- MINION - HUNTER
+// [CORE_KAR_006] Cloaked Huntress - COST:3 [ATK:3/HP:4]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: Your <b>Secrets</b> cost (0).
+// --------------------------------------------------------
+// RefTag:
+// - SECRET = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - CORE_KAR_006 : Cloaked Huntress")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Cloaked Huntress"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Snake Trap"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Snipe"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    CHECK_EQ(card2->GetCost(), 2);
+    CHECK_EQ(card3->GetCost(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(card2->GetCost(), 0);
+    CHECK_EQ(card3->GetCost(), 0);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 7);
+    CHECK_EQ(card2->GetCost(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card1));
+    CHECK_EQ(card2->GetCost(), 2);
+}
+
+// ---------------------------------------- MINION - HUNTER
 // [CS3_015] Selective Breeder - COST:2 [ATK:1/HP:3]
 // - Set: CORE, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -1831,6 +1831,61 @@ TEST_CASE("[Hunter : Minion] - CORE_KAR_006 : Cloaked Huntress")
     CHECK_EQ(card2->GetCost(), 2);
 }
 
+// ---------------------------------------- WEAPON - HUNTER
+// [CORE_LOOT_222] Candleshot - COST:1
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: Your hero is <b>Immune</b> while attacking.
+// --------------------------------------------------------
+// GameTag:
+// - DURABILITY = 3
+// --------------------------------------------------------
+// RefTag:
+// - IMMUNE = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Weapon] - CORE_LOOT_222 : Candleshot")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Candleshot"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    CHECK_EQ(curPlayer->GetWeapon().GetAttack(), 1);
+    CHECK_EQ(curPlayer->GetWeapon().GetDurability(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(curPlayer->GetHero(), card2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
+    CHECK_EQ(curPlayer->GetHero()->IsImmune(), false);
+}
+
 // ---------------------------------------- MINION - HUNTER
 // [CS3_015] Selective Breeder - COST:2 [ATK:1/HP:3]
 // - Set: CORE, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -1087,6 +1087,68 @@ TEST_CASE("[Hunter : Spell] - CORE_BRM_013 : Quick Shot")
 }
 
 // ----------------------------------------- SPELL - HUNTER
+// [CORE_DAL_371] Marked Shot - COST:4
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: Deal 4 damage to a minion. <b>Discover</b> a spell.
+// --------------------------------------------------------
+// GameTag:
+// - DISCOVER = 1
+// - USE_DISCOVER_VISUALS = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+// RefTag:
+// - DISCOVER = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Spell] - CORE_DAL_371 : Marked Shot")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Marked Shot"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField[0]->GetHealth(), 8);
+    CHECK(opPlayer->choice != nullptr);
+
+    auto cards = TestUtils::GetChoiceCards(game);
+    for (auto& card : cards)
+    {
+        CHECK_EQ(card->GetCardType(), CardType::SPELL);
+        CHECK(card->IsCardClass(CardClass::PALADIN));
+    }
+}
+
+// ----------------------------------------- SPELL - HUNTER
 // [CORE_DS1_184] Tracking - COST:1
 // - Set: CORE, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -1634,6 +1634,70 @@ TEST_CASE("[Hunter : Spell] - CORE_EX1_617 : Deadly Shot")
     CHECK_EQ(curField.GetCount(), 0);
 }
 
+// ---------------------------------------- MINION - HUNTER
+// [CORE_GIL_650] Houndmaster Shaw - COST:4 [ATK:3/HP:6]
+// - Set: CORE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: Your other minions have <b>Rush</b>.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - AURA = 1
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - CORE_GIL_650 : Houndmaster Shaw")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Houndmaster Shaw"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bloodfen Raptor"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bluegill Warrior"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasRush(), false);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->HasRush(), true);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[1]->HasRush(), false);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [CORE_GIL_828] Dire Frenzy - COST:4
 // - Set: CORE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/GilneasCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/GilneasCardsGenTests.cpp
@@ -19,6 +19,69 @@ using namespace PlayMode;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ---------------------------------------- MINION - HUNTER
+// [GIL_650] Houndmaster Shaw - COST:4 [ATK:3/HP:6]
+// - Set: Gilneas, Rarity: Legendary
+// --------------------------------------------------------
+// Text: Your other minions have <b>Rush</b>.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - AURA = 1
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - GIL_650 : Houndmaster Shaw")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Houndmaster Shaw"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bloodfen Raptor"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bluegill Warrior"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->HasRush(), false);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->HasRush(), true);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[1]->HasRush(), false);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [GIL_828] Dire Frenzy - COST:4
 // - Set: Gilneas, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
@@ -90,6 +90,65 @@ TEST_CASE("[Druid : Minion] - KAR_300 : Enchanted Raven")
     // Do nothing
 }
 
+// ---------------------------------------- MINION - HUNTER
+// [KAR_006] Cloaked Huntress - COST:3 [ATK:3/HP:4]
+// - Set: Kara, Rarity: Common
+// --------------------------------------------------------
+// Text: Your <b>Secrets</b> cost (0).
+// --------------------------------------------------------
+// RefTag:
+// - SECRET = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - KAR_006 : Cloaked Huntress")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Cloaked Huntress"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Snake Trap"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Snipe"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    CHECK_EQ(card2->GetCost(), 2);
+    CHECK_EQ(card3->GetCost(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(card2->GetCost(), 0);
+    CHECK_EQ(card3->GetCost(), 0);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 7);
+    CHECK_EQ(card2->GetCost(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card1));
+    CHECK_EQ(card2->GetCost(), 2);
+}
+
 // ------------------------------------------ MINION - MAGE
 // [KAR_009] Babbling Book - COST:1 [ATK:1/HP:1]
 // - Set: Kara, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/LootapaloozaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LootapaloozaCardsGenTests.cpp
@@ -17,6 +17,60 @@ using namespace PlayMode;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ---------------------------------------- WEAPON - HUNTER
+// [LOOT_222] Candleshot - COST:1 [ATK:1/HP:0]
+// - Set: Lootapalooza, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Immune</b> while attacking.
+// --------------------------------------------------------
+// GameTag:
+// - DURABILITY = 3
+// --------------------------------------------------------
+// RefTag:
+// - IMMUNE = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Weapon] - LOOT_222 : Candleshot")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Candleshot"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    CHECK_EQ(curPlayer->GetWeapon().GetAttack(), 1);
+    CHECK_EQ(curPlayer->GetWeapon().GetDurability(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, AttackTask(curPlayer->GetHero(), card2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
+    CHECK_EQ(curPlayer->GetHero()->IsImmune(), false);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [LOOT_124] Lone Champion - COST:3 [ATK:2/HP:4]
 // - Set: Lootapalooza, Rarity: Rare


### PR DESCRIPTION
This revision includes:
- Implement 6 CORE cards (#755)
  - Marked Shot (CORE_DAL_371)
  - Houndmaster Shaw (CORE_GIL_650)
  - Cloaked Huntress (CORE_KAR_006)
  - Candleshot (CORE_LOOT_222)
  - Animal Companion (CORE_NEW1_031)
  - Springpaw (CORE_TRL_348)
- Implement 1 GILNEAS card
  - Houndmaster Shaw (GIL_650)
- Implement 1 KARA card
  - Cloaked Huntress (KAR_006)
- Implement 1 LOOTAPALOOZA card
  - Candleshot (LOOT_222)
- Implement 1 TROLL card
  - Springpaw (TRL_348)
- Delete getter/setter for 'GameTag::CHOOSE_BOTH'
- Add getter/setter for 'GameTag::RUSH'
  - GetRush(): Returns the value of GameTag::RUSH
  - SetRush(): Sets the value of GameTag::RUSH