### PR TITLE
Implement 5 CORE cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -77,8 +77,8 @@ CORE | CORE_DAL_371 | Marked Shot | O
 CORE | CORE_DAL_416 | Hench-Clan Burglar |  
 CORE | CORE_DAL_609 | Kalecgos | O
 CORE | CORE_DRG_090 | Murozond the Infinite |  
-CORE | CORE_DRG_226 | Amber Watcher |  
-CORE | CORE_DRG_229 | Bronze Explorer |  
+CORE | CORE_DRG_226 | Amber Watcher | O
+CORE | CORE_DRG_229 | Bronze Explorer | O
 CORE | CORE_DS1_184 | Tracking | O
 CORE | CORE_DS1_185 | Arcane Shot | O
 CORE | CORE_EX1_005 | Big Game Hunter | O
@@ -214,11 +214,11 @@ CORE | CORE_OG_044 | Fandral Staghelm | O
 CORE | CORE_OG_047 | Feral Rage | O
 CORE | CORE_OG_109 | Darkshire Librarian |  
 CORE | CORE_OG_218 | Bloodhoof Brave |  
-CORE | CORE_OG_229 | Ragnaros, Lightlord |  
+CORE | CORE_OG_229 | Ragnaros, Lightlord | O
 CORE | CORE_OG_273 | Stand Against Darkness | O
 CORE | CORE_TRL_243 | Pounce | O
 CORE | CORE_TRL_252 | High Priestess Jeklik |  
-CORE | CORE_TRL_307 | Flash of Light |  
+CORE | CORE_TRL_307 | Flash of Light | O
 CORE | CORE_TRL_315 | Pyromaniac | O
 CORE | CORE_TRL_345 | Krag'wa, the Frog |  
 CORE | CORE_TRL_348 | Springpaw | O
@@ -243,7 +243,7 @@ CORE | CS3_007 | Novice Zapper | O
 CORE | CS3_008 | Bloodsail Deckhand | O
 CORE | CS3_013 | Shadowed Spirit | O
 CORE | CS3_015 | Selective Breeder | O
-CORE | CS3_016 | Reckoning |  
+CORE | CS3_016 | Reckoning | O
 CORE | CS3_017 | Gan'arg Glaivesmith | O
 CORE | CS3_019 | Kor'vas Bloodthorn | O
 CORE | CS3_020 | Illidari Inquisitor | O
@@ -261,7 +261,7 @@ CORE | CS3_036 | Deathwing the Destroyer | O
 CORE | CS3_037 | Emerald Skytalon | O
 CORE | CS3_038 | Redgill Razorjaw | O
 
-- Progress: 76% (191 of 250 Cards)
+- Progress: 78% (196 of 250 Cards)
 
 ## Forged in the Barrens
 

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -957,7 +957,7 @@ OG | OG_220 | Malkorok |
 OG | OG_221 | Selfless Hero |  
 OG | OG_222 | Rallying Blade |  
 OG | OG_223 | Divine Strength |  
-OG | OG_229 | Ragnaros, Lightlord |  
+OG | OG_229 | Ragnaros, Lightlord | O
 OG | OG_234 | Darkshire Alchemist |  
 OG | OG_239 | DOOM! |  
 OG | OG_241 | Possessed Villager | O
@@ -1014,7 +1014,7 @@ OG | OG_338 | Nat, the Darkfisher |
 OG | OG_339 | Skeram Cultist |  
 OG | OG_340 | Soggoth the Slitherer |  
 
-- Progress: 3% (5 of 134 Cards)
+- Progress: 4% (6 of 134 Cards)
 
 ## One Night in Karazhan
 
@@ -1834,7 +1834,7 @@ TROLL | TRL_302 | Time Out! |
 TROLL | TRL_304 | Farraki Battleaxe |  
 TROLL | TRL_305 | A New Challenger... |  
 TROLL | TRL_306 | Immortal Prelate |  
-TROLL | TRL_307 | Flash of Light |  
+TROLL | TRL_307 | Flash of Light | O
 TROLL | TRL_308 | High Priest Thekal |  
 TROLL | TRL_309 | Spirit of the Tiger |  
 TROLL | TRL_310 | Elemental Evocation |  
@@ -1919,7 +1919,7 @@ TROLL | TRL_570 | Soup Vendor |
 TROLL | TRL_900 | Halazzi, the Lynx |  
 TROLL | TRL_901 | Spirit of the Lynx |  
 
-- Progress: 2% (4 of 135 Cards)
+- Progress: 3% (5 of 135 Cards)
 
 ## Rise of Shadows
 

--- a/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
+++ b/Includes/Rosetta/PlayMode/Conditions/SelfCondition.hpp
@@ -430,6 +430,13 @@ class SelfCondition
     //! \return Generated SelfCondition for intended purpose.
     static SelfCondition IsAttack(int value, RelaSign relaSign);
 
