### PR TITLE
Implement 5 CORE cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -42,7 +42,7 @@ CORE | CORE_CS1_130 | Holy Smite | O
 CORE | CORE_CS2_009 | Mark of the Wild | O
 CORE | CORE_CS2_013 | Wild Growth | O
 CORE | CORE_CS2_023 | Arcane Intellect | O
-CORE | CORE_CS2_028 | Blizzard |  
+CORE | CORE_CS2_028 | Blizzard | O
 CORE | CORE_CS2_029 | Fireball | O
 CORE | CORE_CS2_032 | Flamestrike | O
 CORE | CORE_CS2_042 | Fire Elemental | O
@@ -75,7 +75,7 @@ CORE | CORE_CS2_235 | Northshire Cleric |
 CORE | CORE_DAL_086 | Sunreaver Spy | O
 CORE | CORE_DAL_371 | Marked Shot | O
 CORE | CORE_DAL_416 | Hench-Clan Burglar |  
-CORE | CORE_DAL_609 | Kalecgos |  
+CORE | CORE_DAL_609 | Kalecgos | O
 CORE | CORE_DRG_090 | Murozond the Infinite |  
 CORE | CORE_DRG_226 | Amber Watcher |  
 CORE | CORE_DRG_229 | Bronze Explorer |  
@@ -122,7 +122,7 @@ CORE | CORE_EX1_248 | Feral Spirit | O
 CORE | CORE_EX1_249 | Baron Geddon | O
 CORE | CORE_EX1_259 | Lightning Storm | O
 CORE | CORE_EX1_275 | Cone of Cold | O
-CORE | CORE_EX1_279 | Pyroblast |  
+CORE | CORE_EX1_279 | Pyroblast | O
 CORE | CORE_EX1_284 | Azure Drake |  
 CORE | CORE_EX1_287 | Counterspell | O
 CORE | CORE_EX1_289 | Ice Barrier | O
@@ -195,7 +195,7 @@ CORE | CORE_LOE_076 | Sir Finley Mrrgglton |
 CORE | CORE_LOE_077 | Brann Bronzebeard |  
 CORE | CORE_LOE_079 | Elise Starseeker |  
 CORE | CORE_LOEA10_3 | Murloc Tinyfin | O
-CORE | CORE_LOOT_101 | Explosive Runes |  
+CORE | CORE_LOOT_101 | Explosive Runes | O
 CORE | CORE_LOOT_124 | Lone Champion | O
 CORE | CORE_LOOT_137 | Sleepy Dragon | O
 CORE | CORE_LOOT_222 | Candleshot | O
@@ -219,7 +219,7 @@ CORE | CORE_OG_273 | Stand Against Darkness | O
 CORE | CORE_TRL_243 | Pounce | O
 CORE | CORE_TRL_252 | High Priestess Jeklik |  
 CORE | CORE_TRL_307 | Flash of Light |  
-CORE | CORE_TRL_315 | Pyromaniac |  
+CORE | CORE_TRL_315 | Pyromaniac | O
 CORE | CORE_TRL_345 | Krag'wa, the Frog |  
 CORE | CORE_TRL_348 | Springpaw | O
 CORE | CORE_ULD_191 | Beaming Sidekick |  
@@ -261,7 +261,7 @@ CORE | CS3_036 | Deathwing the Destroyer | O
 CORE | CS3_037 | Emerald Skytalon | O
 CORE | CS3_038 | Redgill Razorjaw | O
 
-- Progress: 74% (186 of 250 Cards)
+- Progress: 76% (191 of 250 Cards)
 
 ## Forged in the Barrens
 

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -1383,7 +1383,7 @@ LOOTAPALOOZA | LOOT_085 | Rhok'delar |
 LOOTAPALOOZA | LOOT_088 | Potion of Heroism |  
 LOOTAPALOOZA | LOOT_091 | Lesser Pearl Spellstone |  
 LOOTAPALOOZA | LOOT_093 | Call to Arms |  
