### PR TITLE
Implement 8 THE_SUNKEN_CITY cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -843,15 +843,15 @@ THE_SUNKEN_CITY | TSC_017 | Baba Naga | O
 THE_SUNKEN_CITY | TSC_020 | Barbaric Sorceress |  
 THE_SUNKEN_CITY | TSC_023 | Barbed Nets |  
 THE_SUNKEN_CITY | TSC_026 | Colaque | O
-THE_SUNKEN_CITY | TSC_029 | Gaia, the Techtonic |  
+THE_SUNKEN_CITY | TSC_029 | Gaia, the Techtonic | O
 THE_SUNKEN_CITY | TSC_030 | The Leviathan | O
 THE_SUNKEN_CITY | TSC_032 | Blademaster Okani |  
 THE_SUNKEN_CITY | TSC_034 | Gorloc Ravager |  
 THE_SUNKEN_CITY | TSC_039 | Azsharan Scavenger |  
 THE_SUNKEN_CITY | TSC_052 | School Teacher |  
 THE_SUNKEN_CITY | TSC_053 | Rainbow Glowscale | O
-THE_SUNKEN_CITY | TSC_054 | Mecha-Shark |  
-THE_SUNKEN_CITY | TSC_055 | Seafloor Gateway |  
+THE_SUNKEN_CITY | TSC_054 | Mecha-Shark | O
+THE_SUNKEN_CITY | TSC_055 | Seafloor Gateway | O
 THE_SUNKEN_CITY | TSC_056 | Volcanomancy |  
 THE_SUNKEN_CITY | TSC_057 | Azsharan Defector |  
 THE_SUNKEN_CITY | TSC_058 | Predation | O
@@ -867,7 +867,7 @@ THE_SUNKEN_CITY | TSC_071 | Twinbow Terrorcoil |
 THE_SUNKEN_CITY | TSC_072 | Conch's Call | O
 THE_SUNKEN_CITY | TSC_073 | Raj Naz'jan |  
 THE_SUNKEN_CITY | TSC_074 | Kotori Lightblade |  
-THE_SUNKEN_CITY | TSC_076 | Immortalized in Stone |  
+THE_SUNKEN_CITY | TSC_076 | Immortalized in Stone | O
 THE_SUNKEN_CITY | TSC_079 | Radar Detector |  
 THE_SUNKEN_CITY | TSC_083 | Seafloor Savior |  
 THE_SUNKEN_CITY | TSC_085 | Cutlass Courier |  
@@ -920,7 +920,7 @@ THE_SUNKEN_CITY | TSC_702 | Switcheroo |
 THE_SUNKEN_CITY | TSC_753 | Bloodscent Vilefin |  
 THE_SUNKEN_CITY | TSC_772 | Azsharan Scroll |  
 THE_SUNKEN_CITY | TSC_775 | Azsharan Ritual |  
-THE_SUNKEN_CITY | TSC_776 | Azsharan Sweeper |  
+THE_SUNKEN_CITY | TSC_776 | Azsharan Sweeper | O
 THE_SUNKEN_CITY | TSC_823 | Murkwater Scribe |  
 THE_SUNKEN_CITY | TSC_826 | Crushclaw Enforcer |  
 THE_SUNKEN_CITY | TSC_827 | Vicious Slitherspear |  
@@ -932,7 +932,7 @@ THE_SUNKEN_CITY | TSC_911 | Excavation Specialist |
 THE_SUNKEN_CITY | TSC_912 | Azsharan Vessel |  
 THE_SUNKEN_CITY | TSC_913 | Azsharan Trident |  
 THE_SUNKEN_CITY | TSC_915 | Bone Glaive |  
-THE_SUNKEN_CITY | TSC_916 | Gone Fishin' |  
+THE_SUNKEN_CITY | TSC_916 | Gone Fishin' | O
 THE_SUNKEN_CITY | TSC_917 | Blackscale Brute |  
 THE_SUNKEN_CITY | TSC_919 | Azsharan Sentinel |  
 THE_SUNKEN_CITY | TSC_922 | Anchored Totem |  
@@ -943,7 +943,7 @@ THE_SUNKEN_CITY | TSC_926 | Smothering Starfish |
 THE_SUNKEN_CITY | TSC_927 | Azsharan Gardens |  
 THE_SUNKEN_CITY | TSC_928 | Security Automaton |  
 THE_SUNKEN_CITY | TSC_929 | Emergency Maneuvers |  
