### PR TITLE
Implement 6 CORE cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -222,9 +222,9 @@ CORE | CORE_TRL_307 | Flash of Light | O
 CORE | CORE_TRL_315 | Pyromaniac | O
 CORE | CORE_TRL_345 | Krag'wa, the Frog | O
 CORE | CORE_TRL_348 | Springpaw | O
-CORE | CORE_ULD_191 | Beaming Sidekick |  
-CORE | CORE_ULD_209 | Vulpera Scoundrel |  
-CORE | CORE_ULD_271 | Injured Tol'vir |  
+CORE | CORE_ULD_191 | Beaming Sidekick | O
+CORE | CORE_ULD_209 | Vulpera Scoundrel | O
+CORE | CORE_ULD_271 | Injured Tol'vir | O
 CORE | CORE_UNG_020 | Arcanologist | O
 CORE | CORE_UNG_034 | Radiant Elemental | O
 CORE | CORE_UNG_108 | Earthen Scales | O
@@ -232,10 +232,10 @@ CORE | CORE_UNG_813 | Stormwatcher | O
 CORE | CORE_UNG_817 | Tidal Surge | O
 CORE | CORE_UNG_833 | Lakkari Felhound | O
 CORE | CORE_UNG_844 | Humongous Razorleaf | O
-CORE | CORE_UNG_848 | Primordial Drake |  
-CORE | CORE_UNG_928 | Tar Creeper |  
+CORE | CORE_UNG_848 | Primordial Drake | O
+CORE | CORE_UNG_928 | Tar Creeper | O
 CORE | CORE_UNG_963 | Lyra the Sunshard | O
-CORE | CORE_YOD_006 | Escaped Manasaber |  
+CORE | CORE_YOD_006 | Escaped Manasaber | O
 CORE | CS3_001 | Aegwynn, the Guardian |  
 CORE | CS3_003 | Felsoul Jailer | O
 CORE | CS3_005 | Vanessa VanCleef |  
@@ -261,7 +261,7 @@ CORE | CS3_036 | Deathwing the Destroyer | O
 CORE | CS3_037 | Emerald Skytalon | O
 CORE | CS3_038 | Redgill Razorjaw | O
 
-- Progress: 96% (241 of 250 Cards)
+- Progress: 98% (247 of 250 Cards)
 
 ## Forged in the Barrens
 

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -1304,7 +1304,7 @@ UNGORO | UNG_844 | Humongous Razorleaf | O
 UNGORO | UNG_845 | Igneous Elemental |  
 UNGORO | UNG_846 | Shimmering Tempest |  
 UNGORO | UNG_847 | Blazecaller |  
-UNGORO | UNG_848 | Primordial Drake |  
+UNGORO | UNG_848 | Primordial Drake | O
 UNGORO | UNG_851 | Elise the Trailblazer |  
 UNGORO | UNG_852 | Tyrantus |  
 UNGORO | UNG_854 | Free From Amber |  
@@ -1325,7 +1325,7 @@ UNGORO | UNG_923 | Iron Hide |
 UNGORO | UNG_925 | Ornery Direhorn |  
 UNGORO | UNG_926 | Cornered Sentry |  
 UNGORO | UNG_927 | Sudden Genesis |  
-UNGORO | UNG_928 | Tar Creeper |  
+UNGORO | UNG_928 | Tar Creeper | O
 UNGORO | UNG_929 | Molten Blade |  
 UNGORO | UNG_933 | King Mosh |  
 UNGORO | UNG_934 | Fire Plume's Heart |  
@@ -1348,7 +1348,7 @@ UNGORO | UNG_961 | Adaptation |
 UNGORO | UNG_962 | Lightfused Stegodon |  
 UNGORO | UNG_963 | Lyra the Sunshard | O
 
-- Progress: 5% (8 of 135 Cards)
+- Progress: 7% (10 of 135 Cards)
 
 ## Knights of the Frozen Throne
 
