### PR TITLE
Implement 6 CORE cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -35,7 +35,7 @@ CORE | CORE_BT_491 | Spectral Sight | O
 CORE | CORE_BT_801 | Eye Beam | O
 CORE | CORE_BT_921 | Aldrachi Warblades | O
 CORE | CORE_CFM_120 | Mistress of Mixtures |  
-CORE | CORE_CFM_605 | Drakonid Operative |  
+CORE | CORE_CFM_605 | Drakonid Operative | O
 CORE | CORE_CFM_751 | Abyssal Enforcer |  
 CORE | CORE_CS1_112 | Holy Nova | O
 CORE | CORE_CS1_130 | Holy Smite | O
@@ -71,12 +71,12 @@ CORE | CORE_CS2_188 | Abusive Sergeant | O
 CORE | CORE_CS2_189 | Elven Archer | O
 CORE | CORE_CS2_203 | Ironbeak Owl | O
 CORE | CORE_CS2_222 | Stormwind Champion | O
-CORE | CORE_CS2_235 | Northshire Cleric |  
+CORE | CORE_CS2_235 | Northshire Cleric | O
 CORE | CORE_DAL_086 | Sunreaver Spy | O
 CORE | CORE_DAL_371 | Marked Shot | O
 CORE | CORE_DAL_416 | Hench-Clan Burglar |  
 CORE | CORE_DAL_609 | Kalecgos | O
-CORE | CORE_DRG_090 | Murozond the Infinite |  
+CORE | CORE_DRG_090 | Murozond the Infinite | O
 CORE | CORE_DRG_226 | Amber Watcher | O
 CORE | CORE_DRG_229 | Bronze Explorer | O
 CORE | CORE_DS1_184 | Tracking | O
@@ -173,7 +173,7 @@ CORE | CORE_GIL_622 | Lifedrinker |
 CORE | CORE_GIL_650 | Houndmaster Shaw | O
 CORE | CORE_GIL_801 | Snap Freeze | O
 CORE | CORE_GIL_828 | Dire Frenzy | O
-CORE | CORE_GVG_008 | Lightbomb |  
+CORE | CORE_GVG_008 | Lightbomb | O
 CORE | CORE_GVG_053 | Shieldmaiden | O
 CORE | CORE_GVG_076 | Explosive Sheep | O
 CORE | CORE_GVG_085 | Annoy-o-Tron | O
@@ -226,7 +226,7 @@ CORE | CORE_ULD_191 | Beaming Sidekick |
 CORE | CORE_ULD_209 | Vulpera Scoundrel |  
 CORE | CORE_ULD_271 | Injured Tol'vir |  
 CORE | CORE_UNG_020 | Arcanologist | O
-CORE | CORE_UNG_034 | Radiant Elemental |  
+CORE | CORE_UNG_034 | Radiant Elemental | O
 CORE | CORE_UNG_108 | Earthen Scales | O
 CORE | CORE_UNG_813 | Stormwatcher | O
 CORE | CORE_UNG_817 | Tidal Surge | O
@@ -234,7 +234,7 @@ CORE | CORE_UNG_833 | Lakkari Felhound | O
 CORE | CORE_UNG_844 | Humongous Razorleaf | O
 CORE | CORE_UNG_848 | Primordial Drake |  
 CORE | CORE_UNG_928 | Tar Creeper |  
-CORE | CORE_UNG_963 | Lyra the Sunshard |  
+CORE | CORE_UNG_963 | Lyra the Sunshard | O
 CORE | CORE_YOD_006 | Escaped Manasaber |  
 CORE | CS3_001 | Aegwynn, the Guardian |  
 CORE | CS3_003 | Felsoul Jailer | O
@@ -261,7 +261,7 @@ CORE | CS3_036 | Deathwing the Destroyer | O
 CORE | CS3_037 | Emerald Skytalon | O
 CORE | CS3_038 | Redgill Razorjaw | O
 
