### PR TITLE
Implement 3 CORE cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -149,7 +149,7 @@ CORE | CORE_EX1_534 | Savannah Highmane | O
 CORE | CORE_EX1_543 | King Krush | O
 CORE | CORE_EX1_554 | Snake Trap | O
 CORE | CORE_EX1_564 | Faceless Manipulator | O
-CORE | CORE_EX1_565 | Flametongue Totem |  
+CORE | CORE_EX1_565 | Flametongue Totem | O
 CORE | CORE_EX1_567 | Doomhammer | O
 CORE | CORE_EX1_571 | Force of Nature | O
 CORE | CORE_EX1_573 | Cenarius | O
@@ -185,7 +185,7 @@ CORE | CORE_ICC_809 | Plague Scientist | O
 CORE | CORE_KAR_006 | Cloaked Huntress | O
 CORE | CORE_KAR_009 | Babbling Book | O
 CORE | CORE_KAR_069 | Swashburglar | O
-CORE | CORE_KAR_073 | Maelstrom Portal |  
+CORE | CORE_KAR_073 | Maelstrom Portal | O
 CORE | CORE_LOE_003 | Ethereal Conjurer | O
 CORE | CORE_LOE_011 | Reno Jackson |  
 CORE | CORE_LOE_012 | Tomb Pillager | O
@@ -220,7 +220,7 @@ CORE | CORE_TRL_243 | Pounce | O
 CORE | CORE_TRL_252 | High Priestess Jeklik |  
 CORE | CORE_TRL_307 | Flash of Light | O
 CORE | CORE_TRL_315 | Pyromaniac | O
-CORE | CORE_TRL_345 | Krag'wa, the Frog |  
+CORE | CORE_TRL_345 | Krag'wa, the Frog | O
 CORE | CORE_TRL_348 | Springpaw | O
 CORE | CORE_ULD_191 | Beaming Sidekick |  
 CORE | CORE_ULD_209 | Vulpera Scoundrel |  
@@ -261,7 +261,7 @@ CORE | CS3_036 | Deathwing the Destroyer | O
 CORE | CS3_037 | Emerald Skytalon | O
 CORE | CS3_038 | Redgill Razorjaw | O
 
-- Progress: 82% (207 of 250 Cards)
+- Progress: 84% (210 of 250 Cards)
 
 ## Forged in the Barrens
 

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -1047,7 +1047,7 @@ KARA | KAR_063 | Spirit Claws |
 KARA | KAR_065 | Menagerie Warden | O
 KARA | KAR_069 | Swashburglar | O
 KARA | KAR_070 | Ethereal Peddler |  
-KARA | KAR_073 | Maelstrom Portal |  
+KARA | KAR_073 | Maelstrom Portal | O
 KARA | KAR_075 | Moonglade Portal |  
 KARA | KAR_076 | Firelands Portal |  
 KARA | KAR_077 | Silvermoon Portal |  
@@ -1067,7 +1067,7 @@ KARA | KAR_710 | Arcanosmith |
 KARA | KAR_711 | Arcane Giant |  
 KARA | KAR_712 | Violet Illusionist |  
 
-- Progress: 13% (6 of 45 Cards)
+- Progress: 15% (7 of 45 Cards)
 
 ## Mean Streets of Gadgetzan
 
@@ -1997,7 +1997,7 @@ TROLL | TRL_329 | Akali, the Rhino |
 TROLL | TRL_339 | Master's Call |  
 TROLL | TRL_341 | Treespeaker |  
 TROLL | TRL_343 | Wardruid Loti |  
-TROLL | TRL_345 | Krag'wa, the Frog |  
+TROLL | TRL_345 | Krag'wa, the Frog | O
 TROLL | TRL_347 | Baited Arrow |  
 TROLL | TRL_348 | Springpaw | O
 TROLL | TRL_349 | Bloodscalp Strategist |  
@@ -2059,7 +2059,7 @@ TROLL | TRL_570 | Soup Vendor |
 TROLL | TRL_900 | Halazzi, the Lynx |  
 TROLL | TRL_901 | Spirit of the Lynx |  
 