-LOOTAPALOOZA | LOOT_101 | Explosive Runes |  
+LOOTAPALOOZA | LOOT_101 | Explosive Runes | O
 LOOTAPALOOZA | LOOT_103 | Lesser Ruby Spellstone |  
 LOOTAPALOOZA | LOOT_104 | Shifting Scroll |  
 LOOTAPALOOZA | LOOT_106 | Deck of Wonders |  
@@ -1492,7 +1492,7 @@ LOOTAPALOOZA | LOOT_540 | Dragonhatcher |
 LOOTAPALOOZA | LOOT_541 | King Togwaggle |  
 LOOTAPALOOZA | LOOT_542 | Kingsbane |  
 
-- Progress: 2% (4 of 135 Cards)
+- Progress: 3% (5 of 135 Cards)
 
 ## The Witchwood
 
@@ -1841,7 +1841,7 @@ TROLL | TRL_310 | Elemental Evocation |
 TROLL | TRL_311 | Arcanosaur |  
 TROLL | TRL_312 | Spellzerker |  
 TROLL | TRL_313 | Scorch |  
-TROLL | TRL_315 | Pyromaniac |  
+TROLL | TRL_315 | Pyromaniac | O
 TROLL | TRL_316 | Jan'alai, the Dragonhawk |  
 TROLL | TRL_317 | Blast Wave |  
 TROLL | TRL_318 | Hex Lord Malacrass |  
@@ -1919,7 +1919,7 @@ TROLL | TRL_570 | Soup Vendor |
 TROLL | TRL_900 | Halazzi, the Lynx |  
 TROLL | TRL_901 | Spirit of the Lynx |  
 
-- Progress: 2% (3 of 135 Cards)
+- Progress: 2% (4 of 135 Cards)
 
 ## Rise of Shadows
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 74% Core Set (186 of 235 cards)
+  * 76% Core Set (191 of 235 cards)
   * 81% Forged in the Barrens (139 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
@@ -64,10 +64,10 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 0% Mean Streets of Gadgetzan (0 of 132 Cards)
   * 4% Journey to Un'Goro (6 of 135 Cards)
   * 3% Knights of the Frozen Throne (5 of 135 Cards)
-  * 2% Kobolds & Catacombs (4 of 135 Cards)
+  * 3% Kobolds & Catacombs (5 of 135 Cards)
   * 2% The Witchwood (4 of 135 Cards)
   * 2% The Boomsday Project (4 of 136 Cards)
-  * 2% Rastakhan's Rumble (3 of 135 Cards)
+  * 2% Rastakhan's Rumble (4 of 135 Cards)
   * **100% Rise of Shadows (136 of 136 cards)**
   * **99% Saviors of Uldum (134 of 135 cards)**
     * Except 'Zephrys the Great' (ULD_003)

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -1150,7 +1150,7 @@ void AlteracValleyCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - Spell School: Fire
     // --------------------------------------------------------
     // Text: Deal 1 damage to a minion and its neighbors.
-    //       (Improved by number of  other spells in your hand.)
+    //       (Improved by number of other spells in your hand.)
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
@@ -4417,7 +4417,7 @@ void AlteracValleyCardsGen::AddNeutralNonCollect(
     // - Set: ALTERAC_VALLEY
     // --------------------------------------------------------
     // Text: After your hero attacks,
-    //       deal 4 damage to all enemies.
+    //       deal 4 damage to all enemies.
     // --------------------------------------------------------
     // GameTag:
     // - TRIGGER_VISUAL = 1

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -952,7 +952,7 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // [CORE_TRL_315] Pyromaniac - COST:3 [ATK:3/HP:4]
     // - Set: CORE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Whenever your Hero Power kills a minion, draw a card.
+    // Text: Whenever your Hero Power kills a minion, draw a card.
     // --------------------------------------------------------
     // GameTag:
     // - TRIGGER_VISUAL = 1
@@ -1083,7 +1083,7 @@ void CoreCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // [CORE_DRG_226] Amber Watcher - COST:5 [ATK:4/HP:6]
     // - Race: Dragon, Set: CORE, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Restore 8 Health.
+    // Text: <b>Battlecry:</b> Restore 8 Health.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
@@ -1936,7 +1936,7 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // [CORE_CS2_046] Bloodlust - COST:5
     // - Set: CORE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Give your minions +3 Attack this turn.
+    // Text: Give your minions +3 Attack this turn.
     // --------------------------------------------------------
 
     // ----------------------------------------- SPELL - SHAMAN
@@ -2028,7 +2028,7 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // [CORE_EX1_565] Flametongue Totem - COST:2 [ATK:0/HP:2]
     // - Race: Totem, Set: CORE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Adjacent minions have +2 Attack.
+    // Text: Adjacent minions have +2 Attack.
     // --------------------------------------------------------
     // GameTag:
     // - ADJACENT_BUFF = 1
@@ -2070,7 +2070,7 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // - Set: CORE, Rarity: Rare
     // - Spell School: Nature
     // --------------------------------------------------------
-    // Text: Deal 1 damage to all enemy minions.
+    // Text: Deal 1 damage to all enemy minions.
     //       Summon a random 1-Cost minion.
     // --------------------------------------------------------
 
@@ -3697,7 +3697,7 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - Set: CORE, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Destroy all other minions
-    //       with 2 or less Attack.
+    //       with 2 or less Attack.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -824,6 +824,14 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 10 damage.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 10, true));
+    cardDef.property.playReqs = PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } };
+    cards.emplace("CORE_EX1_279", cardDef);
 
     // ------------------------------------------- SPELL - MAGE
     // [CORE_EX1_287] Counterspell - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -997,6 +997,13 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(std::make_shared<Trigger>(TriggerType::INSPIRE));
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<DrawTask>(1) };
+    cardDef.power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsDefenderDead())
+    };
+    cards.emplace("CORE_TRL_315", cardDef);
 
     // ------------------------------------------ MINION - MAGE
     // [CORE_UNG_020] Arcanologist - COST:2 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -733,6 +733,12 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - FREEZE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 2, true));