+    //! SelfCondition wrapper for checking the attack of event source
+    //! that satisfies condition with \p value and \p relaSign.
+    //! \param value The value to check condition.
+    //! \param relaSign The comparer to check condition.
+    //! \return Generated SelfCondition for intended purpose.
+    static SelfCondition IsEventSourceAttack(int value, RelaSign relaSign);
+
     //! SelfCondition wrapper for checking the health that satisfies
     //! condition with \p value and \p relaSign.
     //! \param value The value to check condition.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 76% Core Set (191 of 235 cards)
+  * 78% Core Set (196 of 235 cards)
   * 81% Forged in the Barrens (139 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
@@ -59,7 +59,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 3% Blackrock Mountain (1 of 31 Cards)
   * 6% The Grand Tournament (9 of 132 Cards)
   * 8% The League of Explorers (4 of 45 Cards)
-  * 3% Whispers of the Old Gods (5 of 134 Cards)
+  * 4% Whispers of the Old Gods (6 of 134 Cards)
   * 13% One Night in Karazhan (6 of 45 Cards)
   * 0% Mean Streets of Gadgetzan (0 of 132 Cards)
   * 4% Journey to Un'Goro (6 of 135 Cards)
@@ -67,7 +67,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 3% Kobolds & Catacombs (5 of 135 Cards)
   * 2% The Witchwood (4 of 135 Cards)
   * 2% The Boomsday Project (4 of 136 Cards)
-  * 2% Rastakhan's Rumble (4 of 135 Cards)
+  * 3% Rastakhan's Rumble (5 of 135 Cards)
   * **100% Rise of Shadows (136 of 136 cards)**
   * **99% Saviors of Uldum (134 of 135 cards)**
     * Except 'Zephrys the Great' (ULD_003)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1156,7 +1156,12 @@ void CoreCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - DISCOVER = 1
     // - LIFESTEAL = 1
+    // - USE_DISCOVER_VISUALS = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DiscoverTask>(DiscoverType::DRAGON));
+    cards.emplace("CORE_DRG_229", cardDef);
 
     // ---------------------------------------- SPELL - PALADIN
     // [CORE_EX1_130] Noble Sacrifice - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1365,6 +1365,16 @@ void CoreCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::AFTER_ATTACKED));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    cardDef.power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsEventSourceAttack(3, RelaSign::GEQ)) };
+    cardDef.power.GetTrigger()->tasks = ComplexTask::ActivateSecret(
+        TaskList{ std::make_shared<DestroyTask>(EntityType::EVENT_SOURCE) });
+    cards.emplace("CS3_016", cardDef);
 }
 
 void CoreCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1135,6 +1135,15 @@ void CoreCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<HealTask>(EntityType::TARGET, 8));
+    cardDef.property.playReqs =
+        PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 } };
+    cards.emplace("CORE_DRG_226", cardDef);
 
     // --------------------------------------- MINION - PALADIN
     // [CORE_DRG_229] Bronze Explorer - COST:3 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1344,6 +1344,15 @@ void CoreCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Restore 4 Health. Draw a card.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<HealTask>(EntityType::TARGET, 4));
+    cardDef.power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cardDef.property.playReqs = PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } };
+    cards.emplace("CORE_TRL_307", cardDef);
 
     // ---------------------------------------- SPELL - PALADIN
     // [CS3_016] Reckoning - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1310,6 +1310,16 @@ void CoreCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    cardDef.power.GetTrigger()->tasks = {
+        std::make_shared<IncludeTask>(EntityType::FRIENDS),
+        std::make_shared<FilterStackTask>(SelfCondList{
+            std::make_shared<SelfCondition>(SelfCondition::IsDamaged()) }),
+        std::make_shared<RandomTask>(EntityType::STACK, 1),
+        std::make_shared<HealTask>(EntityType::STACK, 8)
+    };
+    cards.emplace("CORE_OG_229", cardDef);
 
     // ---------------------------------------- SPELL - PALADIN
     // [CORE_OG_273] Stand Against Darkness - COST:5

--- a/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DalaranCardsGen.cpp
@@ -665,10 +665,10 @@ void DalaranCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
     // ---------------------------------------- WEAPON - HUNTER
     // [DAL_379t] Thori'dal, the Stars' Fury (*) - COST:3 [ATK:2/HP:0]
-    // - Set: Dalaran,
-    // - Set: Dalaran,
+    // - Set: Dalaran
     // --------------------------------------------------------
-    // Text: After your hero attacks, gain <b>Spell Damage +2</b> this turn.
+    // Text: After your hero attacks,
+    //       gain <b>Spell Damage +2</b> this turn.
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1

