### PR TITLE
Implement 5 CORE cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -189,18 +189,18 @@ CORE | CORE_KAR_073 | Maelstrom Portal | O
 CORE | CORE_LOE_003 | Ethereal Conjurer | O
 CORE | CORE_LOE_011 | Reno Jackson | O
 CORE | CORE_LOE_012 | Tomb Pillager | O
-CORE | CORE_LOE_039 | Gorillabot A-3 |  
+CORE | CORE_LOE_039 | Gorillabot A-3 | O
 CORE | CORE_LOE_050 | Mounted Raptor | O
-CORE | CORE_LOE_076 | Sir Finley Mrrgglton |  
-CORE | CORE_LOE_077 | Brann Bronzebeard |  
-CORE | CORE_LOE_079 | Elise Starseeker |  
+CORE | CORE_LOE_076 | Sir Finley Mrrgglton | O
+CORE | CORE_LOE_077 | Brann Bronzebeard | O
+CORE | CORE_LOE_079 | Elise Starseeker | O
 CORE | CORE_LOEA10_3 | Murloc Tinyfin | O
 CORE | CORE_LOOT_101 | Explosive Runes | O
 CORE | CORE_LOOT_124 | Lone Champion | O
 CORE | CORE_LOOT_137 | Sleepy Dragon | O
 CORE | CORE_LOOT_222 | Candleshot | O
 CORE | CORE_LOOT_413 | Plated Beetle | O
-CORE | CORE_LOOT_516 | Zola the Gorgon |  
+CORE | CORE_LOOT_516 | Zola the Gorgon | O
 CORE | CORE_NEW1_008 | Ancient of Lore | O
 CORE | CORE_NEW1_010 | Al'Akir the Windlord | O
 CORE | CORE_NEW1_018 | Bloodsail Raider | O
@@ -261,7 +261,7 @@ CORE | CS3_036 | Deathwing the Destroyer | O
 CORE | CS3_037 | Emerald Skytalon | O
 CORE | CS3_038 | Redgill Razorjaw | O
 
-- Progress: 94% (236 of 250 Cards)
+- Progress: 96% (241 of 250 Cards)
 
 ## Forged in the Barrens
 

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -848,7 +848,7 @@ LOE | LOE_026 | Anyfin Can Happen |
 LOE | LOE_027 | Sacred Trial |  
 LOE | LOE_029 | Jeweled Scarab |  
 LOE | LOE_038 | Naga Sea Witch |  
-LOE | LOE_039 | Gorillabot A-3 |  
+LOE | LOE_039 | Gorillabot A-3 | O
 LOE | LOE_046 | Huge Toad |  
 LOE | LOE_047 | Tomb Spider |  
 LOE | LOE_050 | Mounted Raptor | O
@@ -856,9 +856,9 @@ LOE | LOE_051 | Jungle Moonkin |
 LOE | LOE_053 | Djinni of Zephyrs |  
 LOE | LOE_061 | Anubisath Sentinel |  
 LOE | LOE_073 | Fossilized Devilsaur |  
-LOE | LOE_076 | Sir Finley Mrrgglton |  
-LOE | LOE_077 | Brann Bronzebeard |  
-LOE | LOE_079 | Elise Starseeker |  
+LOE | LOE_076 | Sir Finley Mrrgglton | O
+LOE | LOE_077 | Brann Bronzebeard | O
+LOE | LOE_079 | Elise Starseeker | O
 LOE | LOE_086 | Summoning Stone |  
 LOE | LOE_089 | Wobbling Runts |  
 LOE | LOE_092 | Arch-Thief Rafaam |  
@@ -874,7 +874,7 @@ LOE | LOE_118 | Cursed Blade |
 LOE | LOE_119 | Animated Armor |  
 LOE | LOEA10_3 | Murloc Tinyfin | O
 
-- Progress: 11% (5 of 45 Cards)
+- Progress: 20% (9 of 45 Cards)
 
 ## Whispers of the Old Gods
 
@@ -1613,7 +1613,7 @@ LOOTAPALOOZA | LOOT_504 | Unstable Evolution |
 LOOTAPALOOZA | LOOT_506 | The Runespear |  
 LOOTAPALOOZA | LOOT_507 | Lesser Diamond Spellstone |  
 LOOTAPALOOZA | LOOT_511 | Kathrena Winterwisp |  