-- Progress: 78% (196 of 250 Cards)
+- Progress: 80% (202 of 250 Cards)
 
 ## Forged in the Barrens
 

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -12,6 +12,7 @@
 * [The League of Explorers](#the-league-of-explorers)
 * [Whispers of the Old Gods](#whispers-of-the-old-gods)
 * [One Night in Karazhan](#one-night-in-karazhan)
+* [Mean Streets of Gadgetzan](#mean-streets-of-gadgetzan)
 * [Journey to Un'Goro](#journey-to-ungoro)
 * [Knights of the Frozen Throne](#knights-of-the-frozen-throne)
 * [Kobolds & Catacombs](#kobolds--catacombs)
@@ -527,7 +528,7 @@ GVG | GVG_004 | Goblin Blastmage |
 GVG | GVG_005 | Echo of Medivh |  
 GVG | GVG_006 | Mechwarper |  
 GVG | GVG_007 | Flame Leviathan |  
-GVG | GVG_008 | Lightbomb |  
+GVG | GVG_008 | Lightbomb | O
 GVG | GVG_009 | Shadowbomber |  
 GVG | GVG_010 | Velen's Chosen |  
 GVG | GVG_011 | Shrinkmeister |  
@@ -644,7 +645,7 @@ GVG | GVG_121 | Clockwork Giant | O
 GVG | GVG_122 | Wee Spellstopper |  
 GVG | GVG_123 | Soot Spewer |  
 
-- Progress: 5% (7 of 123 Cards)
+- Progress: 6% (8 of 123 Cards)
 
 ## Blackrock Mountain
 
@@ -1068,6 +1069,145 @@ KARA | KAR_712 | Violet Illusionist |
 
 - Progress: 13% (6 of 45 Cards)
 
+## Mean Streets of Gadgetzan
+
+Set | ID | Name | Implemented
+:---: | :---: | :---: | :---:
+GANGS | CFM_020 | Raza the Chained |  
+GANGS | CFM_021 | Freezing Potion |  
+GANGS | CFM_025 | Wind-up Burglebot |  
+GANGS | CFM_026 | Hidden Cache |  
+GANGS | CFM_039 | Street Trickster |  
+GANGS | CFM_060 | Red Mana Wyrm |  
+GANGS | CFM_061 | Jinyu Waterspeaker |  
+GANGS | CFM_062 | Grimestreet Protector |  
+GANGS | CFM_063 | Kooky Chemist |  
+GANGS | CFM_064 | Blubber Baron |  
+GANGS | CFM_065 | Volcanic Potion |  
+GANGS | CFM_066 | Kabal Lackey |  
+GANGS | CFM_067 | Hozen Healer |  
+GANGS | CFM_094 | Felfire Potion |  
+GANGS | CFM_095 | Weasel Tunneler |  
+GANGS | CFM_120 | Mistress of Mixtures |  
+GANGS | CFM_300 | Public Defender |  
+GANGS | CFM_305 | Smuggler's Run |  
+GANGS | CFM_308 | Kun the Forgotten King |  
+GANGS | CFM_310 | Call in the Finishers |  
+GANGS | CFM_312 | Jade Chieftain |  
+GANGS | CFM_313 | Finders Keepers |  
+GANGS | CFM_315 | Alleycat |  
+GANGS | CFM_316 | Rat Pack |  
+GANGS | CFM_321 | Grimestreet Informant |  
+GANGS | CFM_324 | White Eyes |  
+GANGS | CFM_325 | Small-Time Buccaneer |  
+GANGS | CFM_328 | Fight Promoter |  
+GANGS | CFM_333 | Knuckles |  
+GANGS | CFM_334 | Smuggler's Crate |  
+GANGS | CFM_335 | Dispatch Kodo |  
+GANGS | CFM_336 | Shaky Zipgunner |  
+GANGS | CFM_337 | Piranha Launcher |  
+GANGS | CFM_338 | Trogg Beastrager |  
+GANGS | CFM_341 | Sergeant Sally |  
+GANGS | CFM_342 | Luckydo Buccaneer |  
+GANGS | CFM_343 | Jade Behemoth |  
+GANGS | CFM_344 | Finja, the Flying Star |  
+GANGS | CFM_602 | Jade Idol |  
+GANGS | CFM_603 | Potion of Madness |  
+GANGS | CFM_604 | Greater Healing Potion |  
+GANGS | CFM_605 | Drakonid Operative | O
+GANGS | CFM_606 | Mana Geode |  
+GANGS | CFM_608 | Blastcrystal Potion |  
+GANGS | CFM_609 | Fel Orc Soulfiend |  
+GANGS | CFM_610 | Crystalweaver |  
+GANGS | CFM_611 | Bloodfury Potion |  
+GANGS | CFM_614 | Mark of the Lotus |  
+GANGS | CFM_616 | Pilfered Power |  
+GANGS | CFM_617 | Celestial Dreamer |  
+GANGS | CFM_619 | Kabal Chemist |  
+GANGS | CFM_620 | Potion of Polymorph |  
+GANGS | CFM_621 | Kazakus |  
+GANGS | CFM_623 | Greater Arcane Missiles |  
+GANGS | CFM_626 | Kabal Talonpriest |  
+GANGS | CFM_630 | Counterfeit Coin |  
+GANGS | CFM_631 | Brass Knuckles |  
+GANGS | CFM_634 | Lotus Assassin |  
+GANGS | CFM_636 | Shadow Rager |  
+GANGS | CFM_637 | Patches the Pirate |  
+GANGS | CFM_639 | Grimestreet Enforcer |  
+GANGS | CFM_643 | Hobart Grapplehammer |  
+GANGS | CFM_646 | Backstreet Leper |  
+GANGS | CFM_647 | Blowgill Sniper |  
+GANGS | CFM_648 | Big-Time Racketeer |  
+GANGS | CFM_649 | Kabal Courier |  
+GANGS | CFM_650 | Grimscale Chum |  
+GANGS | CFM_651 | Naga Corsair |  
+GANGS | CFM_652 | Second-Rate Bruiser |  
+GANGS | CFM_653 | Hired Gun |  
+GANGS | CFM_654 | Friendly Bartender |  
+GANGS | CFM_655 | Toxic Sewer Ooze |  
+GANGS | CFM_656 | Streetwise Investigator |  
+GANGS | CFM_657 | Kabal Songstealer |  
+GANGS | CFM_658 | Backroom Bouncer |  
+GANGS | CFM_659 | Gadgetzan Socialite |  
+GANGS | CFM_660 | Manic Soulcaster |  
+GANGS | CFM_661 | Pint-Size Potion |  
+GANGS | CFM_662 | Dragonfire Potion |  
+GANGS | CFM_663 | Kabal Trafficker |  
+GANGS | CFM_665 | Worgen Greaser |  
+GANGS | CFM_666 | Grook Fu Master |  
+GANGS | CFM_667 | Bomb Squad |  
+GANGS | CFM_668 | Doppelgangster |  
+GANGS | CFM_669 | Burgly Bully |  
+GANGS | CFM_670 | Mayor Noggenfogger |  
+GANGS | CFM_671 | Cryomancer |  
+GANGS | CFM_672 | Madam Goya |  
+GANGS | CFM_685 | Don Han'Cho |  
+GANGS | CFM_687 | Inkmaster Solia |  
+GANGS | CFM_688 | Spiked Hogrider |  
+GANGS | CFM_690 | Jade Shuriken |  
+GANGS | CFM_691 | Jade Swarmer |  
+GANGS | CFM_693 | Gadgetzan Ferryman |  
+GANGS | CFM_694 | Shadow Sensei |  
+GANGS | CFM_696 | Devolve |  
+GANGS | CFM_697 | Lotus Illusionist |  
+GANGS | CFM_699 | Seadevil Stinger |  
+GANGS | CFM_707 | Jade Lightning |  
+GANGS | CFM_713 | Jade Blossom |  
+GANGS | CFM_715 | Jade Spirit |  
+GANGS | CFM_716 | Sleep with the Fishes |  
+GANGS | CFM_717 | Jade Claws |  
+GANGS | CFM_750 | Krul the Unshackled |  
+GANGS | CFM_751 | Abyssal Enforcer |  
+GANGS | CFM_752 | Stolen Goods |  
+GANGS | CFM_753 | Grimestreet Outfitter |  
+GANGS | CFM_754 | Grimy Gadgeteer |  
+GANGS | CFM_755 | Grimestreet Pawnbroker |  
+GANGS | CFM_756 | Alley Armorsmith |  
+GANGS | CFM_759 | Meanstreet Marshal |  
+GANGS | CFM_760 | Kabal Crystal Runner |  
+GANGS | CFM_781 | Shaku, the Collector |  
+GANGS | CFM_790 | Dirty Rat |  
+GANGS | CFM_800 | Getaway Kodo |  
+GANGS | CFM_806 | Wrathion |  
+GANGS | CFM_807 | Auctionmaster Beardo |  
+GANGS | CFM_808 | Genzo, the Shark |  
+GANGS | CFM_809 | Tanaris Hogchopper |  
+GANGS | CFM_810 | Leatherclad Hogleader |  
+GANGS | CFM_811 | Lunar Visions |  
+GANGS | CFM_815 | Wickerflame Burnbristle |  
+GANGS | CFM_816 | Virmen Sensei |  
+GANGS | CFM_851 | Daring Reporter |  
+GANGS | CFM_852 | Lotus Agents |  
+GANGS | CFM_853 | Grimestreet Smuggler |  
+GANGS | CFM_854 | Ancient of Blossoms |  
+GANGS | CFM_855 | Defias Cleaner |  
+GANGS | CFM_900 | Unlicensed Apothecary |  
+GANGS | CFM_902 | Aya Blackpaw |  
+GANGS | CFM_905 | Small-Time Recruits |  
+GANGS | CFM_940 | I Know a Guy |  
+
+- Progress: 0% (1 of 132 Cards)
+
 ## Journey to Un'Goro
 
 Set | ID | Name | Implemented
@@ -1091,7 +1231,7 @@ UNGORO | UNG_028 | Open the Waygate |
 UNGORO | UNG_029 | Shadow Visions |  
 UNGORO | UNG_030 | Binding Heal |  
 UNGORO | UNG_032 | Crystalline Oracle |  
-UNGORO | UNG_034 | Radiant Elemental |  
+UNGORO | UNG_034 | Radiant Elemental | O
 UNGORO | UNG_035 | Curious Glimmerroot |  
 UNGORO | UNG_037 | Tortollan Shellraiser |  
 UNGORO | UNG_047 | Ravenous Pterrordax |  
@@ -1206,9 +1346,9 @@ UNGORO | UNG_957 | Direhorn Hatchling |
 UNGORO | UNG_960 | Lost in the Jungle |  
 UNGORO | UNG_961 | Adaptation |  
 UNGORO | UNG_962 | Lightfused Stegodon |  
-UNGORO | UNG_963 | Lyra the Sunshard |  
+UNGORO | UNG_963 | Lyra the Sunshard | O
 
-- Progress: 4% (6 of 135 Cards)
+- Progress: 5% (8 of 135 Cards)
 
 ## Knights of the Frozen Throne
 

--- a/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
@@ -14,6 +14,7 @@ enum class DiscoverType
 {
     INVALID,
     DECK,
+    ENEMY_DECK,
     SPELL_FROM_DECK,
     BASIC_TOTEM,
     BASIC_TOTEM_CLASSIC,

--- a/Includes/Rosetta/PlayMode/CardSets/GangsCardsGen.hpp
+++ b/Includes/Rosetta/PlayMode/CardSets/GangsCardsGen.hpp
@@ -1,7 +1,7 @@
 // This code is based on Sabberstone project.
-// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// Copyright (c) 2017-2021 SabberStone Team, darkfriend77 & rnilva
 // RosettaStone is hearthstone simulator using C++ with reinforcement learning.
-// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+// Copyright (c) 2017-2021 Chris Ohk
 
 #ifndef ROSETTASTONE_GANGS_CARDS_GEN_HPP
 #define ROSETTASTONE_GANGS_CARDS_GEN_HPP

--- a/Includes/Rosetta/PlayMode/CardSets/GangsCardsGen.hpp
+++ b/Includes/Rosetta/PlayMode/CardSets/GangsCardsGen.hpp
@@ -1,0 +1,142 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_GANGS_CARDS_GEN_HPP
+#define ROSETTASTONE_GANGS_CARDS_GEN_HPP
+
+#include <Rosetta/PlayMode/Cards/CardDef.hpp>
+
+#include <map>
+#include <string>
+
+namespace RosettaStone::PlayMode
+{
+//!
+//! \brief GangsCardsGen class.
+//!
+//! This structure adds GANGS cards to the data storage with powers,
+//! play requirements and entourages.
+//!
+class GangsCardsGen
+{
+ public:
+    //! Adds hero cards to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddHeroes(std::map<std::string, CardDef>& cards);
+
+    //! Adds hero power cards to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddHeroPowers(std::map<std::string, CardDef>& cards);
+
+    //! Adds druid cards that are collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddDruid(std::map<std::string, CardDef>& cards);
+
+    //! Adds druid cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddDruidNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds hunter cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddHunter(std::map<std::string, CardDef>& cards);
+
+    //! Adds hunter cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddHunterNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds mage cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddMage(std::map<std::string, CardDef>& cards);
+
+    //! Adds mage cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddMageNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds paladin cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddPaladin(std::map<std::string, CardDef>& cards);
+
+    //! Adds paladin cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddPaladinNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds priest cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddPriest(std::map<std::string, CardDef>& cards);
+
+    //! Adds priest cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddPriestNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds rogue cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddRogue(std::map<std::string, CardDef>& cards);
+
+    //! Adds rogue cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddRogueNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds shaman cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddShaman(std::map<std::string, CardDef>& cards);
+
+    //! Adds shaman cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddShamanNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds warlock cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddWarlock(std::map<std::string, CardDef>& cards);
+
+    //! Adds warlock cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddWarlockNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds warrior cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddWarrior(std::map<std::string, CardDef>& cards);
+
+    //! Adds warrior cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddWarriorNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds neutral cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddNeutral(std::map<std::string, CardDef>& cards);
+
+    //! Adds neutral cards that are not collectible to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddNeutralNonCollect(std::map<std::string, CardDef>& cards);
+
+    //! Adds all cards to \p cards.
+    //! \param cards A list of cards to store the data such as powers,
+    //! play requirements and entourages.
+    static void AddAll(std::map<std::string, CardDef>& cards);
+};
+}  // namespace RosettaStone::PlayMode
+
+#endif  // ROSETTASTONE_GANGS_CARDS_GEN_HPP

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -93,6 +93,7 @@
 #include <Rosetta/PlayMode/CardSets/DemonHunterInitCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/DragonsCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/Expert1CardsGen.hpp>
+#include <Rosetta/PlayMode/CardSets/GangsCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/GilneasCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/GvgCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/IcecrownCardsGen.hpp>

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 78% Core Set (196 of 235 cards)
+  * 80% Core Set (202 of 235 cards)
   * 81% Forged in the Barrens (139 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
@@ -55,14 +55,14 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * **100% Expert1 (245 of 245 Cards)**
   * **100% Demon Hunter Initiate (20 of 20 Cards)**
   * **100% Curse of Naxxramas (30 of 30 Cards)**
-  * 5% Goblins vs Gnomes (7 of 123 Cards)
+  * 6% Goblins vs Gnomes (8 of 123 Cards)
   * 3% Blackrock Mountain (1 of 31 Cards)
   * 6% The Grand Tournament (9 of 132 Cards)
   * 8% The League of Explorers (4 of 45 Cards)
   * 4% Whispers of the Old Gods (6 of 134 Cards)
   * 13% One Night in Karazhan (6 of 45 Cards)
-  * 0% Mean Streets of Gadgetzan (0 of 132 Cards)
-  * 4% Journey to Un'Goro (6 of 135 Cards)
+  * 0% Mean Streets of Gadgetzan (1 of 132 Cards)
+  * 5% Journey to Un'Goro (8 of 135 Cards)
   * 3% Knights of the Frozen Throne (5 of 135 Cards)
   * 3% Kobolds & Catacombs (5 of 135 Cards)
   * 2% The Witchwood (4 of 135 Cards)

--- a/Sources/Rosetta/PlayMode/Actions/Generic.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Generic.cpp
@@ -24,6 +24,14 @@ void TakeDamageToCharacter(Playable* source, Character* target, int amount,
 {
     if (isSpellDamage)
     {
+        amount += source->player->GetCurrentSpellPower();
+
+        if (const auto spell = dynamic_cast<Spell*>(source); spell)
+        {
+            const SpellSchool spellSchool = spell->GetSpellSchool();
+            amount += source->player->GetExtraSpellPower(spellSchool);
+        }
+
         if (const auto value = source->player->playerAuraEffects.GetValue(
                 GameTag::SPELLPOWER_DOUBLE);
             value > 0)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1717,6 +1717,15 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - AURA = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(std::make_shared<Aura>(
+        AuraType::HAND, EffectList{ Effects::ReduceCost(1) }));
+    {
+        const auto aura = dynamic_cast<Aura*>(cardDef.power.GetAura());
+        aura->condition =
+            std::make_shared<SelfCondition>(SelfCondition::IsSpell());
+    }
+    cards.emplace("CORE_UNG_034", cardDef);
 
     // ---------------------------------------- MINION - PRIEST
     // [CORE_UNG_963] Lyra the Sunshard - COST:5 [ATK:3/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1477,6 +1477,11 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(std::make_shared<Trigger>(TriggerType::TAKE_HEAL));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::ALL_MINIONS;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<DrawTask>(1) };
+    cards.emplace("CORE_CS2_235", cardDef);
 
     // ---------------------------------------- MINION - PRIEST
     // [CORE_DRG_090] Murozond the Infinite - COST:8 [ATK:8/HP:8]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -971,15 +971,12 @@ void CoreCardsGen::AddMage(std::map<std::string, CardDef>& cards)
                     const auto realTarget = dynamic_cast<Character*>(target);
 
                     const int targetHealth = realTarget->GetHealth();
-                    const int realDamage =
-                        6 + source->player->GetCurrentSpellPower();
-
-                    Generic::TakeDamageToCharacter(realSource, realTarget,
-                                                   realDamage, true);
+                    Generic::TakeDamageToCharacter(realSource, realTarget, 6,
+                                                   true);
 
                     if (realTarget->isDestroyed)
                     {
-                        const int remainDamage = realDamage - targetHealth;
+                        const int remainDamage = 6 - targetHealth;
                         if (remainDamage > 0)
                         {
                             Generic::TakeDamageToCharacter(

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1688,6 +1688,25 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - AFFECTED_BY_SPELL_POWER = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<IncludeTask>(EntityType::SOURCE));
+    cardDef.power.AddPowerTask(std::make_shared<IncludeTask>(
+        EntityType::ALL_MINIONS, std::vector<EntityType>(), true));
+    cardDef.power.AddPowerTask(std::make_shared<FuncPlayableTask>(
+        [=](const std::vector<Playable*>& playables) {
+            const auto source = playables[0];
+
+            for (std::size_t i = 1; i < playables.size(); ++i)
+            {
+                const auto character = dynamic_cast<Character*>(playables[i]);
+                Generic::TakeDamageToCharacter(source, character,
+                                               character->GetAttack(), true);
+            }
+
+            return std::vector<Playable*>{};
+        }));
+    cards.emplace("CORE_GVG_008", cardDef);
 
     // ---------------------------------------- MINION - PRIEST
     // [CORE_UNG_034] Radiant Elemental - COST:2 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -3,8 +3,11 @@
 // RosettaStone is hearthstone simulator using C++ with reinforcement learning.
 // Copyright (c) 2017-2021 Chris Ohk
 
+#include <Rosetta/PlayMode/Actions/CastSpell.hpp>
 #include <Rosetta/PlayMode/Actions/Choose.hpp>
 #include <Rosetta/PlayMode/Actions/Draw.hpp>
+#include <Rosetta/PlayMode/Actions/PlayCard.hpp>
+#include <Rosetta/PlayMode/Actions/Summon.hpp>
 #include <Rosetta/PlayMode/Auras/AdaptiveEffect.hpp>
 #include <Rosetta/PlayMode/Auras/AdjacentAura.hpp>
 #include <Rosetta/PlayMode/Auras/EnrageEffect.hpp>
@@ -1494,6 +1497,93 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<CustomTask>(
+        [](Player* player, [[maybe_unused]] Entity* source,
+           [[maybe_unused]] Playable* target) {
+            auto cardsOpPlayedLastTurn = player->opponent->cardsPlayedThisTurn;
+            Random::shuffle(cardsOpPlayedLastTurn.begin(),
+                            cardsOpPlayedLastTurn.end());
+
+            for (auto& card : cardsOpPlayedLastTurn)
+            {
+                auto validTargets = card->GetValidPlayTargets(player);
+                if (card->mustHaveToTargetToPlay && validTargets.empty())
+                {
+                    continue;
+                }
+
+                const auto targetIdx =
+                    Random::get<std::size_t>(0, validTargets.size() - 1);
+                const auto randTarget =
+                    validTargets.empty() ? nullptr : validTargets[targetIdx];
+                const auto chooseOneIdx = Random::get<int>(1, 2);
+
+                Entity* entity = Entity::GetFromCard(player, card);
+
+                switch (card->GetCardType())
+                {
+                    case CardType::HERO:
+                    {
+                        Generic::PlayHero(player, dynamic_cast<Hero*>(entity),
+                                          randTarget, chooseOneIdx);
+                        break;
+                    }
+                    case CardType::MINION:
+                    {
+                        if (player->GetFieldZone()->IsFull())
+                        {
+                            break;
+                        }
+
+                        Generic::Summon(dynamic_cast<Minion*>(entity), -1,
+                                        player);
+
+                        player->game->ProcessDestroyAndUpdateAura();
+                        break;
+                    }
+                    case CardType::SPELL:
+                    {
+                        Generic::CastSpell(player, dynamic_cast<Spell*>(entity),
+                                           randTarget, chooseOneIdx);
+
+                        while (player->choice != nullptr)
+                        {
+                            const auto choiceIdx = Random::get<std::size_t>(
+                                0, player->choice->choices.size());
+                            Generic::ChoicePick(player,
+                                                static_cast<int>(choiceIdx));
+                        }
+
+                        player->game->ProcessDestroyAndUpdateAura();
+                        break;
+                    }
+                    case CardType::WEAPON:
+                    {
+                        auto weapon = dynamic_cast<Weapon*>(entity);
+
+                        if (auto aura = weapon->card->power.GetAura(); aura)
+                        {
+                            aura->Activate(weapon);
+                        }
+
+                        if (auto trigger = weapon->card->power.GetTrigger();
+                            trigger)
+                        {
+                            trigger->Activate(weapon);
+                        }
+
+                        player->GetHero()->AddWeapon(*weapon);
+                        break;
+                    }
+                    default:
+                        throw std::invalid_argument(
+                            "Murozond the Infinite (CORE_DRG_090) - Invalid "
+                            "card type!");
+                }
+            }
+        }));
+    cards.emplace("CORE_DRG_090", cardDef);
 
     // ---------------------------------------- MINION - PRIEST
     // [CORE_EX1_193] Psychic Conjurer - COST:1 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1419,13 +1419,21 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // - Race: Dragon, Set: CORE, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> If you're holding a Dragon,
-    //       <b>Discover</b> a copy of a card in
-    //       your opponent's deck.
+    //       <b>Discover</b> a copy of a card
+    //       in your opponent's deck.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
     // - DISCOVER = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsHoldingRace(Race::DRAGON)) }));
+    cardDef.power.AddPowerTask(std::make_shared<FlagTask>(
+        true,
+        TaskList{ std::make_shared<DiscoverTask>(DiscoverType::ENEMY_DECK) }));
+    cards.emplace("CORE_CFM_605", cardDef);
 
     // ----------------------------------------- SPELL - PRIEST
     // [CORE_CS1_112] Holy Nova - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1738,6 +1738,15 @@ void CoreCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::CAST_SPELL));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    cardDef.power.GetTrigger()->tasks = {
+        std::make_shared<RandomCardTask>(CardType::SPELL, CardClass::PRIEST),
+        std::make_shared<AddStackToTask>(EntityType::HAND)
+    };
+    cards.emplace("CORE_UNG_963", cardDef);
 
     // ---------------------------------------- MINION - PRIEST
     // [CS3_013] Shadowed Spirit - COST:3 [ATK:4/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/DragonsCardsGen.cpp
@@ -1845,8 +1845,8 @@ void DragonsCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // [DRG_090] Murozond the Infinite - COST:8 [ATK:8/HP:8]
     // - Race: Dragon, Set: Dragons, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Play all cards your opponent
-    //       played last turn.
+    // Text: <b>Battlecry:</b> Play all cards
+    //       your opponent played last turn.
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1

--- a/Sources/Rosetta/PlayMode/CardSets/GangsCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/GangsCardsGen.cpp
@@ -1,13 +1,17 @@
 // This code is based on Sabberstone project.
-// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
-// Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
-// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+// Copyright (c) 2017-2021 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2017-2021 Chris Ohk
 
 #include <Rosetta/PlayMode/CardSets/GangsCardsGen.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 
+using namespace RosettaStone::PlayMode::SimpleTasks;
+
 namespace RosettaStone::PlayMode
 {
+using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
+
 void GangsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
     // Do nothing
@@ -513,6 +517,8 @@ void GangsCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 
 void GangsCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ---------------------------------------- MINION - PRIEST
     // [CFM_020] Raza the Chained - COST:5 [ATK:5/HP:5]
     // - Set: GANGS, Rarity: Legendary
@@ -554,6 +560,14 @@ void GangsCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - DISCOVER = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsHoldingRace(Race::DRAGON)) }));
+    cardDef.power.AddPowerTask(std::make_shared<FlagTask>(
+        true,
+        TaskList{ std::make_shared<DiscoverTask>(DiscoverType::ENEMY_DECK) }));
+    cards.emplace("CFM_605", cardDef);
 
     // ---------------------------------------- MINION - PRIEST
     // [CFM_606] Mana Geode - COST:2 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/GangsCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/GangsCardsGen.cpp
@@ -1,0 +1,134 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// Hearthstone++ is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#include <Rosetta/PlayMode/CardSets/GangsCardsGen.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
+
+namespace RosettaStone::PlayMode
+{
+void GangsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddMage(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
+{
+}
+
+void GangsCardsGen::AddAll(std::map<std::string, CardDef>& cards)
+{
+    AddHeroes(cards);
+    AddHeroPowers(cards);
+
+    AddDruid(cards);
+    AddDruidNonCollect(cards);
+
+    AddHunter(cards);
+    AddHunterNonCollect(cards);
+
+    AddMage(cards);
+    AddMageNonCollect(cards);
+
+    AddPaladin(cards);
+    AddPaladinNonCollect(cards);
+
+    AddPriest(cards);
+    AddPriestNonCollect(cards);
+
+    AddRogue(cards);
+    AddRogueNonCollect(cards);
+
+    AddShaman(cards);
+    AddShamanNonCollect(cards);
+
+    AddWarlock(cards);
+    AddWarlockNonCollect(cards);
+
+    AddWarrior(cards);
+    AddWarriorNonCollect(cards);
+
+    AddNeutral(cards);
+    AddNeutralNonCollect(cards);
+}
+}  // namespace RosettaStone::PlayMode

--- a/Sources/Rosetta/PlayMode/CardSets/GangsCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/GangsCardsGen.cpp
@@ -10,90 +10,2459 @@ namespace RosettaStone::PlayMode
 {
 void GangsCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
+    // Do nothing
 }
 
 void GangsCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 {
+    // Do nothing
 }
 
 void GangsCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------------- MINION - DRUID
+    // [CFM_308] Kun the Forgotten King - COST:10 [ATK:7/HP:7]
+    // - Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Choose One -</b> Gain 10 Armor;
+    //       or Refresh your Mana Crystals.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - CHOOSE_ONE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [CFM_343] Jade Behemoth - COST:6 [ATK:3/HP:6]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> Summon a {1}/{0} <b>Jade Golem</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - TAUNT = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [CFM_602] Jade Idol - COST:1
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Choose One -</b> Summon a {1}/{0} <b>Jade Golem</b>;
+    //       or Shuffle 3 copies of this card into your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CHOOSE_ONE = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [CFM_614] Mark of the Lotus - COST:1
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Give your minions +1/+1.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [CFM_616] Pilfered Power - COST:3
+    // - Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Gain an empty Mana Crystal for each friendly minion.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [CFM_617] Celestial Dreamer - COST:3 [ATK:3/HP:3]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you control a minion
+    //       with 5 or more Attack, gain +2/+2.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [CFM_713] Jade Blossom - COST:3
+    // - Set: GANGS, Rarity: Common
+    // - Spell School: Nature
+    // --------------------------------------------------------
+    // Text: Summon a {1}/{0} <b>Jade Golem</b>.
+    //       Gain an empty Mana Crystal.
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [CFM_811] Lunar Visions - COST:5
+    // - Set: GANGS, Rarity: Epic
+    // - Spell School: Arcane
+    // --------------------------------------------------------
+    // Text: Draw 2 cards. Minions drawn cost (2) less.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [CFM_816] Virmen Sensei - COST:5 [ATK:4/HP:5]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a friendly Beast +2/+2.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ------------------------------------------ SPELL - DRUID
+    // [CFM_308a] Forgotten Armor - COST:10
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Gain 10 Armor.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [CFM_308b] Forgotten Mana - COST:10
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Refresh your Mana Crystals.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [CFM_602a] Cut from Jade - COST:1
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Summon a {1}/{0} <b>Jade Golem</b>.
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [CFM_602b] Jade Stash - COST:1
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Shuffle 3 Jade Idols into your deck.
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------------- SPELL - HUNTER
+    // [CFM_026] Hidden Cache - COST:2
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Secret:</b> After your opponent plays a minion,
+    //       give a random minion in your hand +2/+2.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [CFM_315] Alleycat - COST:1 [ATK:1/HP:1]
+    // - Race: Beast, Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon a 1/1 Cat.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [CFM_316] Rat Pack - COST:3 [ATK:2/HP:2]
+    // - Race: Beast, Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Summon a number of 1/1 Rats
+    //       equal to this minion's Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [CFM_333] Knuckles - COST:5 [ATK:3/HP:7]
+    // - Race: Beast, Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: After this attacks a minion,
+    //       it also hits the enemy hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - FINISH_ATTACK_SPELL_ON_DAMAGE = 1
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [CFM_334] Smuggler's Crate - COST:1
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Give a random Beast in your hand +2/+2.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [CFM_335] Dispatch Kodo - COST:4 [ATK:2/HP:4]
+    // - Race: Beast, Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Deal damage equal to
+    //       this minion's Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [CFM_336] Shaky Zipgunner - COST:3 [ATK:3/HP:3]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Give a random minion
+    //       in your hand +2/+2.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- WEAPON - HUNTER
+    // [CFM_337] Piranha Launcher - COST:5
+    // - Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: After your hero attacks, summon a 1/1 Piranha.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [CFM_338] Trogg Beastrager - COST:2 [ATK:3/HP:2]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a random Beast
+    //       in your hand +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------- ENCHANTMENT - HUNTER
+    // [CFM_026e] Smuggling - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +2/+2 from Hidden Cache.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [CFM_315t] Tabbycat - COST:1 [ATK:1/HP:1]
+    // - Race: Beast, Set: GANGS
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [CFM_316t] Rat - COST:1 [ATK:1/HP:1]
+    // - Race: Beast, Set: GANGS
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [CFM_337t] Piranha - COST:1 [ATK:1/HP:1]
+    // - Race: Beast, Set: GANGS
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - HUNTER
+    // [CFM_338e] Smuggling - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +1/+1 from Trogg Beastrager.
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    // ------------------------------------------- SPELL - MAGE
+    // [CFM_021] Freezing Potion - COST:0
+    // - Set: GANGS, Rarity: Common
+    // - Spell School: Frost
+    // --------------------------------------------------------
+    // Text: <b>Freeze</b> an enemy.
+    // --------------------------------------------------------
+    // RefTag:
+    // - FREEZE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [CFM_065] Volcanic Potion - COST:3
+    // - Set: GANGS, Rarity: Rare
+    // - Spell School: Fire
+    // --------------------------------------------------------
+    // Text: Deal 2 damage to all minions.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [CFM_066] Kabal Lackey - COST:1 [ATK:2/HP:1]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> The next <b>Secret</b>
+    //       you play this turn costs (0).
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [CFM_620] Potion of Polymorph - COST:3
+    // - Set: GANGS, Rarity: Rare
+    // - Spell School: Arcane
+    // --------------------------------------------------------
+    // Text: <b>Secret:</b> After your opponent plays a minion,
+    //       transform it into a 1/1 Sheep.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [CFM_623] Greater Arcane Missiles - COST:7
+    // - Set: GANGS, Rarity: Epic
+    // - Spell School: Arcane
+    // --------------------------------------------------------
+    // Text: Shoot three missiles at random enemies
+    //       that deal 3 damage each.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [CFM_660] Manic Soulcaster - COST:3 [ATK:3/HP:4]
+    // - Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Choose a friendly minion.
+    //       Shuffle a copy into your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [CFM_671] Cryomancer - COST:5 [ATK:5/HP:5]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If an enemy is <b>Frozen</b>,
+    //       gain +2/+2.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - FREEZE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [CFM_687] Inkmaster Solia - COST:7 [ATK:5/HP:5]
+    // - Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your deck has no duplicates,
+    //       the next spell you cast this turn costs (0).
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [CFM_760] Kabal Crystal Runner - COST:6 [ATK:5/HP:5]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Costs (2) less for each <b>Secret</b>
+    //       you've played this game.
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ------------------------------------- ENCHANTMENT - MAGE
+    // [CFM_687e] Free Spell - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: The next spell you cast this turn costs (0).
+    // --------------------------------------------------------
+    // GameTag:
+    // - CANT_BE_SILENCED = 1
+    // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 {
+    // --------------------------------------- MINION - PALADIN
+    // [CFM_062] Grimestreet Protector - COST:7 [ATK:6/HP:6]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> Give adjacent minions
+    //       <b>Divine Shield</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - TAUNT = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DIVINE_SHIELD = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [CFM_305] Smuggler's Run - COST:1
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Give all minions in your hand +1/+1.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [CFM_639] Grimestreet Enforcer - COST:5 [ATK:4/HP:4]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: At the end of your turn,
+    //       give all minions in your hand +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [CFM_650] Grimscale Chum - COST:1 [ATK:2/HP:1]
+    // - Race: Murloc, Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a random Murloc
+    //       in your hand +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [CFM_753] Grimestreet Outfitter - COST:2 [ATK:1/HP:1]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give all minions
+    //       in your hand +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [CFM_759] Meanstreet Marshal - COST:1 [ATK:1/HP:2]
+    // - Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> If this minion has 2 or
+    //       more Attack, draw a card.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [CFM_800] Getaway Kodo - COST:1
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Secret:</b> When a friendly minion dies,
+    //       return it to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [CFM_815] Wickerflame Burnbristle - COST:3 [ATK:2/HP:2]
+    // - Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Divine Shield, Taunt, Lifesteal</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DIVINE_SHIELD = 1
+    // - LIFESTEAL = 1
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [CFM_905] Small-Time Recruits - COST:3
+    // - Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Draw three 1-Cost minions from your deck.
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [CFM_305e] Smuggling - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +1/+1 from Smuggler's Run.
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- MINION - PRIEST
+    // [CFM_020] Raza the Chained - COST:5 [ATK:5/HP:5]
+    // - Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your deck has no duplicates,
+    //       your Hero Power costs (0) this game.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [CFM_603] Potion of Madness - COST:1
+    // - Set: GANGS, Rarity: Common
+    // - Spell School: Shadow
+    // --------------------------------------------------------
+    // Text: Gain control of an enemy minion with 2
+    //       or less Attack until end of turn.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [CFM_604] Greater Healing Potion - COST:4
+    // - Set: GANGS, Rarity: Rare
+    // - Spell School: Holy
+    // --------------------------------------------------------
+    // Text: Restore 12 Health to a friendly character.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [CFM_605] Drakonid Operative - COST:5 [ATK:5/HP:6]
+    // - Race: Dragon, Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you're holding a Dragon,
+    //       <b>Discover</b> a copy of a card
+    //       in your opponent's deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [CFM_606] Mana Geode - COST:2 [ATK:2/HP:3]
+    // - Race: Elemental, Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Whenever this minion is healed, summon a 2/2 Crystal.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [CFM_626] Kabal Talonpriest - COST:3 [ATK:3/HP:4]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a friendly minion +3 Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [CFM_657] Kabal Songstealer - COST:5 [ATK:5/HP:5]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Silence</b> a minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SILENCE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [CFM_661] Pint-Size Potion - COST:1
+    // - Set: GANGS, Rarity: Rare
+    // - Spell School: Shadow
+    // --------------------------------------------------------
+    // Text: Give all enemy minions -3 Attack this turn only.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [CFM_662] Dragonfire Potion - COST:6
+    // - Set: GANGS, Rarity: Epic
+    // - Spell School: Fire
+    // --------------------------------------------------------
+    // Text: Deal 5 damage to all minions except Dragons.
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------- ENCHANTMENT - PRIEST
+    // [CFM_603e] Madness Potion - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: This minion has switched controllers this turn.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [CFM_606t] Crystal - COST:2 [ATK:2/HP:2]
+    // - Race: Elemental, Set: GANGS
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - PRIEST
+    // [CFM_661e] Shrunk - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: -3 Attack this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 {
+    // ----------------------------------------- MINION - ROGUE
+    // [CFM_342] Luckydo Buccaneer - COST:6 [ATK:5/HP:5]
+    // - Race: Pirate, Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your weapon has at least
+    //       3 Attack, gain +4/+4.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [CFM_630] Counterfeit Coin - COST:0
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Gain 1 Mana Crystal this turn only.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [CFM_634] Lotus Assassin - COST:5 [ATK:5/HP:5]
+    // - Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b>.
+    //       Whenever this attacks and kills a minion,
+    //       gain <b>Stealth</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - STEALTH = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [CFM_636] Shadow Rager - COST:3 [ATK:5/HP:1]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - STEALTH = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [CFM_690] Jade Shuriken - COST:2
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Deal 2 damage.
+    //       <b>Combo:</b> Summon a {1}/{0} <b>Jade Golem</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - COMBO = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - CHOOSE_ONE = 1
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [CFM_691] Jade Swarmer - COST:2 [ATK:1/HP:1]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b>
+    //       <b>Deathrattle:</b> Summon a {1}/{0} <b>Jade Golem</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // - STEALTH = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [CFM_693] Gadgetzan Ferryman - COST:2 [ATK:2/HP:3]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Combo:</b> Return a friendly minion to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - COMBO = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [CFM_694] Shadow Sensei - COST:4 [ATK:4/HP:4]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a <b>Stealthed</b> minion +2/+2.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - STEALTH = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [CFM_781] Shaku, the Collector - COST:3 [ATK:2/HP:3]
+    // - Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b>. Whenever this attacks,
+    //       add a random card to your hand
+    //       <i>(from your opponent's class).</i>
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - STEALTH = 1
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ------------------------------------ ENCHANTMENT - ROGUE
+    // [CFM_342e] Looted Blade - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +4/+4.
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - ROGUE
+    // [CFM_694e] Trained - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +2/+2.
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- MINION - SHAMAN
+    // [CFM_061] Jinyu Waterspeaker - COST:4 [ATK:3/HP:6]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Restore 6 Health.
+    //       <b>Overload:</b> (1)
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - OVERLOAD = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [CFM_310] Call in the Finishers - COST:4
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Summon four 1/1 Murlocs.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [CFM_312] Jade Chieftain - COST:7 [ATK:5/HP:5]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon a {1}/{0} <b>Jade Golem</b>.
+    //       Give it <b>Taunt</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [CFM_313] Finders Keepers - COST:1
+    // - Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Discover</b> a card with <b>Overload</b>.
+    //       <b>Overload:</b> (1)
+    // --------------------------------------------------------
+    // GameTag:
+    // - DISCOVER = 1
+    // - OVERLOAD = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [CFM_324] White Eyes - COST:5 [ATK:5/HP:5]
+    // - Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Deathrattle:</b> Shuffle 'The Storm Guardian'
+    //       into your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DEATHRATTLE = 1
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [CFM_696] Devolve - COST:2
+    // - Set: GANGS, Rarity: Rare
+    // - Spell School: Nature
+    // --------------------------------------------------------
+    // Text: Transform all enemy minions into random ones
+    //       that cost (1) less.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [CFM_697] Lotus Illusionist - COST:4 [ATK:3/HP:5]
+    // - Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: After this minion attacks a hero,
+    //       transform it into a random 6-Cost minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [CFM_707] Jade Lightning - COST:4
+    // - Set: GANGS, Rarity: Common
+    // - Spell School: Nature
+    // --------------------------------------------------------
+    // Text: Deal 4 damage. Summon a {1}/{0} <b>Jade Golem</b>.
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- WEAPON - SHAMAN
+    // [CFM_717] Jade Claws - COST:2
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon a {1}/{0} <b>Jade Golem</b>.
+    //       <b><b>Overload</b>:</b> (1)
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - OVERLOAD = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- MINION - SHAMAN
+    // [CFM_310t] Murloc Razorgill - COST:1 [ATK:1/HP:1]
+    // - Race: Murloc, Set: GANGS
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [CFM_324t] The Storm Guardian - COST:5 [ATK:10/HP:10]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - TAUNT = 1
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------------- SPELL - WARLOCK
+    // [CFM_094] Felfire Potion - COST:6
+    // - Set: GANGS, Rarity: Rare
+    // - Spell School: Fel
+    // --------------------------------------------------------
+    // Text: Deal 5 damage to all characters.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [CFM_608] Blastcrystal Potion - COST:4
+    // - Set: GANGS, Rarity: Common
+    // - Spell School: Shadow
+    // --------------------------------------------------------
+    // Text: Destroy a minion and one of your Mana Crystals.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [CFM_610] Crystalweaver - COST:4 [ATK:5/HP:4]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give your Demons +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [CFM_611] Bloodfury Potion - COST:3
+    // - Set: GANGS, Rarity: Rare
+    // - Spell School: Shadow
+    // --------------------------------------------------------
+    // Text: Give a minion +3 Attack.
+    //       If it's a Demon, also give it +3 Health.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [CFM_663] Kabal Trafficker - COST:6 [ATK:6/HP:6]
+    // - Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: At the end of your turn,
+    //       add a random Demon to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [CFM_699] Seadevil Stinger - COST:4 [ATK:4/HP:2]
+    // - Race: Murloc, Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> The next Murloc you play
+    //       this turn costs Health instead of Mana.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [CFM_750] Krul the Unshackled - COST:9 [ATK:7/HP:9]
+    // - Race: Demon, Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your deck has no duplicates,
+    //       summon all Demons from your hand. 
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [CFM_751] Abyssal Enforcer - COST:7 [ATK:6/HP:6]
+    // - Race: Demon, Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Deal 3 damage to all other characters.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [CFM_900] Unlicensed Apothecary - COST:3 [ATK:5/HP:5]
+    // - Race: Demon, Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: After you summon a minion, deal 5 damage to your hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // Do nothing
 }
 
 void GangsCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 {
+    // --------------------------------------- MINION - WARRIOR
+    // [CFM_300] Public Defender - COST:2 [ATK:0/HP:7]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- WEAPON - WARRIOR
+    // [CFM_631] Brass Knuckles - COST:4
+    // - Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: After your hero attacks,
+    //       give a random minion in your hand +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [CFM_643] Hobart Grapplehammer - COST:2 [ATK:2/HP:2]
+    // - Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give all weapons in your hand
+    //       and deck +1 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [CFM_716] Sleep with the Fishes - COST:2
+    // - Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Deal 3 damage to all damaged minions.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [CFM_752] Stolen Goods - COST:2
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Give a random <b>Taunt</b> minion in your hand +3/+3.
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [CFM_754] Grimy Gadgeteer - COST:4 [ATK:4/HP:3]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: At the end of your turn,
+    //       give a random minion in your hand +2/+2.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [CFM_755] Grimestreet Pawnbroker - COST:3 [ATK:3/HP:3]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a random weapon
+    //       in your hand +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [CFM_756] Alley Armorsmith - COST:5 [ATK:2/HP:7]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       Whenever this minion deals damage,
+    //       gain that much Armor.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [CFM_940] I Know a Guy - COST:1
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Discover</b> a <b>Taunt</b> minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------- ENCHANTMENT - WARRIOR
+    // [CFM_643e] Smuggling - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +1 Attack from Hobart Grapplehammer.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARRIOR
+    // [CFM_643e2] Smuggling - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +1 Attack from Hobart Grapplehammer.
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 {
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_025] Wind-up Burglebot - COST:6 [ATK:5/HP:5]
+    // - Race: Mechanical, Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Whenever this attacks a minion and survives,
+    //       draw a card.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_039] Street Trickster - COST:3 [ATK:0/HP:7]
+    // - Race: Demon, Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Spell Damage +1</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - SPELLPOWER = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_060] Red Mana Wyrm - COST:5 [ATK:2/HP:6]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Whenever you cast a spell, gain +2 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_063] Kooky Chemist - COST:4 [ATK:4/HP:4]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Swap the Attack
+    //       and Health of a minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_064] Blubber Baron - COST:3 [ATK:1/HP:1]
+    // - Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Whenever you summon a <b>Battlecry</b> minion
+    //       while this is in your hand, gain +1/+1.
+    // --------------------------------------------------------
+    // RefTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_067] Hozen Healer - COST:4 [ATK:2/HP:6]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry</b>: Restore a minion to full Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_095] Weasel Tunneler - COST:1 [ATK:1/HP:1]
+    // - Race: Beast, Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Shuffle this minion
+    //       into your opponent's deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_120] Mistress of Mixtures - COST:1 [ATK:2/HP:2]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Restore 4 Health to each hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_321] Grimestreet Informant - COST:2 [ATK:1/HP:1]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Discover</b> a Hunter,
+    //       Paladin, or Warrior card.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - GRIMY_GOONS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_325] Small-Time Buccaneer - COST:1 [ATK:1/HP:1]
+    // - Race: Pirate, Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Has +2 Attack while you have a weapon equipped.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_328] Fight Promoter - COST:6 [ATK:4/HP:4]
+    // - Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you control a minion with 6
+    //       or more Health, draw two cards.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_341] Sergeant Sally - COST:3 [ATK:1/HP:1]
+    // - Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Deal damage equal to
+    //       this minion's Attack to all enemy minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_344] Finja, the Flying Star - COST:5 [ATK:2/HP:4]
+    // - Race: Murloc, Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Stealth</b>
+    //       Whenever this attacks and kills a minion,
+    //       summon 2 Murlocs from your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - STEALTH = 1
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_609] Fel Orc Soulfiend - COST:3 [ATK:3/HP:7]
+    // - Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: At the start of your turn,
+    //       deal 2 damage to this minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_619] Kabal Chemist - COST:4 [ATK:3/HP:3]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Add a random Potion to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - KABAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_621] Kazakus - COST:4 [ATK:3/HP:3]
+    // - Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your deck has no duplicates,
+    //       create a custom spell.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - KABAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_637] Patches the Pirate - COST:1 [ATK:1/HP:1]
+    // - Race: Pirate, Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: After you play a Pirate,
+    //       summon this minion from your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_646] Backstreet Leper - COST:3 [ATK:3/HP:1]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Deathrattle:</b> Deal 2 damage to the enemy hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_647] Blowgill Sniper - COST:2 [ATK:2/HP:1]
+    // - Race: Murloc, Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Deal 1 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_648] Big-Time Racketeer - COST:6 [ATK:1/HP:1]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon a 6/6 Ogre.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_649] Kabal Courier - COST:3 [ATK:2/HP:2]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Discover</b> a Mage,
+    //       Priest, or Warlock card.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - KABAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_651] Naga Corsair - COST:4 [ATK:5/HP:4]
+    // - Race: Pirate, Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give your weapon +1 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_652] Second-Rate Bruiser - COST:5 [ATK:4/HP:5]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       Costs (2) less if your opponent has
+    //       at least three minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_653] Hired Gun - COST:3 [ATK:4/HP:3]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_654] Friendly Bartender - COST:2 [ATK:2/HP:3]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: At the end of your turn,
+    //       restore 1 Health to your hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_655] Toxic Sewer Ooze - COST:3 [ATK:4/HP:3]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Remove 1 Durability
+    //       from your opponent's weapon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_656] Streetwise Investigator - COST:5 [ATK:4/HP:6]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Enemy minions lose <b>Stealth</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - STEALTH = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_658] Backroom Bouncer - COST:4 [ATK:4/HP:4]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Whenever a friendly minion dies, gain +1 Attack.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_659] Gadgetzan Socialite - COST:2 [ATK:2/HP:2]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Restore 2 Health.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_665] Worgen Greaser - COST:4 [ATK:6/HP:4]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_666] Grook Fu Master - COST:5 [ATK:3/HP:5]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Windfury</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - WINDFURY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_667] Bomb Squad - COST:5 [ATK:2/HP:2]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Deal 5 damage to an enemy minion.
+    //       <b>Deathrattle:</b> Deal 5 damage to your hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DEATHRATTLE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_668] Doppelgangster - COST:5 [ATK:2/HP:2]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon 2 copies of this minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_669] Burgly Bully - COST:5 [ATK:4/HP:6]
+    // - Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: Whenever your opponent casts a spell,
+    //       add a Coin to your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_670] Mayor Noggenfogger - COST:9 [ATK:5/HP:4]
+    // - Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: All targets are chosen randomly.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_672] Madam Goya - COST:6 [ATK:4/HP:3]
+    // - Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Choose a friendly minion.
+    //       Swap it with a minion in your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_685] Don Han'Cho - COST:7 [ATK:5/HP:6]
+    // - Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a random minion
+    //       in your hand +5/+5.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - GRIMY_GOONS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_688] Spiked Hogrider - COST:5 [ATK:5/HP:5]
+    // - Race: Quilboar, Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If an enemy minion has <b>Taunt</b>,
+    //       gain <b>Charge</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - CHARGE = 1
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_715] Jade Spirit - COST:4 [ATK:2/HP:3]
+    // - Race: Elemental, Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon a {1}/{0} <b>Jade Golem</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - JADE_GOLEM = 1
+    // - JADE_LOTUS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_790] Dirty Rat - COST:2 [ATK:2/HP:6]
+    // - Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Battlecry:</b> Your opponent summons
+    //       a random minion from their hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_806] Wrathion - COST:6 [ATK:4/HP:5]
+    // - Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>.
+    //       <b>Battlecry:</b> Draw cards until you draw one
+    //       that isn't a Dragon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_807] Auctionmaster Beardo - COST:3 [ATK:3/HP:4]
+    // - Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: After you cast a spell, refresh your Hero Power.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_808] Genzo, the Shark - COST:4 [ATK:5/HP:4]
+    // - Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: Whenever this attacks,
+    //       both players draw until they have 3 cards.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_809] Tanaris Hogchopper - COST:4 [ATK:4/HP:4]
+    // - Race: Quilboar, Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your opponent's hand is empty,
+    //       gain <b>Charge</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - CHARGE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_810] Leatherclad Hogleader - COST:6 [ATK:6/HP:6]
+    // - Race: Quilboar, Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your opponent has 6 or
+    //       more cards in hand, gain <b>Charge</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - CHARGE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_851] Daring Reporter - COST:4 [ATK:3/HP:3]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Whenever your opponent draws a card, gain +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_852] Lotus Agents - COST:5 [ATK:5/HP:3]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Discover</b> a Druid,
+    //       Rogue, or Shaman card.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // - JADE_LOTUS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_853] Grimestreet Smuggler - COST:3 [ATK:2/HP:4]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Give a random minion
+    //       in your hand +1/+1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - GRIMY_GOONS = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_854] Ancient of Blossoms - COST:6 [ATK:3/HP:8]
+    // - Set: GANGS, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_855] Defias Cleaner - COST:6 [ATK:5/HP:7]
+    // - Set: GANGS, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Silence</b> a minion
+    //       with <b>Deathrattle</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
+    // - SILENCE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_902] Aya Blackpaw - COST:6 [ATK:5/HP:3]
+    // - Set: GANGS, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry and Deathrattle:</b>
+    //       Summon a {1}/{0} <b>Jade Golem</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - DEATHRATTLE = 1
+    // - JADE_GOLEM = 1
+    // - JADE_LOTUS = 1
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 {
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_020e] Raza Enchant - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Your <b>Hero Power</b> costs (0).
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_060e] Mana Heist - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Increased Attack.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_063e] Kooky Chemistry - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Attack and Health have been swapped by Kooky Chemist.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_064e] Size Increase - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Increased stats.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_325e] Equipped - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +2 Attack.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_334e] Smuggling - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +2/+2 from Smuggler's Crate.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_336e] Smuggling - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +2/+2 from Shaky Zipgunner.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_610e] Serrated Shadows - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +1/+1.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_611e] Demonic Draught - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +3 Attack.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_611e2] Demonic Draught - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +3/+3.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_614e] Savage Mark - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +1/+1.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_617e] Visions of Hypnos - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +2/+2.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_621_m2] Kabal Demon - COST:5 [ATK:5/HP:5]
+    // - Race: Demon, Set: GANGS
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_621_m3] Kabal Demon - COST:8 [ATK:8/HP:8]
+    // - Race: Demon, Set: GANGS
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_621_m4] Kabal Demon - COST:2 [ATK:2/HP:2]
+    // - Race: Demon, Set: GANGS
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_621_m5] Sheep - COST:1 [ATK:1/HP:1]
+    // - Race: Beast, Set: GANGS
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_621e] Goldthorn - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +2 Health.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_621e2] Goldthorn - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +4 Health.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_621e3] Goldthorn - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +6 Health.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t] Kazakus Potion - COST:1
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: {0}
+    //       {1}
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t10] Netherbloom - COST:1
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Summon a 2/2 Demon.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t11] Lesser Potion - COST:1
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Create a 1-Cost spell.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t12] Greater Potion - COST:5
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Create a 5-Cost spell.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t13] Superior Potion - COST:10
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Create a 10-Cost spell.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t14] Kazakus Potion - COST:5
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: {0}
+    //       {1}
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t15] Kazakus Potion - COST:10
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: {0}
+    //       {1}
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t16] Heart of Fire - COST:5
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Deal 5 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AFFECTED_BY_SPELL_POWER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t17] Stonescale Oil - COST:5
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Gain 7 Armor.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t18] Felbloom - COST:5
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Deal 4 damage to all minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AFFECTED_BY_SPELL_POWER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t19] Icecap - COST:5
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: <b>Freeze</b> 2 random enemy minions.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t2] Heart of Fire - COST:1
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Deal 3 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AFFECTED_BY_SPELL_POWER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t20] Netherbloom - COST:5
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Summon a 5/5 Demon.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t21] Mystic Wool - COST:5
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Transform a random enemy minion into a 1/1 Sheep.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t22] Kingsblood - COST:5
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Draw 2 cards.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t23] Shadow Oil - COST:5
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Add 2 random Demons to your hand.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t24] Goldthorn - COST:5
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Give your minions +4 Health.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t25] Heart of Fire - COST:10
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Deal 8 damage.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AFFECTED_BY_SPELL_POWER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t26] Stonescale Oil - COST:10
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Gain 10 Armor.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t27] Icecap - COST:10
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: <b>Freeze</b> 3 random enemy minions.
+    // --------------------------------------------------------
+    // RefTag:
+    // - FREEZE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t28] Netherbloom - COST:10
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Summon an 8/8 Demon.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t29] Mystic Wool - COST:10
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Transform all minions into 1/1 Sheep.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t3] Stonescale Oil - COST:1
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Gain 4 Armor.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t30] Kingsblood - COST:10
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Draw 3 cards.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t31] Shadow Oil - COST:10
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Add 3 random Demons to your hand.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t32] Goldthorn - COST:10
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Give your minions +6 Health.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t33] Felbloom - COST:10
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Deal 6 damage to all minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AFFECTED_BY_SPELL_POWER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t37] Ichor of Undeath - COST:1
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Summon a friendly minion that died this game.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t38] Ichor of Undeath - COST:5
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Summon 2 friendly minions that died this game.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t39] Ichor of Undeath - COST:10
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Summon 3 friendly minions that died this game.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t4] Felbloom - COST:1
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Deal 2 damage to all minions.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AFFECTED_BY_SPELL_POWER = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t5] Icecap - COST:1
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: <b>Freeze</b> a random enemy minion.
+    // --------------------------------------------------------
+    // RefTag:
+    // - FREEZE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t6] Goldthorn - COST:1
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Give your minions +2 Health.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t8] Kingsblood - COST:1
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Draw a card.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - NEUTRAL
+    // [CFM_621t9] Shadow Oil - COST:1
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Add a random Demon to your hand.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_626e] Fortitude - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +3 Health.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_631e] Smuggling - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Increased stats from Brass Knuckles.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_639e] Smuggling - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Increased stats from Grimestreet Enforcer.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_648t] "Little Friend" - COST:6 [ATK:6/HP:6]
+    // - Set: GANGS
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_650e] Smuggling - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +1/+1 from Grimscale Chum.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_651e] Extra Sharp - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +1 Attack.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_658e] Cut Off - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Increased Attack.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_668t] Doppelgangster - COST:5 [ATK:2/HP:2]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon 2 copies of this minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_668t2] Doppelgangster - COST:5 [ATK:2/HP:2]
+    // - Set: GANGS, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Summon 2 copies of this minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_671e] We All Scream - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +2/+2.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_685e] Smuggling - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +5/+5 from Don Han'Cho.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_699e] Seadevil Enchant - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // GameTag:
+    // - CANT_BE_SILENCED = 1
+    // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t01] Jade Golem - COST:1 [ATK:1/HP:1]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t02] Jade Golem - COST:2 [ATK:2/HP:2]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t03] Jade Golem - COST:3 [ATK:3/HP:3]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t04] Jade Golem - COST:4 [ATK:4/HP:4]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t05] Jade Golem - COST:5 [ATK:5/HP:5]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t06] Jade Golem - COST:6 [ATK:6/HP:6]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t07] Jade Golem - COST:7 [ATK:7/HP:7]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t08] Jade Golem - COST:8 [ATK:8/HP:8]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t09] Jade Golem - COST:9 [ATK:9/HP:9]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t10] Jade Golem - COST:10 [ATK:10/HP:10]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t11] Jade Golem - COST:10 [ATK:11/HP:11]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t12] Jade Golem - COST:10 [ATK:12/HP:12]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t13] Jade Golem - COST:10 [ATK:13/HP:13]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t14] Jade Golem - COST:10 [ATK:14/HP:14]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t15] Jade Golem - COST:10 [ATK:15/HP:15]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t16] Jade Golem - COST:10 [ATK:16/HP:16]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t17] Jade Golem - COST:10 [ATK:17/HP:17]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t18] Jade Golem - COST:10 [ATK:18/HP:18]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t19] Jade Golem - COST:10 [ATK:19/HP:19]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t20] Jade Golem - COST:10 [ATK:20/HP:20]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t21] Jade Golem - COST:10 [ATK:21/HP:21]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t22] Jade Golem - COST:10 [ATK:22/HP:22]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t23] Jade Golem - COST:10 [ATK:23/HP:23]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t24] Jade Golem - COST:10 [ATK:24/HP:24]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t25] Jade Golem - COST:10 [ATK:25/HP:25]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t26] Jade Golem - COST:10 [ATK:26/HP:26]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t27] Jade Golem - COST:10 [ATK:27/HP:27]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t28] Jade Golem - COST:10 [ATK:28/HP:28]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t29] Jade Golem - COST:10 [ATK:29/HP:29]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [CFM_712_t30] Jade Golem - COST:10 [ATK:30/HP:30]
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // RefTag:
+    // - JADE_GOLEM = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_752e] Smuggling - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +3/+3 from Stolen Goods.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_753e] Smuggling - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +1/+1 from Grimestreet Outfitter.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_754e] Smuggling - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Increased stats from Grimy Gadgeteer.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_755e] Smuggling - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +1/+1 from Grimestreet Pawnbroker.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_816e] Get Big - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +2/+2.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_851e] The Scoop - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: Increased stats.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [CFM_853e] Smuggling - COST:0
+    // - Set: GANGS
+    // --------------------------------------------------------
+    // Text: +1/+1 from Grimestreet Smuggler.
+    // --------------------------------------------------------
 }
 
 void GangsCardsGen::AddAll(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/GvgCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/GvgCardsGen.cpp
@@ -3,6 +3,7 @@
 // RosettaStone is hearthstone simulator using C++ with reinforcement learning.
 // Copyright (c) 2017-2021 Chris Ohk
 
+#include <Rosetta/PlayMode/Actions/Generic.hpp>
 #include <Rosetta/PlayMode/Auras/AdaptiveEffect.hpp>
 #include <Rosetta/PlayMode/CardSets/GvgCardsGen.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
@@ -517,6 +518,8 @@ void GvgCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 
 void GvgCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ----------------------------------------- SPELL - PRIEST
     // [GVG_008] Lightbomb - COST:6
     // - Set: Gvg, Rarity: Epic
@@ -526,6 +529,25 @@ void GvgCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - AFFECTED_BY_SPELL_POWER = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<IncludeTask>(EntityType::SOURCE));
+    cardDef.power.AddPowerTask(std::make_shared<IncludeTask>(
+        EntityType::ALL_MINIONS, std::vector<EntityType>(), true));
+    cardDef.power.AddPowerTask(std::make_shared<FuncPlayableTask>(
+        [=](const std::vector<Playable*>& playables) {
+            const auto source = playables[0];
+
+            for (std::size_t i = 1; i < playables.size(); ++i)
+            {
+                const auto character = dynamic_cast<Character*>(playables[i]);
+                Generic::TakeDamageToCharacter(source, character,
+                                               character->GetAttack(), true);
+            }
+
+            return std::vector<Playable*>{};
+        }));
+    cards.emplace("GVG_008", cardDef);
 
     // ---------------------------------------- MINION - PRIEST
     // [GVG_009] Shadowbomber - COST:1 [ATK:2/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/LootapaloozaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LootapaloozaCardsGen.cpp
