### PR TITLE
Implement 5 CORE cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -18,7 +18,7 @@ CORE | CORE_AT_064 | Bash |
 CORE | CORE_AT_075 | Warhorse Trainer | O
 CORE | CORE_BOT_453 | Shooting Star | O
 CORE | CORE_BOT_533 | Menacing Nimbus | O
-CORE | CORE_BRM_006 | Imp Gang Boss |  
+CORE | CORE_BRM_006 | Imp Gang Boss | O
 CORE | CORE_BRM_013 | Quick Shot | O
 CORE | CORE_BT_035 | Chaos Strike | O
 CORE | CORE_BT_036 | Coordinated Strike | O
@@ -36,7 +36,7 @@ CORE | CORE_BT_801 | Eye Beam | O
 CORE | CORE_BT_921 | Aldrachi Warblades | O
 CORE | CORE_CFM_120 | Mistress of Mixtures |  
 CORE | CORE_CFM_605 | Drakonid Operative | O
-CORE | CORE_CFM_751 | Abyssal Enforcer |  
+CORE | CORE_CFM_751 | Abyssal Enforcer | O
 CORE | CORE_CS1_112 | Holy Nova | O
 CORE | CORE_CS1_130 | Holy Smite | O
 CORE | CORE_CS2_009 | Mark of the Wild | O
@@ -50,7 +50,7 @@ CORE | CORE_CS2_045 | Rockbiter Weapon | O
 CORE | CORE_CS2_046 | Bloodlust | O
 CORE | CORE_CS2_053 | Far Sight | O
 CORE | CORE_CS2_062 | Hellfire | O
-CORE | CORE_CS2_065 | Voidwalker |  
+CORE | CORE_CS2_065 | Voidwalker | O
 CORE | CORE_CS2_072 | Backstab | O
 CORE | CORE_CS2_073 | Cold Blood | O
 CORE | CORE_CS2_074 | Deadly Poison | O
@@ -212,12 +212,12 @@ CORE | CORE_NEW1_027 | Southsea Captain | O
 CORE | CORE_NEW1_031 | Animal Companion | O
 CORE | CORE_OG_044 | Fandral Staghelm | O
 CORE | CORE_OG_047 | Feral Rage | O
-CORE | CORE_OG_109 | Darkshire Librarian |  
+CORE | CORE_OG_109 | Darkshire Librarian | O
 CORE | CORE_OG_218 | Bloodhoof Brave |  
 CORE | CORE_OG_229 | Ragnaros, Lightlord | O
 CORE | CORE_OG_273 | Stand Against Darkness | O
 CORE | CORE_TRL_243 | Pounce | O
-CORE | CORE_TRL_252 | High Priestess Jeklik |  
+CORE | CORE_TRL_252 | High Priestess Jeklik | O
 CORE | CORE_TRL_307 | Flash of Light | O
 CORE | CORE_TRL_315 | Pyromaniac | O
 CORE | CORE_TRL_345 | Krag'wa, the Frog | O
@@ -261,7 +261,7 @@ CORE | CS3_036 | Deathwing the Destroyer | O
 CORE | CS3_037 | Emerald Skytalon | O
 CORE | CS3_038 | Redgill Razorjaw | O
 
-- Progress: 84% (210 of 250 Cards)
+- Progress: 86% (215 of 250 Cards)
 
 ## Forged in the Barrens
 

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -656,7 +656,7 @@ BRM | BRM_002 | Flamewaker |
 BRM | BRM_003 | Dragon's Breath |  
 BRM | BRM_004 | Twilight Whelp |  
 BRM | BRM_005 | Demonwrath |  
-BRM | BRM_006 | Imp Gang Boss |  
+BRM | BRM_006 | Imp Gang Boss | O
 BRM | BRM_007 | Gang Up |  
 BRM | BRM_008 | Dark Iron Skulker |  
 BRM | BRM_009 | Volcanic Lumberer |  
@@ -683,7 +683,7 @@ BRM | BRM_031 | Chromaggus |
 BRM | BRM_033 | Blackwing Technician |  
 BRM | BRM_034 | Blackwing Corruptor |  
 