@@ -2501,7 +2501,7 @@ YEAR_OF_THE_DRAGON | YOD_001 | Rising Winds | O
 YEAR_OF_THE_DRAGON | YOD_003 | Winged Guardian | O
 YEAR_OF_THE_DRAGON | YOD_004 | Chopshop Copter | O
 YEAR_OF_THE_DRAGON | YOD_005 | Fresh Scent | O
-YEAR_OF_THE_DRAGON | YOD_006 | Escaped Manasaber |  
+YEAR_OF_THE_DRAGON | YOD_006 | Escaped Manasaber | O
 YEAR_OF_THE_DRAGON | YOD_007 | Animated Avalanche | O
 YEAR_OF_THE_DRAGON | YOD_008 | Arcane Amplifier | O
 YEAR_OF_THE_DRAGON | YOD_009 | The Amazing Reno |  
@@ -2533,7 +2533,7 @@ YEAR_OF_THE_DRAGON | YOD_041 | Eye of the Storm | O
 YEAR_OF_THE_DRAGON | YOD_042 | The Fist of Ra-den |  
 YEAR_OF_THE_DRAGON | YOD_043 | Scalelord | O
 
-- Progress: 57% (20 of 35 Cards)
+- Progress: 60% (21 of 35 Cards)
 
 ## Ashes of Outland
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
 
 ### Standard Format
 