@@ -399,15 +399,12 @@ void LootapaloozaCardsGen::AddMage(std::map<std::string, CardDef>& cards)
                     const auto realTarget = dynamic_cast<Character*>(target);
 
                     const int targetHealth = realTarget->GetHealth();
-                    const int realDamage =
-                        6 + source->player->GetCurrentSpellPower();
-
-                    Generic::TakeDamageToCharacter(realSource, realTarget,
-                                                   realDamage, true);
+                    Generic::TakeDamageToCharacter(realSource, realTarget, 6,
+                                                   true);
 
                     if (realTarget->isDestroyed)
                     {
-                        const int remainDamage = realDamage - targetHealth;
+                        const int remainDamage = 6 - targetHealth;
                         if (remainDamage > 0)
                         {
                             Generic::TakeDamageToCharacter(

--- a/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
@@ -935,7 +935,17 @@ void UngoroCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
+    // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::CAST_SPELL));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    cardDef.power.GetTrigger()->tasks = {
+        std::make_shared<RandomCardTask>(CardType::SPELL, CardClass::PRIEST),
+        std::make_shared<AddStackToTask>(EntityType::HAND)
+    };
+    cards.emplace("UNG_963", cardDef);
 }
 
 void UngoroCardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
@@ -13,6 +13,7 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 namespace RosettaStone::PlayMode
 {
 using PlayReqs = std::map<PlayReq, int>;
+using EffectList = std::vector<std::shared_ptr<IEffect>>;
 
 void UngoroCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
@@ -796,6 +797,8 @@ void UngoroCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 
 void UngoroCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ---------------------------------------- MINION - PRIEST
     // [UNG_022] Mirage Caller - COST:3 [ATK:2/HP:3]
     // - Set: Ungoro, Rarity: Rare
@@ -853,6 +856,15 @@ void UngoroCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - AURA = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(std::make_shared<Aura>(
+        AuraType::HAND, EffectList{ Effects::ReduceCost(1) }));
+    {
+        const auto aura = dynamic_cast<Aura*>(cardDef.power.GetAura());
+        aura->condition =
+            std::make_shared<SelfCondition>(SelfCondition::IsSpell());
+    }
+    cards.emplace("UNG_034", cardDef);
 
     // ---------------------------------------- MINION - PRIEST
     // [UNG_035] Curious Glimmerroot - COST:3 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/Cards/CardDefs.cpp
+++ b/Sources/Rosetta/PlayMode/Cards/CardDefs.cpp
@@ -13,6 +13,7 @@
 #include <Rosetta/PlayMode/CardSets/DemonHunterInitCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/DragonsCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/Expert1CardsGen.hpp>
+#include <Rosetta/PlayMode/CardSets/GangsCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/GilneasCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/GvgCardsGen.hpp>
 #include <Rosetta/PlayMode/CardSets/IcecrownCardsGen.hpp>
@@ -54,6 +55,7 @@ CardDefs::CardDefs()
     LoECardsGen::AddAll(m_data);
     OgCardsGen::AddAll(m_data);
     KaraCardsGen::AddAll(m_data);
+    GangsCardsGen::AddAll(m_data);
     UngoroCardsGen::AddAll(m_data);
     IcecrownCardsGen::AddAll(m_data);
     LootapaloozaCardsGen::AddAll(m_data);

--- a/Sources/Rosetta/PlayMode/Models/Player.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Player.cpp
@@ -92,15 +92,13 @@ int Player::GetCurrentSpellPower() const
 {
     int value = 0;
 
-    for (auto& minion : GetFieldZone()->GetAll())
-    {
-        if (minion->IsUntouchable())
+    m_fieldZone->ForEach([&](Playable* playable) {
+        if (auto minion = dynamic_cast<Minion*>(playable);
+            minion && !minion->IsUntouchable())
         {
-            continue;
+            value += minion->GetSpellPower();
         }
-
-        value += minion->GetSpellPower();
-    }
+    });
 
     value += GetHero()->GetSpellPower();
     value += GetGameTag(GameTag::SPELLPOWER);

--- a/Sources/Rosetta/PlayMode/Models/Player.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Player.cpp
@@ -111,29 +111,27 @@ int Player::GetExtraSpellPower(SpellSchool spellSchool) const
 {
     int value = 0;
 
-    for (const auto& minion : GetFieldZone()->GetAll())
-    {
-        if (minion->IsUntouchable())
+    m_fieldZone->ForEach([&](Playable* playable) {
+        if (auto minion = dynamic_cast<Minion*>(playable);
+            minion && !minion->IsUntouchable())
         {
-            continue;
+            switch (spellSchool)
+            {
+                case SpellSchool::NATURE:
+                    value += minion->GetSpellPowerNature();
+                    break;
+                case SpellSchool::NONE:
+                case SpellSchool::ARCANE:
+                case SpellSchool::FIRE:
+                case SpellSchool::FROST:
+                case SpellSchool::HOLY:
+                case SpellSchool::SHADOW:
+                case SpellSchool::FEL:
+                case SpellSchool::PHYSICAL_COMBAT:
+                    break;
+            }
         }
-
-        switch (spellSchool)
-        {
-            case SpellSchool::NATURE:
-                value += minion->GetSpellPowerNature();
-                break;
-            case SpellSchool::NONE:
-            case SpellSchool::ARCANE:
-            case SpellSchool::FIRE:
-            case SpellSchool::FROST:
-            case SpellSchool::HOLY:
-            case SpellSchool::SHADOW:
-            case SpellSchool::FEL:
-            case SpellSchool::PHYSICAL_COMBAT:
-                break;
-        }
-    }
+    });
 
     return value;
 }

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DamageNumberTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DamageNumberTask.cpp
@@ -21,30 +21,17 @@ TaskStatus DamageNumberTask::Impl(Player* player)
 {
     int damage = m_source->game->taskStack.num[0];
 
-    if (m_isSpellDamage)
-    {
-        damage += m_source->player->GetCurrentSpellPower();
-
-        if (const auto spell = dynamic_cast<Spell*>(m_source); spell)
-        {
-            const SpellSchool spellSchool = spell->GetSpellSchool();
-            damage += m_source->player->GetExtraSpellPower(spellSchool);
-        }
-    }
-
     auto playables =
         IncludeTask::GetEntities(m_entityType, player, m_source, m_target);
 
     for (auto& playable : playables)
     {
-        const auto character = dynamic_cast<Character*>(playable);
-        if (character == nullptr)
+        if (const auto character = dynamic_cast<Character*>(playable);
+            character)
         {
-            continue;
+            Generic::TakeDamageToCharacter(dynamic_cast<Playable*>(m_source),
+                                           character, damage, m_isSpellDamage);
         }
-
-        Generic::TakeDamageToCharacter(dynamic_cast<Playable*>(m_source),
-                                       character, damage, m_isSpellDamage);
     }
 
     return TaskStatus::COMPLETE;

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.cpp
@@ -33,13 +33,13 @@ DamageTask::DamageTask(EntityType entityType, int damage, int randomDamage,
 
 TaskStatus DamageTask::Impl(Player* player)
 {
-    int damage = m_damage;
-
     auto playables =
         IncludeTask::GetEntities(m_entityType, player, m_source, m_target);
 
     for (auto& playable : playables)
     {
+        int damage = m_damage;
+
         const auto source = dynamic_cast<Playable*>(m_source);
         const auto character = dynamic_cast<Character*>(playable);
 

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DamageTask.cpp
@@ -35,33 +35,20 @@ TaskStatus DamageTask::Impl(Player* player)
 {
     int damage = m_damage;
 
-    if (m_isSpellDamage)
-    {
-        damage += m_source->player->GetCurrentSpellPower();
-
-        if (const auto spell = dynamic_cast<Spell*>(m_source); spell)
-        {
-            const SpellSchool spellSchool = spell->GetSpellSchool();
-            damage += m_source->player->GetExtraSpellPower(spellSchool);
-        }
-    }
-
     auto playables =
         IncludeTask::GetEntities(m_entityType, player, m_source, m_target);
 
     for (auto& playable : playables)
     {
-        int realDamage = damage;
-
         const auto source = dynamic_cast<Playable*>(m_source);
         const auto character = dynamic_cast<Character*>(playable);
 
         if (m_randomDamage > 0)
         {
-            realDamage += Random::get<int>(0, m_randomDamage);
+            damage += Random::get<int>(0, m_randomDamage);
         }
 
-        Generic::TakeDamageToCharacter(source, character, realDamage,
+        Generic::TakeDamageToCharacter(source, character, damage,
                                        m_isSpellDamage);
     }
 

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
@@ -256,6 +256,16 @@ auto DiscoverTask::Discover(Game* game, Player* player,
             }
             break;
         }
+        case DiscoverType::ENEMY_DECK:
+        {
+            choiceAction = ChoiceAction::HAND_COPY;
+            for (auto& playable : player->opponent->GetDeckZone()->GetAll())
+            {
+                cardsForOtherEffect.emplace_back(
+                    playable->GetGameTag(GameTag::ENTITY_ID));
+            }
+            break;
+        }
         case DiscoverType::SPELL_FROM_DECK:
         {
             choiceAction = ChoiceAction::DRAW_FROM_DECK;

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4353,6 +4353,61 @@ TEST_CASE("[Priest : Spell] - CORE_CS1_130 : Holy Smite")
 }
 
 // ---------------------------------------- MINION - PRIEST
+// [CORE_CS2_235] Northshire Cleric - COST:1 [ATK:1/HP:3]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: Whenever a minion is healed, draw a card.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - CORE_CS2_235 : Northshire Cleric")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(6);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Northshire Cleric"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Voodoo Doctor"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Voodoo Doctor"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 6);
+
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card2, curPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 26);
+
+    curField[0]->SetDamage(2);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card3, card1));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+}
+
+// ---------------------------------------- MINION - PRIEST
 // [CORE_EX1_193] Psychic Conjurer - COST:1 [ATK:1/HP:1]
 // - Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4755,6 +4755,73 @@ TEST_CASE("[Priest : Spell] - CORE_EX1_622 : Shadow Word: Death")
     CHECK_EQ(opField.GetCount(), 1);
 }
 
+// ----------------------------------------- SPELL - PRIEST
+// [CORE_GVG_008] Lightbomb - COST:6
+// - Set: CORE, Rarity: Epic
+// - Spell School: Holy
+// --------------------------------------------------------
+// Text: Deal damage to each minion equal to its Attack.
+// --------------------------------------------------------
+// GameTag:
+// - AFFECTED_BY_SPELL_POWER = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - CORE_GVG_008 : Lightbomb")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Lightbomb"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Righteous Protector"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Sen'jin Shieldmasta"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->HasDivineShield(), false);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+    CHECK_EQ(opField.GetCount(), 0);
+}
+
 // ---------------------------------------- MINION - PRIEST
 // [CS3_013] Shadowed Spirit - COST:3 [ATK:4/HP:3]
 // - Set: CORE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7681,7 +7681,6 @@ TEST_CASE("[Demon Hunter : Spell] - CORE_BT_235 : Chaos Nova")
     game.ProcessUntil(Step::MAIN_ACTION);
 
     game.Process(opPlayer, PlayCardTask::Minion(card5));
-
     game.Process(opPlayer, PlayCardTask::Spell(card4));
     CHECK_EQ(curField.GetCount(), 1);
     CHECK_EQ(curField[0]->GetHealth(), 2);

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4122,6 +4122,86 @@ TEST_CASE("[Priest : Spell] - CORE_AT_055 : Flash Heal")
     CHECK_EQ(opHero->GetHealth(), 25);
 }
 
+// ---------------------------------------- MINION - PRIEST
+// [CORE_CFM_605] Drakonid Operative - COST:5 [ATK:5/HP:6]
+// - Race: Dragon, Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you're holding a Dragon,
+//       <b>Discover</b> a copy of a card
+//       in your opponent's deck.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - DISCOVER = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - CORE_CFM_605 : Drakonid Operative")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player2Deck[i] = Cards::FindCardByName("Wisp");
+        config.player2Deck[i + 1] = Cards::FindCardByName("Fireball");
+        config.player2Deck[i + 2] = Cards::FindCardByName("Blizzard");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& opDeck = *(opPlayer->GetDeckZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Drakonid Operative"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Drakonid Operative"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK(curPlayer->choice != nullptr);
+    CHECK_EQ(curPlayer->choice->choices.size(), 3);
+
+    auto cards = TestUtils::GetChoiceCards(game);
+    for (auto& card : cards)
+    {
+        const bool checkName = card->name == "Wisp" ||
+                               card->name == "Fireball" ||
+                               card->name == "Blizzard";
+        CHECK(checkName);
+    }
+
+    TestUtils::ChooseNthChoice(game, 1);
+    CHECK_EQ(curHand.GetCount(), 3);
+    CHECK_EQ(opDeck.GetCount(), 26);
+
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK(curPlayer->choice == nullptr);
+}
+
 // ----------------------------------------- SPELL - PRIEST
 // [CORE_CS1_112] Holy Nova - COST:4
 // - Set: CORE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4823,6 +4823,64 @@ TEST_CASE("[Priest : Spell] - CORE_GVG_008 : Lightbomb")
 }
 
 // ---------------------------------------- MINION - PRIEST