-- Progress: 3% (1 of 31 Cards)
+- Progress: 6% (2 of 31 Cards)
 
 ## The Grand Tournament
 
@@ -913,7 +913,7 @@ OG | OG_100 | Shadow Word: Horror |
 OG | OG_101 | Forbidden Shaping |  
 OG | OG_102 | Darkspeaker |  
 OG | OG_104 | Embrace the Shadow |  
-OG | OG_109 | Darkshire Librarian |  
+OG | OG_109 | Darkshire Librarian | O
 OG | OG_113 | Darkshire Councilman |  
 OG | OG_114 | Forbidden Ritual |  
 OG | OG_116 | Spreading Madness |  
@@ -1015,7 +1015,7 @@ OG | OG_338 | Nat, the Darkfisher |
 OG | OG_339 | Skeram Cultist |  
 OG | OG_340 | Soggoth the Slitherer |  
 
-- Progress: 4% (6 of 134 Cards)
+- Progress: 5% (7 of 134 Cards)
 
 ## One Night in Karazhan
 
@@ -1177,7 +1177,7 @@ GANGS | CFM_715 | Jade Spirit |
 GANGS | CFM_716 | Sleep with the Fishes |  
 GANGS | CFM_717 | Jade Claws |  
 GANGS | CFM_750 | Krul the Unshackled |  
-GANGS | CFM_751 | Abyssal Enforcer |  
+GANGS | CFM_751 | Abyssal Enforcer | O
 GANGS | CFM_752 | Stolen Goods |  
 GANGS | CFM_753 | Grimestreet Outfitter |  
 GANGS | CFM_754 | Grimy Gadgeteer |  
@@ -1206,7 +1206,7 @@ GANGS | CFM_902 | Aya Blackpaw |
 GANGS | CFM_905 | Small-Time Recruits |  
 GANGS | CFM_940 | I Know a Guy |  
 
-- Progress: 0% (1 of 132 Cards)
+- Progress: 1% (2 of 132 Cards)
 
 ## Journey to Un'Goro
 
@@ -1961,7 +1961,7 @@ TROLL | TRL_246 | Void Contract |
 TROLL | TRL_247 | Soulwarden |  
 TROLL | TRL_249 | Grim Rally |  
 TROLL | TRL_251 | Spirit of the Bat |  
-TROLL | TRL_252 | High Priestess Jeklik |  
+TROLL | TRL_252 | High Priestess Jeklik | O
 TROLL | TRL_253 | Hir'eek, the Bat |  
 TROLL | TRL_254 | Mark of the Loa |  
 TROLL | TRL_255 | Stampeding Roar |  
@@ -2059,7 +2059,7 @@ TROLL | TRL_570 | Soup Vendor |
 TROLL | TRL_900 | Halazzi, the Lynx |  
 TROLL | TRL_901 | Spirit of the Lynx |  
 