+    cardDef.power.AddPowerTask(
+        std::make_shared<FreezeTask>(EntityType::ENEMY_MINIONS));
+    cards.emplace("CORE_CS2_028", cardDef);
 
     // ------------------------------------------- SPELL - MAGE
     // [CORE_CS2_029] Fireball - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -8,14 +8,12 @@
 #include <Rosetta/PlayMode/Auras/AdaptiveEffect.hpp>
 #include <Rosetta/PlayMode/Auras/AdjacentAura.hpp>
 #include <Rosetta/PlayMode/Auras/EnrageEffect.hpp>
+#include <Rosetta/PlayMode/Auras/SwitchingAura.hpp>
 #include <Rosetta/PlayMode/CardSets/CoreCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Effects.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
-#include <Rosetta/PlayMode/Zones/FieldZone.hpp>
-#include <Rosetta/PlayMode/Zones/GraveyardZone.hpp>
-#include <Rosetta/PlayMode/Zones/HandZone.hpp>
 
 using namespace RosettaStone::PlayMode::SimpleTasks;
 
@@ -781,6 +779,18 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - DISCOVER = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(std::make_shared<SwitchingAura>(
+        AuraType::HAND, SelfCondition::SpellsCastThisTurn(0),
+        TriggerType::CAST_SPELL, EffectList{ Effects::SetCost(0) }));
+    {
+        const auto aura = dynamic_cast<SwitchingAura*>(cardDef.power.GetAura());
+        aura->condition =
+            std::make_shared<SelfCondition>(SelfCondition::IsSpell());
+    }
+    cardDef.power.AddPowerTask(
+        std::make_shared<DiscoverTask>(DiscoverType::SPELL));
+    cards.emplace("CORE_DAL_609", cardDef);
 
     // ------------------------------------------- SPELL - MAGE
     // [CORE_EX1_275] Cone of Cold - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -1273,7 +1273,8 @@ void Expert1CardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - Faction: Neutral, Set: Expert1, Rarity: Rare
     // - Spell School: Frost
     // --------------------------------------------------------
