### PR TITLE
Implement 5 BRM cards

### DIFF
--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -652,19 +652,19 @@ GVG | GVG_123 | Soot Spewer |
 Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
 BRM | BRM_001 | Solemn Vigil |  
-BRM | BRM_002 | Flamewaker |  
-BRM | BRM_003 | Dragon's Breath |  
+BRM | BRM_002 | Flamewaker | O
+BRM | BRM_003 | Dragon's Breath | O
 BRM | BRM_004 | Twilight Whelp |  
 BRM | BRM_005 | Demonwrath |  
 BRM | BRM_006 | Imp Gang Boss | O
 BRM | BRM_007 | Gang Up |  
 BRM | BRM_008 | Dark Iron Skulker |  
-BRM | BRM_009 | Volcanic Lumberer |  
-BRM | BRM_010 | Druid of the Flame |  
+BRM | BRM_009 | Volcanic Lumberer | O
+BRM | BRM_010 | Druid of the Flame | O
 BRM | BRM_011 | Lava Shock |  
 BRM | BRM_012 | Fireguard Destroyer |  
 BRM | BRM_013 | Quick Shot | O
-BRM | BRM_014 | Core Rager |  
+BRM | BRM_014 | Core Rager | O
 BRM | BRM_015 | Revenge |  
 BRM | BRM_016 | Axe Flinger |  
 BRM | BRM_017 | Resurrect |  
@@ -683,7 +683,7 @@ BRM | BRM_031 | Chromaggus |
 BRM | BRM_033 | Blackwing Technician |  
 BRM | BRM_034 | Blackwing Corruptor |  
 
-- Progress: 6% (2 of 31 Cards)
+- Progress: 22% (7 of 31 Cards)
 
 ## The Grand Tournament
 

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
@@ -335,6 +335,23 @@ class ComplexTask
                          std::make_shared<SimpleTasks::CopyTask>(
                              EntityType::STACK, ZoneType::HAND) };
     }
+
+    //! Returns a list of task for dealing damage to random target(s).
+    //! \param entityType The type of entity.
+    //! \param numTarget The number of target(s).
+    //! \param damage A value indicating how much to deal.
+    //! \param isSpellDamage true if it is spell damage, and false otherwise.
+    static TaskList DamageRandomTargets(EntityType entityType, int numTarget, 
+                                        int damage, bool isSpellDamage = false)
+    {
+        return TaskList{
+            std::make_shared<SimpleTasks::FilterStackTask>(SelfCondList{
+                std::make_shared<SelfCondition>(SelfCondition::IsNotDead()) }),
+            std::make_shared<SimpleTasks::RandomTask>(entityType, numTarget),
+            std::make_shared<SimpleTasks::DamageTask>(EntityType::STACK, damage,
+                                                      isSpellDamage)
+        };
+    }
 };
 }  // namespace RosettaStone::PlayMode
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * **100% Demon Hunter Initiate (20 of 20 Cards)**
   * **100% Curse of Naxxramas (30 of 30 Cards)**
   * 6% Goblins vs Gnomes (8 of 123 Cards)
-  * 6% Blackrock Mountain (2 of 31 Cards)
+  * 22% Blackrock Mountain (7 of 31 Cards)
   * 8% The Grand Tournament (11 of 132 Cards)
   * 20% The League of Explorers (9 of 45 Cards)
   * 5% Whispers of the Old Gods (8 of 134 Cards)

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -69,16 +69,27 @@ void BrmCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - CHOOSE_ONE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<TransformTask>(EntityType::SOURCE, "OG_044b"));
+    cardDef.property.chooseCardIDs = ChooseCardIDs{ "BRM_010a", "BRM_010b" };
+    cards.emplace("BRM_010", cardDef);
 }
 
 void BrmCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ------------------------------------------ SPELL - DRUID
     // [BRM_010a] Firecat Form (*) - COST:0
     // - Set: Brm
     // --------------------------------------------------------
     // Text: Transform into a 5/2 minion.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<TransformTask>(EntityType::SOURCE, "BRM_010t"));
+    cards.emplace("BRM_010a", cardDef);
 
     // ------------------------------------------ SPELL - DRUID
     // [BRM_010b] Fire Hawk Form (*) - COST:0