-THE_SUNKEN_CITY | TSC_932 | Blood in the Water |  
+THE_SUNKEN_CITY | TSC_932 | Blood in the Water | O
 THE_SUNKEN_CITY | TSC_933 | Bootstrap Sunkeneer |  
 THE_SUNKEN_CITY | TSC_934 | Pirate Admiral Hooktusk |  
 THE_SUNKEN_CITY | TSC_935 | Selfish Shellfish |  
@@ -952,7 +952,7 @@ THE_SUNKEN_CITY | TSC_937 | Crabatoa |
 THE_SUNKEN_CITY | TSC_938 | Treasure Guard | O
 THE_SUNKEN_CITY | TSC_939 | Forged in Flame |  
 THE_SUNKEN_CITY | TSC_940 | From the Depths |  
-THE_SUNKEN_CITY | TSC_941 | Guard the City |  
+THE_SUNKEN_CITY | TSC_941 | Guard the City | O
 THE_SUNKEN_CITY | TSC_942 | Obsidiansmith |  
 THE_SUNKEN_CITY | TSC_943 | Lady Ashvane |  
 THE_SUNKEN_CITY | TSC_944 | The Fires of Zin-Azshari |  
@@ -970,7 +970,7 @@ THE_SUNKEN_CITY | TSC_960 | Twin-fin Fin Twin |
 THE_SUNKEN_CITY | TSC_962 | Gigafin |  
 THE_SUNKEN_CITY | TSC_963 | Filletfighter | O
 
-- Progress: 8% (14 of 170 Cards)
+- Progress: 12% (22 of 170 Cards)
 
 ## Murder at Castle Nathria
 

--- a/Includes/Rosetta/Common/Enums/TaskEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/TaskEnums.hpp
@@ -93,6 +93,15 @@ enum class SummonSide
                          //!< alternately for opponent.
 };
 
+//! \brief An enumerator for identifying the position of putting card(s)
+//! on the deck.
+enum class DeckPosition
+{
+    RANDOM,  //! Putting card(s) on the random position.
+    TOP,     //! Putting card(s) on the top position.
+    BOTTOM,  //! Putting card(s) on the bottom position.
+};
+
 //! \brief An enumerator for evaluating the relation between primitive values
 //! during game simulation.
 enum class RelaSign

--- a/Includes/Rosetta/PlayMode/Enchants/Power.hpp
+++ b/Includes/Rosetta/PlayMode/Enchants/Power.hpp
@@ -158,6 +158,7 @@ class Power
     std::vector<std::shared_ptr<ITask>> m_comboTask;
     std::vector<std::shared_ptr<ITask>> m_topdeckTask;
     std::vector<std::shared_ptr<ITask>> m_afterChooseTask;
+    std::vector<std::shared_ptr<ITask>> m_afterChooseForComboTask;
     std::vector<std::shared_ptr<ITask>> m_outcastTask;
     std::vector<std::shared_ptr<ITask>> m_spellburstTask;
     std::vector<std::shared_ptr<ITask>> m_frenzyTask;

--- a/Includes/Rosetta/PlayMode/Enchants/Power.hpp
+++ b/Includes/Rosetta/PlayMode/Enchants/Power.hpp
@@ -61,6 +61,10 @@ class Power
     //! \return A list of after choose tasks.
     std::vector<std::shared_ptr<ITask>>& GetAfterChooseTask();
 
+    //! Returns a list of after choose tasks for combo.
+    //! \return A list of after choose tasks for combo.
+    std::vector<std::shared_ptr<ITask>>& GetAfterChooseForComboTask();
+
     //! Returns a list of outcast tasks.
     //! \return A list of outcast tasks.
     std::vector<std::shared_ptr<ITask>>& GetOutcastTask();

--- a/Includes/Rosetta/PlayMode/Enchants/Power.hpp
+++ b/Includes/Rosetta/PlayMode/Enchants/Power.hpp
@@ -124,6 +124,10 @@ class Power
     //! \param task A pointer to after choose task.
     void AddAfterChooseTask(const std::shared_ptr<ITask>& task);
 
+    //! Adds after choose task for combo task.
+    //! \param task A pointer to after choose task for combo task.
+    void AddAfterChooseForComboTask(const std::shared_ptr<ITask>& task);
+
     //! Adds outcast task.
     //! \param task A pointer to outcast task.
     void AddOutcastTask(const std::shared_ptr<ITask>& task);

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks.hpp
@@ -76,6 +76,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/MoveToSetasideTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/NumberConditionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/PlayTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/PutCardDeckTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/QuestProgressTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomCardTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomEntourageTask.hpp>