-- Progress: 3% (5 of 135 Cards)
+- Progress: 4% (6 of 135 Cards)
 
 ## Rise of Shadows
 

--- a/Includes/Rosetta/PlayMode/Logs/PlayHistory.hpp
+++ b/Includes/Rosetta/PlayMode/Logs/PlayHistory.hpp
@@ -17,8 +17,8 @@ namespace RosettaStone::PlayMode
 //!
 struct PlayHistory
 {
-    explicit PlayHistory(const Playable* source,
-                         const Playable* target = nullptr, int _chooseOne = -1)
+    explicit PlayHistory(const Playable* source, const Playable* target,
+                         int _turn, int _chooseOne)
     {
         sourcePlayer = source->player;
         sourceCard = source->card;
@@ -30,6 +30,7 @@ struct PlayHistory
             targetCard = target->card;
         }
 
+        turn = _turn;
         chooseOne = _chooseOne;
     }
 
@@ -38,6 +39,7 @@ struct PlayHistory
     Card* sourceCard = nullptr;
     Card* targetCard = nullptr;
     int sourceID = -1;
+    int turn = -1;
     int chooseOne = -1;
 };
 }  // namespace RosettaStone::PlayMode

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 82% Core Set (207 of 235 cards)
+  * 84% Core Set (210 of 235 cards)
   * 81% Forged in the Barrens (139 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
@@ -60,14 +60,14 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 7% The Grand Tournament (10 of 132 Cards)
   * 8% The League of Explorers (4 of 45 Cards)
   * 4% Whispers of the Old Gods (6 of 134 Cards)
-  * 13% One Night in Karazhan (6 of 45 Cards)
+  * 15% One Night in Karazhan (7 of 45 Cards)
   * 0% Mean Streets of Gadgetzan (1 of 132 Cards)
   * 5% Journey to Un'Goro (8 of 135 Cards)
   * 3% Knights of the Frozen Throne (5 of 135 Cards)
   * 3% Kobolds & Catacombs (5 of 135 Cards)
   * 3% The Witchwood (5 of 135 Cards)
   * 2% The Boomsday Project (4 of 136 Cards)
-  * 3% Rastakhan's Rumble (5 of 135 Cards)
+  * 4% Rastakhan's Rumble (6 of 135 Cards)
   * **100% Rise of Shadows (136 of 136 cards)**
   * **99% Saviors of Uldum (134 of 135 cards)**
     * Except 'Zephrys the Great' (ULD_003)

--- a/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
@@ -76,7 +76,8 @@ void PlayCard(Player* player, Playable* source, Character* target, int fieldPos,
     // Increase the number of cards played this turn
     const int val = player->GetNumCardsPlayedThisTurn();
     player->SetNumCardsPlayedThisTurn(val + 1);
-    player->playHistory.emplace_back(PlayHistory(source, target, chooseOne));
+    player->playHistory.emplace_back(
+        PlayHistory(source, target, player->game->GetTurn(), chooseOne));
 
     // Record played cards for effect of cards
     // (i.e. Obsidian Shard and Lynessa Sunsorrow)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2384,6 +2384,9 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // - ADJACENT_BUFF = 1
     // - AURA = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(std::make_shared<AdjacentAura>("EX1_565o"));
+    cards.emplace("CORE_EX1_565", cardDef);
 
     // ---------------------------------------- WEAPON - SHAMAN
     // [CORE_EX1_567] Doomhammer - COST:5

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2460,6 +2460,39 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<FuncNumberTask>([](Playable* playable) {
+            Player* player = playable->player;
+            int turn = playable->game->GetTurn();
+
+            std::vector<Card*> playedSpells;
+            playedSpells.reserve(10);
+
+            for (auto& history : player->playHistory)
+            {
+                if (history.sourceCard->GetCardType() == CardType::SPELL &&
+                    history.turn == turn - 2)
+                {
+                    playedSpells.emplace_back(history.sourceCard);
+                }
+            }
+
+            const int space = player->GetHandZone()->GetFreeSpace();
+            for (const auto& playedSpell : playedSpells)
+            {
+                Playable* spell = Entity::GetFromCard(player, playedSpell);
+                player->GetHandZone()->Add(spell);
+
+                if (player->GetHandZone()->IsFull())
+                {
+                    break;
+                }
+            }
+
+            return 0;
+        }));
+    cards.emplace("CORE_TRL_345", cardDef);
 
     // ----------------------------------------- SPELL - SHAMAN
     // [CORE_UNG_817] Tidal Surge - COST:3

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2426,6 +2426,13 @@ void CoreCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // Text: Deal 1 damage to all enemy minions.
     //       Summon a random 1-Cost minion.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 1, true));
+    cardDef.power.AddPowerTask(std::make_shared<RandomMinionTask>(
+        TagValues{ { GameTag::COST, 1, RelaSign::EQ } }));
+    cardDef.power.AddPowerTask(std::make_shared<SummonTask>());
+    cards.emplace("CORE_KAR_073", cardDef);
 
     // ---------------------------------------- MINION - SHAMAN
     // [CORE_NEW1_010] Al'Akir the Windlord - COST:8 [ATK:3/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2039,8 +2039,6 @@ void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     cardDef.ClearData();
     cardDef.power.AddPowerTask(
-        std::make_shared<RandomTask>(EntityType::DECK, 3));
-    cardDef.power.AddPowerTask(
         std::make_shared<FuncNumberTask>([](Playable* playable) {
             Player* player = playable->player;
 

--- a/Sources/Rosetta/PlayMode/CardSets/GilneasCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/GilneasCardsGen.cpp
@@ -831,8 +831,6 @@ void GilneasCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     cardDef.ClearData();
     cardDef.power.AddPowerTask(
-        std::make_shared<RandomTask>(EntityType::DECK, 3));
-    cardDef.power.AddPowerTask(
         std::make_shared<FuncNumberTask>([](Playable* playable) {
             Player* player = playable->player;
 

--- a/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
@@ -12,6 +12,7 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 
 namespace RosettaStone::PlayMode
 {
+using TagValues = std::vector<TagValue>;
 using PlayReqs = std::map<PlayReq, int>;
 using EffectList = std::vector<std::shared_ptr<IEffect>>;
 
@@ -344,6 +345,8 @@ void KaraCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)
 
 void KaraCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ---------------------------------------- MINION - SHAMAN
     // [KAR_021] Wicked Witchdoctor - COST:4 [ATK:3/HP:4]
     // - Set: Kara, Rarity: Common
@@ -371,6 +374,13 @@ void KaraCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // Text: Deal 1 damage to all enemy minions.
     //       Summon a random 1-Cost minion.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_MINIONS, 1, true));
+    cardDef.power.AddPowerTask(std::make_shared<RandomMinionTask>(
+        TagValues{ { GameTag::COST, 1, RelaSign::EQ } }));
+    cardDef.power.AddPowerTask(std::make_shared<SummonTask>());
+    cards.emplace("KAR_073", cardDef);
 }
 
 void KaraCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6654,6 +6654,62 @@ TEST_CASE("[Shaman : Minion] - CORE_EX1_575 : Mana Tide Totem")
     CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
 }
 
+// ----------------------------------------- SPELL - SHAMAN
+// [CORE_KAR_073] Maelstrom Portal - COST:2
+// - Set: CORE, Rarity: Rare
+// - Spell School: Nature
+// --------------------------------------------------------
+// Text: Deal 1 damage to all enemy minions.
+//       Summon a random 1-Cost minion.
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Spell] - CORE_KAR_073 : Maelstrom Portal")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Maelstrom Portal"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->GetCost(), 1);
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 11);
+}
+
 // ---------------------------------------- MINION - SHAMAN
 // [CORE_NEW1_010] Al'Akir the Windlord - COST:8 [ATK:3/HP:6]
 // - Race: Elemental, Set: CORE, Rarity: Legendary

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6446,6 +6446,120 @@ TEST_CASE("[Shaman : Spell] - CORE_EX1_259 : Lightning Storm")
     CHECK_EQ(curPlayer->GetOverloadLocked(), 2);
 }
 
