### PR TITLE
Update Hearthstone Patch 23.4.3

### DIFF
--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -142,13 +142,13 @@ constexpr int NUM_TIER1_MINIONS = 20;
 constexpr int NUM_TIER2_MINIONS = 29;
 
 //! The number of tier 3 minions in Battlegrounds.
-constexpr int NUM_TIER3_MINIONS = 31;
+constexpr int NUM_TIER3_MINIONS = 34;
 
 //! The number of tier 4 minions in Battlegrounds.
-constexpr int NUM_TIER4_MINIONS = 35;
+constexpr int NUM_TIER4_MINIONS = 33;
 
 //! The number of tier 5 minions in Battlegrounds.
-constexpr int NUM_TIER5_MINIONS = 29;
+constexpr int NUM_TIER5_MINIONS = 28;
 
 //! The number of tier 6 minions in Battlegrounds.
 constexpr int NUM_TIER6_MINIONS = 19;

--- a/Resources/cards.collectible.json
+++ b/Resources/cards.collectible.json
@@ -2595,7 +2595,7 @@
         "rarity": "RARE",
         "set": "ALTERAC_VALLEY",
         "spellSchool": "FROST",
-        "text": "[x]Deal $5 damage to all\nminions. Costs (1) less\nfor each Armor you have.",
+        "text": "[x]Deal $4 damage to all\nminions. Costs (1) less\nfor each Armor you have.",
         "type": "SPELL"
     },
     {
@@ -2722,7 +2722,7 @@
         "cost": 2,
         "dbfId": 69577,
         "flavor": "\"Welcome to Dun Baldar Felwings! Do you want 'em mild, spicy, or BURNING Legion?\"",
-        "health": 2,
+        "health": 1,
         "id": "AV_118",
         "mechanics": [
             "TRIGGER_VISUAL"
@@ -3367,7 +3367,7 @@
         "artist": "Ursula Dorada",
         "cardClass": "PALADIN",
         "collectible": true,
-        "cost": 7,
+        "cost": 8,
         "dbfId": 67040,
         "elite": true,
         "flavor": "Her faith, unshakable.\nHer shield, immovable.\nHer enemies, irredeemable.",
@@ -3938,14 +3938,14 @@
     },
     {
         "artist": "James Ryman",
-        "attack": 6,
+        "attack": 7,
         "cardClass": "DEMONHUNTER",
         "collectible": true,
-        "cost": 6,
+        "cost": 7,
         "dbfId": 68061,
         "elite": true,
         "flavor": "This is what happens when you keep taking the advice of the little demon on your shoulder.",
-        "health": 6,
+        "health": 7,
         "id": "AV_267",
         "mechanics": [
             "BATTLECRY"
@@ -3953,7 +3953,7 @@
         "name": "Caria Felsoul",
         "rarity": "LEGENDARY",
         "set": "ALTERAC_VALLEY",
-        "text": "<b>Battlecry:</b> Transform into a 6/6 copy of a Demon in your deck.",
+        "text": "<b>Battlecry:</b> Transform into a 7/7 copy of a Demon in your deck.",
         "type": "MINION"
     },
     {
@@ -4243,7 +4243,7 @@
     },
     {
         "artist": "Konstantin Turovec",
-        "attack": 4,
+        "attack": 3,
         "cardClass": "ROGUE",
         "collectible": true,
         "cost": 5,
@@ -22439,7 +22439,7 @@
         "artist": "Mike Azevedo",
         "cardClass": "DRUID",
         "collectible": true,
-        "cost": 1,
+        "cost": 2,
         "dbfId": 86234,
         "flavor": "You can make your own Earthen Scales at home. Step 1: Roll around in the dirt. Step 2: Magic.",
         "howToEarn": "Unlocked at level 9.",
@@ -27961,7 +27961,7 @@
         "attack": 6,
         "cardClass": "NEUTRAL",
         "collectible": true,
-        "cost": 6,
+        "cost": 7,
         "dbfId": 65599,
         "elite": true,
         "flavor": "“Please, Mr. Smite was my father. Call me Yorik.”",
@@ -35185,7 +35185,7 @@
         "race": "MURLOC",
         "rarity": "RARE",
         "set": "EXPERT1",
-        "techLevel": 4,
+        "techLevel": 3,
         "text": "<b>Battlecry:</b> Give your other Murlocs +2 Health.",
         "type": "MINION"
     },
@@ -59321,7 +59321,7 @@
         "rarity": "COMMON",
         "set": "SCHOLOMANCE",
         "spellSchool": "NATURE",
-        "text": "Gain 2 Mana Crystals this turn only.\n<b>Overload:</b> (2)",
+        "text": "Refresh 2 Mana Crystals.\n<b>Overload:</b> (2)",
         "type": "SPELL"
     },
     {
@@ -60481,26 +60481,6 @@
         "rarity": "LEGENDARY",
         "set": "SCHOLOMANCE",
         "text": "[x]Whenever your opponent\n draws a card, add a copy to \n your hand that costs (1).",
-        "type": "MINION"
-    },
-    {
-        "artist": "Konstantin Turovec",
-        "attack": 3,
-        "cardClass": "WARRIOR",
-        "collectible": true,
-        "cost": 4,
-        "dbfId": 92384,
-        "flavor": "Someone got a little too excited inventing a can opener.",
-        "health": 6,
-        "id": "Story_11_RemoteControlPuzzle",
-        "mechanics": [
-            "TRIGGER_VISUAL"
-        ],
-        "name": "Remote-Controlled Golem",
-        "race": "MECHANICAL",
-        "rarity": "EPIC",
-        "set": "STORMWIND",
-        "text": "[x]After this takes damage,\nshuffle two Golem Parts into\nyour deck. When drawn,\n  summon a 2/1 Mech.",
         "type": "MINION"
     },
     {
@@ -63682,7 +63662,7 @@
         "rarity": "COMMON",
         "set": "THE_SUNKEN_CITY",
         "targetingArrowText": "Deal 5 damage.",
-        "text": "<b>Battlecry:</b> Deal 5 damage. Gain 8 Armor.",
+        "text": "<b>Battlecry:</b> Deal 5 damage. Gain 5 Armor.",
         "type": "MINION"
     },
     {
@@ -66681,13 +66661,13 @@
     },
     {
         "artist": "Anton Zemskov",
-        "attack": 5,
+        "attack": 4,
         "cardClass": "NEUTRAL",
         "collectible": true,
         "cost": 4,
         "dbfId": 72598,
         "flavor": "She also tutors 3 Piranha Swarmers on her off hours.",
-        "health": 4,
+        "health": 3,
         "howToEarnGolden": "Earnable on the <i>Voyage to the Sunken City</i> Reward Track.",
         "id": "TSC_052",
         "mechanics": [
@@ -67450,10 +67430,10 @@
         "cardClass": "MAGE",
         "collectible": true,
         "collectionText": "[x]After you cast a spell,\nrefresh two Mana Crystals.\n<i>(Then switch to Naga!)</i>",
-        "cost": 4,
+        "cost": 5,
         "dbfId": 71996,
         "flavor": "Refresh the rainbow.",
-        "health": 5,
+        "health": 6,
         "id": "TSC_620",
         "mechanics": [
             "TRIGGER_VISUAL"
@@ -68709,7 +68689,7 @@
         "artist": "L. Lullabi & K. Turovec",
         "cardClass": "WARRIOR",
         "collectible": true,
-        "cost": 3,
+        "cost": 4,
         "dbfId": 72588,
         "flavor": "\"This is why I'm afraid of the deep end of the pool.\"",
         "id": "TSC_940",
@@ -72756,7 +72736,7 @@
         "artist": "Mike Azevedo",
         "cardClass": "DRUID",
         "collectible": true,
-        "cost": 1,
+        "cost": 2,
         "dbfId": 41081,
         "flavor": "You can make your own Earthen Scales at home. Step 1: Roll around in the dirt. Step 2: Magic.",
         "id": "UNG_108",

--- a/Resources/mercenaries.json
+++ b/Resources/mercenaries.json
@@ -1199,6 +1199,7 @@
         "name": "Scabbs Cutterbutter",
         "shortName": "Scabbs",
         "skinDbfIds": [
+            92037,
             64530,
             64531,
             64532
@@ -1756,6 +1757,7 @@
         "id": 11,
         "name": "Rokara",
         "skinDbfIds": [
+            92040,
             64543,
             64545,
             64544
@@ -2108,6 +2110,7 @@
         "name": "Millhouse Manastorm",
         "shortName": "Millhouse",
         "skinDbfIds": [
+            92031,
             63994,
             64505,
             64506
@@ -2661,6 +2664,7 @@
         "name": "Cariel Roame",
         "shortName": "Cariel",
         "skinDbfIds": [
+            92032,
             64558,
             64559,
             64560
@@ -2851,6 +2855,7 @@
         "id": 19,
         "name": "Xyrella",
         "skinDbfIds": [
+            92033,
             64562,
             64564,
             64563
@@ -3216,6 +3221,7 @@
         "id": 21,
         "name": "Bru'kan",
         "skinDbfIds": [
+            92039,
             64586,
             64587,
             64588
@@ -4872,6 +4878,7 @@
         "name": "Morgl the Oracle",
         "shortName": "Morgl",
         "skinDbfIds": [
+            92041,
             64580,
             64582,
             64581
@@ -5433,6 +5440,7 @@
         "name": "Tavish Stormpike",
         "shortName": "Tavish",
         "skinDbfIds": [
+            92035,
             64607,
             64609,
             64608
@@ -5619,6 +5627,7 @@
         "name": "Tamsin Roame",
         "shortName": "Tamsin",
         "skinDbfIds": [
+            92038,
             64610,
             64611,
             64612
@@ -8041,6 +8050,7 @@
         "name": "Tyrande",
         "shortName": "Tyrande",
         "skinDbfIds": [
+            92034,
             70937,
             70936,
             70935
@@ -9772,7 +9782,25 @@
         "skinDbfIds": [
             75472
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 159,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9784,7 +9812,25 @@
         "skinDbfIds": [
             75474
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 166,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9796,7 +9842,45 @@
         "skinDbfIds": [
             75481
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 269,
+                        "name": "Shadow Bolt",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 66164,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 66165,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 65399,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76408,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76409,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 167,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9808,7 +9892,56 @@
         "skinDbfIds": [
             75482
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 524,
+                        "name": "Taunt",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 72602,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 72603,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 72604,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76813,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76814,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 168,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9820,7 +9953,25 @@
         "skinDbfIds": [
             75483
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 169,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9832,7 +9983,45 @@
         "skinDbfIds": [
             75597
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 306,
+                        "name": "Arcane Bolt",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 70774,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 70773,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 70771,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76763,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76764,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 187,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9844,7 +10033,25 @@
         "skinDbfIds": [
             75598
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 188,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9856,7 +10063,25 @@
         "skinDbfIds": [
             75599
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 189,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9868,7 +10093,25 @@
         "skinDbfIds": [
             75600
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 190,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9880,7 +10123,25 @@
         "skinDbfIds": [
             75601
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 191,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9892,7 +10153,25 @@
         "skinDbfIds": [
             75602
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 192,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9904,7 +10183,25 @@
         "skinDbfIds": [
             75603
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 193,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9916,7 +10213,25 @@
         "skinDbfIds": [
             75604
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 194,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9928,7 +10243,25 @@
         "skinDbfIds": [
             75606
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 195,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9940,7 +10273,56 @@
         "skinDbfIds": [
             75607
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 524,
+                        "name": "Taunt",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 72602,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 72603,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 72604,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76813,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76814,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 196,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9952,7 +10334,25 @@
         "skinDbfIds": [
             75608
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 197,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9964,7 +10364,25 @@
         "skinDbfIds": [
             75609
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 587,
+                        "name": "Charge Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77418,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 198,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9976,7 +10394,25 @@
         "skinDbfIds": [
             75610
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 591,
+                        "name": "Firebolt",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 77682,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 199,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -9988,7 +10424,25 @@
         "skinDbfIds": [
             75611
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 591,
+                        "name": "Firebolt",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 77682,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 200,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10000,7 +10454,25 @@
         "skinDbfIds": [
             75612
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 201,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10012,7 +10484,56 @@
         "skinDbfIds": [
             75613
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 302,
+                        "name": "Ice Lance",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 70602,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 70603,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 70604,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76883,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76884,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 202,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10024,7 +10545,25 @@
         "skinDbfIds": [
             76986
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 601,
+                        "name": "Ancient Growth",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77916,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 206,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": true,
@@ -10798,7 +11337,25 @@
         "skinDbfIds": [
             77740
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 593,
+                        "name": "Doubling",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77741,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 222,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10810,7 +11367,25 @@
         "skinDbfIds": [
             77742
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 594,
+                        "name": "Mad Summoning",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77743,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 223,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10822,7 +11397,25 @@
         "skinDbfIds": [
             77764
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 595,
+                        "name": "Crack the Whip",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77771,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 224,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10834,7 +11427,25 @@
         "skinDbfIds": [
             77772
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 596,
+                        "name": "Dread Fire",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77773,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 225,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10846,7 +11457,25 @@
         "skinDbfIds": [
             77862
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 597,
+                        "name": "Blood Imp Ritual",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77863,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 226,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10858,7 +11487,25 @@
         "skinDbfIds": [
             77867
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 227,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10870,7 +11517,36 @@
         "skinDbfIds": [
             77900
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 598,
+                        "name": "Owlbeast Frenzy",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77901,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 228,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10882,7 +11558,36 @@
         "skinDbfIds": [
             77902
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 599,
+                        "name": "Windcrazed Howl",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77903,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 229,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10894,7 +11599,36 @@
         "skinDbfIds": [
             77921
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 605,
+                        "name": "Ancient Lore",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77944,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 230,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10906,7 +11640,36 @@
         "skinDbfIds": [
             77922
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 606,
+                        "name": "Ancient Endurance",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77946,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 231,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10918,7 +11681,36 @@
         "skinDbfIds": [
             77923
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 602,
+                        "name": "Sundew",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77927,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 232,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10930,7 +11722,25 @@
         "skinDbfIds": [
             77924
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 233,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10942,7 +11752,25 @@
         "skinDbfIds": [
             77925
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 234,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10954,7 +11782,47 @@
         "skinDbfIds": [
             77949
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 626,
+                        "name": "Ragepaw",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78022,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 627,
+                        "name": "Tur Defense",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78029,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 628,
+                        "name": "Chain Lightning",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78030,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 237,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10966,7 +11834,36 @@
         "skinDbfIds": [
             77950
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 620,
+                        "name": "Totemic Shock",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78020,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 622,
+                        "name": "Totemic Summon",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78002,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 238,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10978,7 +11875,25 @@
         "skinDbfIds": [
             77951
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 608,
+                        "name": "Ursa Claw",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77983,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 239,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -10990,7 +11905,25 @@
         "skinDbfIds": [
             77952
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 609,
+                        "name": "Furbolg Defense",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77984,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 240,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11002,7 +11935,25 @@
         "skinDbfIds": [
             77953
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 610,
+                        "name": "Furbolg Balance",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77986,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 241,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11014,7 +11965,25 @@
         "skinDbfIds": [
             77954
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 242,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11026,7 +11995,25 @@
         "skinDbfIds": [
             77955
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 607,
+                        "name": "Furbolg Challenge",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77980,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 243,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11038,7 +12025,25 @@
         "skinDbfIds": [
             77961
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 611,
+                        "name": "Mangle",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77962,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 244,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11050,7 +12055,36 @@
         "skinDbfIds": [
             77968
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 613,
+                        "name": "Corrosive Spit",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77969,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 614,
+                        "name": "Wing Buffet",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77971,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 246,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11062,7 +12096,36 @@
         "skinDbfIds": [
             77972
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 615,
+                        "name": "Volatile Instability",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77973,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 616,
+                        "name": "Wyrdling Rush",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77974,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 247,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11074,7 +12137,36 @@
         "skinDbfIds": [
             77976
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 617,
+                        "name": "Savage",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77977,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 618,
+                        "name": "Yaulp",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77978,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 248,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11086,7 +12178,36 @@
         "skinDbfIds": [
             77995
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 611,
+                        "name": "Mangle",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77962,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 619,
+                        "name": "Shattering Rout",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77996,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 249,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11098,7 +12219,25 @@
         "skinDbfIds": [
             78021
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 612,
+                        "name": "Flyby Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77965,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 250,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11110,7 +12249,36 @@
         "skinDbfIds": [
             78024
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 624,
+                        "name": "Shivering Salvo",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78025,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 625,
+                        "name": "Razor's Edge",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78026,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 251,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11122,7 +12290,36 @@
         "skinDbfIds": [
             78039
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 629,
+                        "name": "Spriggan Snowball",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78040,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 630,
+                        "name": "Winter's Rally",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78041,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 252,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11134,7 +12331,25 @@
         "skinDbfIds": [
             78042
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 631,
+                        "name": "Shredding Spiral",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78043,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 253,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11146,7 +12361,25 @@
         "skinDbfIds": [
             78051
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 632,
+                        "name": "Cumulating Force",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78054,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 254,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11158,7 +12391,25 @@
         "skinDbfIds": [
             78055
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 633,
+                        "name": "Crushing Advance",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78056,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 255,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11170,7 +12421,36 @@
         "skinDbfIds": [
             78058
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 634,
+                        "name": "Biting Cold",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78059,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 635,
+                        "name": "Hungry Ice",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78060,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 256,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11182,7 +12462,36 @@
         "skinDbfIds": [
             78064
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 598,
+                        "name": "Owlbeast Frenzy",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 77901,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 257,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11194,7 +12503,13 @@
         "skinDbfIds": [
             78183
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [],
+                "id": 261,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11206,7 +12521,25 @@
         "skinDbfIds": [
             78207
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 650,
+                        "name": "Energizing Strike",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78499,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 262,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11218,7 +12551,36 @@
         "skinDbfIds": [
             78208
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 645,
+                        "name": "Feeding Time",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78374,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 644,
+                        "name": "Set the Table",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78369,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 263,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11230,7 +12592,25 @@
         "skinDbfIds": [
             78210
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 648,
+                        "name": "Drakonid Crush",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78491,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 264,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11242,7 +12622,25 @@
         "skinDbfIds": [
             78211
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 646,
+                        "name": "Sorcerous Fire",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78422,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 265,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11254,7 +12652,25 @@
         "skinDbfIds": [
             78213
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 266,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11266,7 +12682,25 @@
         "skinDbfIds": [
             78214
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 647,
+                        "name": "Volcanic Fire",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78458,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 267,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11278,7 +12712,25 @@
         "skinDbfIds": [
             78215
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 268,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11290,7 +12742,36 @@
         "skinDbfIds": [
             78167
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 636,
+                        "name": "Cauterizing Maw",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78170,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 637,
+                        "name": "Ancient Despair",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78171,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 269,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11302,7 +12783,36 @@
         "skinDbfIds": [
             78204
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 638,
+                        "name": "Smash",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78216,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 639,
+                        "name": "Aegis of Rock and Flame",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78217,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 270,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11314,7 +12824,36 @@
         "skinDbfIds": [
             78205
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 591,
+                        "name": "Firebolt",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 77682,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 641,
+                        "name": "Summon Lava Spawn",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78223,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 271,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11326,7 +12865,36 @@
         "skinDbfIds": [
             78206
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 642,
+                        "name": "Immolate",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78231,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 643,
+                        "name": "Massive Eruption",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78232,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 272,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11338,7 +12906,36 @@
         "skinDbfIds": [
             78209
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 652,
+                        "name": "Flamewaker Trident",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78559,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 273,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11350,7 +12947,25 @@
         "skinDbfIds": [
             78212
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 655,
+                        "name": "Spreading Flames",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78173,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 274,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11362,7 +12977,25 @@
         "skinDbfIds": [
             78235
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 275,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11374,7 +13007,25 @@
         "skinDbfIds": [
             78237
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 276,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11386,7 +13037,25 @@
         "skinDbfIds": [
             78519
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 280,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11398,7 +13067,25 @@
         "skinDbfIds": [
             78515
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 651,
+                        "name": "Axe Fling",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78518,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 279,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11410,7 +13097,36 @@
         "skinDbfIds": [
             78563
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 653,
+                        "name": "Fiery Assault",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78564,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 654,
+                        "name": "Towering Inferno",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 78567,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 282,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -11422,7 +13138,25 @@
         "skinDbfIds": [
             90351
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 287,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13698,7 +15432,36 @@
         "skinDbfIds": [
             82670
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 703,
+                        "name": "Slash",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 82676,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 704,
+                        "name": "Bladestorm",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 82738,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 312,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13710,7 +15473,36 @@
         "skinDbfIds": [
             82677
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 705,
+                        "name": "Healing Stim",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83041,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 706,
+                        "name": "Laser Beam",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83042,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 313,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13722,7 +15514,36 @@
         "skinDbfIds": [
             83239
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 708,
+                        "name": "Lightning Bolt",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83240,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 709,
+                        "name": "Chain Lightning",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83241,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 316,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13734,7 +15555,25 @@
         "skinDbfIds": [
             83242
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 710,
+                        "name": "Trogg Smash!",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83389,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 317,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13746,7 +15585,36 @@
         "skinDbfIds": [
             83390
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 710,
+                        "name": "Trogg Smash!",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83389,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 711,
+                        "name": "Trogg Hate Magic",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83392,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 318,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13758,7 +15626,47 @@
         "skinDbfIds": [
             83421
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 712,
+                        "name": "Take Aim",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83422,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 713,
+                        "name": "Headshot",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83506,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 753,
+                        "name": "Bayonet Stab",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 84131,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 319,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13770,7 +15678,36 @@
         "skinDbfIds": [
             83508
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 715,
+                        "name": "Repair",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83509,
+                                "tier": 3
+                            }
+                        ]
+                    },
+                    {
+                        "id": 716,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83510,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 320,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13782,7 +15719,25 @@
         "skinDbfIds": [
             83511
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 717,
+                        "name": "Recruit",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83512,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 321,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13794,7 +15749,25 @@
         "skinDbfIds": [
             83513
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 718,
+                        "name": "For Frostwolf!",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83514,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 322,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13806,7 +15779,13 @@
         "skinDbfIds": [
             83235
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [],
+                "id": 323,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13818,7 +15797,36 @@
         "skinDbfIds": [
             83654
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 719,
+                        "name": "Get Down!",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83655,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 752,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83924,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 324,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13830,7 +15838,25 @@
         "skinDbfIds": [
             83810
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 720,
+                        "name": "Flurry",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83825,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 325,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13842,7 +15868,56 @@
         "skinDbfIds": [
             83834
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 721,
+                        "name": "Prove Yourself",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83836,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 530,
+                        "name": "Battlefury",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 72624,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 72625,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 72626,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76666,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76667,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 326,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13854,7 +15929,107 @@
         "skinDbfIds": [
             83838
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 525,
+                        "name": "Flash Heal",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 72548,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 72555,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 72556,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76819,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76820,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 27,
+                        "name": "Holy Nova",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 65872,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 65873,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 64002,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76688,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76689,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 198,
+                        "name": "Holy Blast",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 73826,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 73827,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 73828,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76798,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76799,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 327,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13866,7 +16041,56 @@
         "skinDbfIds": [
             83844
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 688,
+                        "name": "Frightening Shout",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 82252,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 82253,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 82254,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 82255,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 82256,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 716,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83510,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 329,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13878,7 +16102,36 @@
         "skinDbfIds": [
             83835
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 734,
+                        "name": "Taunt",
+                        "tiers": [
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76813,
+                                "tier": 4
+                            }
+                        ]
+                    }
+                ],
+                "id": 331,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13890,7 +16143,25 @@
         "skinDbfIds": [
             83846
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 723,
+                        "name": "Gotcha!",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83847,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 330,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13902,7 +16173,25 @@
         "skinDbfIds": [
             83850
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 724,
+                        "name": "Ramming Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83853,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 333,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13914,7 +16203,25 @@
         "skinDbfIds": [
             83862
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 725,
+                        "name": "Crazed Flurry",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 66789,
+                                "tier": 3
+                            }
+                        ]
+                    }
+                ],
+                "id": 334,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13926,7 +16233,36 @@
         "skinDbfIds": [
             83860
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 726,
+                        "name": "Banana Frenzy",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 70884,
+                                "tier": 3
+                            }
+                        ]
+                    },
+                    {
+                        "id": 727,
+                        "name": "Dinner Time",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 70885,
+                                "tier": 3
+                            }
+                        ]
+                    }
+                ],
+                "id": 335,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13938,7 +16274,36 @@
         "skinDbfIds": [
             83837
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 728,
+                        "name": "Defender of the Horde",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83843,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 336,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13950,7 +16315,36 @@
         "skinDbfIds": [
             83841
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 729,
+                        "name": "Bloodthirsty Frenzy",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83845,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 337,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13962,7 +16356,36 @@
         "skinDbfIds": [
             83842
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 730,
+                        "name": "Frostwolf",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83866,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 731,
+                        "name": "Mend Pet",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83856,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 338,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13974,7 +16397,25 @@
         "skinDbfIds": [
             83861
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 339,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -13986,7 +16427,107 @@
         "skinDbfIds": [
             83863
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 657,
+                        "name": "Ice Floes",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 79587,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 79589,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 79590,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 79591,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 79592,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 464,
+                        "name": "Mend Beast",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 74831,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 74830,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 71906,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76825,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76826,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 357,
+                        "name": "Primal Power",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 71419,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 71418,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 70886,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76835,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76836,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 340,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": true,
@@ -17579,7 +20120,45 @@
         "skinDbfIds": [
             86436
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 701,
+                        "name": "Tail Swipe",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 82352,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 82378,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 82379,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 82380,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 82381,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 370,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17591,7 +20170,56 @@
         "skinDbfIds": [
             86462
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 815,
+                        "name": "Torment",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86463,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 198,
+                        "name": "Holy Blast",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 73826,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 73827,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 73828,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76798,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76799,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 371,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17603,7 +20231,25 @@
         "skinDbfIds": [
             86464
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 816,
+                        "name": "Gnaw",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86526,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 372,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17615,7 +20261,36 @@
         "skinDbfIds": [
             86566
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 818,
+                        "name": "Slay the Dragons",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86569,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 819,
+                        "name": "Slice and Dice",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86576,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 373,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17627,7 +20302,56 @@
         "skinDbfIds": [
             86617
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 545,
+                        "name": "Magma Blast",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 73461,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 73469,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 73475,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76698,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76699,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 374,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17639,7 +20363,36 @@
         "skinDbfIds": [
             86610
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 821,
+                        "name": "Timed Explosion",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86614,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 375,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17651,7 +20404,36 @@
         "skinDbfIds": [
             86575
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 819,
+                        "name": "Slice and Dice",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86576,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 820,
+                        "name": "Execution",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86609,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 376,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17663,7 +20445,25 @@
         "skinDbfIds": [
             86620
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 822,
+                        "name": "Shadow Rain",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86627,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 377,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17675,7 +20475,25 @@
         "skinDbfIds": [
             86623
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 822,
+                        "name": "Shadow Rain",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86627,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 378,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17687,7 +20505,36 @@
         "skinDbfIds": [
             86695
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 822,
+                        "name": "Shadow Rain",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86627,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 823,
+                        "name": "Vacuum",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86697,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 379,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17699,7 +20546,36 @@
         "skinDbfIds": [
             86698
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 824,
+                        "name": "Soul Fissure",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86699,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 752,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 83924,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 380,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17711,7 +20587,25 @@
         "skinDbfIds": [
             86702
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 825,
+                        "name": "Whispering Shadows",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86703,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 381,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17723,7 +20617,25 @@
         "skinDbfIds": [
             86707
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 826,
+                        "name": "Repeating Strike",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86708,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 382,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17735,7 +20647,25 @@
         "skinDbfIds": [
             86564
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 817,
+                        "name": "Scratch",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86565,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 383,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17747,7 +20677,25 @@
         "skinDbfIds": [
             86901
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 836,
+                        "name": "Hang Six, Brogrgl!!",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86997,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 386,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17759,7 +20707,36 @@
         "skinDbfIds": [
             86998
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 837,
+                        "name": "Break Time!",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86999,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 838,
+                        "name": "Don't Look At Me",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 87000,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 387,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17771,7 +20748,56 @@
         "skinDbfIds": [
             87003
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 319,
+                        "name": "Giantfin",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 66306,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 66307,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 65443,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76503,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76508,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 388,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17783,7 +20809,25 @@
         "skinDbfIds": [
             87006
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 839,
+                        "name": "Excitement of N'Zoth",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 87010,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 389,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17795,7 +20839,45 @@
         "skinDbfIds": [
             87016
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 317,
+                        "name": "Finvasion",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 70807,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 70806,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 70805,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76493,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76494,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 390,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17820,7 +20902,76 @@
         "skinDbfIds": [
             87032
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 552,
+                        "name": "Mind Thief",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 73555,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 73554,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 73536,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76897,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76898,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 269,
+                        "name": "Shadow Bolt",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 66164,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 66165,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 65399,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76408,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76409,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 391,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -17832,7 +20983,107 @@
         "skinDbfIds": [
             87033
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 328,
+                        "name": "Devouring Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 71417,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 71416,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 70820,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76482,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76483,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 70,
+                        "name": "Scaly Taunt",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 66437,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 66436,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 63807,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76485,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76486,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 329,
+                        "name": "Devour",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 71421,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 71420,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 70829,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76489,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76490,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 392,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": true,
@@ -18224,7 +21475,87 @@
         "skinDbfIds": [
             87034
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 328,
+                        "name": "Devouring Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 71417,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 71416,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 70820,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76482,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76483,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 840,
+                        "name": "Feeding Frenzy",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 87035,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 234,
+                        "name": "Felfin Navigator",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 66310,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 66311,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 65458,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76495,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76497,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 401,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -18236,7 +21567,76 @@
         "skinDbfIds": [
             86876
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 778,
+                        "name": "Tidal Strike",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 87818,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 87817,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 87816,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 87815,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 85129,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 780,
+                        "name": "Blessing of the Tides",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 87822,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 87821,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 87820,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 87819,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 85132,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 403,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -18248,7 +21648,76 @@
         "skinDbfIds": [
             86877
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 775,
+                        "name": "Witch's Curse",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 87579,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 87574,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 87573,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 87572,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 85063,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 777,
+                        "name": "Wavethrasher",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 87634,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 87632,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 87631,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 87630,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 85066,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 404,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -18260,7 +21729,56 @@
         "skinDbfIds": [
             87711
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 853,
+                        "name": "Twilight Shards",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 87714,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 415,
+                        "name": "Shadow Shock",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 71447,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 71446,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 71301,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76442,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76443,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 407,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -18272,7 +21790,45 @@
         "skinDbfIds": [
             88233
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 328,
+                        "name": "Devouring Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 71417,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 71416,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 70820,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76482,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76483,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 410,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -18284,7 +21840,36 @@
         "skinDbfIds": [
             88234
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 860,
+                        "name": "Doppelganger",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 88235,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 861,
+                        "name": "Barrage",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 88236,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 411,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -18296,7 +21881,25 @@
         "skinDbfIds": [
             88238
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 863,
+                        "name": "All Hands Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 88239,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 412,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -18308,7 +21911,56 @@
         "skinDbfIds": [
             88317
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 862,
+                        "name": "Corrupted Power",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 88323,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 328,
+                        "name": "Devouring Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 71417,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 71416,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 70820,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76482,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76483,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 413,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -18320,7 +21972,56 @@
         "skinDbfIds": [
             88646
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 864,
+                        "name": "Azsharan Ritual",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 88648,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 763,
+                        "name": "Shifting Tides",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 86918,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 86917,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 86916,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 86915,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 84408,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 414,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -18332,7 +22033,56 @@
         "skinDbfIds": [
             88695
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 533,
+                        "name": "Shadow Surge",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 72734,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 72735,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 72736,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76444,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76445,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 415,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -18344,7 +22094,76 @@
         "skinDbfIds": [
             88693
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 761,
+                        "name": "Build-A-Golem",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 84179,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 84199,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 84200,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 84201,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 84202,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 760,
+                        "name": "Shadow Claws",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 84170,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 84172,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 84173,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 84174,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 84175,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 416,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -18356,7 +22175,56 @@
         "skinDbfIds": [
             89347
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 866,
+                        "name": "Flagellation",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 89348,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 269,
+                        "name": "Shadow Bolt",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 66164,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 66165,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 65399,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76408,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76409,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 418,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -18368,7 +22236,25 @@
         "skinDbfIds": [
             89353
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 863,
+                        "name": "All Hands Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 88239,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 419,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -18380,7 +22266,56 @@
         "skinDbfIds": [
             89358
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 815,
+                        "name": "Torment",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 86463,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 328,
+                        "name": "Devouring Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 71417,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 71416,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 70820,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76482,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76483,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 420,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": true,
@@ -18471,7 +22406,107 @@
             89547,
             89546
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 871,
+                        "name": "Knowledge",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 90562,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 90563,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 90564,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90565,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 89549,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 873,
+                        "name": "Patience",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 90587,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 90588,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 90589,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90590,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 89563,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 872,
+                        "name": "Wisdom",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 90594,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 90595,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 90596,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90597,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 89599,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 422,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": true,
@@ -18561,7 +22596,107 @@
             89721,
             89719
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 874,
+                        "name": "Vindicator's Fury",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 90620,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 90621,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 90622,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90624,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 89736,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 875,
+                        "name": "Radiant Light",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 90616,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 90617,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 90618,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90619,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 89775,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 876,
+                        "name": "Wrath of the Lightbound",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 90625,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 90626,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 90627,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90628,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 89778,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 423,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": true,
@@ -18642,7 +22777,107 @@
             89588,
             89587
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 883,
+                        "name": "Mulgore Might",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 89665,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 89664,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 89663,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 89662,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 89590,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 881,
+                        "name": "Chain Heal",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 89661,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 89660,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 89659,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 89658,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 89655,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 882,
+                        "name": "Earthmother's Fury",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 89718,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 89717,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 89716,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 89715,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 89712,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 426,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": true,
@@ -18718,7 +22953,107 @@
             90031,
             90029
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 884,
+                        "name": "Single-Minded Pursuit",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 90650,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 90651,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 90652,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90654,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90033,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 886,
+                        "name": "Coup de Grâce",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 90659,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 90658,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 90657,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90656,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90066,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 885,
+                        "name": "Imprison",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 90663,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 90662,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 90661,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90660,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90075,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 427,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": true,
@@ -18804,7 +23139,107 @@
             90026,
             90025
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 888,
+                        "name": "Trusty Whip",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 91423,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 91422,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 91421,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 91419,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90028,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 889,
+                        "name": "Summit Campfire",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 91427,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 91426,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 91425,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 91424,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90073,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 890,
+                        "name": "The Bronzebeard Spirit",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 91431,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 91430,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 91429,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 91428,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90076,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 428,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": true,
@@ -19097,7 +23532,107 @@
             90928,
             90870
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 897,
+                        "name": "Dirty Tricks",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 91618,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 91617,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 91616,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 91615,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90872,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 898,
+                        "name": "Shifting Strike",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 91622,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 91621,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 91620,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 91619,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90887,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 899,
+                        "name": "Sudden Betrayal",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 91626,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 91625,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 91624,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 91623,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90936,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 430,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": true,
@@ -19178,7 +23713,107 @@
             90838,
             90837
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 900,
+                        "name": "Gatling Wand",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 91396,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 91395,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 91394,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 91392,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90840,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 902,
+                        "name": "Dazzlin' Flexin'",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 91400,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 91399,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 91398,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 91397,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90909,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 901,
+                        "name": "That's My Treasure!",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 91407,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 91406,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 91405,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 91404,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90843,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 431,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -19190,7 +23825,56 @@
         "skinDbfIds": [
             91032
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 560,
+                        "name": "Entangling Roots",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 73593,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 73592,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 73590,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76731,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76732,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 433,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -19202,7 +23886,56 @@
         "skinDbfIds": [
             91034
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 537,
+                        "name": "Hammer of Justice",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 72906,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 72905,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 72903,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76807,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76808,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 434,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -19214,7 +23947,56 @@
         "skinDbfIds": [
             91033
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 735,
+                        "name": "Equalizing Strike",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 84254,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 84253,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 84252,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 84251,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 83931,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 435,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -19226,7 +24008,25 @@
         "skinDbfIds": [
             91036
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 575,
+                        "name": "Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 63746,
+                                "tier": 1
+                            }
+                        ]
+                    }
+                ],
+                "id": 436,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": true,
@@ -19312,7 +24112,107 @@
             90743,
             90742
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 903,
+                        "name": "Starseeker",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 91682,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 91681,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 91680,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 91679,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90745,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 904,
+                        "name": "Guiding Path",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 91686,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 91685,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 91684,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 91683,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90973,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 905,
+                        "name": "Quest for the Golden Monkey",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 91725,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 91718,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 91710,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 91702,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90974,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 437,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -19324,7 +24224,76 @@
         "skinDbfIds": [
             89158
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 669,
+                        "name": "Avast ye Matey",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 80720,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 80719,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 80718,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 80717,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 80259,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 808,
+                        "name": "Turnabout Strike",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 86086,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 90373,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 90374,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90375,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 90376,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 443,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -19336,7 +24305,76 @@
         "skinDbfIds": [
             89162
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 115,
+                        "name": "Lightning Bolt",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 66069,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 66070,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 64839,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76723,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76724,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 907,
+                        "name": "Blazing Horns",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 86073,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 86099,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 86100,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 86101,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 86102,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 444,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -19348,7 +24386,25 @@
         "skinDbfIds": [
             91222
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 908,
+                        "name": "Happy Hour",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 91224,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 445,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -19372,7 +24428,76 @@
         "skinDbfIds": [
             89731
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 198,
+                        "name": "Holy Blast",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 73826,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 73827,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 73828,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76798,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76799,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 682,
+                        "name": "Shifting Satchel",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 82002,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 82001,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 82000,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 81999,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 81203,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 447,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -19384,7 +24509,56 @@
         "skinDbfIds": [
             89140
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 909,
+                        "name": "Out of the Hat",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 89141,
+                                "tier": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 34,
+                        "name": "Blessing of Kings",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 63771,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 63770,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 63756,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76794,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76795,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 448,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -19396,7 +24570,25 @@
         "skinDbfIds": [
             91513
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 910,
+                        "name": "Madness Abound",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 91514,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 449,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -19408,7 +24600,25 @@
         "skinDbfIds": [
             89742
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 913,
+                        "name": "Double Attack",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 72804,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 452,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -19420,7 +24630,76 @@
         "skinDbfIds": [
             89351
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 247,
+                        "name": "Crazed Flurry",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 67160,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 67159,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 66789,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76475,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 76476,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 814,
+                        "name": "Pufferfisher",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 87887,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 87886,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 87885,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 87884,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 86653,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 453,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,
@@ -19432,7 +24711,25 @@
         "skinDbfIds": [
             92028
         ],
-        "specializations": []
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 914,
+                        "name": "Tainted Fruit",
+                        "tiers": [
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 92029,
+                                "tier": 2
+                            }
+                        ]
+                    }
+                ],
+                "id": 454,
+                "name": ""
+            }
+        ]
     },
     {
         "collectible": false,

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -102,7 +102,7 @@ void AlteracValleyCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- HERO - PALADIN
-    // [AV_206] Lightforged Cariel - COST:7
+    // [AV_206] Lightforged Cariel - COST:8
     // - Set: ALTERAC_VALLEY, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Deal 2 damage to all enemies.
@@ -1863,7 +1863,7 @@ void AlteracValleyCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     cards.emplace("AV_201", cardDef);
 
     // ----------------------------------------- MINION - ROGUE
-    // [AV_298] Wildpaw Gnoll - COST:5 [ATK:4/HP:5]
+    // [AV_298] Wildpaw Gnoll - COST:5 [ATK:3/HP:5]
     // - Set: ALTERAC_VALLEY, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Rush</b>
@@ -2590,12 +2590,12 @@ void AlteracValleyCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // - Set: ALTERAC_VALLEY, Rarity: Rare
     // - Spell School: Frost
     // --------------------------------------------------------
-    // Text: Deal 5 damage to all minions.
+    // Text: Deal 4 damage to all minions.
     //       Costs (1) less for each Armor you have.
     // --------------------------------------------------------
     cardDef.ClearData();
     cardDef.power.AddPowerTask(
-        std::make_shared<DamageTask>(EntityType::ALL_MINIONS, 5, true));
+        std::make_shared<DamageTask>(EntityType::ALL_MINIONS, 4, true));
     cardDef.power.AddAura(
         std::make_shared<AdaptiveCostEffect>([](Playable* playable) {
             return playable->player->GetHero()->GetArmor();
@@ -2846,7 +2846,7 @@ void AlteracValleyCardsGen::AddDemonHunter(
     CardDef cardDef;
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [AV_118] Battleworn Vanguard - COST:2 [ATK:2/HP:2]
+    // [AV_118] Battleworn Vanguard - COST:2 [ATK:2/HP:1]
     // - Set: ALTERAC_VALLEY, Rarity: Common
     // --------------------------------------------------------
     // Text: After your hero attacks, summon two 1/1 Felwings.
@@ -2928,10 +2928,10 @@ void AlteracValleyCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [AV_267] Caria Felsoul - COST:6 [ATK:6/HP:6]
+    // [AV_267] Caria Felsoul - COST:7 [ATK:7/HP:7]
     // - Set: ALTERAC_VALLEY, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Transform into a 6/6 copy
+    // Text: <b>Battlecry:</b> Transform into a 7/7 copy
     //       of a Demon in your deck.
     // --------------------------------------------------------
     // GameTag:
@@ -3043,7 +3043,7 @@ void AlteracValleyCardsGen::AddDemonHunterNonCollect(
     // [AV_267e2] Demonic - COST:0
     // - Set: ALTERAC_VALLEY
     // --------------------------------------------------------
-    // Text: Attack and Health set to 6.
+    // Text: Attack and Health set to 7.
     // --------------------------------------------------------
 
     // ------------------------------ ENCHANTMENT - DEMONHUNTER

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -328,7 +328,7 @@ void CoreCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     cards.emplace("CORE_TRL_243", cardDef);
 
     // ------------------------------------------ SPELL - DRUID
-    // [CORE_UNG_108] Earthen Scales - COST:1
+    // [CORE_UNG_108] Earthen Scales - COST:2
     // - Set: CORE, Rarity: Rare
     // - Spell School: Nature
     // --------------------------------------------------------

--- a/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/ScholomanceCardsGen.cpp
@@ -79,14 +79,14 @@ void ScholomanceCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - Set: SCHOLOMANCE, Rarity: Common
     // - Spell School: Nature
     // --------------------------------------------------------
-    // Text: Gain 2 Mana Crystals this turn only.
+    // Text: Refresh 2 Mana Crystals.
     //       <b>Overload:</b> (2)
     // --------------------------------------------------------
     // GameTag:
     // - OVERLOAD = 1
     // --------------------------------------------------------
     cardDef.ClearData();
-    cardDef.power.AddPowerTask(std::make_shared<TempManaTask>(2));
+    cardDef.power.AddPowerTask(std::make_shared<RefreshManaTask>(2));
     cards.emplace("SCH_427", cardDef);
 
     // ------------------------------------------ SPELL - DRUID

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -3615,7 +3615,7 @@ void StormwindCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [DED_006] Mr. Smite - COST:6 [ATK:6/HP:5]
+    // [DED_006] Mr. Smite - COST:7 [ATK:6/HP:5]
     // - Race: Pirate, Set: STORMWIND, Rarity: Legendary
     // --------------------------------------------------------
     // Text: Your Pirates have <b>Charge</b>.

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -665,7 +665,7 @@ void TheSunkenCityCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ MINION - MAGE
-    // [TSC_620] Spitelash Siren - COST:4 [ATK:2/HP:5]
+    // [TSC_620] Spitelash Siren - COST:5 [ATK:2/HP:6]
     // - Race: Naga, Set: THE_SUNKEN_CITY, Rarity: Epic
     // --------------------------------------------------------
     // Text: After you play a Naga,
@@ -2240,7 +2240,7 @@ void TheSunkenCityCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARRIOR
-    // [TSC_940] From the Depths - COST:3
+    // [TSC_940] From the Depths - COST:4
     // - Set: THE_SUNKEN_CITY, Rarity: Rare
     // --------------------------------------------------------
     // Text: Reduce the Cost of the bottom five cards
@@ -2321,7 +2321,7 @@ void TheSunkenCityCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // [TID_716] Tidal Revenant - COST:8 [ATK:5/HP:8]
     // - Race: Elemental, Set: THE_SUNKEN_CITY, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Deal 5 damage. Gain 8 Armor.
+    // Text: <b>Battlecry:</b> Deal 5 damage. Gain 5 Armor.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
@@ -2350,7 +2350,8 @@ void TheSunkenCityCardsGen::AddWarriorNonCollect(
     // - Race: Beast, Set: THE_SUNKEN_CITY
     // --------------------------------------------------------
     // Text: <b><b>Taunt</b>.</b> <b>Deathrattle:</b>
-    //       Add Nellie's Pirate crew to your hand. They cost (1).
+    //       Add Nellie's Pirate crew to your hand.
+    //       They Cost (1) less.
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
@@ -2837,7 +2838,7 @@ void TheSunkenCityCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [TSC_052] School Teacher - COST:4 [ATK:5/HP:4]
+    // [TSC_052] School Teacher - COST:4 [ATK:4/HP:3]
     // - Race: Naga, Set: THE_SUNKEN_CITY, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Add a 1/1 Nagaling to your hand.

--- a/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
@@ -108,7 +108,7 @@ void UngoroCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------------ SPELL - DRUID
-    // [UNG_108] Earthen Scales - COST:1
+    // [UNG_108] Earthen Scales - COST:2
     // - Faction: Neutral, Set: Ungoro, Rarity: Rare
     // --------------------------------------------------------
     // Text: Give a friendly minion +1/+1,

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -1824,7 +1824,7 @@ TEST_CASE("[Warlock : Minion] - AV_308 : Grave Defiler")
 // - Set: ALTERAC_VALLEY, Rarity: Rare
 // - Spell School: Frost
 // --------------------------------------------------------
-// Text: Deal 5 damage to all minions.
+// Text: Deal 4 damage to all minions.
 //       Costs (1) less for each Armor you have.
 // --------------------------------------------------------
 TEST_CASE("[Warrior : Spell] - AV_108 : Shield Shatter")
@@ -1881,8 +1881,8 @@ TEST_CASE("[Warrior : Spell] - AV_108 : Shield Shatter")
     CHECK_EQ(card1->GetCost(), 5);
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
-    CHECK_EQ(curField[0]->GetHealth(), 1);
-    CHECK_EQ(opField[0]->GetHealth(), 7);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(opField[0]->GetHealth(), 8);
 }
 
 // ---------------------------------------- SPELL - WARRIOR

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -987,7 +987,7 @@ TEST_CASE("[Druid : Spell] - CORE_TRL_243 : Pounce")
 }
 
 // ------------------------------------------ SPELL - DRUID
-// [CORE_UNG_108] Earthen Scales - COST:1
+// [CORE_UNG_108] Earthen Scales - COST:2
 // - Set: CORE, Rarity: Rare
 // - Spell School: Nature
 // --------------------------------------------------------
@@ -1025,16 +1025,16 @@ TEST_CASE("[Druid : Spell] - CORE_UNG_108 : Earthen Scales")
     const auto card1 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Earthen Scales"));
     const auto card2 =
-        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
 
     game.Process(curPlayer, PlayCardTask::Minion(card2));
-    CHECK_EQ(curField[0]->GetAttack(), 4);
-    CHECK_EQ(curField[0]->GetHealth(), 12);
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
 
     game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
-    CHECK_EQ(curField[0]->GetAttack(), 5);
-    CHECK_EQ(curField[0]->GetHealth(), 13);
-    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 4);
 }
 
 // ----------------------------------------- SPELL - HUNTER

--- a/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/ScholomanceCardsGenTests.cpp
@@ -147,7 +147,7 @@ TEST_CASE("[Druid : Spell] - SCH_333 : Nature Studies")
 // - Set: SCHOLOMANCE, Rarity: Common
 // - Spell School: Nature
 // --------------------------------------------------------
-// Text: Gain 2 Mana Crystals this turn only.
+// Text: Refresh 2 Mana Crystals.
 //       <b>Overload:</b> (2)
 // --------------------------------------------------------
 // GameTag:
@@ -179,18 +179,23 @@ TEST_CASE("[Druid : Spell] - SCH_427 : Lightning Bloom")
         curPlayer, Cards::FindCardByName("Dragonling Mechanic"));
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
-    CHECK_EQ(curPlayer->GetRemainingMana(), 10);
-    CHECK_EQ(curPlayer->GetTemporaryMana(), 2);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 8);
     CHECK_EQ(curPlayer->GetTotalMana(), 8);
     CHECK_EQ(curPlayer->GetUsedMana(), 0);
 
     game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 4);
+    CHECK_EQ(curPlayer->GetTotalMana(), 8);
+    CHECK_EQ(curPlayer->GetUsedMana(), 4);
+    CHECK_EQ(curPlayer->GetOverloadLocked(), 0);
+    CHECK_EQ(curPlayer->GetOverloadOwed(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card2));
     CHECK_EQ(curPlayer->GetRemainingMana(), 6);
-    CHECK_EQ(curPlayer->GetTemporaryMana(), 0);
     CHECK_EQ(curPlayer->GetTotalMana(), 8);
     CHECK_EQ(curPlayer->GetUsedMana(), 2);
     CHECK_EQ(curPlayer->GetOverloadLocked(), 0);
-    CHECK_EQ(curPlayer->GetOverloadOwed(), 2);
+    CHECK_EQ(curPlayer->GetOverloadOwed(), 4);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);
@@ -198,17 +203,9 @@ TEST_CASE("[Druid : Spell] - SCH_427 : Lightning Bloom")
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);
 
-    CHECK_EQ(curPlayer->GetRemainingMana(), 7);
-    CHECK_EQ(curPlayer->GetOverloadLocked(), 2);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 5);
+    CHECK_EQ(curPlayer->GetOverloadLocked(), 4);
     CHECK_EQ(curPlayer->GetOverloadOwed(), 0);
-
-    game.Process(curPlayer, PlayCardTask::Spell(card2));
-    CHECK_EQ(curPlayer->GetRemainingMana(), 9);
-    CHECK_EQ(curPlayer->GetTemporaryMana(), 2);
-    CHECK_EQ(curPlayer->GetTotalMana(), 9);
-    CHECK_EQ(curPlayer->GetUsedMana(), 0);
-    CHECK_EQ(curPlayer->GetOverloadLocked(), 2);
-    CHECK_EQ(curPlayer->GetOverloadOwed(), 2);
 }
 
 // ------------------------------------------ SPELL - DRUID

--- a/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
@@ -19,7 +19,7 @@ using namespace PlayerTasks;
 using namespace SimpleTasks;
 
 // ------------------------------------------ SPELL - DRUID
-// [UNG_108] Earthen Scales - COST:1
+// [UNG_108] Earthen Scales - COST:2
 // - Faction: Neutral, Set: Ungoro, Rarity: Rare
 // --------------------------------------------------------
 // Text: Give a friendly minion +1/+1,
@@ -55,16 +55,16 @@ TEST_CASE("[Druid : Spell] - UNG_108 : Earthen Scales")
     const auto card1 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Earthen Scales"));
     const auto card2 =
-        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wolfrider"));
 
     game.Process(curPlayer, PlayCardTask::Minion(card2));
-    CHECK_EQ(curField[0]->GetAttack(), 4);
-    CHECK_EQ(curField[0]->GetHealth(), 12);
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
 
     game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
-    CHECK_EQ(curField[0]->GetAttack(), 5);
-    CHECK_EQ(curField[0]->GetHealth(), 13);
-    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 5);
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 4);
 }
 
 // ------------------------------------------ MINION - MAGE


### PR DESCRIPTION
This revision includes:
- Update Hearthstone Patch 23.4.3 (Resolves #792)
  - Update card data
    - Shield Shatter: Old: Deal 5 damage to all minions. Costs (1) less for each Armor you have. → New: Deal 4 damage to all minions. Costs (1) less for each Armor you have.
    - Tidal Revenant: Old: Battlecry: Deal 5 damage. Gain 8 Armor. → New: Battlecry: Deal 5 damage. Gain 5 Armor.
    - Nellie’s Pirate Ship (the Colossal appendage summoned by Nellie, the Great Thresher): Old: Taunt. Deathrattle: Add Nellie’s Pirate crew to your hand. They Cost (1). → New: Taunt. Deathrattle: Add Nellie’s Pirate crew to your hand. They Cost (1) less.
    - From the Depths: Old: [Costs 3] → New: [Costs 4]
    - Caria Felsoul: Old: [Costs 6] 6 Attack, 6 Health. Battlecry: Transform into a 6/6 copy of a Demon in your deck. → New: [Costs 7] 7 Attack, 7 Health. Battlecry: Transform into a 7/7 copy of a Demon in your deck.
    - Battleworn Vanguard: Old: 2 Attack, 2 Health → New: 2 Attack, 1 Health
    - Wildpaw Gnoll: Old: 4 Attack, 5 Health → New: 3 Attack, 5 Health
    - Lightforged Cariel: Old: [Costs 7] → New: [Costs 8]
    - Spitelash Siren: Old: [Costs 4] 2 Attack, 5 Health → New: [Costs 5] 2 Attack, 6 Health
    - Earthen Scales: Old: [Costs 1] → New: [Costs 2]
    - Lightning Bloom: Old: Gain 2 Mana Crystals this turn only. Overload: (2). → New: Refresh 2 Mana Crystals. Overload: (2).
    - Mr. Smite: Old: [Costs 6] → New: [Costs 7]
    - School Teacher: Old: 5 Attack, 4 Health → New: 4 Attack, 3 Health
  - Update Battlegrounds data
    - Onyxia Broodmother – Broodmother: Old: Avenge (4): Summon a 2/1 Whelp. It attacks immediately. →  New: Avenge (4): Summon a 3/1 Whelp. It attacks immediately.
    - Ozumat – Tentacular: Old: Passive. Start of Combat: Summon a 2/2 Tentacle with Taunt. (Upgrades after you sell a minion!) → New: Passive. Start of Combat: Summon a 2/2 Tentacle with Taunt. (Gains +1/+1 after you sell a minion!)
    - Pyramad — Brick by Brick: Old: [Costs 1] Give a random friendly minion +4 Health. →  New: [Costs 0] Give a minion +2 Health. (Gains +1 Health each turn you don’t use this!)
    - Tamsin Roame — Fragrant Phylactery: Old: Start of Combat: Destroy your lowest Health minion. Give its stats to four friendly minions. → New: Start of Combat: Destroy your lowest Health minion. Give its stats to five friendly minions.
    - Bubblette: Old: 2 Attack, 5 Health → New: 5 Attack, 4 Health
    - Tarecgosa: Old: Tavern Tier 4 → New: Tavern Tier 3
    - Coldlight Seer: Old: Tavern Tier 4 → New: Tavern Tier 3
    - Shoal Commander: Old: 1 Attack, 2 Health → New: 2 Attack, 2 Health
    - Waverider: Old: Spellcraft: Give a minion +1/+1 and Windfury until next turn. → New: Spellcraft: Give a minion +2/+2 and Windfury until next turn.
    - Critter Wrangler: Old: 5 Attack, 6 Health. After you cast a Spellcraft spell on a minion, give it +2/+1. → New: 5 Attack, 7 Health. After you cast a Spellcraft spell on a minion, give it +2/+2.
    - Corrupted Myrmidon: Old: 2 Attack, 2 Health → New: 3 Attack, 3 Health
    - Tidemistress Athissa: Old: 7 Attack, 3 Health → New: 7 Attack, 8 Health
    - The minion Stormscale Siren will be removed from the minion pool. The minion Warden of Old will be returned to the minion pool at Tier 3 (now with the Naga minion type).