--- a/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/PutCardDeckTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/SimpleTasks/PutCardDeckTask.hpp
@@ -1,0 +1,44 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2019 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2019 Chris Ohk, Youngjoong Kim, SeungHyun Jeon
+
+#ifndef ROSETTASTONE_PLAYMODE_PUT_CARD_DECK_TASK_HPP
+#define ROSETTASTONE_PLAYMODE_PUT_CARD_DECK_TASK_HPP
+
+#include <Rosetta/PlayMode/Tasks/ITask.hpp>
+
+namespace RosettaStone::PlayMode::SimpleTasks
+{
+//!
+//! \brief PutCardDeckTask class.
+//!
+//! This class represents the task for putting card(s) on the deck.
+//!
+class PutCardDeckTask : public ITask
+{
+ public:
+    //! Constructs task with given \p cardID, \p position and \p amount.
+    //! \param cardID The ID of card to put on the deck.
+    //! \param position The position of card to put on the deck.
+    //! \param amount The number of card to put on the deck.
+    explicit PutCardDeckTask(std::string cardID, DeckPosition position,
+                             int amount = 1);
+
+ private:
+    //! Processes task logic internally and returns meta data.
+    //! \param player The player to run task.
+    //! \return The result of task processing.
+    TaskStatus Impl(Player* player) override;
+
+    //! Internal method of Clone().
+    //! \return The cloned task.
+    std::unique_ptr<ITask> CloneImpl() override;
+
+    std::string m_cardID;
+    DeckPosition m_position;
+    int m_amount = 1;
+};
+}  // namespace RosettaStone::PlayMode::SimpleTasks
+
+#endif  // ROSETTASTONE_PLAYMODE_PUT_CARD_DECK_TASK_HPP

--- a/Includes/Rosetta/RosettaStone.hpp
+++ b/Includes/Rosetta/RosettaStone.hpp
@@ -247,6 +247,7 @@
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/MoveToSetasideTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/NumberConditionTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/PlayTask.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/PutCardDeckTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/QuestProgressTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomCardTask.hpp>
 #include <Rosetta/PlayMode/Tasks/SimpleTasks/RandomEntourageTask.hpp>

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 81% Forged in the Barrens (139 of 170 cards)
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
-  * 8% Voyage to the Sunken City (14 of 170 cards)
+  * 12% Voyage to the Sunken City (22 of 170 cards)
   * 0% Murder at Castle Nathria (0 of 1 cards)
 
 ### Wild Format

--- a/Sources/Rosetta/PlayMode/Actions/Choose.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Choose.cpp
@@ -346,6 +346,12 @@ bool ChoicePick(Player* player, int choice)
 
                 clonedTask->Run();
             }
+
+            // Set combo active to true
+            if (!player->IsComboActive())
+            {
+                player->SetComboActive(true);
+            }
         }
 
         // NOTE: Temporary code for 'Dwarven Archaeologist' (ULD_309)

--- a/Sources/Rosetta/PlayMode/Actions/Choose.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Choose.cpp
@@ -318,8 +318,11 @@ bool ChoicePick(Player* player, int choice)
         // Process after choose tasks
         if (choiceVal->source)
         {
+            const auto card = choiceVal->source->card;
             const auto tasks =
-                choiceVal->source->card->power.GetAfterChooseTask();
+                player->IsComboActive() && card->HasGameTag(GameTag::COMBO)
+                    ? card->power.GetAfterChooseForComboTask()
+                    : card->power.GetAfterChooseTask();
 
             if (!choiceVal->entityStack.empty())
             {

--- a/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
@@ -185,7 +185,7 @@ void PlayCard(Player* player, Playable* source, Character* target, int fieldPos,
     }
 
     // Set combo active to true
-    if (!player->IsComboActive())
+    if (!player->IsComboActive() && !player->choice)
     {
         player->SetComboActive(true);
     }

--- a/Sources/Rosetta/PlayMode/Actions/Summon.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Summon.cpp
@@ -88,7 +88,7 @@ void SummonAppendages(
             std::nullopt, summoner->player->GetFieldZone()));
         int alternateCount = 0;
         const int summonPos = SummonTask::GetPosition(
-            summoner, SummonSide::RIGHT, appendageMinion, alternateCount);
+            summoner, std::get<1>(appendage), appendageMinion, alternateCount);
 
         Summon(appendageMinion, summonPos, summoner);
     }

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -2319,6 +2319,8 @@ void TheSunkenCityCardsGen::AddWarlockNonCollect(
 
 void TheSunkenCityCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // --------------------------------------- MINION - WARRIOR
     // [TSC_659] Trenchstalker - COST:9 [ATK:8/HP:9]
     // - Race: Beast, Set: THE_SUNKEN_CITY, Rarity: Epic
@@ -2397,6 +2399,11 @@ void TheSunkenCityCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<ArmorTask>(3));
+    cardDef.power.AddPowerTask(
+        std::make_shared<SummonTask>("TSC_941t", SummonSide::SPELL));
+    cards.emplace("TSC_941", cardDef);
 
     // --------------------------------------- MINION - WARRIOR
     // [TSC_942] Obsidiansmith - COST:2 [ATK:3/HP:2]
