### PR TITLE
Implement 6 CORE cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -34,7 +34,7 @@ CORE | CORE_BT_480 | Crimson Sigil Runner | O
 CORE | CORE_BT_491 | Spectral Sight | O
 CORE | CORE_BT_801 | Eye Beam | O
 CORE | CORE_BT_921 | Aldrachi Warblades | O
-CORE | CORE_CFM_120 | Mistress of Mixtures |  
+CORE | CORE_CFM_120 | Mistress of Mixtures | O
 CORE | CORE_CFM_605 | Drakonid Operative | O
 CORE | CORE_CFM_751 | Abyssal Enforcer | O
 CORE | CORE_CS1_112 | Holy Nova | O
@@ -82,13 +82,13 @@ CORE | CORE_DRG_229 | Bronze Explorer | O
 CORE | CORE_DS1_184 | Tracking | O
 CORE | CORE_DS1_185 | Arcane Shot | O
 CORE | CORE_EX1_005 | Big Game Hunter | O
-CORE | CORE_EX1_007 | Acolyte of Pain |  
+CORE | CORE_EX1_007 | Acolyte of Pain | O
 CORE | CORE_EX1_010 | Worgen Infiltrator | O
 CORE | CORE_EX1_011 | Voodoo Doctor | O
 CORE | CORE_EX1_012 | Bloodmage Thalnos | O
 CORE | CORE_EX1_017 | Jungle Panther | O
 CORE | CORE_EX1_028 | Stranglethorn Tiger | O
-CORE | CORE_EX1_043 | Twilight Drake |  
+CORE | CORE_EX1_043 | Twilight Drake | O
 CORE | CORE_EX1_046 | Dark Iron Dwarf | O
 CORE | CORE_EX1_049 | Youthful Brewmaster | O
 CORE | CORE_EX1_059 | Crazed Alchemist | O
@@ -123,7 +123,7 @@ CORE | CORE_EX1_249 | Baron Geddon | O
 CORE | CORE_EX1_259 | Lightning Storm | O
 CORE | CORE_EX1_275 | Cone of Cold | O
 CORE | CORE_EX1_279 | Pyroblast | O
-CORE | CORE_EX1_284 | Azure Drake |  
+CORE | CORE_EX1_284 | Azure Drake | O
 CORE | CORE_EX1_287 | Counterspell | O
 CORE | CORE_EX1_289 | Ice Barrier | O
 CORE | CORE_EX1_302 | Mortal Coil | O
@@ -143,7 +143,7 @@ CORE | CORE_EX1_410 | Shield Slam | O
 CORE | CORE_EX1_411 | Gorehowl | O
 CORE | CORE_EX1_414 | Grommash Hellscream | O
 CORE | CORE_EX1_506 | Murloc Tidehunter | O
-CORE | CORE_EX1_507 | Murloc Warleader |  
+CORE | CORE_EX1_507 | Murloc Warleader | O
 CORE | CORE_EX1_509 | Murloc Tidecaller | O
 CORE | CORE_EX1_534 | Savannah Highmane | O
 CORE | CORE_EX1_543 | King Krush | O
@@ -154,7 +154,7 @@ CORE | CORE_EX1_567 | Doomhammer | O
 CORE | CORE_EX1_571 | Force of Nature | O
 CORE | CORE_EX1_573 | Cenarius | O
 CORE | CORE_EX1_575 | Mana Tide Totem | O
-CORE | CORE_EX1_586 | Sea Giant |  
+CORE | CORE_EX1_586 | Sea Giant | O
 CORE | CORE_EX1_603 | Cruel Taskmaster | O
 CORE | CORE_EX1_604 | Frothing Berserker | O
 CORE | CORE_EX1_606 | Shield Block | O
@@ -261,7 +261,7 @@ CORE | CS3_036 | Deathwing the Destroyer | O
 CORE | CS3_037 | Emerald Skytalon | O
 CORE | CS3_038 | Redgill Razorjaw | O
 
-- Progress: 88% (222 of 250 Cards)
+- Progress: 91% (228 of 250 Cards)
 
 ## Forged in the Barrens
 

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -1088,7 +1088,7 @@ GANGS | CFM_066 | Kabal Lackey |
 GANGS | CFM_067 | Hozen Healer |  
 GANGS | CFM_094 | Felfire Potion |  
 GANGS | CFM_095 | Weasel Tunneler |  
