### PR TITLE
Implement 8 BRM cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,8 @@ build
 
 # CLion files
 /.idea
-cmake-build-debug
-cmake-build-release
+cmake-build-debug*
+cmake-build-release*
 
 # vi files
 .clang_complete

--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -669,21 +669,21 @@ BRM | BRM_015 | Revenge | O
 BRM | BRM_016 | Axe Flinger | O
 BRM | BRM_017 | Resurrect | O
 BRM | BRM_018 | Dragon Consort | O
-BRM | BRM_019 | Grim Patron |  
-BRM | BRM_020 | Dragonkin Sorcerer |  
-BRM | BRM_022 | Dragon Egg |  
-BRM | BRM_024 | Drakonid Crusher |  
-BRM | BRM_025 | Volcanic Drake |  
-BRM | BRM_026 | Hungry Dragon |  
-BRM | BRM_027 | Majordomo Executus |  
-BRM | BRM_028 | Emperor Thaurissan |  
+BRM | BRM_019 | Grim Patron | O
+BRM | BRM_020 | Dragonkin Sorcerer | O
+BRM | BRM_022 | Dragon Egg | O
+BRM | BRM_024 | Drakonid Crusher | O
+BRM | BRM_025 | Volcanic Drake | O
+BRM | BRM_026 | Hungry Dragon | O
+BRM | BRM_027 | Majordomo Executus | O
+BRM | BRM_028 | Emperor Thaurissan | O
 BRM | BRM_029 | Rend Blackhand |  
 BRM | BRM_030 | Nefarian |  
 BRM | BRM_031 | Chromaggus |  
 BRM | BRM_033 | Blackwing Technician |  
 BRM | BRM_034 | Blackwing Corruptor |  
 
-- Progress: 58% (18 of 31 Cards)
+- Progress: 83% (26 of 31 Cards)
 
 ## The Grand Tournament
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * **100% Demon Hunter Initiate (20 of 20 Cards)**
   * **100% Curse of Naxxramas (30 of 30 Cards)**
   * 6% Goblins vs Gnomes (8 of 123 Cards)
-  * 58% Blackrock Mountain (18 of 31 Cards)
+  * 83% Blackrock Mountain (26 of 31 Cards)
   * 8% The Grand Tournament (11 of 132 Cards)
   * 20% The League of Explorers (9 of 45 Cards)
   * 5% Whispers of the Old Gods (8 of 134 Cards)

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -542,6 +542,8 @@ void BrmCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)
 
 void BrmCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // --------------------------------------- MINION - NEUTRAL
     // [BRM_019] Grim Patron - COST:5 [ATK:3/HP:3]
     // - Set: Brm, Rarity: Rare
@@ -549,6 +551,16 @@ void BrmCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // Text: After this minion survives damage,
     //       summon another Grim Patron.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::TAKE_DAMAGE));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    cardDef.power.GetTrigger()->conditions = SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsNotDead())