@@ -2471,6 +2478,8 @@ void TheSunkenCityCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 void TheSunkenCityCardsGen::AddWarriorNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [TSC_660e] Mercenary's Fee - COST:0
     // - Set: THE_SUNKEN_CITY
@@ -2536,6 +2545,9 @@ void TheSunkenCityCardsGen::AddWarriorNonCollect(
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("TSC_941t", cardDef);
 
     // ---------------------------------- ENCHANTMENT - WARRIOR
     // [TSC_942e] Flameforged - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -691,6 +691,16 @@ void TheSunkenCityCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // Text: Draw a Mech.
     //       Reduce the Cost of Mechs in your hand by (1).
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DrawRaceMinionTask>(Race::MECHANICAL, 1, false));
+    cardDef.power.AddPowerTask(std::make_shared<IncludeTask>(EntityType::HAND));
+    cardDef.power.AddPowerTask(std::make_shared<FilterStackTask>(
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsRace(Race::MECHANICAL)) }));
+    cardDef.power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("TSC_055e", EntityType::STACK));
+    cards.emplace("TSC_055", cardDef);
 
     // ------------------------------------------- SPELL - MAGE
     // [TSC_056] Volcanomancy - COST:2
@@ -845,6 +855,9 @@ void TheSunkenCityCardsGen::AddMageNonCollect(
     // --------------------------------------------------------
     // Text: Costs (1) less.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddEnchant(std::make_shared<Enchant>(Effects::ReduceCost(1)));
+    cards.emplace("TSC_055e", cardDef);
 
     // ------------------------------------- ENCHANTMENT - MAGE
     // [TSC_056e] Explosive - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -1037,9 +1037,22 @@ void TheSunkenCityCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Summon a 1/2, 2/4 and 4/8 Elemental with <b>Taunt</b>.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_NUM_MINION_SLOTS = 1
+    // --------------------------------------------------------
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<SummonTask>("TSC_076t", SummonSide::SPELL));
+    cardDef.power.AddPowerTask(
+        std::make_shared<SummonTask>("TSC_076t2", SummonSide::SPELL));
+    cardDef.power.AddPowerTask(
+        std::make_shared<SummonTask>("TSC_076t3", SummonSide::SPELL));
+    cardDef.property.playReqs =
+        PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } };
+    cards.emplace("TSC_076", cardDef);
 
     // ---------------------------------------- SPELL - PALADIN
     // [TSC_079] Radar Detector - COST:2
@@ -1165,6 +1178,9 @@ void TheSunkenCityCardsGen::AddPaladinNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("TSC_076t", cardDef);
 
     // --------------------------------------- MINION - PALADIN
     // [TSC_076t2] Living Statue - COST:3 [ATK:2/HP:4]
@@ -1175,6 +1191,9 @@ void TheSunkenCityCardsGen::AddPaladinNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("TSC_076t2", cardDef);
 
     // --------------------------------------- MINION - PALADIN
     // [TSC_076t3] Pristine Statue - COST:5 [ATK:4/HP:8]
@@ -1185,6 +1204,9 @@ void TheSunkenCityCardsGen::AddPaladinNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("TSC_076t3", cardDef);
 
     // --------------------------------------- MINION - PALADIN
     // [TSC_644t] Sunken Mooncatcher - COST:3 [ATK:4/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -1479,6 +1479,11 @@ void TheSunkenCityCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // - COMBO = 1
     // - DREDGE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<DredgeTask>());
+    cardDef.power.AddComboTask(std::make_shared<DredgeTask>());
+    cardDef.power.AddAfterChooseForComboTask(std::make_shared<DrawTask>(1));
+    cards.emplace("TSC_916", cardDef);
 
     // ------------------------------------------ SPELL - ROGUE
     // [TSC_932] Blood in the Water - COST:6

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -772,6 +772,10 @@ void TheSunkenCityCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<PutCardDeckTask>("TSC_776t", DeckPosition::BOTTOM));
+    cards.emplace("TSC_776", cardDef);
 
     // ------------------------------------------- SPELL - MAGE
     // [TSC_948] Gifts of Azshara - COST:2