+// [CORE_UNG_034] Radiant Elemental - COST:2 [ATK:2/HP:3]
+// - Race: Elemental, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: Your spells cost (1) less.
+// --------------------------------------------------------
+// GameTag:
+// - AURA = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - CORE_UNG_034 : Radiant Elemental")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Radiant Elemental"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Radiant Elemental"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Power Infusion"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Silence"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(card3->GetCost(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(card3->GetCost(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card1));
+    CHECK_EQ(card3->GetCost(), 3);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card2));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 7);
+}
+
+// ---------------------------------------- MINION - PRIEST
 // [CS3_013] Shadowed Spirit - COST:3 [ATK:4/HP:3]
 // - Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4881,6 +4881,54 @@ TEST_CASE("[Priest : Minion] - CORE_UNG_034 : Radiant Elemental")
 }
 
 // ---------------------------------------- MINION - PRIEST
+// [CORE_UNG_963] Lyra the Sunshard - COST:5 [ATK:3/HP:5]
+// - Race: Elemental, Set: CORE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: Whenever you cast a spell,
+//       add a random Priest spell to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - CORE_UNG_963 : Lyra the Sunshard")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Lyra the Sunshard"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flash Heal"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->GetCardClass(), CardClass::PRIEST);
+    CHECK_EQ(curHand[0]->card->GetCardType(), CardType::SPELL);
+}
+
+// ---------------------------------------- MINION - PRIEST
 // [CS3_013] Shadowed Spirit - COST:3 [ATK:4/HP:3]
 // - Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -4408,6 +4408,66 @@ TEST_CASE("[Priest : Minion] - CORE_CS2_235 : Northshire Cleric")
 }
 
 // ---------------------------------------- MINION - PRIEST