-- Progress: 4% (6 of 135 Cards)
+- Progress: 5% (7 of 135 Cards)
 
 ## Rise of Shadows
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 84% Core Set (210 of 235 cards)
+  * 86% Core Set (215 of 250 cards)
   * 81% Forged in the Barrens (139 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
@@ -56,18 +56,18 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * **100% Demon Hunter Initiate (20 of 20 Cards)**
   * **100% Curse of Naxxramas (30 of 30 Cards)**
   * 6% Goblins vs Gnomes (8 of 123 Cards)
-  * 3% Blackrock Mountain (1 of 31 Cards)
+  * 6% Blackrock Mountain (2 of 31 Cards)
   * 7% The Grand Tournament (10 of 132 Cards)
   * 8% The League of Explorers (4 of 45 Cards)
-  * 4% Whispers of the Old Gods (6 of 134 Cards)
+  * 5% Whispers of the Old Gods (7 of 134 Cards)
   * 15% One Night in Karazhan (7 of 45 Cards)
-  * 0% Mean Streets of Gadgetzan (1 of 132 Cards)
+  * 1% Mean Streets of Gadgetzan (2 of 132 Cards)
   * 5% Journey to Un'Goro (8 of 135 Cards)
   * 3% Knights of the Frozen Throne (5 of 135 Cards)
   * 3% Kobolds & Catacombs (5 of 135 Cards)
   * 3% The Witchwood (5 of 135 Cards)
   * 2% The Boomsday Project (4 of 136 Cards)
-  * 4% Rastakhan's Rumble (6 of 135 Cards)
+  * 5% Rastakhan's Rumble (7 of 135 Cards)
   * **100% Rise of Shadows (136 of 136 cards)**
   * **99% Saviors of Uldum (134 of 135 cards)**
     * Except 'Zephrys the Great' (ULD_003)

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -306,6 +306,8 @@ void BrmCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
 void BrmCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ---------------------------------------- SPELL - WARLOCK
     // [BRM_005] Demonwrath - COST:3
     // - Set: Brm, Rarity: Rare
@@ -322,14 +324,26 @@ void BrmCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Whenever this minion takes damage, summon a 1/1 Imp.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::TAKE_DAMAGE));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<SummonTask>(
+        "BRM_006t", SummonSide::RIGHT) };
+    cards.emplace("BRM_006", cardDef);
 }
 
 void BrmCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // --------------------------------------- MINION - WARLOCK
     // [BRM_006t] Imp (*) - COST:1 [ATK:1/HP:1]
     // - Race: Demon, Set: Brm
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("BRM_006t", cardDef);
 }
 
 void BrmCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2787,6 +2787,13 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - TAUNT = 1
     // - InvisibleDeathrattle = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(std::make_shared<Trigger>(TriggerType::DISCARD));
+    cardDef.power.GetTrigger()->triggerActivation = TriggerActivation::HAND;
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<CopyTask>(
+        EntityType::SOURCE, ZoneType::HAND, 2) };
+    cards.emplace("CORE_TRL_252", cardDef);
 
     // --------------------------------------- MINION - WARLOCK
     // [CORE_UNG_833] Lakkari Felhound - COST:4 [ATK:3/HP:8]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2571,6 +2571,13 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::TAKE_DAMAGE));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<SummonTask>(
+        "BRM_006t", SummonSide::RIGHT) };
+    cards.emplace("CORE_BRM_006", cardDef);
 
     // --------------------------------------- MINION - WARLOCK
     // [CORE_CFM_751] Abyssal Enforcer - COST:7 [ATK:6/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2768,6 +2768,10 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<DiscardTask>(1));
+    cardDef.power.AddDeathrattleTask(std::make_shared<DrawTask>(1));
+    cards.emplace("CORE_OG_109", cardDef);
 
     // --------------------------------------- MINION - WARLOCK
     // [CORE_TRL_252] High Priestess Jeklik - COST:4 [ATK:3/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2614,6 +2614,9 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("CORE_CS2_065", cardDef);
 
     // ---------------------------------------- SPELL - WARLOCK
     // [CORE_EX1_302] Mortal Coil - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -2588,6 +2588,10 @@ void CoreCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ALL_NOSOURCE, 3));
+    cards.emplace("CORE_CFM_751", cardDef);
 
     // ---------------------------------------- SPELL - WARLOCK
     // [CORE_CS2_062] Hellfire - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/GangsCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/GangsCardsGen.cpp
@@ -904,6 +904,8 @@ void GangsCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
 void GangsCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ---------------------------------------- SPELL - WARLOCK
     // [CFM_094] Felfire Potion - COST:6
     // - Set: GANGS, Rarity: Rare
@@ -982,6 +984,10 @@ void GangsCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ALL_NOSOURCE, 3));
+    cards.emplace("CFM_751", cardDef);
 
     // --------------------------------------- MINION - WARLOCK
     // [CFM_900] Unlicensed Apothecary - COST:3 [ATK:5/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/OgCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/OgCardsGen.cpp