@@ -875,6 +879,13 @@ void TheSunkenCityCardsGen::AddMageNonCollect(
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<EnqueueTask>(
+        TaskList{ std::make_shared<RandomCardTask>(
+                      CardType::MINION, CardClass::INVALID, Race::MECHANICAL),
+                  std::make_shared<AddStackToTask>(EntityType::HAND) },
+        3));
+    cards.emplace("TSC_776t", cardDef);
 
     // ------------------------------------- ENCHANTMENT - MAGE
     // [TID_707e] Submerged - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -630,6 +630,8 @@ void TheSunkenCityCardsGen::AddHunterNonCollect(
 
 void TheSunkenCityCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ------------------------------------------ MINION - MAGE
     // [TSC_029] Gaia, the Techtonic - COST:8 [ATK:5/HP:7]
     // - Race: Mechanical, Set: THE_SUNKEN_CITY, Rarity: Legendary
@@ -643,6 +645,18 @@ void TheSunkenCityCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // - COLOSSAL = 1
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::MINIONS;
+    cardDef.power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::MECHANICAL))
+    };
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<DamageTask>(
+        EntityType::ENEMIES, 1) };
+    cardDef.property.appendages = { { "TSC_029t", SummonSide::LEFT },
+                                    { "TSC_029t2", SummonSide::RIGHT } };
+    cards.emplace("TSC_029", cardDef);
 
     // ------------------------------------------ MINION - MAGE
     // [TSC_054] Mecha-Shark - COST:3 [ATK:4/HP:3]
@@ -782,6 +796,8 @@ void TheSunkenCityCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 void TheSunkenCityCardsGen::AddMageNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ------------------------------------------ MINION - MAGE
     // [TSC_029t] Gaia's Drill - COST:3 [ATK:2/HP:3]
     // - Race: Mechanical, Set: THE_SUNKEN_CITY
@@ -791,6 +807,9 @@ void TheSunkenCityCardsGen::AddMageNonCollect(
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("TSC_029t", cardDef);
 
     // ------------------------------------------ MINION - MAGE
     // [TSC_029t2] Gaia's Drill - COST:3 [ATK:2/HP:3]
@@ -801,6 +820,9 @@ void TheSunkenCityCardsGen::AddMageNonCollect(
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("TSC_029t2", cardDef);
 
     // ------------------------------------- ENCHANTMENT - MAGE
     // [TSC_055e] Mechanical Marvel - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -1492,9 +1492,21 @@ void TheSunkenCityCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // Text: Deal 3 damage to an enemy.
     //       Summon a 5/5 Shark with <b>Rush</b>.
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_ENEMY_TARGET = 0
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
     // RefTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 3, true));
+    cardDef.power.AddPowerTask(
+        std::make_shared<SummonTask>("TSC_932t", SummonSide::SPELL));
+    cardDef.property.playReqs = PlayReqs{ { PlayReq::REQ_ENEMY_TARGET, 0 },
+                                          { PlayReq::REQ_TARGET_TO_PLAY, 0 } };
+    cards.emplace("TSC_932", cardDef);
 
     // ----------------------------------------- MINION - ROGUE
     // [TSC_933] Bootstrap Sunkeneer - COST:5 [ATK:4/HP:4]
@@ -1606,6 +1618,8 @@ void TheSunkenCityCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 void TheSunkenCityCardsGen::AddRogueNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ------------------------------------ ENCHANTMENT - ROGUE
     // [TSC_086e] Sharp Point - COST:0
     // - Set: THE_SUNKEN_CITY
@@ -1656,6 +1670,9 @@ void TheSunkenCityCardsGen::AddRogueNonCollect(
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("TSC_932t", cardDef);
 
     // ------------------------------------------ SPELL - ROGUE
     // [TSC_934t] Take their Supplies! - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -668,6 +668,21 @@ void TheSunkenCityCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::AFTER_SUMMON));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    cardDef.power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsRace(Race::MECHANICAL))
+    };
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<EnqueueTask>(
+        TaskList{
+            std::make_shared<FilterStackTask>(SelfCondList{
+                std::make_shared<SelfCondition>(SelfCondition::IsNotDead()) }),
+            std::make_shared<RandomTask>(EntityType::ENEMIES, 1),
+            std::make_shared<DamageTask>(EntityType::STACK, 1) },
+        3) };
+    cards.emplace("TSC_054", cardDef);
 
     // ------------------------------------------- SPELL - MAGE
     // [TSC_055] Seafloor Gateway - COST:3

--- a/Sources/Rosetta/PlayMode/Enchants/Power.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/Power.cpp
@@ -143,6 +143,11 @@ void Power::AddAfterChooseTask(const std::shared_ptr<ITask>& task)
     m_afterChooseTask.emplace_back(task);
 }
 