+// ---------------------------------------- MINION - SHAMAN
+// [CORE_EX1_565] Flametongue Totem - COST:2 [ATK:0/HP:2]
+// - Race: Totem, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: Adjacent minions have +2 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - ADJACENT_BUFF = 1
+// - AURA = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Minion] - CORE_EX1_565 : Flametongue Totem")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Flametongue Totem"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Flametongue Totem"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Flametongue Totem"));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Flametongue Totem"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+    const auto card6 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Dalaran Mage"));
+    const auto card7 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card8 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 0);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(curField[1]->GetAttack(), 8);
+    CHECK_EQ(curField[1]->GetHealth(), 7);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 10);
+    CHECK_EQ(curField[1]->GetHealth(), 7);
+    CHECK_EQ(curField[2]->GetAttack(), 0);
+    CHECK_EQ(curField[2]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card6));
+    CHECK_EQ(curField[3]->GetAttack(), 3);
+    CHECK_EQ(curField[3]->GetHealth(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField[3]->GetAttack(), 5);
+    CHECK_EQ(curField[3]->GetHealth(), 4);
+    CHECK_EQ(curField[4]->GetAttack(), 0);
+    CHECK_EQ(curField[4]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card7));
+    CHECK_EQ(curField[5]->GetAttack(), 5);
+    CHECK_EQ(curField[5]->GetHealth(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(curField[5]->GetAttack(), 7);
+    CHECK_EQ(curField[5]->GetHealth(), 1);
+    CHECK_EQ(curField[6]->GetAttack(), 0);
+    CHECK_EQ(curField[6]->GetHealth(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card8));
+    game.Process(opPlayer, AttackTask(card8, card7));
+
+    CHECK_EQ(curField[4]->GetAttack(), 2);
+    CHECK_EQ(curField[4]->GetHealth(), 2);
+    CHECK_EQ(curField[5]->GetAttack(), 2);
+    CHECK_EQ(curField[5]->GetHealth(), 2);
+}
+
 // ---------------------------------------- WEAPON - SHAMAN
 // [CORE_EX1_567] Doomhammer - COST:5
 // - Set: CORE, Rarity: Epic

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6728,6 +6728,82 @@ TEST_CASE("[Shaman : Minion] - CORE_NEW1_010 : Al'Akir the Windlord")
     // Do nothing
 }
 