-LOOTAPALOOZA | LOOT_516 | Zola the Gorgon |  
+LOOTAPALOOZA | LOOT_516 | Zola the Gorgon | O
 LOOTAPALOOZA | LOOT_517 | Murmuring Elemental |  
 LOOTAPALOOZA | LOOT_518 | Windshear Stormcaller |  
 LOOTAPALOOZA | LOOT_519 | Geosculptor Yip |  
@@ -1632,7 +1632,7 @@ LOOTAPALOOZA | LOOT_540 | Dragonhatcher |
 LOOTAPALOOZA | LOOT_541 | King Togwaggle |  
 LOOTAPALOOZA | LOOT_542 | Kingsbane |  
 
-- Progress: 4% (6 of 135 Cards)
+- Progress: 5% (7 of 135 Cards)
 
 ## The Witchwood
 

--- a/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
@@ -33,6 +33,7 @@ enum class DiscoverType
     SECRET,
     DEMON,
     DRAGON,
+    MECHANICAL,
     LACKEY,
     HEISTBARON_TOGWAGGLE,
     MADAME_LAZUL,

--- a/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/ChoiceEnums.hpp
@@ -13,6 +13,7 @@ namespace RosettaStone
 enum class DiscoverType
 {
     INVALID,
+    HERO_POWER,
     DECK,
     ENEMY_DECK,
     SPELL_FROM_DECK,

--- a/Includes/Rosetta/PlayMode/Models/Playable.hpp
+++ b/Includes/Rosetta/PlayMode/Models/Playable.hpp
@@ -73,6 +73,10 @@ class Playable : public Entity
     //! \param value The flag that indicates whether it is transformed.
     void SetTransformed(bool value);
 
+    //! Returns the flag that indicates whether it is golden card.
+    //! \return The flag that indicates whether it is golden card.
+    bool IsGoldenCard() const;
+
     //! Returns the flag that indicates whether it has combo.
     //! \return The flag that indicates whether it has combo.
     bool HasCombo() const;

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 94% Core Set (236 of 250 cards)
+  * 96% Core Set (241 of 250 cards)
   * 81% Forged in the Barrens (139 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
@@ -58,13 +58,13 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 6% Goblins vs Gnomes (8 of 123 Cards)
   * 6% Blackrock Mountain (2 of 31 Cards)
   * 8% The Grand Tournament (11 of 132 Cards)
-  * 11% The League of Explorers (5 of 45 Cards)
+  * 20% The League of Explorers (9 of 45 Cards)
   * 5% Whispers of the Old Gods (8 of 134 Cards)
   * 15% One Night in Karazhan (7 of 45 Cards)
   * 2% Mean Streets of Gadgetzan (3 of 132 Cards)
   * 5% Journey to Un'Goro (8 of 135 Cards)
   * 4% Knights of the Frozen Throne (6 of 135 Cards)
-  * 4% Kobolds & Catacombs (6 of 135 Cards)
+  * 5% Kobolds & Catacombs (7 of 135 Cards)
   * 5% The Witchwood (8 of 135 Cards)
   * 2% The Boomsday Project (4 of 136 Cards)
   * 5% Rastakhan's Rumble (7 of 135 Cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4364,11 +4364,20 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b><b>Battlecry:</b> Discover</b> a new basic Hero Power.
     // --------------------------------------------------------
+    // Entourage: HERO_01bp, HERO_02bp, HERO_03bp, HERO_04bp,
+    //            HERO_05bp, HERO_06bp, HERO_07bp, HERO_08bp,
+    //            HERO_09bp, HERO_10bp
+    // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
     // - BATTLECRY = 1
     // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DiscoverTask>(DiscoverType::HERO_POWER));
+    cards.emplace("CORE_LOE_076", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_LOE_077] Brann Bronzebeard - COST:3 [ATK:2/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4483,6 +4483,21 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<CopyTask>(
+        EntityType::TARGET, ZoneType::HAND, 1, true));
+    cardDef.power.AddPowerTask(std::make_shared<SetGameTagTask>(
+        EntityType::STACK, GameTag::PREMIUM, 1));
+    cardDef.property.playReqs =
+        PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },
+                  { PlayReq::REQ_FRIENDLY_TARGET, 0 },
+                  { PlayReq::REQ_MINION_TARGET, 0 } };
+    cards.emplace("CORE_LOOT_516", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_NEW1_018] Bloodsail Raider - COST:2 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4346,7 +4346,17 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::MINIONS_NOSOURCE,
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsControllingRace(Race::MECHANICAL)) }));
+    cardDef.power.AddPowerTask(std::make_shared<FlagTask>(
+        true,
+        TaskList{ std::make_shared<DiscoverTask>(DiscoverType::MECHANICAL) }));
+    cards.emplace("CORE_LOE_039", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_LOE_076] Sir Finley Mrrgglton - COST:1 [ATK:1/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4392,6 +4392,12 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(std::make_shared<Aura>(
+        AuraType::PLAYER,
+        EffectList{ std::make_shared<Effect>(GameTag::EXTRA_BATTLECRIES_BASE,
+                                             EffectOperator::SET, 1) }));
+    cards.emplace("CORE_LOE_077", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_LOE_079] Elise Starseeker - COST:4 [ATK:3/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4403,13 +4403,17 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [CORE_LOE_079] Elise Starseeker - COST:4 [ATK:3/HP:5]
     // - Set: CORE, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Shuffle the 'Map to the Golden Monkey'
-    //       into your deck.
+    // Text: <b>Battlecry:</b> Shuffle the
+    //       'Map to the Golden Monkey' into your deck.
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::DECK, "LOE_019t", 1));
+    cards.emplace("CORE_LOE_079", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_LOEA10_3] Murloc Tinyfin - COST:0 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
@@ -674,10 +674,10 @@ void LoECardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
-    // PlayReq:
-    // - REQ_FRIENDLY_TARGET = 0
-    // - REQ_MINION_TARGET = 0
-    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::DECK, "LOE_019t", 1));
+    cards.emplace("LOE_079", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [LOE_086] Summoning Stone - COST:5 [ATK:0/HP:6]
@@ -740,6 +740,8 @@ void LoECardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
 void LoECardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ---------------------------------------- SPELL - NEUTRAL
     // [LOE_008] Eye of Hakkar (*) - COST:1
     // - Set: LoE
@@ -775,6 +777,11 @@ void LoECardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Shuffle the Golden Monkey into your deck. Draw a card.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<AddCardTask>(EntityType::DECK, "LOE_019t2", 1));
+    cardDef.power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cards.emplace("LOE_019t", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [LOE_019t2] Golden Monkey (*) - COST:4 [ATK:6/HP:6]
@@ -788,6 +795,14 @@ void LoECardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
     // - TAUNT = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<ChangeEntityTask>(
+        EntityType::HAND, CardType::MINION, CardClass::INVALID, Race::INVALID,
+        Rarity::LEGENDARY));
+    cardDef.power.AddPowerTask(std::make_shared<ChangeEntityTask>(
+        EntityType::DECK, CardType::MINION, CardClass::INVALID, Race::INVALID,
+        Rarity::LEGENDARY));
+    cards.emplace("LOE_019t2", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [LOE_024t] Rolling Boulder (*) - COST:4 [ATK:0/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
@@ -627,8 +627,9 @@ void LoECardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Battlecry: Discover</b> a new basic Hero Power.
     // --------------------------------------------------------
-    // Entourage: DS1h_292, CS2_056, CS2_101, CS1h_001, CS2_049,
-    //            CS2_102, CS2_083b, CS2_034, CS2_017
+    // Entourage: HERO_01bp, HERO_02bp, HERO_03bp, HERO_04bp,
+    //            HERO_05bp, HERO_06bp, HERO_07bp, HERO_08bp,
+    //            HERO_09bp, HERO_10bp
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
@@ -636,6 +637,10 @@ void LoECardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - DISCOVER = 1
     // - USE_DISCOVER_VISUALS = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DiscoverTask>(DiscoverType::HERO_POWER));
+    cards.emplace("LOE_076", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [LOE_077] Brann Bronzebeard - COST:3 [ATK:2/HP:4]

--- a/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
@@ -11,6 +11,7 @@ using namespace RosettaStone::PlayMode::SimpleTasks;
 namespace RosettaStone::PlayMode
 {
 using TagValues = std::vector<TagValue>;
+using PlayReqs = std::map<PlayReq, int>;
 using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
 
 void LoECardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
@@ -553,6 +554,15 @@ void LoECardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - DISCOVER = 1
     // - USE_DISCOVER_VISUALS = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::MINIONS_NOSOURCE,
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsControllingRace(Race::MECHANICAL)) }));
+    cardDef.power.AddPowerTask(std::make_shared<FlagTask>(
+        true,
+        TaskList{ std::make_shared<DiscoverTask>(DiscoverType::MECHANICAL) }));
+    cards.emplace("LOE_039", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [LOE_046] Huge Toad - COST:2 [ATK:3/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
@@ -13,6 +13,7 @@ namespace RosettaStone::PlayMode
 using TagValues = std::vector<TagValue>;
 using PlayReqs = std::map<PlayReq, int>;
 using SelfCondList = std::vector<std::shared_ptr<SelfCondition>>;
+using EffectList = std::vector<std::shared_ptr<IEffect>>;
 
 void LoECardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
@@ -651,13 +652,16 @@ void LoECardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - ELITE = 1
     // - AURA = 1
-    // - 1429 = 58400
-    // - TECH_LEVEL = 5
-    // - IS_BACON_POOL_MINION = 1
     // --------------------------------------------------------
     // RefTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(std::make_shared<Aura>(
+        AuraType::PLAYER,
+        EffectList{ std::make_shared<Effect>(GameTag::EXTRA_BATTLECRIES_BASE,
+                                             EffectOperator::SET, 1) }));
+    cards.emplace("LOE_077", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [LOE_079] Elise Starseeker - COST:4 [ATK:3/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/LootapaloozaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LootapaloozaCardsGen.cpp
@@ -2244,6 +2244,16 @@ void LootapaloozaCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - REQ_FRIENDLY_TARGET = 0
     // - REQ_MINION_TARGET = 0
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<CopyTask>(
+        EntityType::TARGET, ZoneType::HAND, 1, true));
+    cardDef.power.AddPowerTask(std::make_shared<SetGameTagTask>(
+        EntityType::STACK, GameTag::PREMIUM, 1));
+    cardDef.property.playReqs =
+        PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },
+                  { PlayReq::REQ_FRIENDLY_TARGET, 0 },
+                  { PlayReq::REQ_MINION_TARGET, 0 } };
+    cards.emplace("LOOT_516", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [LOOT_521] Master Oakheart - COST:9 [ATK:5/HP:5]

--- a/Sources/Rosetta/PlayMode/Models/Playable.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Playable.cpp
@@ -104,6 +104,11 @@ void Playable::SetTransformed(bool value)
     SetGameTag(GameTag::TRANSFORMED_FROM_CARD, static_cast<int>(value));
 }
 