--- a/Sources/Rosetta/PlayMode/CardSets/OgCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/OgCardsGen.cpp
@@ -13,6 +13,7 @@ namespace RosettaStone::PlayMode
 {
 using PlayReqs = std::map<PlayReq, int>;
 using ChooseCardIDs = std::vector<std::string>;
+using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
 using EffectList = std::vector<std::shared_ptr<IEffect>>;
 
 void OgCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
@@ -551,6 +552,16 @@ void OgCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - ELITE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    cardDef.power.GetTrigger()->tasks = {
+        std::make_shared<IncludeTask>(EntityType::FRIENDS),
+        std::make_shared<FilterStackTask>(SelfCondList{
+            std::make_shared<SelfCondition>(SelfCondition::IsDamaged()) }),
+        std::make_shared<RandomTask>(EntityType::STACK, 1),
+        std::make_shared<HealTask>(EntityType::STACK, 8)
+    };
+    cards.emplace("OG_229", cardDef);
 
     // ---------------------------------------- SPELL - PALADIN
     // [OG_273] Stand Against Darkness - COST:5

--- a/Sources/Rosetta/PlayMode/CardSets/TrollCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TrollCardsGen.cpp
@@ -11,6 +11,7 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 
 namespace RosettaStone::PlayMode
 {
+using PlayReqs = std::map<PlayReq, int>;
 using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
 
 void TrollCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
@@ -613,6 +614,8 @@ void TrollCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
 
 void TrollCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // --------------------------------------- MINION - PALADIN
     // [TRL_300] Shirvallah, the Tiger - COST:25 [ATK:7/HP:5]
     // - Race: Beast, Set: Troll, Rarity: Legendary
@@ -689,6 +692,12 @@ void TrollCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // PlayReq:
     // - REQ_TARGET_TO_PLAY = 0
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<HealTask>(EntityType::TARGET, 4));
+    cardDef.power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cardDef.property.playReqs = PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } };
+    cards.emplace("TRL_307", cardDef);
 
     // --------------------------------------- MINION - PALADIN
     // [TRL_308] High Priest Thekal - COST:3 [ATK:3/HP:4]

--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -888,6 +888,28 @@ SelfCondition SelfCondition::IsAttack(int value, RelaSign relaSign)
     });
 }
 
+SelfCondition SelfCondition::IsEventSourceAttack(int value, RelaSign relaSign)
+{
+    return SelfCondition([value, relaSign](Playable* playable) {
+        if (const auto eventData = playable->game->currentEventData.get();
+            eventData)
+        {
+            if (const auto character =
+                    dynamic_cast<Character*>(eventData->eventSource))
+            {
+                return (relaSign == RelaSign::EQ &&
+                        character->GetAttack() == value) ||
+                       (relaSign == RelaSign::GEQ &&
+                        character->GetAttack() >= value) ||
+                       (relaSign == RelaSign::LEQ &&
+                        character->GetAttack() <= value);
+            }
+        }
+
+        return false;
+    });
+}
+
 SelfCondition SelfCondition::IsHealth(int value, RelaSign relaSign)
 {
     return SelfCondition([value, relaSign](Playable* playable) {

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -3818,6 +3818,89 @@ TEST_CASE("[Paladin : Minion] - CORE_ICC_038 : Righteous Protector")
     // Do nothing
 }
 
+// --------------------------------------- MINION - PALADIN
+// [CORE_OG_229] Ragnaros, Lightlord - COST:8 [ATK:8/HP:8]
+// - Race: Elemental, Set: CORE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: At the end of your turn,
+//       restore 8 Health to a damaged friendly character.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Minion] - CORE_OG_229 : Ragnaros, Lightlord")
+{
+    GameConfig config;
+
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Ragnaros, Lightlord"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Pyroblast"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Pyroblast"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    int totalHealth =
+        curPlayer->GetHero()->GetHealth() + curField[0]->GetHealth();
+    CHECK_EQ(totalHealth, 42);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card3, card2));
+    totalHealth = curPlayer->GetHero()->GetHealth() + curField[0]->GetHealth();
+    CHECK_EQ(totalHealth, 32);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    totalHealth = curPlayer->GetHero()->GetHealth() + curField[0]->GetHealth();
+    CHECK_EQ(totalHealth, 40);
+
+    game.Process(opPlayer,
+                 PlayCardTask::SpellTarget(card4, curPlayer->GetHero()));
+    totalHealth = curPlayer->GetHero()->GetHealth() + curField[0]->GetHealth();
+    CHECK_EQ(totalHealth, 30);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    totalHealth = curPlayer->GetHero()->GetHealth() + curField[0]->GetHealth();
+    const bool checkHealth = totalHealth == 32 || totalHealth == 38;
+    CHECK(checkHealth);
+}
+
 // ---------------------------------------- SPELL - PALADIN
 // [CORE_OG_273] Stand Against Darkness - COST:5
 // - Set: CORE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -3362,6 +3362,55 @@ TEST_CASE("[Paladin : Minion] - CORE_DRG_226 : Amber Watcher")
     CHECK_EQ(opField[0]->GetHealth(), 12);
 }
 
