### PR TITLE
Implement 8 CORE cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -165,11 +165,11 @@ CORE | CORE_EX1_619 | Equality | O
 CORE | CORE_EX1_622 | Shadow Word: Death | O
 CORE | CORE_FP1_007 | Nerubian Egg | O
 CORE | CORE_FP1_020 | Avenge | O
-CORE | CORE_GIL_124 | Mossy Horror |  
+CORE | CORE_GIL_124 | Mossy Horror | O
 CORE | CORE_GIL_191 | Fiendish Circle | O
 CORE | CORE_GIL_547 | Darius Crowley | O
 CORE | CORE_GIL_598 | Tess Greymane | O
-CORE | CORE_GIL_622 | Lifedrinker |  
+CORE | CORE_GIL_622 | Lifedrinker | O
 CORE | CORE_GIL_650 | Houndmaster Shaw | O
 CORE | CORE_GIL_801 | Snap Freeze | O
 CORE | CORE_GIL_828 | Dire Frenzy | O
@@ -178,7 +178,7 @@ CORE | CORE_GVG_053 | Shieldmaiden | O
 CORE | CORE_GVG_076 | Explosive Sheep | O
 CORE | CORE_GVG_085 | Annoy-o-Tron | O
 CORE | CORE_ICC_026 | Grim Necromancer | O
-CORE | CORE_ICC_029 | Cobalt Scalebane |  
+CORE | CORE_ICC_029 | Cobalt Scalebane | O
 CORE | CORE_ICC_038 | Righteous Protector | O
 CORE | CORE_ICC_055 | Drain Soul | O
 CORE | CORE_ICC_809 | Plague Scientist | O
@@ -187,7 +187,7 @@ CORE | CORE_KAR_009 | Babbling Book | O
 CORE | CORE_KAR_069 | Swashburglar | O
 CORE | CORE_KAR_073 | Maelstrom Portal | O
 CORE | CORE_LOE_003 | Ethereal Conjurer | O
-CORE | CORE_LOE_011 | Reno Jackson |  
+CORE | CORE_LOE_011 | Reno Jackson | O
 CORE | CORE_LOE_012 | Tomb Pillager | O
 CORE | CORE_LOE_039 | Gorillabot A-3 |  
 CORE | CORE_LOE_050 | Mounted Raptor | O
@@ -199,14 +199,14 @@ CORE | CORE_LOOT_101 | Explosive Runes | O
 CORE | CORE_LOOT_124 | Lone Champion | O
 CORE | CORE_LOOT_137 | Sleepy Dragon | O
 CORE | CORE_LOOT_222 | Candleshot | O
-CORE | CORE_LOOT_413 | Plated Beetle |  
+CORE | CORE_LOOT_413 | Plated Beetle | O
 CORE | CORE_LOOT_516 | Zola the Gorgon |  
 CORE | CORE_NEW1_008 | Ancient of Lore | O
 CORE | CORE_NEW1_010 | Al'Akir the Windlord | O
 CORE | CORE_NEW1_018 | Bloodsail Raider | O
-CORE | CORE_NEW1_020 | Wild Pyromancer |  
-CORE | CORE_NEW1_021 | Doomsayer |  
-CORE | CORE_NEW1_023 | Faerie Dragon |  
+CORE | CORE_NEW1_020 | Wild Pyromancer | O
+CORE | CORE_NEW1_021 | Doomsayer | O
+CORE | CORE_NEW1_023 | Faerie Dragon | O
 CORE | CORE_NEW1_026 | Violet Teacher | O
 CORE | CORE_NEW1_027 | Southsea Captain | O
 CORE | CORE_NEW1_031 | Animal Companion | O
@@ -261,7 +261,7 @@ CORE | CS3_036 | Deathwing the Destroyer | O
 CORE | CS3_037 | Emerald Skytalon | O
 CORE | CS3_038 | Redgill Razorjaw | O
 
-- Progress: 91% (228 of 250 Cards)
+- Progress: 94% (236 of 250 Cards)
 
 ## Forged in the Barrens
 

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -834,7 +834,7 @@ LOE | LOE_006 | Museum Curator |
 LOE | LOE_007 | Curse of Rafaam |  
 LOE | LOE_009 | Obsidian Destroyer |  
 LOE | LOE_010 | Pit Snake |  