-  * 96% Core Set (241 of 250 cards)
+  * 98% Core Set (247 of 250 cards)
   * 81% Forged in the Barrens (139 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
@@ -62,7 +62,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 5% Whispers of the Old Gods (8 of 134 Cards)
   * 15% One Night in Karazhan (7 of 45 Cards)
   * 2% Mean Streets of Gadgetzan (3 of 132 Cards)
-  * 5% Journey to Un'Goro (8 of 135 Cards)
+  * 7% Journey to Un'Goro (10 of 135 Cards)
   * 4% Knights of the Frozen Throne (6 of 135 Cards)
   * 5% Kobolds & Catacombs (7 of 135 Cards)
   * 5% The Witchwood (8 of 135 Cards)
@@ -72,7 +72,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * **99% Saviors of Uldum (134 of 135 cards)**
     * Except 'Zephrys the Great' (ULD_003)
   * **100% Descent of Dragons (140 of 140 cards)**
-  * 57% Galakrond's Awakening (20 of 35 cards)
+  * 60% Galakrond's Awakening (21 of 35 cards)
   * 60% Ashes of Outland (82 of 135 cards)
   * 57% Scholomance Academy (78 of 135 cards)
   * 46% Madness at the Darkmoon Faire (79 of 170 cards)

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4632,7 +4632,12 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // - DISCOVER = 1
+    // - USE_DISCOVER_VISUALS = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DiscoverTask>(DiscoverType::VULPERA_SCOUNDREL, 4));
+    cards.emplace("CORE_ULD_209", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_ULD_271] Injured Tol'vir - COST:2 [ATK:2/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4608,6 +4608,19 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_IF_AVAILABLE = 0
+    // - REQ_FRIENDLY_TARGET = 0
+    // - REQ_MINION_TARGET = 0
+    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("ULD_191e", EntityType::TARGET));
+    cardDef.property.playReqs =
+        PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },
+                  { PlayReq::REQ_FRIENDLY_TARGET, 0 },
+                  { PlayReq::REQ_MINION_TARGET, 0 } };
+    cards.emplace("CORE_ULD_191", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_ULD_209] Vulpera Scoundrel - COST:3 [ATK:2/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4727,6 +4727,11 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - STEALTH = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(std::make_shared<Trigger>(TriggerType::ATTACK));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<TempManaTask>(1) };
+    cards.emplace("CORE_YOD_006", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CS3_022] Fogsail Freebooter - COST:2 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4692,6 +4692,10 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ALL_MINIONS_NOSOURCE, 2));
+    cards.emplace("CORE_UNG_848", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_UNG_928] Tar Creeper - COST:3 [ATK:1/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4707,6 +4707,13 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(std::make_shared<AdaptiveEffect>(
+        GameTag::ATK, EffectOperator::ADD, [=](Playable* playable) {
+            return playable->player == playable->game->GetOpponentPlayer() ? 2
+                                                                           : 0;
+        }));
+    cards.emplace("CORE_UNG_928", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_YOD_006] Escaped Manasaber - COST:4 [ATK:3/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -4650,6 +4650,10 @@ void CoreCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::SOURCE, 3));
+    cards.emplace("CORE_ULD_271", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [CORE_UNG_813] Stormwatcher - COST:7 [ATK:4/HP:8]

--- a/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
@@ -2167,6 +2167,10 @@ void UngoroCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - TAUNT = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::ALL_MINIONS_NOSOURCE, 2));
+    cards.emplace("UNG_848", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [UNG_851] Elise the Trailblazer - COST:5 [ATK:5/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/UngoroCardsGen.cpp
@@ -3,6 +3,7 @@
 // RosettaStone is hearthstone simulator using C++ with reinforcement learning.
 // Copyright (c) 2017-2021 Chris Ohk
 
+#include <Rosetta/PlayMode/Auras/AdaptiveEffect.hpp>
 #include <Rosetta/PlayMode/CardSets/UngoroCardsGen.hpp>
 #include <Rosetta/PlayMode/Enchants/Enchants.hpp>
 #include <Rosetta/PlayMode/Tasks/ComplexTask.hpp>
@@ -2222,6 +2223,13 @@ void UngoroCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(std::make_shared<AdaptiveEffect>(
+        GameTag::ATK, EffectOperator::ADD, [=](Playable* playable) {
+            return playable->player == playable->game->GetOpponentPlayer() ? 2
+                                                                           : 0;
+        }));
+    cards.emplace("UNG_928", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [UNG_937] Primalfin Lookout - COST:3 [ATK:3/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/YoDCardsGen.cpp
@@ -723,13 +723,19 @@ void YoDCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // [YOD_006] Escaped Manasaber - COST:4 [ATK:3/HP:5]
     // - Race: Beast, Faction: Neutral, Set: YoD, Rarity: Epic
     // --------------------------------------------------------
-    // Text: <b>Stealth</b>Whenever this attacks,
+    // Text: <b>Stealth</b>
+    //       Whenever this attacks,
     //       gain 1 Mana Crystal this turn only.
     // --------------------------------------------------------
     // GameTag:
     // - STEALTH = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(std::make_shared<Trigger>(TriggerType::ATTACK));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<TempManaTask>(1) };
+    cards.emplace("YOD_006", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [YOD_028] Skydiving Instructor - COST:3 [ATK:2/HP:2]

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -13147,6 +13147,70 @@ TEST_CASE("[Neutral : Minion] - CORE_UNG_928 : Tar Creeper")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_YOD_006] Escaped Manasaber - COST:4 [ATK:3/HP:5]
+// - Race: Beast, Set: CORE, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Stealth</b>
+//       Whenever this attacks,
+//       gain 1 Mana Crystal this turn only.
+// --------------------------------------------------------
+// GameTag:
+// - STEALTH = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_YOD_006 : Escaped Manasaber")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(5);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Escaped Manasaber"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetTotalMana(), 6);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 6);
+    CHECK_EQ(curPlayer->GetTemporaryMana(), 0);
+
+    game.Process(curPlayer, AttackTask(card1, opPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetTotalMana(), 6);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 7);
+    CHECK_EQ(curPlayer->GetTemporaryMana(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetTotalMana(), 7);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 7);
+    CHECK_EQ(curPlayer->GetTemporaryMana(), 0);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CS3_022] Fogsail Freebooter - COST:2 [ATK:2/HP:2]
 // - Race: Pirate, Set: CORE, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -12966,6 +12966,47 @@ TEST_CASE("[Neutral : Minion] - CORE_ULD_209 : Vulpera Scoundrel")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_ULD_271] Injured Tol'vir - COST:2 [ATK:2/HP:6]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Battlecry:</b> Deal 3 damage to this minion.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_ULD_271 : Injured Tol'vir")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Injured Tol'vir"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetDamage(), 3);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_UNG_813] Stormwatcher - COST:7 [ATK:4/HP:8]
 // - Race: Elemental, Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -12829,6 +12829,63 @@ TEST_CASE("[Neutral : Minion] - CORE_NEW1_027 : Southsea Captain")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_ULD_191] Beaming Sidekick - COST:1 [ATK:1/HP:2]
+// - Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give a friendly minion +2 Health.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// - REQ_FRIENDLY_TARGET = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_ULD_191 : Beaming Sidekick")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Beaming Sidekick"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Beaming Sidekick"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Beaming Sidekick"));
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card1, nullptr));
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card1));
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card3, card2));
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(curField[1]->GetHealth(), 4);
+    CHECK_EQ(curField[2]->GetHealth(), 2);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_UNG_813] Stormwatcher - COST:7 [ATK:4/HP:8]
 // - Race: Elemental, Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -12886,6 +12886,86 @@ TEST_CASE("[Neutral : Minion] - CORE_ULD_191 : Beaming Sidekick")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_ULD_209] Vulpera Scoundrel - COST:3 [ATK:2/HP:3]