@@ -1063,8 +1063,11 @@ void OgCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // - BATTLECRY = 1
-    // - 890 = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<DiscardTask>(1));
+    cardDef.power.AddDeathrattleTask(std::make_shared<DrawTask>(1));
+    cards.emplace("OG_109", cardDef);
 
     // --------------------------------------- MINION - WARLOCK
     // [OG_113] Darkshire Councilman - COST:3 [ATK:1/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/TrollCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TrollCardsGen.cpp
@@ -1246,6 +1246,8 @@ void TrollCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
 void TrollCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ---------------------------------------- SPELL - WARLOCK
     // [TRL_245] Shriek - COST:1
     // - Set: Troll, Rarity: Rare
@@ -1313,6 +1315,13 @@ void TrollCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - InvisibleDeathrattle = 1
     // - LIFESTEAL = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(std::make_shared<Trigger>(TriggerType::DISCARD));
+    cardDef.power.GetTrigger()->triggerActivation = TriggerActivation::HAND;
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<CopyTask>(
+        EntityType::SOURCE, ZoneType::HAND, 2) };
+    cards.emplace("TRL_252", cardDef);
 
     // --------------------------------------- MINION - WARLOCK
     // [TRL_253] Hir'eek, the Bat - COST:8 [ATK:1/HP:1]

--- a/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
@@ -10,6 +10,7 @@
 
 #include <Rosetta/PlayMode/Actions/Draw.hpp>
 #include <Rosetta/PlayMode/Cards/Cards.hpp>
+#include <Rosetta/PlayMode/Zones/FieldZone.hpp>
 
 using namespace RosettaStone;
 using namespace PlayMode;
@@ -63,4 +64,48 @@ TEST_CASE("[Hunter : Spell] - BRM_013 : Quick Shot")
     game.Process(curPlayer,
                  PlayCardTask::SpellTarget(card2, opPlayer->GetHero()));
     CHECK_EQ(curPlayer->GetHero()->GetHealth(), 15);
+}
+
+// --------------------------------------- MINION - WARLOCK
+// [BRM_006] Imp Gang Boss - COST:3 [ATK:2/HP:4]
+// - Race: Demon, Set: Brm, Rarity: Common
+// --------------------------------------------------------
+// Text: Whenever this minion takes damage, summon a 1/1 Imp.
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - BRM_006 : Imp Gang Boss")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Imp Gang Boss"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[1]->card->name, "Imp");
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
 }

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7113,6 +7113,20 @@ TEST_CASE("[Warlock : Spell] - CORE_CS2_062 : Hellfire")
     CHECK_EQ(opField[0]->GetHealth(), 4);
 }
 
+// --------------------------------------- MINION - WARLOCK
+// [CORE_CS2_065] Voidwalker - COST:1 [ATK:1/HP:3]
+// - Race: Demon, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - CORE_CS2_065 : Voidwalker")
+{
+    // Do nothing
+}
+
 // ---------------------------------------- SPELL - WARLOCK
 // [CORE_EX1_302] Mortal Coil - COST:1
 // - Set: CORE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6932,6 +6932,54 @@ TEST_CASE("[Warlock : Minion] - CORE_AT_021 : Tiny Knight of Evil")
     CHECK_EQ(curField[0]->GetHealth(), 3);
 }
 
+// --------------------------------------- MINION - WARLOCK
+// [CORE_BRM_006] Imp Gang Boss - COST:3 [ATK:2/HP:4]
+// - Race: Demon, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: Whenever this minion takes damage, summon a 1/1 Imp.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - CORE_BRM_006 : Imp Gang Boss")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Imp Gang Boss"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[1]->card->name, "Imp");
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+}
+
 // ---------------------------------------- SPELL - WARLOCK
 // [CORE_CS2_062] Hellfire - COST:4
 // - Set: CORE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -6980,6 +6980,74 @@ TEST_CASE("[Warlock : Minion] - CORE_BRM_006 : Imp Gang Boss")
     CHECK_EQ(curField[1]->GetHealth(), 1);
 }
 