-LOE | LOE_011 | Reno Jackson |  
+LOE | LOE_011 | Reno Jackson | O
 LOE | LOE_012 | Tomb Pillager | O
 LOE | LOE_016 | Rumbling Elemental |  
 LOE | LOE_017 | Keeper of Uldaman |  
@@ -874,7 +874,7 @@ LOE | LOE_118 | Cursed Blade |
 LOE | LOE_119 | Animated Armor |  
 LOE | LOEA10_3 | Murloc Tinyfin | O
 
-- Progress: 8% (4 of 45 Cards)
+- Progress: 11% (5 of 45 Cards)
 
 ## Whispers of the Old Gods
 
@@ -1362,7 +1362,7 @@ ICECROWN | ICC_025 | Rattling Rascal |
 ICECROWN | ICC_026 | Grim Necromancer | O
 ICECROWN | ICC_027 | Bone Drake |  
 ICECROWN | ICC_028 | Sunborne Val'kyr |  
-ICECROWN | ICC_029 | Cobalt Scalebane |  
+ICECROWN | ICC_029 | Cobalt Scalebane | O
 ICECROWN | ICC_031 | Night Howler |  
 ICECROWN | ICC_032 | Venomancer |  
 ICECROWN | ICC_034 | Arrogant Crusader |  
@@ -1490,7 +1490,7 @@ ICECROWN | ICC_911 | Keening Banshee |
 ICECROWN | ICC_912 | Corpsetaker |  
 ICECROWN | ICC_913 | Tainted Zealot |  
 
-- Progress: 3% (5 of 135 Cards)
+- Progress: 4% (6 of 135 Cards)
 
 ## Kobolds & Catacombs
 
@@ -1602,7 +1602,7 @@ LOOTAPALOOZA | LOOT_394 | Shrieking Shroom |
 LOOTAPALOOZA | LOOT_398 | Benevolent Djinn |  
 LOOTAPALOOZA | LOOT_410 | Duskbreaker |  
 LOOTAPALOOZA | LOOT_412 | Kobold Illusionist |  
-LOOTAPALOOZA | LOOT_413 | Plated Beetle |  
+LOOTAPALOOZA | LOOT_413 | Plated Beetle | O
 LOOTAPALOOZA | LOOT_414 | Grand Archivist |  
 LOOTAPALOOZA | LOOT_415 | Rin, the First Disciple |  
 LOOTAPALOOZA | LOOT_417 | Cataclysm |  
@@ -1632,7 +1632,7 @@ LOOTAPALOOZA | LOOT_540 | Dragonhatcher |
 LOOTAPALOOZA | LOOT_541 | King Togwaggle |  
 LOOTAPALOOZA | LOOT_542 | Kingsbane |  
 
-- Progress: 3% (5 of 135 Cards)
+- Progress: 4% (6 of 135 Cards)
 
 ## The Witchwood
 
@@ -1645,7 +1645,7 @@ GILNEAS | GIL_118 | Deranged Doctor |
 GILNEAS | GIL_119 | Cauldron Elemental |  
 GILNEAS | GIL_120 | Furious Ettin |  
 GILNEAS | GIL_121 | Darkmire Moonkin |  
-GILNEAS | GIL_124 | Mossy Horror |  
+GILNEAS | GIL_124 | Mossy Horror | O
 GILNEAS | GIL_125 | Mad Hatter |  
 GILNEAS | GIL_128 | Emeriss |  
 GILNEAS | GIL_130 | Gloom Stag |  
@@ -1714,7 +1714,7 @@ GILNEAS | GIL_614 | Voodoo Doll |
 GILNEAS | GIL_616 | Splitting Festeroot |  
 GILNEAS | GIL_618 | Glinda Crowskin |  
 GILNEAS | GIL_620 | Dollmaster Dorian |  