+// [CORE_DRG_090] Murozond the Infinite - COST:8 [ATK:8/HP:8]
+// - Race: Dragon, Set: CORE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Play all cards
+//       your opponent played last turn.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - CORE_DRG_090 : Murozond the Infinite")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::PRIEST;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opHand = *(opPlayer->GetHandZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fiery War Axe"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Shield Block"));
+    const auto card4 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Murozond the Infinite"));
+
+    game.Process(curPlayer, PlayCardTask::Weapon(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Spell(card3));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opPlayer->GetHero()->HasWeapon(), true);
+    CHECK_EQ(opPlayer->GetHero()->weapon->card->name, "Fiery War Axe");
+    CHECK_EQ(opField.GetCount(), 2);
+    CHECK_EQ(opField[1]->card->name, "Wolfrider");
+    CHECK_EQ(opHand.GetCount(), 7);
+    CHECK_EQ(opPlayer->GetHero()->GetArmor(), 5);
+}
+
+// ---------------------------------------- MINION - PRIEST
 // [CORE_EX1_193] Psychic Conjurer - COST:1 [ATK:1/HP:1]
 // - Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/DragonsCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/DragonsCardsGenTests.cpp
@@ -3680,8 +3680,8 @@ TEST_CASE("[Paladin : Minion] - DRG_309 : Nozdormu the Timeless")
 // [DRG_090] Murozond the Infinite - COST:8 [ATK:8/HP:8]
 // - Race: Dragon, Set: Dragons, Rarity: Legendary
 // --------------------------------------------------------