-GANGS | CFM_120 | Mistress of Mixtures |  
+GANGS | CFM_120 | Mistress of Mixtures | O
 GANGS | CFM_300 | Public Defender |  
 GANGS | CFM_305 | Smuggler's Run |  
 GANGS | CFM_308 | Kun the Forgotten King |  
@@ -1206,7 +1206,7 @@ GANGS | CFM_902 | Aya Blackpaw |
 GANGS | CFM_905 | Small-Time Recruits |  
 GANGS | CFM_940 | I Know a Guy |  
 
-- Progress: 1% (2 of 132 Cards)
+- Progress: 2% (3 of 132 Cards)
 
 ## Journey to Un'Goro
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 88% Core Set (222 of 250 cards)
+  * 91% Core Set (228 of 250 cards)
   * 81% Forged in the Barrens (139 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
@@ -61,7 +61,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 8% The League of Explorers (4 of 45 Cards)
   * 5% Whispers of the Old Gods (8 of 134 Cards)
   * 15% One Night in Karazhan (7 of 45 Cards)
-  * 1% Mean Streets of Gadgetzan (2 of 132 Cards)
+  * 2% Mean Streets of Gadgetzan (3 of 132 Cards)
   * 5% Journey to Un'Goro (8 of 135 Cards)
   * 3% Knights of the Frozen Throne (5 of 135 Cards)
   * 3% Kobolds & Catacombs (5 of 135 Cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -3752,6 +3752,12 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::TAKE_DAMAGE));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<DrawTask>(1) };
