### PR TITLE
Fix crash problem in unit test of card 'Diseased Vulture' (ULD_167)

### DIFF
--- a/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
+++ b/Sources/Rosetta/PlayMode/Conditions/SelfCondition.cpp
@@ -942,9 +942,13 @@ SelfCondition SelfCondition::IsProposedDefender(CardType cardType)
 SelfCondition SelfCondition::IsDefenderDead()
 {
     return SelfCondition([](Playable* playable) {
-        if (playable->game->currentEventData)
+        if (const auto eventData = playable->game->currentEventData.get();
+            eventData)
         {
-            return playable->game->currentEventData->eventTarget->isDestroyed;
+            if (const auto eventTarget = eventData->eventTarget; eventTarget)
+            {
+                return eventTarget->isDestroyed;
+            }
         }
 
         return false;


### PR DESCRIPTION
This revision includes:
- Fix crash problem in unit test of card 'Diseased Vulture' (Resolves #780)
  - Add code to check that 'eventTarget' is 'nullptr'