-GILNEAS | GIL_622 | Lifedrinker |  
+GILNEAS | GIL_622 | Lifedrinker | O
 GILNEAS | GIL_623 | Witchwood Grizzly |  
 GILNEAS | GIL_624 | Night Prowler |  
 GILNEAS | GIL_634 | Bellringer Sentry |  
@@ -1774,7 +1774,7 @@ GILNEAS | GIL_902 | Cutthroat Buccaneer |
 GILNEAS | GIL_903 | Hidden Wisdom |  
 GILNEAS | GIL_905 | Carrion Drake |  
 
-- Progress: 4% (6 of 135 Cards)
+- Progress: 5% (8 of 135 Cards)
 
 ## The Boomsday Project
 

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
@@ -239,6 +239,20 @@ class ComplexTask
         };
     }
 
+    //! Returns a list of task for giving buff to another random minion
+    //! in field.
+    //! \param enchantmentCardID The ID of enchantment card to give buff.
+    static TaskList GiveBuffToAnotherRandomMinionInField(
+        std::string_view enchantmentCardID)
+    {
+        return TaskList{ std::make_shared<SimpleTasks::IncludeTask>(
+                             EntityType::MINIONS_NOSOURCE),
+                         std::make_shared<SimpleTasks::RandomTask>(
+                             EntityType::STACK, 1),
+                         std::make_shared<SimpleTasks::AddEnchantmentTask>(
+                             enchantmentCardID, EntityType::STACK) };
+    }
+
     //! Returns a list of task for activating a secret card.
     //! \param tasks A list of task of secret card.
     static TaskList ActivateSecret(TaskList tasks)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 91% Core Set (228 of 250 cards)
+  * 94% Core Set (236 of 250 cards)
   * 81% Forged in the Barrens (139 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
@@ -58,14 +58,14 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 6% Goblins vs Gnomes (8 of 123 Cards)
   * 6% Blackrock Mountain (2 of 31 Cards)
   * 8% The Grand Tournament (11 of 132 Cards)
-  * 8% The League of Explorers (4 of 45 Cards)
+  * 11% The League of Explorers (5 of 45 Cards)
   * 5% Whispers of the Old Gods (8 of 134 Cards)
   * 15% One Night in Karazhan (7 of 45 Cards)
   * 2% Mean Streets of Gadgetzan (3 of 132 Cards)
   * 5% Journey to Un'Goro (8 of 135 Cards)
-  * 3% Knights of the Frozen Throne (5 of 135 Cards)
-  * 3% Kobolds & Catacombs (5 of 135 Cards)
-  * 4% The Witchwood (6 of 135 Cards)
+  * 4% Knights of the Frozen Throne (6 of 135 Cards)
+  * 4% Kobolds & Catacombs (6 of 135 Cards)
+  * 5% The Witchwood (8 of 135 Cards)
   * 2% The Boomsday Project (4 of 136 Cards)
   * 5% Rastakhan's Rumble (7 of 135 Cards)
   * **100% Rise of Shadows (136 of 136 cards)**

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4248,6 +4248,11 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 3));
+    cardDef.power.AddPowerTask(std::make_shared<HealTask>(EntityType::HERO, 3));
+    cards.emplace("CORE_GIL_622", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_GVG_076] Explosive Sheep - COST:2 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4326,7 +4326,15 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - ELITE = 1
     // - BATTLECRY = 1
+    // - AFFECTED_BY_HEALING_DOES_DAMAGE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsNoDuplicateInDeck()) }));
+    cardDef.power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<HealFullTask>(EntityType::HERO) }));
+    cards.emplace("CORE_LOE_011", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_LOE_039] Gorillabot A-3 - COST:3 [ATK:3/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4476,11 +4476,17 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [CORE_NEW1_020] Wild Pyromancer - COST:2 [ATK:3/HP:2]
     // - Set: CORE, Rarity: Rare
     // --------------------------------------------------------
-    // Text: After you cast a spell, deal 1 damage to ALL minions.
+    // Text: After you cast a spell, deal 1 damage to all minions.
     // --------------------------------------------------------
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::AFTER_CAST));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<DamageTask>(
+        EntityType::ALL_MINIONS, 1) };
+    cards.emplace("CORE_NEW1_020", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_NEW1_021] Doomsayer - COST:2 [ATK:0/HP:7]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4439,6 +4439,9 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddDeathrattleTask(std::make_shared<ArmorTask>(3));
+    cards.emplace("CORE_LOOT_413", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_LOOT_516] Zola the Gorgon - COST:3 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4514,6 +4514,9 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - CANT_BE_TARGETED_BY_SPELLS = 1
     // - CANT_BE_TARGETED_BY_HERO_POWERS = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("CORE_NEW1_023", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_NEW1_026] Violet Teacher - COST:4 [ATK:3/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4309,6 +4309,12 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    cardDef.power.GetTrigger()->tasks = {