@@ -86,21 +97,34 @@ void BrmCardsGen::AddDruidNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Transform into a 2/5 minion.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<TransformTask>(EntityType::SOURCE, "BRM_010t2"));
+    cards.emplace("BRM_010b", cardDef);
 
     // ----------------------------------------- MINION - DRUID
     // [BRM_010t] Druid of the Flame (*) - COST:3 [ATK:5/HP:2]
     // - Race: Beast, Set: Brm, Rarity: Common
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("BRM_010t", cardDef);
 
     // ----------------------------------------- MINION - DRUID
     // [BRM_010t2] Druid of the Flame (*) - COST:3 [ATK:2/HP:5]
     // - Race: Beast, Set: Brm, Rarity: Common
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("BRM_010t2", cardDef);
 
     // ----------------------------------------- MINION - DRUID
     // [OG_044b] Druid of the Flame (*) - COST:3 [ATK:5/HP:5]
     // - Race: Beast, Set: Brm, Rarity: Common
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("OG_044b", cardDef);
 }
 
 void BrmCardsGen::AddHunter(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -40,6 +40,8 @@ void BrmCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 
 void BrmCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ----------------------------------------- MINION - DRUID
     // [BRM_009] Volcanic Lumberer - COST:9 [ATK:7/HP:8]
     // - Set: Brm, Rarity: Rare
@@ -50,6 +52,12 @@ void BrmCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(
+        std::make_shared<AdaptiveCostEffect>([=](const Playable* playable) {
+            return playable->player->GetNumFriendlyMinionsDiedThisTurn();
+        }));
+    cards.emplace("BRM_009", cardDef);
 
     // ----------------------------------------- MINION - DRUID
     // [BRM_010] Druid of the Flame - COST:3 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -218,6 +218,15 @@ void BrmCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // PlayReq:
     // - REQ_TARGET_TO_PLAY = 0
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 4, true));
+    cardDef.power.AddAura(
+        std::make_shared<AdaptiveCostEffect>([=](const Playable* playable) {
+            return playable->player->GetNumFriendlyMinionsDiedThisTurn();
+        }));
+    cardDef.property.playReqs = PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } };
+    cards.emplace("BRM_003", cardDef);
 }
 
 void BrmCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -191,6 +191,8 @@ void BrmCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 
 void BrmCardsGen::AddMage(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ------------------------------------------ MINION - MAGE
     // [BRM_002] Flamewaker - COST:3 [ATK:2/HP:4]
     // - Set: Brm, Rarity: Rare
@@ -198,6 +200,13 @@ void BrmCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // Text: After you cast a spell,
     //       deal 2 damage randomly split among all enemies.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::AFTER_CAST));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::FRIENDLY;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<EnqueueTask>(
+        ComplexTask::DamageRandomTargets(EntityType::ENEMIES, 1, 1), 2) };
+    cards.emplace("BRM_002", cardDef);
 
     // ------------------------------------------- SPELL - MAGE
     // [BRM_003] Dragon's Breath - COST:5

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -164,16 +164,29 @@ void BrmCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsHandEmpty()) }));
+    cardDef.power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<AddEnchantmentTask>(
+                  "BRM_014e", EntityType::SOURCE) }));
+    cards.emplace("BRM_014", cardDef);
 }
 
 void BrmCardsGen::AddHunterNonCollect(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [BRM_014e] Power Rager (*) - COST:0
     // - Set: Brm
     // --------------------------------------------------------
     // Text: +3/+3
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddEnchant(Enchants::GetEnchantFromText("BRM_014e"));
+    cards.emplace("BRM_014e", cardDef);
 }
 
 void BrmCardsGen::AddMage(std::map<std::string, CardDef>& cards)

--- a/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
@@ -211,3 +211,48 @@ TEST_CASE("[Warlock : Minion] - BRM_006 : Imp Gang Boss")
     CHECK_EQ(curField[1]->GetAttack(), 1);
     CHECK_EQ(curField[1]->GetHealth(), 1);
 }
+
+// ---------------------------------------- MINION - HUNTER
+// [BRM_014] Core Rager - COST:4 [ATK:4/HP:4]
+// - Race: Beast, Set: Brm, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If your hand is empty, gain +3/+3.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - BRM_014 : Core Rager")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Core Rager"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Core Rager"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 7);
+    CHECK_EQ(curField[1]->GetHealth(), 7);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
@@ -6,6 +6,73 @@
 
 #include <Utils/CardSetHeaders.hpp>
 
+// ----------------------------------------- MINION - DRUID
+// [BRM_009] Volcanic Lumberer - COST:9 [ATK:7/HP:8]
+// - Set: Brm, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       Costs (1) less for each minion that died this turn.
+// --------------------------------------------------------
+// GameTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - BRM_009 : Volcanic Lumberer")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Volcanic Lumberer"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card1->GetCost(), 9);
+
+    game.Process(curPlayer, AttackTask(card2, card4));
+    CHECK_EQ(card1->GetCost(), 8);
+
+    game.Process(curPlayer, AttackTask(card3, card5));
+    CHECK_EQ(card1->GetCost(), 7);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card1->GetCost(), 9);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [BRM_013] Quick Shot - COST:2
 // - Set: Brm, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
@@ -73,6 +73,52 @@ TEST_CASE("[Druid : Minion] - BRM_009 : Volcanic Lumberer")
     CHECK_EQ(card1->GetCost(), 9);
 }
 
+// ----------------------------------------- MINION - DRUID
+// [BRM_010] Druid of the Flame - COST:3 [ATK:2/HP:2]
+// - Set: Brm, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Choose One -</b> Transform into a 5/2 minion;
+//       or a 2/5 minion.
+// --------------------------------------------------------
+// GameTag:
+// - CHOOSE_ONE = 1
+// --------------------------------------------------------
+TEST_CASE("[Druid : Minion] - BRM_010 : Druid of the Flame")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Druid of the Flame"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Druid of the Flame"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1, 1));
+    CHECK_EQ(curField[0]->GetAttack(), 5);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2, 2));
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 5);
+}
+
 // ----------------------------------------- SPELL - HUNTER
 // [BRM_013] Quick Shot - COST:2
 // - Set: Brm, Rarity: Common


### PR DESCRIPTION
This revision includes:
- Implement 5 BRM cards
  - Flamewaker (BRM_002)
  - Dragon's Breath (BRM_003)
  - Volcanic Lumberer (BRM_009)
  - Druid of the Flame (BRM_010)
  - Core Rager (BRM_014)
- Add complex task 'DamageRandomTargets()': Returns a list of task for dealing damage to random target(s)