-// Text: <b>Battlecry:</b> Play all cards your opponent
-//       played last turn.
+// Text: <b>Battlecry:</b> Play all cards
+//       your opponent played last turn.
 // --------------------------------------------------------
 // GameTag:
 // - ELITE = 1

--- a/Tests/UnitTests/PlayMode/CardSets/GangsCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/GangsCardsGenTests.cpp
@@ -1,0 +1,12 @@
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <Utils/CardSetUtils.hpp>
+
+TEST_CASE("[GangsCardsGen] - Temp")
+{
+    CHECK(true);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/GangsCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/GangsCardsGenTests.cpp
@@ -1,12 +1,100 @@
-// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+// Copyright (c) 2017-2021 Chris Ohk
 
 // We are making my contributions/submissions to this project solely in our
 // personal capacity and are not conveying any rights to any intellectual
 // property of any third parties.
 
-#include <Utils/CardSetUtils.hpp>
+#include "doctest_proxy.hpp"
 
-TEST_CASE("[GangsCardsGen] - Temp")
+#include <Utils/CardSetUtils.hpp>
+#include <Utils/TestUtils.hpp>
+
+#include <Rosetta/PlayMode/Actions/Choose.hpp>
+#include <Rosetta/PlayMode/Actions/Draw.hpp>
+#include <Rosetta/PlayMode/Cards/Cards.hpp>
+#include <Rosetta/PlayMode/Zones/DeckZone.hpp>
+#include <Rosetta/PlayMode/Zones/HandZone.hpp>
+
+using namespace RosettaStone;
+using namespace PlayMode;
+using namespace PlayerTasks;
+using namespace SimpleTasks;
+
+// ---------------------------------------- MINION - PRIEST
+// [CFM_605] Drakonid Operative - COST:5 [ATK:5/HP:6]
+// - Race: Dragon, Set: GANGS, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you're holding a Dragon,
+//       <b>Discover</b> a copy of a card
+//       in your opponent's deck.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - DISCOVER = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - CFM_605 : Drakonid Operative")
 {
-    CHECK(true);
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+    config.doShuffle = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player2Deck[i] = Cards::FindCardByName("Wisp");
+        config.player2Deck[i + 1] = Cards::FindCardByName("Fireball");
+        config.player2Deck[i + 2] = Cards::FindCardByName("Blizzard");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+    auto& opDeck = *(opPlayer->GetDeckZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Drakonid Operative"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Drakonid Operative"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK(curPlayer->choice != nullptr);
+    CHECK_EQ(curPlayer->choice->choices.size(), 3);
+
+    auto cards = TestUtils::GetChoiceCards(game);
+    for (auto& card : cards)
+    {
+        const bool checkName = card->name == "Wisp" ||
+                               card->name == "Fireball" ||
+                               card->name == "Blizzard";
+        CHECK(checkName);
+    }
+
+    TestUtils::ChooseNthChoice(game, 1);
+    CHECK_EQ(curHand.GetCount(), 3);
+    CHECK_EQ(opDeck.GetCount(), 26);
+
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK(curPlayer->choice == nullptr);
 }

--- a/Tests/UnitTests/PlayMode/CardSets/GvgCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/GvgCardsGenTests.cpp
@@ -17,6 +17,71 @@ using namespace PlayMode;
 using namespace PlayerTasks;
 using namespace SimpleTasks;
 
+// ----------------------------------------- SPELL - PRIEST
+// [GVG_008] Lightbomb - COST:6
+// - Set: Gvg, Rarity: Epic
+// --------------------------------------------------------
+// Text: Deal damage to each minion equal to its Attack.
+// --------------------------------------------------------
+// GameTag:
+// - AFFECTED_BY_SPELL_POWER = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Minion] - GVG_008 : Lightbomb")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Lightbomb"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Righteous Protector"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 = Generic::DrawCard(
+        opPlayer, Cards::FindCardByName("Sen'jin Shieldmasta"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->HasDivineShield(), false);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+    CHECK_EQ(opField.GetCount(), 0);
+}
+
 // --------------------------------------- MINION - WARRIOR
 // [GVG_053] Shieldmaiden - COST:6 [ATK:5/HP:5]
 // - Set: Gvg, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/GvgCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/GvgCardsGenTests.cpp
@@ -26,7 +26,7 @@ using namespace SimpleTasks;
 // GameTag:
 // - AFFECTED_BY_SPELL_POWER = 1
 // --------------------------------------------------------
-TEST_CASE("[Warrior : Minion] - GVG_008 : Lightbomb")
+TEST_CASE("[Priest : Spell] - GVG_008 : Lightbomb")
 {
     GameConfig config;
     config.player1Class = CardClass::PRIEST;

--- a/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
@@ -173,6 +173,53 @@ TEST_CASE("[Priest : Minion] - UNG_034 : Radiant Elemental")
     CHECK_EQ(curPlayer->GetRemainingMana(), 7);
 }
 
+// ---------------------------------------- MINION - PRIEST
+// [UNG_963] Lyra the Sunshard - COST:5 [ATK:3/HP:5]
+// - Race: Elemental, Set: Ungoro, Rarity: Legendary
+// --------------------------------------------------------
+// Text: Whenever you cast a spell,
+//       add a random Priest spell to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - UNG_963 : Lyra the Sunshard")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Lyra the Sunshard"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Flash Heal"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 1);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->GetCardClass(), CardClass::PRIEST);
+    CHECK_EQ(curHand[0]->card->GetCardType(), CardType::SPELL);
+}
+
 // ----------------------------------------- SPELL - SHAMAN
 // [UNG_817] Tidal Surge - COST:3
 // - Faction: Neutral, Set: Ungoro, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