+        ComplexTask::GiveBuffToAnotherRandomMinionInField("ICC_029e")
+    };
+    cards.emplace("CORE_ICC_029", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_LOE_011] Reno Jackson - COST:6 [ATK:4/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4492,11 +4492,17 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [CORE_NEW1_021] Doomsayer - COST:2 [ATK:0/HP:7]
     // - Set: CORE, Rarity: Epic
     // --------------------------------------------------------
-    // Text: At the start of your turn, destroy ALL minions.
+    // Text: At the start of your turn, destroy all minions.
     // --------------------------------------------------------
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::TURN_START));
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<DestroyTask>(
+        EntityType::ALL_MINIONS) };
+    cards.emplace("CORE_NEW1_021", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_NEW1_023] Faerie Dragon - COST:2 [ATK:3/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4228,6 +4228,15 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<IncludeTask>(EntityType::ALL_MINIONS_NOSOURCE));
+    cardDef.power.AddPowerTask(std::make_shared<FilterStackTask>(
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsTagValue(GameTag::ATK, 2, RelaSign::LEQ)) }));
+    cardDef.power.AddPowerTask(
+        std::make_shared<DestroyTask>(EntityType::STACK));
+    cards.emplace("CORE_GIL_124", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_GIL_622] Lifedrinker - COST:4 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/GilneasCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/GilneasCardsGen.cpp
@@ -1428,6 +1428,8 @@ void GilneasCardsGen::AddWarriorNonCollect(
 
 void GilneasCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // --------------------------------------- MINION - NEUTRAL
     // [GIL_117] Worgen Abomination - COST:7 [ATK:6/HP:6]
     // - Set: Gilneas, Rarity: Epic
@@ -1486,6 +1488,15 @@ void GilneasCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<IncludeTask>(EntityType::ALL_MINIONS_NOSOURCE));
+    cardDef.power.AddPowerTask(std::make_shared<FilterStackTask>(
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsTagValue(GameTag::ATK, 2, RelaSign::LEQ)) }));
+    cardDef.power.AddPowerTask(
+        std::make_shared<DestroyTask>(EntityType::STACK));
+    cards.emplace("GIL_124", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [GIL_125] Mad Hatter - COST:4 [ATK:3/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/GilneasCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/GilneasCardsGen.cpp
@@ -1782,6 +1782,11 @@ void GilneasCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ENEMY_HERO, 3));
+    cardDef.power.AddPowerTask(std::make_shared<HealTask>(EntityType::HERO, 3));
+    cards.emplace("GIL_622", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [GIL_623] Witchwood Grizzly - COST:5 [ATK:3/HP:12]

--- a/Sources/Rosetta/PlayMode/CardSets/IcecrownCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/IcecrownCardsGen.cpp
@@ -5,6 +5,7 @@
 
 #include <Rosetta/PlayMode/CardSets/IcecrownCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
+#include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks.hpp>
 
 using namespace RosettaStone::PlayMode::SimpleTasks;
@@ -1868,6 +1869,15 @@ void IcecrownCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // Text: At the end of your turn,
     //       give another random friendly minion +3 Attack.
     // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    cardDef.power.GetTrigger()->tasks = {
+        ComplexTask::GiveBuffToAnotherRandomMinionInField("ICC_029e")
+    };
+    cards.emplace("ICC_029", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [ICC_031] Night Howler - COST:4 [ATK:3/HP:4]
@@ -2360,6 +2370,9 @@ void IcecrownCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: Attack increased.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddEnchant(std::make_shared<Enchant>(Effects::AttackN(3)));
+    cards.emplace("ICC_029e", cardDef);
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [ICC_031e] Awooooo! (*) - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
@@ -11,6 +11,7 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 namespace RosettaStone::PlayMode
 {
 using TagValues = std::vector<TagValue>;
+using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
 
 void LoECardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
@@ -508,6 +509,15 @@ void LoECardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - AFFECTED_BY_HEALING_DOES_DAMAGE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsNoDuplicateInDeck()) }));
+    cardDef.power.AddPowerTask(std::make_shared<FlagTask>(
+        true,
+        TaskList{
+            std::make_shared<HealFullTask>(EntityType::HERO) }));
+    cards.emplace("LOE_011", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [LOE_029] Jeweled Scarab - COST:2 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/LootapaloozaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LootapaloozaCardsGen.cpp
@@ -2215,6 +2215,9 @@ void LootapaloozaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddDeathrattleTask(std::make_shared<ArmorTask>(3));
+    cards.emplace("LOOT_413", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [LOOT_414] Grand Archivist - COST:8 [ATK:4/HP:7]

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -12183,6 +12183,82 @@ TEST_CASE("[Neutral : Minion] - CORE_NEW1_018 : Bloodsail Raider")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_NEW1_020] Wild Pyromancer - COST:2 [ATK:3/HP:2]
+// - Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: After you cast a spell, deal 1 damage to all minions.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_NEW1_020 : Wild Pyromancer")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wild Pyromancer"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Arcane Shot"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Arcane Shot"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Arcane Shot"));
+    const auto card6 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card7 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card6));
+    game.Process(opPlayer, PlayCardTask::Minion(card7));
+    game.Process(opPlayer,
+                 PlayCardTask::SpellTarget(card5, curPlayer->GetHero()));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card3, opPlayer->GetHero()));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(opField.GetCount(), 1);
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card4, opPlayer->GetHero()));
+    CHECK_EQ(curField.GetCount(), 0);
+    CHECK_EQ(opField.GetCount(), 0);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_NEW1_026] Violet Teacher - COST:4 [ATK:3/HP:5]
 // - Set: CORE, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -11867,7 +11867,7 @@ TEST_CASE("[Neutral : Minion] - CORE_GVG_085 : Annoy-o-Tron")
 // GameTag:
 // - BATTLECRY = 1
 // --------------------------------------------------------