+// --------------------------------------- MINION - WARLOCK
+// [CORE_CFM_751] Abyssal Enforcer - COST:7 [ATK:6/HP:6]
+// - Race: Demon, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Deal 3 damage to all other characters.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - CORE_CFM_751 : Abyssal Enforcer")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Abyssal Enforcer"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Boulderfist Ogre"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 27);
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(curField[1]->GetHealth(), 6);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 4);
+}
+
 // ---------------------------------------- SPELL - WARLOCK
 // [CORE_CS2_062] Hellfire - COST:4
 // - Set: CORE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7508,6 +7508,57 @@ TEST_CASE("[Warlock : Spell] - CORE_ICC_055 : Drain Soul")
 }
 
 // --------------------------------------- MINION - WARLOCK
+// [CORE_OG_109] Darkshire Librarian - COST:2 [ATK:3/HP:2]
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Discard a random card.
+//       <b>Deathrattle:</b> Draw a card.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - CORE_OG_109 : Darkshire Librarian")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Darkshire Librarian"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curHand.GetCount(), 4);
+}
+
+// --------------------------------------- MINION - WARLOCK
 // [CORE_UNG_833] Lakkari Felhound - COST:4 [ATK:3/HP:8]
 // - Race: Demon, Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -7559,6 +7559,56 @@ TEST_CASE("[Warlock : Minion] - CORE_OG_109 : Darkshire Librarian")
 }
 
 // --------------------------------------- MINION - WARLOCK
+// [CORE_TRL_252] High Priestess Jeklik - COST:4 [ATK:3/HP:5]
+// - Set: CORE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Taunt</b>, <b>Lifesteal</b>
+//       When you discard this,
+//       add 2 copies of it to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - LIFESTEAL = 1
+// - TAUNT = 1
+// - InvisibleDeathrattle = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - CORE_TRL_252 : High Priestess Jeklik")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("High Priestess Jeklik"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Darkshire Librarian"));
+
+    CHECK_EQ(curHand.GetCount(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curHand.GetCount(), 2);
+    CHECK_EQ(curHand[0]->card->name, "High Priestess Jeklik");
+    CHECK_EQ(curHand[1]->card->name, "High Priestess Jeklik");
+}
+
+// --------------------------------------- MINION - WARLOCK
 // [CORE_UNG_833] Lakkari Felhound - COST:4 [ATK:3/HP:8]
 // - Race: Demon, Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/TrollCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TrollCardsGenTests.cpp
@@ -346,3 +346,52 @@ TEST_CASE("[Shaman : Minion] - TRL_345 : Krag'wa, the Frog")
     game.Process(curPlayer, PlayCardTask::Minion(card2));
     CHECK_EQ(curHand.GetCount(), 1);
 }
+
+// --------------------------------------- MINION - WARLOCK
+// [TRL_252] High Priestess Jeklik - COST:4 [ATK:3/HP:5]
+// - Set: Troll, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Taunt</b>, <b>Lifesteal</b>
+//       When you discard this,
+//       add 2 copies of it to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - TAUNT = 1
+// - InvisibleDeathrattle = 1
+// - LIFESTEAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - TRL_252 : High Priestess Jeklik")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("High Priestess Jeklik"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Darkshire Librarian"));
+
+    CHECK_EQ(curHand.GetCount(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curHand.GetCount(), 2);
+    CHECK_EQ(curHand[0]->card->name, "High Priestess Jeklik");
+    CHECK_EQ(curHand[1]->card->name, "High Priestess Jeklik");
+}


### PR DESCRIPTION
This revision includes:
- Implement 5 CORE cards (#755)
  - Imp Gang Boss (CORE_BRM_006)
  - Abyssal Enforcer (CORE_CFM_751)
  - Voidwalker (CORE_CS2_065)
  - Darkshire Librarian (CORE_OG_109)
  - High Priestess Jeklik (CORE_TRL_252)
- Implement 1 BRM card
  - Imp Gang Boss (BRM_006)
- Implement 1 GANGS card
  - Abyssal Enforcer (CFM_751)
- Implement 1 OG card
  - Darkshire Librarian (OG_109)
- Implement 1 TROLL card
  - High Priestess Jeklik (TRL_252)