+void Power::AddAfterChooseForComboTask(const std::shared_ptr<ITask>& task)
+{
+    m_afterChooseForComboTask.emplace_back(task);
+}
+
 void Power::AddOutcastTask(const std::shared_ptr<ITask>& task)
 {
     m_outcastTask.emplace_back(task);

--- a/Sources/Rosetta/PlayMode/Enchants/Power.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/Power.cpp
@@ -50,6 +50,11 @@ std::vector<std::shared_ptr<ITask>>& Power::GetAfterChooseTask()
     return m_afterChooseTask;
 }
 
+std::vector<std::shared_ptr<ITask>>& Power::GetAfterChooseForComboTask()
+{
+    return m_afterChooseForComboTask;
+}
+
 std::vector<std::shared_ptr<ITask>>& Power::GetOutcastTask()
 {
     return m_outcastTask;

--- a/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/PlayMode/Loaders/CardLoader.cpp
@@ -135,8 +135,9 @@ void CardLoader::Load(std::vector<Card*>& cards)
         //       Stoneclaw Totem (AT_132_SHAMANc), Wrath of Air Totem
         //       (AT_132_SHAMANd), Strength Totem (AT_132_SHAMANe)
         //       doesn't have Race::TOTEM
-        // NOTE: Wailing Demon (WC_003t) doesn't have GameTag::TAUNT
-        // NOTE: Spring the Trap(AV_224), Axe Berserker (AV_565)
+        // NOTE: Wailing Demon (WC_003t), Naga Centaur (TSC_941t)
+        //       doesn't have GameTag::TAUNT
+        // NOTE: Spring the Trap (AV_224), Axe Berserker (AV_565)
         //       doesn't have GameTag::HONORABLEKILL
         if (dbfID == 56091 || dbfID == 64196)
         {
@@ -159,7 +160,7 @@ void CardLoader::Load(std::vector<Card*>& cards)
         {
             cardRace = static_cast<int>(Race::TOTEM);
         }
-        else if (dbfID == 63500)
+        else if (dbfID == 63500 || dbfID == 74675)
         {
             gameTags.emplace(GameTag::TAUNT, 1);
         }

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/AddCardTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/AddCardTask.cpp
@@ -20,8 +20,6 @@ AddCardTask::AddCardTask(EntityType entityType, std::string cardID, int amount)
 
 TaskStatus AddCardTask::Impl(Player* player)
 {
-    std::vector<Entity*> entities;
-
     switch (m_entityType)
     {
         case EntityType::HAND:

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/PutCardDeckTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/PutCardDeckTask.cpp
@@ -1,0 +1,55 @@
+// This code is based on Sabberstone project.
+// Copyright (c) 2017-2021 SabberStone Team, darkfriend77 & rnilva
+// RosettaStone is hearthstone simulator using C++ with reinforcement learning.
+// Copyright (c) 2017-2021 Chris Ohk
+
+#include <Rosetta/PlayMode/Actions/Generic.hpp>
+#include <Rosetta/PlayMode/Cards/Cards.hpp>
+#include <Rosetta/PlayMode/Tasks/SimpleTasks/PutCardDeckTask.hpp>
+#include <Rosetta/PlayMode/Zones/DeckZone.hpp>
+
+#include <utility>
+
+namespace RosettaStone::PlayMode::SimpleTasks
+{
+PutCardDeckTask::PutCardDeckTask(std::string cardID, DeckPosition position,
+                                 int amount)
+    : m_cardID(std::move(cardID)), m_position(position), m_amount(amount)
+{
+    // Do nothing
+}
+
+TaskStatus PutCardDeckTask::Impl(Player* player)
+{
+    for (int i = 0; i < m_amount; ++i)
+    {
+        if (m_player->GetDeckZone()->IsFull())
+        {
+            break;
+        }
+
+        Card* card = Cards::FindCardByID(m_cardID);
+        Playable* playable = Entity::GetFromCard(player, card);
+
+        switch (m_position)
+        {
+            case DeckPosition::RANDOM:
+                Generic::ShuffleIntoDeck(player, m_source, playable);
+                break;
+            case DeckPosition::TOP:
+                m_player->GetDeckZone()->Add(playable);
+                break;
+            case DeckPosition::BOTTOM:
+                m_player->GetDeckZone()->Add(playable, 0);
+                break;
+        }
+    }
+
+    return TaskStatus::COMPLETE;
+}
+
+std::unique_ptr<ITask> PutCardDeckTask::CloneImpl()
+{
+    return std::make_unique<PutCardDeckTask>(m_cardID, m_position, m_amount);
+}
+}  // namespace RosettaStone::PlayMode::SimpleTasks

--- a/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
@@ -802,6 +802,51 @@ TEST_CASE("[Rogue : Minion] - TSC_963 : Filletfighter")
     CHECK_EQ(opField[0]->GetHealth(), 1);
 }
 
+// ---------------------------------------- SPELL - WARRIOR
+// [TSC_941] Guard the City - COST:2
+// - Set: THE_SUNKEN_CITY, Rarity: Common
+// --------------------------------------------------------
+// Text: Gain 3 Armor.
+//       Summon a 2/3 Naga with <b>Taunt</b>.
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Spell] - TSC_941 : Guard the City")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Guard the City"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 3);
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Naga Centaur");
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+}
+
 // ------------------------------------ SPELL - DEMONHUNTER
 // [TSC_058] Predation - COST:3
 // - Set: THE_SUNKEN_CITY, Rarity: Rare