-TEST_CASE("[Warlock : Spell] - CORE_ICC_026 : Grim Necromancer")
+TEST_CASE("[Neutral : Minion] - CORE_ICC_026 : Grim Necromancer")
 {
     GameConfig config;
     config.formatType = FormatType::STANDARD;

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -11957,6 +11957,64 @@ TEST_CASE("[Neutral : Minion] - CORE_ICC_029 : Cobalt Scalebane")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_LOE_011] Reno Jackson - COST:6 [ATK:4/HP:6]
+// - Set: CORE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If your deck has no duplicates,
+//       fully heal your hero.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// - AFFECTED_BY_HEALING_DOES_DAMAGE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_LOE_011 : Reno Jackson")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 6; ++i)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Wisp");
+        config.player2Deck[i] = Cards::FindCardByName("Wisp");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(20);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Reno Jackson"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Reno Jackson"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 10);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_LOEA10_3] Murloc Tinyfin - COST:0 [ATK:1/HP:1]
 // - Race: Murloc, Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -12325,6 +12325,57 @@ TEST_CASE("[Neutral : Minion] - CORE_NEW1_021 : Doomsayer")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_NEW1_023] Faerie Dragon - COST:2 [ATK:3/HP:2]
+// - Race: Dragon, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: Can't be targeted by spells or Hero Powers.
+// --------------------------------------------------------
+// GameTag:
+// - CANT_BE_TARGETED_BY_SPELLS = 1
+// - CANT_BE_TARGETED_BY_HERO_POWERS = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_NEW1_023 : Faerie Dragon")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Faerie Dragon"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_NEW1_026] Violet Teacher - COST:4 [ATK:3/HP:5]
 // - Set: CORE, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -11744,6 +11744,45 @@ TEST_CASE("[Neutral : Minion] - CORE_GIL_124 : Mossy Horror")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_GIL_622] Lifedrinker - COST:4 [ATK:3/HP:3]