+// ---------------------------------------- MINION - SHAMAN
+// [CORE_TRL_345] Krag'wa, the Frog - COST:6 [ATK:4/HP:6]
+// - Race: Beast, Set: CORE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Return all spells you played
+//       last turn to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Shaman : Minion] - CORE_TRL_345 : Krag'wa, the Frog")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Krag'wa, the Frog"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Krag'wa, the Frog"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Doomhammer"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card4, curPlayer->GetHero()));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curHand.GetCount(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 3);
+    CHECK_EQ(curHand[2]->card->name, "Fireball");
+
+    curPlayer->SetUsedMana(0);
+    game.Process(curPlayer, PlayCardTask::Weapon(card5));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curHand.GetCount(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curHand.GetCount(), 1);
+}
+
 // ----------------------------------------- SPELL - SHAMAN
 // [CORE_UNG_817] Tidal Surge - COST:3
 // - Set: CORE, Rarity: Common


### PR DESCRIPTION
This revision includes:
- Implement 3 CORE cards (#755)
  - Flametongue Totem (CORE_EX1_565)
  - Maelstrom Portal (CORE_KAR_073)
  - Krag'wa, the Frog (CORE_TRL_345)
- Implement 1 KARA card
  - Maelstrom Portal (KAR_073)
- Implement 1 TROLL card
  - Krag'wa, the Frog (TRL_345)
- Add variable 'turn' to struct 'PlayHistory' and code to assign it
- Delete incorrect logic of card 'Tess Greymane' (CORE_GIL_598)