+// - Set: CORE, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Battlecry</b>: <b>Discover</b> a spell
+//       or pick a mystery choice.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - DISCOVER = 1
+// - USE_DISCOVER_VISUALS = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_ULD_209 : Vulpera Scoundrel")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+    curPlayer->GetHero()->SetDamage(6);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Vulpera Scoundrel"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Vulpera Scoundrel"));
+
+    SUBCASE("A spell card - Except ULD_209t")
+    {
+        game.Process(curPlayer, PlayCardTask::Spell(card1));
+        CHECK(curPlayer->choice != nullptr);
+
+        auto cards = TestUtils::GetChoiceCards(game);
+        for (std::size_t i = 0; i < 3; ++i)
+        {
+            CHECK_EQ(cards[i]->IsCardClass(CardClass::DRUID), true);
+            CHECK_EQ(cards[i]->GetCardType(), CardType::SPELL);
+        }
+        CHECK_EQ(cards[3]->id, "ULD_209t");
+
+        TestUtils::ChooseNthChoice(game, 1);
+        CHECK_EQ(curHand.GetCount(), 2);
+        CHECK_EQ(curHand[1]->card->IsCardClass(CardClass::DRUID), true);
+        CHECK_EQ(curHand[1]->card->GetCardType(), CardType::SPELL);
+    }
+
+    SUBCASE("Mystery Choice! - ULD_209t")
+    {
+        game.Process(curPlayer, PlayCardTask::Spell(card2));
+        CHECK(curPlayer->choice != nullptr);
+
+        auto cards = TestUtils::GetChoiceCards(game);
+        for (std::size_t i = 0; i < 3; ++i)
+        {
+            CHECK_EQ(cards[i]->IsCardClass(CardClass::DRUID), true);
+            CHECK_EQ(cards[i]->GetCardType(), CardType::SPELL);
+        }
+        CHECK_EQ(cards[3]->id, "ULD_209t");
+
+        TestUtils::ChooseNthChoice(game, 4);
+        CHECK_EQ(curHand.GetCount(), 2);
+        CHECK_EQ(curHand[1]->card->IsCardClass(CardClass::DRUID), true);
+        CHECK_EQ(curHand[1]->card->GetCardType(), CardType::SPELL);
+    }
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CORE_UNG_813] Stormwatcher - COST:7 [ATK:4/HP:8]
 // - Race: Elemental, Set: CORE, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -13094,6 +13094,59 @@ TEST_CASE("[Neutral : Minion] - CORE_UNG_848 : Primordial Drake")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_UNG_928] Tar Creeper - COST:3 [ATK:1/HP:5]
+// - Race: Elemental, Set: CORE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       Has +2 Attack during your opponent's turn.
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_UNG_928 : Tar Creeper")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Tar Creeper"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CS3_022] Fogsail Freebooter - COST:2 [ATK:2/HP:2]
 // - Race: Pirate, Set: CORE, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -13035,6 +13035,65 @@ TEST_CASE("[Neutral : Minion] - CORE_UNG_844 : Humongous Razorleaf")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [CORE_UNG_848] Primordial Drake - COST:8 [ATK:4/HP:8]
