### PR TITLE
Implement 6 BRM cards

### DIFF
--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -651,14 +651,14 @@ GVG | GVG_123 | Soot Spewer |
 
 Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
-BRM | BRM_001 | Solemn Vigil |  
+BRM | BRM_001 | Solemn Vigil | O
 BRM | BRM_002 | Flamewaker | O
 BRM | BRM_003 | Dragon's Breath | O
-BRM | BRM_004 | Twilight Whelp |  
+BRM | BRM_004 | Twilight Whelp | O
 BRM | BRM_005 | Demonwrath |  
 BRM | BRM_006 | Imp Gang Boss | O
-BRM | BRM_007 | Gang Up |  
-BRM | BRM_008 | Dark Iron Skulker |  
+BRM | BRM_007 | Gang Up | O
+BRM | BRM_008 | Dark Iron Skulker | O
 BRM | BRM_009 | Volcanic Lumberer | O
 BRM | BRM_010 | Druid of the Flame | O
 BRM | BRM_011 | Lava Shock |  
@@ -667,8 +667,8 @@ BRM | BRM_013 | Quick Shot | O
 BRM | BRM_014 | Core Rager | O
 BRM | BRM_015 | Revenge |  
 BRM | BRM_016 | Axe Flinger |  
-BRM | BRM_017 | Resurrect |  
-BRM | BRM_018 | Dragon Consort |  
+BRM | BRM_017 | Resurrect | O
+BRM | BRM_018 | Dragon Consort | O
 BRM | BRM_019 | Grim Patron |  
 BRM | BRM_020 | Dragonkin Sorcerer |  
 BRM | BRM_022 | Dragon Egg |  
@@ -683,7 +683,7 @@ BRM | BRM_031 | Chromaggus |
 BRM | BRM_033 | Blackwing Technician |  
 BRM | BRM_034 | Blackwing Corruptor |  
 
-- Progress: 22% (7 of 31 Cards)
+- Progress: 41% (13 of 31 Cards)
 
 ## The Grand Tournament
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * **100% Demon Hunter Initiate (20 of 20 Cards)**
   * **100% Curse of Naxxramas (30 of 30 Cards)**
   * 6% Goblins vs Gnomes (8 of 123 Cards)
-  * 22% Blackrock Mountain (7 of 31 Cards)
+  * 41% Blackrock Mountain (13 of 31 Cards)
   * 8% The Grand Tournament (11 of 132 Cards)
   * 20% The League of Explorers (9 of 45 Cards)
   * 5% Whispers of the Old Gods (8 of 134 Cards)

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -348,6 +348,8 @@ void BrmCardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)
 
 void BrmCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ------------------------------------------ SPELL - ROGUE
     // [BRM_007] Gang Up - COST:2
     // - Set: Brm, Rarity: Common
@@ -359,6 +361,12 @@ void BrmCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // - REQ_TARGET_TO_PLAY = 0
     // - REQ_MINION_TARGET = 0
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<CopyTask>(EntityType::TARGET, ZoneType::DECK, 3));
+    cardDef.property.playReqs = PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                          { PlayReq::REQ_MINION_TARGET, 0 } };
+    cards.emplace("BRM_007", cardDef);
 
     // ----------------------------------------- MINION - ROGUE
     // [BRM_008] Dark Iron Skulker - COST:5 [ATK:4/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -295,6 +295,8 @@ void BrmCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 
 void BrmCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ---------------------------------------- MINION - PRIEST
     // [BRM_004] Twilight Whelp - COST:1 [ATK:2/HP:1]
     // - Race: Dragon, Set: Brm, Rarity: Common
@@ -305,6 +307,14 @@ void BrmCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsHoldingRace(Race::DRAGON)) }));
+    cardDef.power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<AddEnchantmentTask>(
+                  "BRM_004e", EntityType::SOURCE) }));
+    cards.emplace("BRM_004", cardDef);
 
     // ----------------------------------------- SPELL - PRIEST
     // [BRM_017] Resurrect - COST:2
@@ -602,12 +612,17 @@ void BrmCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 
 void BrmCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [BRM_004e] Twilight Endurance (*) - COST:0
     // - Set: Brm
     // --------------------------------------------------------
     // Text: Increased Health.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddEnchant(std::make_shared<Enchant>(Effects::HealthN(2)));