+bool Playable::IsGoldenCard() const
+{
+    return static_cast<bool>(GetGameTag(GameTag::PREMIUM));
+}
+
 bool Playable::HasCombo() const
 {
     return GetGameTag(GameTag::COMBO) == 1;

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
@@ -452,6 +452,16 @@ auto DiscoverTask::Discover(Game* game, Player* player,
                 }
             }
             break;
+        case DiscoverType::MECHANICAL:
+            choiceAction = ChoiceAction::HAND;
+            for (auto& card : allCards)
+            {
+                if (card->GetRace() == Race::MECHANICAL)
+                {
+                    cardsForGeneration.emplace_back(card);
+                }
+            }
+            break;
         case DiscoverType::LACKEY:
             choiceAction = ChoiceAction::HAND;
             for (const auto& card : Cards::GetAllCards())

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DiscoverTask.cpp
@@ -256,6 +256,23 @@ auto DiscoverTask::Discover(Game* game, Player* player,
             }
             break;
         }
+        case DiscoverType::HERO_POWER:
+        {
+            choiceAction = ChoiceAction::CHANGE_HERO_POWER;
+            cardsForGeneration = {
+                Cards::FindCardByID("HERO_01bp"),
+                Cards::FindCardByID("HERO_02bp"),
+                Cards::FindCardByID("HERO_03bp"),
+                Cards::FindCardByID("HERO_04bp"),
+                Cards::FindCardByID("HERO_05bp"),
+                Cards::FindCardByID("HERO_06bp"),
+                Cards::FindCardByID("HERO_07bp"),
+                Cards::FindCardByID("HERO_08bp"),
+                Cards::FindCardByID("HERO_09bp"),
+                Cards::FindCardByID("HERO_10bp"),
+            };
+            break;
+        }
         case DiscoverType::ENEMY_DECK:
         {
             choiceAction = ChoiceAction::HAND_COPY;

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -12015,6 +12015,59 @@ TEST_CASE("[Neutral : Minion] - CORE_LOE_011 : Reno Jackson")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_LOE_039] Gorillabot A-3 - COST:3 [ATK:3/HP:4]
+// - Race: Mechanical, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you control another Mech,
+//       <b>Discover</b> a Mech.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - DISCOVER = 1
+// - USE_DISCOVER_VISUALS = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_LOE_039 : Gorillabot A-3")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Gorillabot A-3"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Gorillabot A-3"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK(curPlayer->choice == nullptr);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK(curPlayer->choice != nullptr);
+    CHECK_EQ(curPlayer->choice->choices.size(), 3);
+
+    auto cards = TestUtils::GetChoiceCards(game);
+    for (auto& card : cards)
+    {
+        CHECK_EQ(card->GetCardType(), CardType::MINION);
+        CHECK_EQ(card->GetRace(), Race::MECHANICAL);
+    }
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_LOEA10_3] Murloc Tinyfin - COST:0 [ATK:1/HP:1]
 // - Race: Murloc, Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -12068,6 +12068,57 @@ TEST_CASE("[Neutral : Minion] - CORE_LOE_039 : Gorillabot A-3")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_LOE_076] Sir Finley Mrrgglton - COST:1 [ATK:1/HP:3]