-    // Text: Deal 2 damage to all enemy minions and <b>Freeze</b> them.
+    // Text: Deal 2 damage to all enemy minions
+    //       and <b>Freeze</b> them.
     // --------------------------------------------------------
     // GameTag:
     // - FREEZE = 1

--- a/Sources/Rosetta/PlayMode/CardSets/TrollCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TrollCardsGen.cpp
@@ -476,6 +476,8 @@ void TrollCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
 void TrollCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ------------------------------------------- SPELL - MAGE
     // [TRL_310] Elemental Evocation - COST:0
     // - Set: Troll, Rarity: Common
@@ -512,6 +514,16 @@ void TrollCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Whenever your Hero Power kills a minion, draw a card.
     // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(std::make_shared<Trigger>(TriggerType::INSPIRE));
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<DrawTask>(1) };
+    cardDef.power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsDefenderDead())
+    };
+    cards.emplace("TRL_315", cardDef);
 
     // ------------------------------------------ MINION - MAGE
     // [TRL_316] Jan'alai, the Dragonhawk - COST:7 [ATK:4/HP:4]

--- a/Sources/Rosetta/PlayMode/Tasks/PlayerTasks/HeroPowerTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/PlayerTasks/HeroPowerTask.cpp
@@ -56,6 +56,9 @@ TaskStatus HeroPowerTask::Impl(Player* player)
     // Process target trigger
     if (m_target != nullptr)
     {
+        player->game->currentEventData =
+            std::make_unique<EventMetaData>(&power, m_target);
+
         Trigger::ValidateTriggers(player->game, &power, SequenceType::TARGET);
         player->game->taskQueue.StartEvent();
         player->game->triggerManager.OnTargetTrigger(&power);

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -2535,6 +2535,93 @@ TEST_CASE("[Mage : Spell] - CORE_EX1_275 : Cone of Cold")
 }
 
 // ------------------------------------------- SPELL - MAGE
+// [CORE_EX1_279] Pyroblast - COST:10
+// - Set: CORE, Rarity: Epic
+// - Spell School: Fire
+// --------------------------------------------------------
+// Text: Deal 10 damage.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - CORE_EX1_279 : Pyroblast")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Pyroblast"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Pyroblast"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Pyroblast"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Pyroblast"));
+    const auto card5 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+    const auto card6 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card6));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card6));
+    CHECK_EQ(opPlayer->GetFieldZone()->GetCount(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 20);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card5));
+    CHECK_EQ(curPlayer->GetFieldZone()->GetCount(), 0);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card4, curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+}
+
+// ------------------------------------------- SPELL - MAGE
 // [CORE_EX1_287] Counterspell - COST:3
 // - Set: CORE, Rarity: Rare
 // - Spell School: Arcane

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -2981,6 +2981,71 @@ TEST_CASE("[Mage : Spell] - CORE_LOOT_101 : Explosive Runes")
 }
 
 // ------------------------------------------ MINION - MAGE
+// [CORE_TRL_315] Pyromaniac - COST:3 [ATK:3/HP:4]
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: Whenever your Hero Power kills a minion, draw a card.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - CORE_TRL_315 : Pyromaniac")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Pyromaniac"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Goldshire Footman"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(opField[0]->GetHealth(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, HeroPowerTask(card2));
+    CHECK_EQ(opField[0]->GetHealth(), 1);
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, HeroPowerTask(card2));
+    CHECK_EQ(opField.GetCount(), 0);
+    CHECK_EQ(curHand.GetCount(), 7);
+}
+
+// ------------------------------------------ MINION - MAGE
 // [CORE_UNG_020] Arcanologist - COST:2 [ATK:2/HP:3]
 // - Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -2190,6 +2190,77 @@ TEST_CASE("[Mage : Spell] - CORE_CS2_023 : Arcane Intellect")
 }
 
 // ------------------------------------------- SPELL - MAGE