--- a/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
@@ -310,6 +310,63 @@ TEST_CASE("[Mage : Minion] - TSC_029 : Gaia, the Techtonic")
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
 }
 
+// ------------------------------------------ MINION - MAGE
+// [TSC_054] Mecha-Shark - COST:3 [ATK:4/HP:3]
+// - Race: Mechanical, Set: THE_SUNKEN_CITY, Rarity: Common
+// --------------------------------------------------------
+// Text: After you summon a Mech,
+//       deal 3 damage randomly split among all enemies.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - TSC_054 : Mecha-Shark")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Mecha-Shark"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Naval Mine"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(opField[0]->GetHealth(), 12);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+
+    const int totalHealth =
+        opPlayer->GetHero()->GetHealth() + opField[0]->GetHealth();
+    CHECK_EQ(totalHealth, 39);
+}
+
 // --------------------------------------- MINION - PALADIN
 // [TSC_030] The Leviathan - COST:7 [ATK:4/HP:5]
 // - Race: Mechanical, Set: THE_SUNKEN_CITY, Rarity: Legendary

--- a/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
@@ -367,6 +367,57 @@ TEST_CASE("[Mage : Minion] - TSC_054 : Mecha-Shark")
     CHECK_EQ(totalHealth, 39);
 }
 
+// ------------------------------------------- SPELL - MAGE
+// [TSC_055] Seafloor Gateway - COST:3
+// - Set: THE_SUNKEN_CITY, Rarity: Rare
+// --------------------------------------------------------
+// Text: Draw a Mech.
+//       Reduce the Cost of Mechs in your hand by (1).
+// --------------------------------------------------------
+TEST_CASE("[Mage : Spell] - TSC_055 : Seafloor Gateway")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Bloodfen Raptor");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Fireball");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Naval Mine");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Seafloor Gateway"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Naval Mine"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curHand.GetCount(), 7);
+    CHECK_EQ(card2->GetCost(), 1);
+    CHECK_EQ(card3->GetCost(), 9);
+    CHECK_EQ(curHand[6]->card->name, "Naval Mine");
+    CHECK_EQ(curHand[6]->GetCost(), 1);
+}
+
 // --------------------------------------- MINION - PALADIN
 // [TSC_030] The Leviathan - COST:7 [ATK:4/HP:5]
 // - Race: Mechanical, Set: THE_SUNKEN_CITY, Rarity: Legendary

--- a/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
@@ -698,6 +698,56 @@ TEST_CASE("[Rogue : Spell] - TSC_916 : Gone Fishin'")
     CHECK_EQ(curDeck.GetTopCard()->card->name, "Pyroblast");
 }
 