+// - Race: Murloc, Set: CORE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b><b>Battlecry:</b> Discover</b> a new basic Hero Power.
+// --------------------------------------------------------
+// Entourage: HERO_01bp, HERO_02bp, HERO_03bp, HERO_04bp,
+//            HERO_05bp, HERO_06bp, HERO_07bp, HERO_08bp,
+//            HERO_09bp, HERO_10bp
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// - DISCOVER = 1
+// - USE_DISCOVER_VISUALS = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_LOE_076 : Sir Finley Mrrgglton")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Sir Finley Mrrgglton"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK(curPlayer->choice != nullptr);
+    CHECK_EQ(curPlayer->choice->choices.size(), 3);
+
+    auto cards = TestUtils::GetChoiceCards(game);
+    for (auto& card : cards)
+    {
+        CHECK_EQ(card->GetCardType(), CardType::HERO_POWER);
+    }
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_LOEA10_3] Murloc Tinyfin - COST:0 [ATK:1/HP:1]
 // - Race: Murloc, Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -12401,6 +12401,57 @@ TEST_CASE("[Neutral : Minion] - CORE_LOOT_413 : Plated Beetle")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_LOOT_516] Zola the Gorgon - COST:3 [ATK:2/HP:2]
+// - Race: Naga, Set: CORE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Choose a friendly minion.
+//       Add a Golden copy of it to your hand.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// - REQ_FRIENDLY_TARGET = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_LOOT_516 : Zola the Gorgon")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Zola the Gorgon"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card1, card2));
+    CHECK_EQ(curHand.GetCount(), 1);
+    CHECK_EQ(curHand[0]->card->name, "Wisp");
+    CHECK_EQ(curHand[0]->IsGoldenCard(), true);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_NEW1_018] Bloodsail Raider - COST:2 [ATK:2/HP:3]
 // - Race: Pirate, Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -10,6 +10,7 @@
 #include <Utils/TestUtils.hpp>
 
 #include <Rosetta/PlayMode/Actions/Draw.hpp>