+// [CORE_CS2_028] Blizzard - COST:6
+// - Set: CORE, Rarity: Rare
+// - Spell School: Frost
+// --------------------------------------------------------
+// Text: Deal 2 damage to all enemy minions
+//       and <b>Freeze</b> them.
+// --------------------------------------------------------
+// GameTag:
+// - FREEZE = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - CORE_CS2_028 : Blizzard")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Blizzard"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 5);
+    CHECK_EQ(opField[0]->IsFrozen(), true);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 30);
+    CHECK_EQ(opPlayer->GetHero()->IsFrozen(), false);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, AttackTask(card2, curPlayer->GetHero()));
+    CHECK_EQ(opField[0]->IsFrozen(), true);
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(opField[0]->IsFrozen(), false);
+}
+
+// ------------------------------------------- SPELL - MAGE
 // [CORE_CS2_029] Fireball - COST:4
 // - Set: CORE, Rarity: Common
 // - Spell School: Fire

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -2061,7 +2061,8 @@ TEST_CASE("[Hunter : Spell] - EX1_617 : Deadly Shot")
 // - Faction: Neutral, Set: Expert1, Rarity: Rare
 // - Spell School: Frost
 // --------------------------------------------------------
-// Text: Deal 2 damage to all enemy minions and <b>Freeze</b> them.
+// Text: Deal 2 damage to all enemy minions
+//       and <b>Freeze</b> them.
 // --------------------------------------------------------
 // GameTag:
 // - FREEZE = 1

--- a/Tests/UnitTests/PlayMode/CardSets/LootapaloozaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LootapaloozaCardsGenTests.cpp
@@ -11,6 +11,7 @@
 #include <Rosetta/PlayMode/Actions/Draw.hpp>
 #include <Rosetta/PlayMode/Cards/Cards.hpp>
 #include <Rosetta/PlayMode/Zones/FieldZone.hpp>
+#include <Rosetta/PlayMode/Zones/SecretZone.hpp>
 
 using namespace RosettaStone;
 using namespace PlayMode;
@@ -69,6 +70,88 @@ TEST_CASE("[Hunter : Weapon] - LOOT_222 : Candleshot")
     game.Process(curPlayer, AttackTask(curPlayer->GetHero(), card2));
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
     CHECK_EQ(curPlayer->GetHero()->IsImmune(), false);
+}
+
+// ------------------------------------------- SPELL - MAGE
+// [LOOT_101] Explosive Runes - COST:3
+// - Faction: Neutral, Set: Lootapalooza, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Secret:</b> After your opponent plays a minion,
+//       deal 6 damage to it and any excess to their hero.
+// --------------------------------------------------------
+// GameTag:
+// - SECRET = 1
+// - ImmuneToSpellpower = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - LOOT_101 : Explosive Runes")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto curSecret = curPlayer->GetSecretZone();
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Explosive Runes"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Explosive Runes"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Chillwind Yeti"));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Bloodmage Thalnos"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Chillwind Yeti"));
+    const auto card6 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Chillwind Yeti"));
+    const auto card7 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Chillwind Yeti"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curSecret->GetCount(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(curSecret->GetCount(), 0);
+    CHECK_EQ(opField.GetCount(), 0);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 29);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(curSecret->GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card6));
+    CHECK_EQ(curSecret->GetCount(), 0);
+    CHECK_EQ(opField.GetCount(), 0);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card7));
+    CHECK_EQ(opField[0]->GetHealth(), 5);
 }
 
 // --------------------------------------- MINION - NEUTRAL


### PR DESCRIPTION
This revision includes:
- Implement 5 CORE cards (#755)
  - Blizzard (CORE_CS2_028)
  - Kalecgos (CORE_DAL_609)
  - Pyroblast (CORE_EX1_279)
  - Explosive Runes (CORE_LOOT_101)
  - Pyromaniac (CORE_TRL_315)
- Implement 1 LOOTAPALOOZA card
  - Explosive Runes (LOOT_101)
- Implement 1 TROLL card
  - Pyromaniac (TRL_315)
- Replace 'NBSP' with whitespace
- Add code to set the value of current event data