+// ------------------------------------------ SPELL - ROGUE
+// [TSC_932] Blood in the Water - COST:6
+// - Set: THE_SUNKEN_CITY, Rarity: Common
+// --------------------------------------------------------
+// Text: Deal 3 damage to an enemy.
+//       Summon a 5/5 Shark with <b>Rush</b>.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_ENEMY_TARGET = 0
+// - REQ_TARGET_TO_PLAY = 0
+// --------------------------------------------------------
+// RefTag:
+// - RUSH = 1
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Spell] - TSC_932 : Blood in the Water")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Blood in the Water"));
+
+    game.Process(curPlayer,
+                 PlayCardTask::SpellTarget(card1, opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 27);
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Tiger Shark");
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+    CHECK_EQ(curField[0]->HasRush(), true);
+}
+
 // ----------------------------------------- MINION - ROGUE
 // [TSC_963] Filletfighter - COST:1 [ATK:3/HP:1]
 // - Race: Pirate, Set: THE_SUNKEN_CITY, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
@@ -565,6 +565,58 @@ TEST_CASE("[Paladin : Minion] - TSC_030 : The Leviathan")
     CHECK_EQ(curHand[5]->card->name, "Pyroblast");
 }
 
+// ---------------------------------------- SPELL - PALADIN
+// [TSC_076] Immortalized in Stone - COST:7
+// - Set: THE_SUNKEN_CITY, Rarity: Common
+// - Spell School: Holy
+// --------------------------------------------------------
+// Text: Summon a 1/2, 2/4 and 4/8 Elemental with <b>Taunt</b>.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Spell] - TSC_076 : Immortalized in Stone")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doShuffle = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Immortalized in Stone"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[0]->GetAttack(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 4);
+    CHECK_EQ(curField[1]->HasTaunt(), true);
+    CHECK_EQ(curField[2]->GetAttack(), 4);
+    CHECK_EQ(curField[2]->GetHealth(), 8);
+    CHECK_EQ(curField[2]->HasTaunt(), true);
+}
+
 // ----------------------------------------- MINION - ROGUE
 // [TSC_963] Filletfighter - COST:1 [ATK:3/HP:1]
 // - Race: Pirate, Set: THE_SUNKEN_CITY, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheSunkenCityCardsGenTests.cpp
@@ -418,6 +418,64 @@ TEST_CASE("[Mage : Spell] - TSC_055 : Seafloor Gateway")
     CHECK_EQ(curHand[6]->GetCost(), 1);
 }
 
+// ------------------------------------------ MINION - MAGE
+// [TSC_776] Azsharan Sweeper - COST:3 [ATK:3/HP:4]
+// - Race: Mechanical, Set: THE_SUNKEN_CITY, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b>
+//       Put a 'Sunken Sweeper' on the bottom of your deck.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Mage : Minion] - TSC_776 : Azsharan Sweeper")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 3)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Bloodfen Raptor");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Fireball");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Naval Mine");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curDeck = *(curPlayer->GetDeckZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Azsharan Sweeper"));
+    // Sunken Sweeper (TSC_776t)
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByID("TSC_776t"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+    CHECK_EQ(curDeck.GetCount(), 27);
+    CHECK_EQ(curDeck.GetBottomCard()->card->name, "Sunken Sweeper");
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curHand.GetCount(), 7);
+    CHECK_EQ(curHand[4]->card->GetRace(), Race::MECHANICAL);
+    CHECK_EQ(curHand[5]->card->GetRace(), Race::MECHANICAL);
+    CHECK_EQ(curHand[6]->card->GetRace(), Race::MECHANICAL);
+}
+
 // --------------------------------------- MINION - PALADIN
 // [TSC_030] The Leviathan - COST:7 [ATK:4/HP:5]
 // - Race: Mechanical, Set: THE_SUNKEN_CITY, Rarity: Legendary


### PR DESCRIPTION
This revision includes:
- Implement 8 THE_SUNKEN_CITY cards
  - Gaia, the Techtonic (TSC_029)
  - Mecha-Shark (TSC_054)
  - Seafloor Gateway (TSC_055)
  - Immortalized in Stone (TSC_076)
  - Azsharan Sweeper (TSC_776)
  - Gone Fishin' (TSC_916)
  - Blood in the Water (TSC_932)
  - Guard the City (TSC_941)
- Add enum 'DeckPosition': An enumerator for identifying the position of putting card(s) on the deck
- Create class 'PutCardDeckTask': This class represents the task for putting card(s) on the deck
- Add variable 'm_afterChooseForComboTask'
  - Add related methods
    - GetAfterChooseForComboTask(): Returns a list of after choose tasks for combo
    - AddAfterChooseForComboTask(): Adds after choose task for combo task
  - Add code to check the player is choosing a card
  - Add code to process after choose for combo task
  - Add code to set combo active to true
- Correct code to summon appendages according to summon side
- Add code to emplace missing game tag 'TAUNT'
- Delete unused code to define local variable