+#include <Rosetta/PlayMode/Actions/Generic.hpp>
 #include <Rosetta/PlayMode/Cards/Cards.hpp>
 #include <Rosetta/PlayMode/Zones/DeckZone.hpp>
 #include <Rosetta/PlayMode/Zones/FieldZone.hpp>
@@ -12191,6 +12192,94 @@ TEST_CASE("[Neutral : Minion] - CORE_LOE_077 : Brann Bronzebeard")
     game.Process(curPlayer, PlayCardTask::MinionTarget(card4, card2));
     CHECK_EQ(curField[0]->GetAttack(), 3);
     CHECK_EQ(curField[0]->GetHealth(), 1);
+}
+
+// --------------------------------------- MINION - NEUTRAL
+// [CORE_LOE_079] Elise Starseeker - COST:4 [ATK:3/HP:5]
+// - Set: CORE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Shuffle the
+//       'Map to the Golden Monkey' into your deck.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_LOE_079 : Elise Starseeker")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    config.player1Deck[0] = Cards::FindCardByName("Bloodfen Raptor");
+    config.player1Deck[1] = Cards::FindCardByName("Young Dragonhawk");
+    config.player1Deck[2] = Cards::FindCardByName("Faerie Dragon");
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    opPlayer->GetHero()->SetDamage(0);
+
+    auto& curDeck = *(curPlayer->GetDeckZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Elise Starseeker"));
+
+    CHECK_EQ(curHand.GetCount(), 4);
+    CHECK_EQ(curDeck.GetCount(), 0);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 3);
+    CHECK_EQ(curDeck.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curHand.GetCount(), 4);
+    CHECK_EQ(curHand[3]->card->name, "Map to the Golden Monkey");
+
+    game.Process(curPlayer, PlayCardTask::Spell(curHand[3]));
+    CHECK_EQ(curHand.GetCount(), 4);
+    CHECK_EQ(curHand[3]->card->name, "Golden Monkey");
+    CHECK_EQ(curDeck.GetCount(), 0);
+
+    Card* wispCard = Cards::FindCardByName("Wisp");
+    Generic::ShuffleIntoDeck(curPlayer, curPlayer,
+                             Entity::GetFromCard(curPlayer, wispCard));
+    Generic::ShuffleIntoDeck(curPlayer, curPlayer,
+                             Entity::GetFromCard(curPlayer, wispCard));
+    Generic::ShuffleIntoDeck(curPlayer, curPlayer,
+                             Entity::GetFromCard(curPlayer, wispCard));
+    CHECK_EQ(curDeck.GetCount(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[3]));
+    CHECK_EQ(curHand[0]->card->GetCardType(), CardType::MINION);
+    CHECK_EQ(curHand[0]->card->GetRarity(), Rarity::LEGENDARY);
+    CHECK_EQ(curHand[1]->card->GetCardType(), CardType::MINION);
+    CHECK_EQ(curHand[1]->card->GetRarity(), Rarity::LEGENDARY);
+    CHECK_EQ(curHand[2]->card->GetCardType(), CardType::MINION);
+    CHECK_EQ(curHand[2]->card->GetRarity(), Rarity::LEGENDARY);
+    CHECK_EQ(curDeck[0]->card->GetCardType(), CardType::MINION);
+    CHECK_EQ(curDeck[0]->card->GetRarity(), Rarity::LEGENDARY);
+    CHECK_EQ(curDeck[1]->card->GetCardType(), CardType::MINION);
+    CHECK_EQ(curDeck[1]->card->GetRarity(), Rarity::LEGENDARY);
+    CHECK_EQ(curDeck[2]->card->GetCardType(), CardType::MINION);
+    CHECK_EQ(curDeck[2]->card->GetRarity(), Rarity::LEGENDARY);
 }
 
 // --------------------------------------- MINION - NEUTRAL

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -12119,6 +12119,81 @@ TEST_CASE("[Neutral : Minion] - CORE_LOE_076 : Sir Finley Mrrgglton")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_LOE_077] Brann Bronzebeard - COST:3 [ATK:2/HP:4]
+// - Set: CORE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: Your <b>Battlecries</b> trigger twice.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - AURA = 1
+// --------------------------------------------------------
+// RefTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_LOE_077 : Brann Bronzebeard")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    opPlayer->GetHero()->SetDamage(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Brann Bronzebeard"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Elven Archer"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Razorfen Hunter"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Abusive Sergeant"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->ExtraBattlecry(), true);
+
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(card2, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curField.GetCount(), 5);
+    CHECK_EQ(curField[2]->card->name, "Razorfen Hunter");
+    CHECK_EQ(curField[3]->card->name, "Boar");
+    CHECK_EQ(curField[4]->card->name, "Boar");
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card5, card1));
+    CHECK_EQ(curPlayer->ExtraBattlecry(), false);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card4, card2));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_LOEA10_3] Murloc Tinyfin - COST:0 [ATK:1/HP:1]
 // - Race: Murloc, Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