+    cards.emplace("CORE_EX1_007", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_EX1_010] Worgen Infiltrator - COST:1 [ATK:2/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -3837,12 +3837,17 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [CORE_EX1_043] Twilight Drake - COST:4 [ATK:4/HP:1]
     // - Race: Dragon, Set: CORE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Gain +1 Health for each card
-    //       in your hand.
+    // Text: <b>Battlecry:</b> Gain +1 Health
+    //       for each card in your hand.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<CountTask>(EntityType::HAND));
+    cardDef.power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
+        "EX1_043e", EntityType::SOURCE, true));
+    cards.emplace("CORE_EX1_043", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_EX1_046] Dark Iron Dwarf - COST:4 [ATK:4/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4111,6 +4111,9 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - SPELLPOWER = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cards.emplace("CORE_EX1_284", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_EX1_506] Murloc Tidehunter - COST:2 [ATK:2/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4138,6 +4138,15 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - AURA = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(
+        std::make_shared<Aura>(AuraType::FIELD_EXCEPT_SOURCE, "EX1_507e"));
+    {
+        const auto aura = dynamic_cast<Aura*>(cardDef.power.GetAura());
+        aura->condition = std::make_shared<SelfCondition>(
+            SelfCondition::IsRace(Race::MURLOC));
+    }
+    cards.emplace("CORE_EX1_507", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_EX1_509] Murloc Tidecaller - COST:1 [ATK:1/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4196,6 +4196,13 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // Text: Costs (1) less for each other minion
     //       on the battlefield.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(
+        std::make_shared<AdaptiveCostEffect>([=](Playable* playable) {
+            return playable->player->GetFieldZone()->GetCount() +
+                   playable->player->opponent->GetFieldZone()->GetCount();
+        }));
+    cards.emplace("CORE_EX1_586", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_FP1_007] Nerubian Egg - COST:2 [ATK:0/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -3563,6 +3563,12 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddDeathrattleTask(
+        std::make_shared<HealTask>(EntityType::HERO, 4));
+    cardDef.power.AddDeathrattleTask(
+        std::make_shared<HealTask>(EntityType::ENEMY_HERO, 4));
+    cards.emplace("CORE_CFM_120", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_CS2_122] Raid Leader - COST:3 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -5889,7 +5889,8 @@ void Expert1CardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [EX1_586] Sea Giant - COST:10 [ATK:8/HP:8]
     // - Faction: Neutral, Set: Expert1, Rarity: Epic
     // --------------------------------------------------------
-    // Text: Costs (1) less for each other minion on the battlefield.
+    // Text: Costs (1) less for each other minion
+    //       on the battlefield.
     // --------------------------------------------------------
     cardDef.ClearData();
     cardDef.power.AddAura(

--- a/Sources/Rosetta/PlayMode/CardSets/GangsCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/GangsCardsGen.cpp
@@ -172,7 +172,7 @@ void GangsCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // [CFM_315] Alleycat - COST:1 [ATK:1/HP:1]
     // - Race: Beast, Set: GANGS, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Summon a 1/1 Cat.
+    // Text: <b>Battlecry:</b> Summon a 1/1ï¿½Cat.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
@@ -383,7 +383,7 @@ void GangsCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - Set: GANGS, Rarity: Rare
     // --------------------------------------------------------
     // Text: Costs (2) less for each <b>Secret</b>
-    //       you've played this game.
+    //       you've played thisï¿½game.
     // --------------------------------------------------------
     // RefTag:
     // - SECRET = 1
@@ -573,7 +573,7 @@ void GangsCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // [CFM_606] Mana Geode - COST:2 [ATK:2/HP:3]
     // - Race: Elemental, Set: GANGS, Rarity: Epic
     // --------------------------------------------------------
-    // Text: Whenever this minion is healed, summon a 2/2 Crystal.
+    // Text: Whenever this minion is healed, summon a 2/2ï¿½Crystal.
     // --------------------------------------------------------
     // GameTag:
     // - TRIGGER_VISUAL = 1
@@ -968,7 +968,7 @@ void GangsCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - Race: Demon, Set: GANGS, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> If your deck has no duplicates,
-    //       summon all Demons from your hand. 
+    //       summon all Demons from your hand.ï¿½
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
@@ -1125,6 +1125,8 @@ void GangsCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)
 
 void GangsCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // --------------------------------------- MINION - NEUTRAL
     // [CFM_025] Wind-up Burglebot - COST:6 [ATK:5/HP:5]
     // - Race: Mechanical, Set: GANGS, Rarity: Epic
@@ -1208,6 +1210,12 @@ void GangsCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddDeathrattleTask(
+        std::make_shared<HealTask>(EntityType::HERO, 4));
+    cardDef.power.AddDeathrattleTask(
+        std::make_shared<HealTask>(EntityType::ENEMY_HERO, 4));
+    cards.emplace("CFM_120", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CFM_321] Grimestreet Informant - COST:2 [ATK:1/HP:1]
@@ -1335,7 +1343,7 @@ void GangsCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [CFM_648] Big-Time Racketeer - COST:6 [ATK:1/HP:1]
     // - Set: GANGS, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Summon a 6/6 Ogre.
+    // Text: <b>Battlecry:</b> Summon a 6/6ï¿½Ogre.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
@@ -1435,7 +1443,7 @@ void GangsCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [CFM_659] Gadgetzan Socialite - COST:2 [ATK:2/HP:2]
     // - Set: GANGS, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Restore 2 Health.
+    // Text: <b>Battlecry:</b> Restore 2ï¿½Health.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
@@ -1544,7 +1552,7 @@ void GangsCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [CFM_715] Jade Spirit - COST:4 [ATK:2/HP:3]
     // - Race: Elemental, Set: GANGS, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Summon a {1}/{0} <b>Jade Golem</b>.
+    // Text: <b>Battlecry:</b> Summon a {1}/{0} <b>Jadeï¿½Golem</b>.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -10155,6 +10155,53 @@ TEST_CASE("[Neutral : Minion] - CORE_EX1_005 : Big Game Hunter")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_EX1_007] Acolyte of Pain - COST:3 [ATK:1/HP:3]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: Whenever this minion takes damage, draw a card.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_EX1_007 : Acolyte of Pain")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Acolyte of Pain"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Stonetusk Boar"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 4);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(opPlayer, AttackTask(card2, card1));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_EX1_010] Worgen Infiltrator - COST:1 [ATK:2/HP:1]
 // - Faction: Alliance, Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -11364,6 +11364,77 @@ TEST_CASE("[Neutral : Minion] - CORE_EX1_506 : Murloc Tidehunter")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_EX1_507] Murloc Warleader - COST:3 [ATK:3/HP:3]
+// - Race: Murloc, Set: CORE, Rarity: Epic
+// --------------------------------------------------------
+// Text: Your other Murlocs have +2 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - AURA = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_EX1_507 : Murloc Warleader")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Murloc Raider"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Murloc Raider"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card6 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Murloc Warleader"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    game.Process(opPlayer, PlayCardTask::Minion(card6));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(opField[0]->GetAttack(), 4);
+    CHECK_EQ(opField[1]->GetAttack(), 1);
+    CHECK_EQ(opField[2]->GetAttack(), 3);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card6));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(opField[0]->GetAttack(), 2);
+    CHECK_EQ(opField[1]->GetAttack(), 1);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_EX1_509] Murloc Tidecaller - COST:1 [ATK:1/HP:2]
 // - Race: Murloc, Set: CORE, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -11572,6 +11572,62 @@ TEST_CASE("[Neutral : Minion] - CORE_EX1_564 : Faceless Manipulator")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_EX1_586] Sea Giant - COST:10 [ATK:8/HP:8]