+    cards.emplace("BRM_004e", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [BRM_004t] Whelp (*) - COST:1 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -236,6 +236,8 @@ void BrmCardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
 
 void BrmCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ---------------------------------------- SPELL - PALADIN
     // [BRM_001] Solemn Vigil - COST:5
     // - Set: Brm, Rarity: Common
@@ -243,6 +245,13 @@ void BrmCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // Text: Draw 2 cards.
     //       Costs (1) less for each minion that died this turn.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<DrawTask>(2));
+    cardDef.power.AddAura(
+        std::make_shared<AdaptiveCostEffect>([=](const Playable* playable) {
+            return playable->player->GetNumFriendlyMinionsDiedThisTurn();
+        }));
+    cards.emplace("BRM_001", cardDef);
 
     // --------------------------------------- MINION - PALADIN
     // [BRM_018] Dragon Consort - COST:5 [ATK:5/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -372,12 +372,20 @@ void BrmCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // [BRM_008] Dark Iron Skulker - COST:5 [ATK:4/HP:3]
     // - Set: Brm, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Deal 2 damage to all undamaged
-    //       enemy minions.
+    // Text: <b>Battlecry:</b> Deal 2 damage
+    //       to all undamaged enemy minions.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<IncludeTask>(EntityType::ENEMY_MINIONS));
+    cardDef.power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsUndamaged()) }));
+    cardDef.power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::STACK, 2));
+    cards.emplace("BRM_008", cardDef);
 }
 
 void BrmCardsGen::AddRogueNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -326,6 +326,19 @@ void BrmCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // - REQ_NUM_MINION_SLOTS = 1
     // - REQ_FRIENDLY_MINION_DIED_THIS_GAME = 0
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<IncludeTask>(EntityType::GRAVEYARD));
+    cardDef.power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsDead()) }));
+    cardDef.power.AddPowerTask(
+        std::make_shared<RandomTask>(EntityType::STACK, 1));
+    cardDef.power.AddPowerTask(
+        std::make_shared<CopyTask>(EntityType::STACK, ZoneType::PLAY));
+    cardDef.property.playReqs =
+        PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 0 },
+                  { PlayReq::REQ_FRIENDLY_MINION_DIED_THIS_GAME, 0 } };
+    cards.emplace("BRM_017", cardDef);
 }
 
 void BrmCardsGen::AddPriestNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -257,22 +257,40 @@ void BrmCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // [BRM_018] Dragon Consort - COST:5 [ATK:5/HP:5]
     // - Race: Dragon, Set:Bbrm, Rarity: Rare
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> The next Dragon you play costs
-    //       (2) less.
+    // Text: <b>Battlecry:</b> The next Dragon
+    //       you play costs (2) less.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("BRM_018e", EntityType::SOURCE));
+    cards.emplace("BRM_018", cardDef);
 }
 
 void BrmCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ---------------------------------- ENCHANTMENT - PALADIN
     // [BRM_018e] Unchained! (*) - COST:0
     // - Set: Brm
     // --------------------------------------------------------
     // Text: Your next Dragon costs (2) less.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(std::make_shared<Aura>(
+        AuraType::HAND, EffectList{ Effects::ReduceCost(2) }));
+    {
+        const auto aura = dynamic_cast<Aura*>(cardDef.power.GetAura());
+        aura->condition = std::make_shared<SelfCondition>(
+            SelfCondition::IsRace(Race::DRAGON));
+        aura->removeTrigger = { TriggerType::PLAY_MINION,
+                                std::make_shared<SelfCondition>(
+                                    SelfCondition::IsRace(Race::DRAGON)) };
+    }
+    cards.emplace("BRM_018e", cardDef);
 }
 
 void BrmCardsGen::AddPriest(std::map<std::string, CardDef>& cards)

--- a/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
@@ -498,3 +498,49 @@ TEST_CASE("[Paladin : Minion] - BRM_018 : Dragon Consort")
     CHECK_EQ(card2->GetCost(), 5);
     CHECK_EQ(card4->GetCost(), 5);
 }
+
+// ---------------------------------------- MINION - PRIEST
+// [BRM_004] Twilight Whelp - COST:1 [ATK:2/HP:1]
+// - Race: Dragon, Set: Brm, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If you're holding a Dragon,
+//       gain +2 Health.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - BRM_004 : Twilight Whelp")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::DRUID;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Twilight Whelp"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Twilight Whelp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
@@ -601,3 +601,51 @@ TEST_CASE("[Priest : Spell] - BRM_017 : Resurrect")
     CHECK_EQ(curField[0]->GetAttack(), 4);
     CHECK_EQ(curField[0]->GetHealth(), 7);
 }
+
+// ------------------------------------------ SPELL - ROGUE
+// [BRM_007] Gang Up - COST:2
+// - Set: Brm, Rarity: Common
+// --------------------------------------------------------
+// Text: Choose a minion.
+//       Shuffle 3 copies of it into your deck.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Rogue : Spell] - BRM_007 : Gang Up")
+{
+    GameConfig config;
+    config.player1Class = CardClass::ROGUE;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curDeck = *(curPlayer->GetDeckZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Gang Up"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Injured Blademaster"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curDeck.GetCount(), 0);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(curDeck.GetCount(), 3);
+    CHECK_EQ(curDeck[0]->card->name, "Injured Blademaster");
+    CHECK_EQ(curDeck[1]->card->name, "Injured Blademaster");
+    CHECK_EQ(curDeck[2]->card->name, "Injured Blademaster");
+}

--- a/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
@@ -443,3 +443,58 @@ TEST_CASE("[Paladin : Spell] - BRM_001 : Solemn Vigil")
     CHECK_EQ(curHand.GetCount(), 7);
     CHECK_EQ(curPlayer->GetRemainingMana(), 7);
 }
+
+// --------------------------------------- MINION - PALADIN
+// [BRM_018] Dragon Consort - COST:5 [ATK:5/HP:5]
+// - Race: Dragon, Set:Bbrm, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> The next Dragon
+//       you play costs (2) less.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Minion] - BRM_018 : Dragon Consort")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Dragon Consort"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Azure Drake"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Twilight Whelp"));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Glaivebound Adept"));
+
+    CHECK_EQ(card2->GetCost(), 5);
+    CHECK_EQ(card3->GetCost(), 1);
+    CHECK_EQ(card4->GetCost(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 5);
+    CHECK_EQ(card2->GetCost(), 3);
+    CHECK_EQ(card3->GetCost(), 0);
+    CHECK_EQ(card4->GetCost(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    CHECK_EQ(curPlayer->GetRemainingMana(), 5);
+    CHECK_EQ(card2->GetCost(), 5);
+    CHECK_EQ(card4->GetCost(), 5);
+}


### PR DESCRIPTION
This revision includes:
- Implement 6 BRM cards
  - Solemn Vigil (BRM_001)
  - Twilight Whelp (BRM_004)
  - Gang Up (BRM_007)
  - Dark Iron Skulker (BRM_008)
  - Resurrect (BRM_017)
  - Dragon Consort (BRM_018)