+// - Race: Beast, Set: CORE, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Deal 3 damage to the enemy hero.
+//       Restore 3 Health to your hero.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_GIL_622 : Lifedrinker")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Lifedrinker"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 23);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 17);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_GVG_076] Explosive Sheep - COST:2 [ATK:1/HP:1]
 // - Race: Mechanical, Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -11907,6 +11907,56 @@ TEST_CASE("[Warlock : Spell] - CORE_ICC_026 : Grim Necromancer")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_ICC_029] Cobalt Scalebane - COST:5 [ATK:5/HP:5]
+// - Race: Dragon, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: At the end of your turn,
+//       give another random friendly minion +3 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_ICC_029 : Cobalt Scalebane")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Cobalt Scalebane"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[1]->GetAttack(), 4);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_LOEA10_3] Murloc Tinyfin - COST:0 [ATK:1/HP:1]
 // - Race: Murloc, Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -12259,6 +12259,72 @@ TEST_CASE("[Neutral : Minion] - CORE_NEW1_020 : Wild Pyromancer")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_NEW1_021] Doomsayer - COST:2 [ATK:0/HP:7]
+// - Set: CORE, Rarity: Epic
+// --------------------------------------------------------
+// Text: At the start of your turn, destroy all minions.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_NEW1_021 : Doomsayer")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Doomsayer"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Kor'kron Elite"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Water Elemental"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Acidic Swamp Ooze"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 4);
+    CHECK_EQ(curField.GetCount(), 3);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(opPlayer->GetHandZone()->GetCount(), 6);
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+    CHECK_EQ(curPlayer->GetHandZone()->GetCount(), 5);
+    CHECK_EQ(curField.GetCount(), 0);
+    CHECK_EQ(opPlayer->GetHandZone()->GetCount(), 6);
+    CHECK_EQ(opField.GetCount(), 0);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_NEW1_026] Violet Teacher - COST:4 [ATK:3/HP:5]
 // - Set: CORE, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -12089,6 +12089,50 @@ TEST_CASE("[Neutral : Minion] - CORE_LOOT_137 : Sleepy Dragon")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_LOOT_413] Plated Beetle - COST:2 [ATK:2/HP:3]
+// - Race: Beast, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Gain 3 Armor.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_LOOT_413 : Plated Beetle")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Plated Beetle"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 3);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_NEW1_018] Bloodsail Raider - COST:2 [ATK:2/HP:3]
 // - Race: Pirate, Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -11678,6 +11678,72 @@ TEST_CASE("[Neutral : Minion] - CORE_FP1_007 : Nerubian Egg")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_GIL_124] Mossy Horror - COST:6 [ATK:2/HP:7]
+// - Set: CORE, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Destroy all other minions
+//       with 2 or less Attack.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_GIL_124 : Mossy Horror")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mossy Horror"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Wolfrider");
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->card->name, "Wolfrider");
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_GVG_076] Explosive Sheep - COST:2 [ATK:1/HP:1]
 // - Race: Mechanical, Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/GilneasCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/GilneasCardsGenTests.cpp
@@ -464,3 +464,41 @@ TEST_CASE("[Neutral : Minion] - GIL_124 : Mossy Horror")
     CHECK_EQ(opField.GetCount(), 1);
     CHECK_EQ(opField[0]->card->name, "Wolfrider");
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [GIL_622] Lifedrinker - COST:4 [ATK:3/HP:3]
+// - Race: Beast, Set: Gilneas, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Deal 3 damage to the enemy hero.
+//       Restore 3 Health to your hero.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - GIL_622 : Lifedrinker")
+{
+    GameConfig config;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Lifedrinker"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 23);
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 17);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/GilneasCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/GilneasCardsGenTests.cpp
@@ -399,3 +399,68 @@ TEST_CASE("[Warrior : Minion] - GIL_547 : Darius Crowley")
     CHECK_EQ(curField[0]->GetAttack(), 6);
     CHECK_EQ(curField[0]->GetHealth(), 3);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [GIL_124] Mossy Horror - COST:6 [ATK:2/HP:7]