+    };
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<SummonTask>(
+        "BRM_019", SummonSide::RIGHT) };
+    cards.emplace("BRM_019", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [BRM_020] Dragonkin Sorcerer - COST:4 [ATK:3/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -585,6 +585,16 @@ void BrmCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // Text: Whenever this minion takes damage,
     //       summon a 2/1 Whelp.
     // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::TAKE_DAMAGE));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<SummonTask>(
+        "BRM_022t", SummonSide::RIGHT) };
+    cards.emplace("BRM_022", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [BRM_024] Drakonid Crusher - COST:6 [ATK:6/HP:6]
@@ -749,6 +759,9 @@ void BrmCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
     // [BRM_022t] Black Whelp (*) - COST:1 [ATK:2/HP:1]
     // - Race: Dragon, Set: Brm, Rarity: Common
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("BRM_022t", cardDef);
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [BRM_024e] Large Talons (*) - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -606,6 +606,14 @@ void BrmCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::HERO, SelfCondList{ std::make_shared<SelfCondition>(
+                              SelfCondition::IsHealth(15, RelaSign::LEQ)) }));
+    cardDef.power.AddPowerTask(std::make_shared<FlagTask>(
+        true, TaskList{ std::make_shared<AddEnchantmentTask>(
+                  "BRM_024e", EntityType::SOURCE) }));
+    cards.emplace("BRM_024", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [BRM_025] Volcanic Drake - COST:6 [ATK:6/HP:4]
@@ -769,6 +777,9 @@ void BrmCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: +3/+3.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddEnchant(Enchants::GetEnchantFromText("BRM_024e"));
+    cards.emplace("BRM_024e", cardDef);
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [BRM_028e] Imperial Favor (*) - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -638,6 +638,11 @@ void BrmCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<RandomMinionTask>(
+        TagValues{ { GameTag::COST, 1, RelaSign::EQ } }, 1, true));
+    cardDef.power.AddPowerTask(std::make_shared<SummonOpTask>());
+    cards.emplace("BRM_026", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [BRM_027] Majordomo Executus - COST:9 [ATK:9/HP:7]

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -686,6 +686,11 @@ void BrmCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - ELITE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "BRM_028e", EntityType::HAND) };
+    cards.emplace("BRM_028", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [BRM_029] Rend Blackhand - COST:7 [ATK:8/HP:4]
@@ -818,6 +823,9 @@ void BrmCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Costs (1) less.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddEnchant(std::make_unique<Enchant>(Effects::ReduceCost(1)));
+    cards.emplace("BRM_028e", cardDef);
 
     // ---------------------------------------- SPELL - NEUTRAL
     // [BRM_030t] Tail Swipe (*) - COST:4

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -10,6 +10,8 @@ namespace RosettaStone::PlayMode
 {
 void BrmCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ----------------------------------------- HERO - NEUTRAL
     // [BRM_027h] Ragnaros the Firelord (*) - COST:0 [ATK:0/HP:8]
     // - Set: Brm
@@ -17,10 +19,15 @@ void BrmCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - HERO_POWER = 2319
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("BRM_027h", cardDef);
 }
 
 void BrmCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ----------------------------------- HERO_POWER - NEUTRAL
     // [BRM_027p] DIE, INSECT! (*) - COST:2
     // - Set: Brm
@@ -28,6 +35,10 @@ void BrmCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // Text: <b>Hero Power</b>
     //       Deal 8 damage to a random enemy.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        ComplexTask::DamageRandomTargets(EntityType::ENEMIES, 1, 8));
+    cards.emplace("BRM_027p", cardDef);
 
     // ----------------------------------- HERO_POWER - NEUTRAL
     // [BRM_027pH] DIE, INSECTS! (*) - COST:2
@@ -36,6 +47,11 @@ void BrmCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // Text: <b>Hero Power</b>
     //       Deal 8 damage to a random enemy. TWICE.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<EnqueueTask>(
+        TaskList{ ComplexTask::DamageRandomTargets(EntityType::ENEMIES, 1, 8) },
+        2));
+    cards.emplace("BRM_027pH", cardDef);
 }
 
 void BrmCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
@@ -655,6 +671,10 @@ void BrmCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddDeathrattleTask(
+        std::make_shared<ReplaceHeroTask>("BRM_027h", "BRM_027p"));
+    cards.emplace("BRM_027", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [BRM_028] Emperor Thaurissan - COST:6 [ATK:5/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -621,6 +621,12 @@ void BrmCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Costs (1) less for each minion that died this turn.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(
+        std::make_shared<AdaptiveCostEffect>([=](const Playable* playable) {
+            return playable->player->GetNumFriendlyMinionsDiedThisTurn();
+        }));
+    cards.emplace("BRM_025", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [BRM_026] Hungry Dragon - COST:4 [ATK:5/HP:6]

--- a/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/BrmCardsGen.cpp
@@ -569,6 +569,14 @@ void BrmCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // Text: Whenever <b>you</b> target this minion with a spell,
     //       gain +1/+1.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::CAST_SPELL));
+    cardDef.power.GetTrigger()->triggerSource =
+        TriggerSource::SPELLS_CASTED_ON_THIS;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<AddEnchantmentTask>(
+        "BRM_020e", EntityType::SOURCE) };
+    cards.emplace("BRM_020", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [BRM_022] Dragon Egg - COST:1 [ATK:0/HP:2]
@@ -732,6 +740,10 @@ void BrmCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Increased stats.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddEnchant(
+        std::make_shared<Enchant>(Effects::AttackHealthN(1)));
+    cards.emplace("BRM_020e", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [BRM_022t] Black Whelp (*) - COST:1 [ATK:2/HP:1]

--- a/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
@@ -1415,3 +1415,60 @@ TEST_CASE("[Neutral : Minion] - BRM_027 : Majordomo Executus")
     game.Process(curPlayer, HeroPowerTask());
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 22);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BRM_028] Emperor Thaurissan - COST:6 [ATK:5/HP:5]
+// - Set: Brm, Rarity: Legendary
+// --------------------------------------------------------
+// Text: At the end of your turn,
+//       reduce the Cost of cards in your hand by (1).
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BRM_028 : Emperor Thaurissan")
+{
+    GameConfig config;
+    config.player1Class = CardClass::MAGE;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Emperor Thaurissan"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Worgen Infiltrator"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Blizzard"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(card2->GetCost(), 1);
+    CHECK_EQ(card3->GetCost(), 6);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card2->GetCost(), 0);
+    CHECK_EQ(card3->GetCost(), 5);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(card2->GetCost(), 0);
+    CHECK_EQ(card3->GetCost(), 4);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
@@ -1162,3 +1162,51 @@ TEST_CASE("[Neutral : Minion] - BRM_020 : Dragonkin Sorcerer")
     CHECK_EQ(curField[0]->GetAttack(), 8);
     CHECK_EQ(curField[0]->GetHealth(), 10);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BRM_022] Dragon Egg - COST:1 [ATK:0/HP:2]
+// - Set: Brm, Rarity: Rare
+// --------------------------------------------------------
+// Text: Whenever this minion takes damage,
+//       summon a 2/1 Whelp.
+// --------------------------------------------------------
+// GameTag:
+// - TRIGGER_VISUAL = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BRM_022 : Dragon Egg")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Dragon Egg"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[1]->card->name, "Black Whelp");
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
@@ -1103,3 +1103,62 @@ TEST_CASE("[Neutral : Minion] - BRM_019 : Grim Patron")
     game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
     CHECK_EQ(curField.GetCount(), 1);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BRM_020] Dragonkin Sorcerer - COST:4 [ATK:3/HP:5]