@@ -116,6 +116,63 @@ TEST_CASE("[Mage : Minion] - UNG_020 : Arcanologist")
     CHECK_EQ(curHand[4]->card->IsSecret(), true);
 }
 
+// ---------------------------------------- MINION - PRIEST
+// [UNG_034] Radiant Elemental - COST:2 [ATK:2/HP:3]
+// - Race: Elemental, Faction: Neutral, Set: Ungoro, Rarity: Common
+// --------------------------------------------------------
+// Text: Your spells cost (1) less.
+// --------------------------------------------------------
+// GameTag:
+// - AURA = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - UNG_034 : Radiant Elemental")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Radiant Elemental"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Radiant Elemental"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Power Infusion"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Silence"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(card3->GetCost(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(card3->GetCost(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card4, card1));
+    CHECK_EQ(card3->GetCost(), 3);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card2));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 7);
+}
+
 // ----------------------------------------- SPELL - SHAMAN
 // [UNG_817] Tidal Surge - COST:3
 // - Faction: Neutral, Set: Ungoro, Rarity: Common


### PR DESCRIPTION
This revision includes:
- Implement 6 CORE cards (#755)
  - Drakonid Operative (CORE_CFM_605)
  - Northshire Cleric (CORE_CS2_235)
  - Murozond the Infinite (CORE_DRG_090)
  - Lightbomb (CORE_GVG_008)
  - Radiant Elemental (CORE_UNG_034)
  - Lyra the Sunshard (CORE_UNG_963)
- Implement 1 GANGS card
  - Drakonid Operative (CFM_605)
- Implement 1 GVG card
  - Lightbomb (GVG_008)
- Implement 2 UNG cards
  - Radiant Elemental (UNG_034)
  - Lyra the Sunshard (UNG_963)
- Refactor code to calculate current spell power (Resolves #778)
  - Refactor code to calculate current spell power
  - Correct code to get current spell power
  - Correct code to get current extra spell power
  - Apply changes of the logic to calculate current spell power
- Create card generation files for 'GANGS'
  - Add code to load card data of 'GANGS'
  - Create unit test file for 'GANGS' cards
- Add enum value 'DiscoverType::ENEMY_DECK'
  - Add code to process enum 'DiscoverType::ENEMY_DECK'
- Separate text to improve readability