+// --------------------------------------- MINION - PALADIN
+// [CORE_DRG_229] Bronze Explorer - COST:3 [ATK:3/HP:3]
+// - Race: Dragon, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Lifesteal</b>
+//       <b>Battlecry:</b> <b>Discover</b> a Dragon.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - DISCOVER = 1
+// - LIFESTEAL = 1
+// - USE_DISCOVER_VISUALS = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Minion] - CORE_DRG_229 : Bronze Explorer")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bronze Explorer"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK(curPlayer->choice != nullptr);
+    CHECK_EQ(curPlayer->choice->choices.size(), 3);
+
+    auto cards = TestUtils::GetChoiceCards(game);
+    for (auto& card : cards)
+    {
+        CHECK_EQ(card->GetCardType(), CardType::MINION);
+        CHECK_EQ(card->GetRace(), Race::DRAGON);
+    }
+}
+
 // ---------------------------------------- SPELL - PALADIN
 // [CORE_EX1_130] Noble Sacrifice - COST:1
 // - Set: CORE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -3302,6 +3302,66 @@ TEST_CASE("[Paladin : Weapon] - CORE_CS2_097 : Truesilver Champion")
     CHECK_EQ(curPlayer->GetWeapon().GetDurability(), 1);
 }
 
+// --------------------------------------- MINION - PALADIN
+// [CORE_DRG_226] Amber Watcher - COST:5 [ATK:4/HP:6]
+// - Race: Dragon, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Restore 8 Health.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Minion] - CORE_DRG_226 : Amber Watcher")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(10);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Amber Watcher"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Amber Watcher"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    opField[0]->SetDamage(6);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card1, curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 28);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card3));
+    CHECK_EQ(opField[0]->GetHealth(), 12);
+}
+
 // ---------------------------------------- SPELL - PALADIN
 // [CORE_EX1_130] Noble Sacrifice - COST:1
 // - Set: CORE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -3952,6 +3952,62 @@ TEST_CASE("[Paladin : Spell] - CORE_OG_273 : Stand Against Darkness")
     CHECK_EQ(curField[6]->card->name, "Silver Hand Recruit");
 }
 
+// ---------------------------------------- SPELL - PALADIN
+// [CORE_TRL_307] Flash of Light - COST:2
+// - Set: CORE, Rarity: Common
+// - Spell School: Holy
+// --------------------------------------------------------
+// Text: Restore 4 Health. Draw a card.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Spell] - CORE_TRL_307 : Flash of Light")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flash of Light"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer,
+                 PlayCardTask::SpellTarget(card2, curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 24);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curHand.GetCount(), 6);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card1, curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 28);
+    CHECK_EQ(curHand.GetCount(), 6);
+}
+
 // ----------------------------------------- SPELL - PRIEST
 // [CORE_AT_055] Flash Heal - COST:1
 // - Set: CORE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/TrollCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TrollCardsGenTests.cpp
@@ -217,3 +217,57 @@ TEST_CASE("[Mage : Minion] - TRL_315 : Pyromaniac")
     CHECK_EQ(opField.GetCount(), 0);
     CHECK_EQ(curHand.GetCount(), 7);
 }
+
+// ---------------------------------------- SPELL - PALADIN
+// [TRL_307] Flash of Light - COST:2
+// - Set: Troll, Rarity: Common
+// --------------------------------------------------------
+// Text: Restore 4 Health. Draw a card.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Spell] - TRL_307 : Flash of Light")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flash of Light"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer,
+                 PlayCardTask::SpellTarget(card2, curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 24);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curHand.GetCount(), 6);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card1, curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 28);
+    CHECK_EQ(curHand.GetCount(), 6);
+}


### PR DESCRIPTION
This revision includes:
- Implement 5 CORE cards (#755)
  - Amber Watcher (CORE_DRG_226)
  - Bronze Explorer (CORE_DRG_229)
  - Ragnaros, Lightlord (CORE_OG_229)
  - Flash of Light (CORE_TRL_307)
  - Reckoning (CS3_016)
- Implement 1 OG card
  - Ragnaros, Lightlord (OG_229)
- Implement 1 TROLL card
  - Flash of Light (TRL_307)
- Add self condition 'IsEventSourceAttack()': SelfCondition wrapper for checking the attack of event source that satisfies condition with value and relaSign
- Separate text to improve readability