@@ -222,6 +222,58 @@ TEST_CASE("[Neutral : Minion] - LOE_011 : Reno Jackson")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [LOE_039] Gorillabot A-3 - COST:3 [ATK:3/HP:4]
+// - Race: Mechanical, Set: LoE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you control another Mech,
+//       <b>Discover</b> a Mech.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - DISCOVER = 1
+// - USE_DISCOVER_VISUALS = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - LOE_039 : Gorillabot A-3")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Gorillabot A-3"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Gorillabot A-3"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK(curPlayer->choice == nullptr);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK(curPlayer->choice != nullptr);
+    CHECK_EQ(curPlayer->choice->choices.size(), 3);
+
+    auto cards = TestUtils::GetChoiceCards(game);
+    for (auto& card : cards)
+    {
+        CHECK_EQ(card->GetCardType(), CardType::MINION);
+        CHECK_EQ(card->GetRace(), Race::MECHANICAL);
+    }
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [LOEA10_3] Murloc Tinyfin - COST:0 [ATK:1/HP:1]
 // - Race: Murloc, Set: LoE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
@@ -274,6 +274,56 @@ TEST_CASE("[Neutral : Minion] - LOE_039 : Gorillabot A-3")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [LOE_076] Sir Finley Mrrgglton - COST:1 [ATK:1/HP:3]
+// - Race: Murloc, Set: LoE, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Battlecry: Discover</b> a new basic Hero Power.
+// --------------------------------------------------------
+// Entourage: HERO_01bp, HERO_02bp, HERO_03bp, HERO_04bp,
+//            HERO_05bp, HERO_06bp, HERO_07bp, HERO_08bp,
+//            HERO_09bp, HERO_10bp
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - BATTLECRY = 1
+// - DISCOVER = 1
+// - USE_DISCOVER_VISUALS = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - LOE_076 : Sir Finley Mrrgglton")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Sir Finley Mrrgglton"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK(curPlayer->choice != nullptr);
+    CHECK_EQ(curPlayer->choice->choices.size(), 3);
+
+    auto cards = TestUtils::GetChoiceCards(game);
+    for (auto& card : cards)
+    {
+        CHECK_EQ(card->GetCardType(), CardType::HERO_POWER);
+    }
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [LOEA10_3] Murloc Tinyfin - COST:0 [ATK:1/HP:1]
 // - Race: Murloc, Set: LoE, Rarity: Common
 // --------------------------------------------------------


### PR DESCRIPTION
This revision includes:
- Implement 5 CORE cards (#755)
  - Gorillabot A-3 (CORE_LOE_039)
  - Sir Finley Mrrgglton (CORE_LOE_076)
  - Brann Bronzebeard (CORE_LOE_077)
  - Elise Starseeker (CORE_LOE_079)
  - Zola the Gorgon (CORE_LOOT_516)
- Implement 4 LOE card
  - Gorillabot A-3 (LOE_039)
  - Sir Finley Mrrgglton (LOE_076)
  - Brann Bronzebeard (LOE_077)
  - Elise Starseeker (LOE_079)
- Implement 1 LOOTAPALOOZA card
  - Zola the Gorgon (LOOT_516)
- Add enum value 'DiscoverType::HERO_POWER'
  - Add code to process discover type 'HERO_POWER'
- Add method 'IsGoldenCard()'
  - Returns the flag that indicates whether it is golden card