+// - Race: Dragon, Set: Brm, Rarity: Common
+// --------------------------------------------------------
+// Text: Whenever <b>you</b> target this minion with a spell,
+//       gain +1/+1.
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BRM_020 : Dragonkin Sorcerer")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Dragonkin Sorcerer"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Blessing of Kings"));
+    const auto card3 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Blessing of Kings"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card2, card4));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 5);
+
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card3, card1));
+    CHECK_EQ(curField[0]->GetAttack(), 8);
+    CHECK_EQ(curField[0]->GetHealth(), 10);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
@@ -1055,3 +1055,51 @@ TEST_CASE("[Warrior : Minion] - BRM_016 : Axe Flinger")
     game.Process(curPlayer, AttackTask(card1, card2));
     CHECK_EQ(opPlayer->GetHero()->GetHealth(), 28);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BRM_019] Grim Patron - COST:5 [ATK:3/HP:3]
+// - Set: Brm, Rarity: Rare
+// --------------------------------------------------------
+// Text: After this minion survives damage,
+//       summon another Grim Patron.
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BRM_019 : Grim Patron")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Grim Patron"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Frostbolt"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField.GetCount(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
@@ -1210,3 +1210,52 @@ TEST_CASE("[Neutral : Minion] - BRM_022 : Dragon Egg")
     CHECK_EQ(curField[1]->GetAttack(), 2);
     CHECK_EQ(curField[1]->GetHealth(), 1);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BRM_024] Drakonid Crusher - COST:6 [ATK:6/HP:6]
+// - Race: Dragon, Set: Brm, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> If your opponent has 15 or
+//       less Health, gain +3/+3.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BRM_024 : Drakonid Crusher")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Drakonid Crusher"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Drakonid Crusher"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 6);
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+
+    curPlayer->GetHero()->SetDamage(15);
+    curPlayer->SetUsedMana(0);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField[1]->GetAttack(), 9);
+    CHECK_EQ(curField[1]->GetHealth(), 9);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/BrmCardsGenTests.cpp
@@ -1322,3 +1322,43 @@ TEST_CASE("[Neutral : Minion] - BRM_025 : Volcanic Drake")
 
     CHECK_EQ(card1->GetCost(), 6);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [BRM_026] Hungry Dragon - COST:4 [ATK:5/HP:6]
+// - Race: Dragon, Set: Brm, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Summon a random 1-Cost minion
+//       for your opponent.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - BRM_026 : Hungry Dragon")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Hungry Dragon"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opField[0]->GetCost(), 1);
+}


### PR DESCRIPTION
This revision includes:
- Implement 8 BRM cards
  - Grim Patron (BRM_019)
  - Dragonkin Sorcerer (BRM_020)
  - Dragon Egg (BRM_022)
  - Drakonid Crusher (BRM_024)
  - Volcanic Drake (BRM_025)
  - Hungry Dragon (BRM_026)
  - Majordomo Executus (BRM_027)
  - Emperor Thaurissan (BRM_028)