+// - Set: Gilneas, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Destroy all other minions
+//       with 2 or less Attack.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - GIL_124 : Mossy Horror")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mossy Horror"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wolfrider"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField.GetCount(), 2);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Wolfrider");
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->card->name, "Wolfrider");
+}

--- a/Tests/UnitTests/PlayMode/CardSets/IcecrownCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/IcecrownCardsGenTests.cpp
@@ -197,3 +197,52 @@ TEST_CASE("[Warlock : Spell] - ICC_026 : Grim Necromancer")
     CHECK_EQ(curField[2]->GetAttack(), 1);
     CHECK_EQ(curField[2]->GetHealth(), 1);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [ICC_029] Cobalt Scalebane - COST:5 [ATK:5/HP:5]
+// - Race: Dragon, Set: Icecrown, Rarity: Common
+// --------------------------------------------------------
+// Text: At the end of your turn,
+//       give another random friendly minion +3 Attack.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - ICC_029 : Cobalt Scalebane")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Cobalt Scalebane"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[1]->GetAttack(), 4);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/IcecrownCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/IcecrownCardsGenTests.cpp
@@ -160,7 +160,7 @@ TEST_CASE("[Warlock : Spell] - ICC_055 : Drain Soul")
 // GameTag:
 // - BATTLECRY = 1
 // --------------------------------------------------------
-TEST_CASE("[Warlock : Spell] - ICC_026 : Grim Necromancer")
+TEST_CASE("[Neutral : Minion] - ICC_026 : Grim Necromancer")
 {
     GameConfig config;
     config.player1Class = CardClass::WARLOCK;

--- a/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
@@ -165,6 +165,63 @@ TEST_CASE("[Rogue : Minion] - LOE_012 : Tomb Pillager")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [LOE_011] Reno Jackson - COST:6 [ATK:4/HP:6]
+// - Set: LoE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If your deck has no duplicates,
+//       fully heal your hero.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// - AFFECTED_BY_HEALING_DOES_DAMAGE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - LOE_011 : Reno Jackson")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 6; ++i)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Wisp");
+        config.player2Deck[i] = Cards::FindCardByName("Wisp");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(20);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Reno Jackson"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Reno Jackson"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 10);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curPlayer->GetHero()->GetHealth(), 30);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [LOEA10_3] Murloc Tinyfin - COST:0 [ATK:1/HP:1]
 // - Race: Murloc, Set: LoE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/LootapaloozaCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LootapaloozaCardsGenTests.cpp
@@ -233,3 +233,46 @@ TEST_CASE("[Neutral : Minion] - LOOT_137 : Sleepy Dragon")
 {
     // Do nothing
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [LOOT_413] Plated Beetle - COST:2 [ATK:2/HP:3]
+// - Race: Beast, Set: Lootapalooza, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Gain 3 Armor.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - LOOT_413 : Plated Beetle")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Plated Beetle"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 3);
+}


### PR DESCRIPTION
This revision includes:
- Implement 8 CORE cards (#755)
  - Mossy Horror (CORE_GIL_124)
  - Lifedrinker (CORE_GIL_622)
  - Cobalt Scalebane (CORE_ICC_029)
  - Reno Jackson (CORE_LOE_011)
  - Plated Beetle (CORE_LOOT_413)
  - Wild Pyromancer (CORE_NEW1_020)
  - Doomsayer (CORE_NEW1_021)
  - Faerie Dragon (CORE_NEW1_023)
- Implement 2 GILNEAS cards
  - Mossy Horror (GIL_124)
  - Lifedrinker (GIL_622)
- Implement 1 ICECROWN card
  - Cobalt Scalebane (ICC_029)
- Implement 1 LOE card
  - Reno Jackson (LOE_011)
- Implement 1 LOOTAPALOOZA card
  - Plated Beetle (LOOT_413)
- Add complex task 'GiveBuffToAnotherRandomMinionInField()'
  - Returns a list of task for giving buff to another random minion in field