+// - Set: CORE, Rarity: Epic
+// --------------------------------------------------------
+// Text: Costs (1) less for each other minion
+//       on the battlefield.
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_EX1_586 : Sea Giant")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Sea Giant"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card6 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+
+    CHECK_EQ(card1->GetCost(), 10);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(card1->GetCost(), 7);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    game.Process(opPlayer, PlayCardTask::Minion(card6));
+    CHECK_EQ(card1->GetCost(), 5);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_FP1_007] Nerubian Egg - COST:2 [ATK:0/HP:2]
 // - Set: CORE, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -10379,6 +10379,48 @@ TEST_CASE("[Neutral : Minion] - CORE_EX1_028 : Stranglethorn Tiger")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_EX1_043] Twilight Drake - COST:4 [ATK:4/HP:1]
+// - Race: Dragon, Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Gain +1 Health
+//       for each card in your hand.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_EX1_043 : Twilight Drake")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Twilight Drake"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 4);
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_EX1_046] Dark Iron Dwarf - COST:4 [ATK:4/HP:4]
 // - Faction: Alliance, Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -9632,6 +9632,54 @@ TEST_CASE("[Demon Hunter : Minion] - CS3_020 : Illidari Inquisitor")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_CFM_120] Mistress of Mixtures - COST:1 [ATK:2/HP:2]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Restore 4 Health to each hero.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_CFM_120 : Mistress of Mixtures")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Mistress of Mixtures"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 15);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 24);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 19);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_CS2_122] Raid Leader - COST:3 [ATK:2/HP:3]
 // - Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -11265,6 +11265,64 @@ TEST_CASE("[Neutral : Minion] - CORE_EX1_249 : Baron Geddon")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_EX1_284] Azure Drake - COST:5 [ATK:4/HP:5]
+// - Race: Dragon, Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Spell Damage +1</b>
+//       <b>Battlecry:</b> Draw a card.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - SPELLPOWER = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_EX1_284 : Azure Drake")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Azure Drake"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Fireball"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Archmage"));
+
+    const auto curHandCount = curPlayer->GetHandZone()->GetCount();
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), curHandCount);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card3));
+
+    CHECK_EQ(curPlayer->GetFieldZone()->GetCount(), 1);
+    CHECK_EQ(opPlayer->GetFieldZone()->GetCount(), 0);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_EX1_506] Murloc Tidehunter - COST:2 [ATK:2/HP:1]
 // - Race: Murloc, Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -13179,7 +13179,8 @@ TEST_CASE("[Neutral : Minion] - EX1_584 : Ancient Mage")
 // [EX1_586] Sea Giant - COST:10 [ATK:8/HP:8]
 // - Faction: Neutral, Set: Expert1, Rarity: Epic
 // --------------------------------------------------------
-// Text: Costs (1) less for each other minion on the battlefield.
+// Text: Costs (1) less for each other minion
+//       on the battlefield.
 // --------------------------------------------------------
 TEST_CASE("[Neutral : Minion] - EX1_586 : Sea Giant")
 {

--- a/Tests/UnitTests/PlayMode/CardSets/GangsCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/GangsCardsGenTests.cpp
@@ -166,3 +166,50 @@ TEST_CASE("[Warlock : Minion] - CFM_751 : Abyssal Enforcer")
     CHECK_EQ(opField.GetCount(), 1);
     CHECK_EQ(opField[0]->GetHealth(), 4);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [CFM_120] Mistress of Mixtures - COST:1 [ATK:2/HP:2]
+// - Set: GANGS, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Restore 4 Health to each hero.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CFM_120 : Mistress of Mixtures")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Mistress of Mixtures"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 20);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 15);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 24);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 19);
+}


### PR DESCRIPTION
This revision includes:
- Implement 6 CORE cards (#755)
  - Mistress of Mixtures (CORE_CFM_120)
  - Acolyte of Pain (CORE_EX1_007)
  - Twilight Drake (CORE_EX1_043)
  - Azure Drake (CORE_EX1_284)
  - Murloc Warleader (CORE_EX1_507)
  - Sea Giant (CORE_EX1_586)
- Implement 1 GANGS card
  - Mistress of Mixtures (CFM_120)
- Separate text to improve readability