+// - Race: Dragon, Set: CORE, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Battlecry:</b> Deal 2 damage to all other minions.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CORE_UNG_848 : Primordial Drake")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Primordial Drake"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetHealth(), 12);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField[0]->GetHealth(), 12);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetHealth(), 10);
+    CHECK_EQ(opField[0]->GetHealth(), 10);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [CS3_022] Fogsail Freebooter - COST:2 [ATK:2/HP:2]
 // - Race: Pirate, Set: CORE, Rarity: Rare
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
@@ -408,3 +408,55 @@ TEST_CASE("[Neutral : Minion] - UNG_848 : Primordial Drake")
     CHECK_EQ(curField[0]->GetHealth(), 10);
     CHECK_EQ(opField[0]->GetHealth(), 10);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [UNG_928] Tar Creeper - COST:3 [ATK:1/HP:5]
+// - Race: Elemental, Set: Ungoro, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       Has +2 Attack during your opponent's turn.
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - UNG_928 : Tar Creeper")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Tar Creeper"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/UngoroCardsGenTests.cpp
@@ -350,3 +350,61 @@ TEST_CASE("[Neutral : Minion] - UNG_844 : Humongous Razorleaf")
 {
     // Do nothing
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [UNG_848] Primordial Drake - COST:8 [ATK:4/HP:8]
+// - Race: Dragon, Set: Ungoro, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Battlecry:</b> Deal 2 damage to all other minions.
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - UNG_848 : Primordial Drake")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Primordial Drake"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[0]->GetHealth(), 12);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField[0]->GetHealth(), 12);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetHealth(), 10);
+    CHECK_EQ(opField[0]->GetHealth(), 10);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/YoDCardsGenTests.cpp
@@ -987,6 +987,69 @@ TEST_CASE("[Warrior : Minion] - YOD_024 : Bomb Wrangler")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [YOD_006] Escaped Manasaber - COST:4 [ATK:3/HP:5]
+// - Race: Beast, Faction: Neutral, Set: YoD, Rarity: Epic
+// --------------------------------------------------------
+// Text: <b>Stealth</b>
+//       Whenever this attacks,
+//       gain 1 Mana Crystal this turn only.
+// --------------------------------------------------------
+// GameTag:
+// - STEALTH = 1
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - YOD_006 : Escaped Manasaber")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(5);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Escaped Manasaber"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetTotalMana(), 6);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 6);
+    CHECK_EQ(curPlayer->GetTemporaryMana(), 0);
+
+    game.Process(curPlayer, AttackTask(card1, opPlayer->GetHero()));
+    CHECK_EQ(curPlayer->GetTotalMana(), 6);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 7);
+    CHECK_EQ(curPlayer->GetTemporaryMana(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curPlayer->GetTotalMana(), 7);
+    CHECK_EQ(curPlayer->GetRemainingMana(), 7);
+    CHECK_EQ(curPlayer->GetTemporaryMana(), 0);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [YOD_030] Licensed Adventurer - COST:2 [ATK:2/HP:2]
 // - Faction: Neutral, Set: YoD, Rarity: Rare
 // --------------------------------------------------------


### PR DESCRIPTION
This revision includes:
- Implement 6 CORE cards (Resolves #755)
  - Beaming Sidekick (CORE_ULD_191)
  - Vulpera Scoundrel (CORE_ULD_209)
  - Injured Tol'vir (CORE_ULD_271)
  - Primordial Drake (CORE_UNG_848)
  - Tar Creeper (CORE_UNG_928)
  - Escaped Manasaber (CORE_YOD_006)
- Implement 2 UNGORO cards
  - Primordial Drake (UNG_848)
  - Tar Creeper (UNG_928)
- Implement 1 YEAR_OF_THE_DRAGON card
  - Escaped Manasaber (YOD_006)