### PR TITLE
Fix intermittent unit test failure of Puzzle Box of Yogg-Saron (ULD_216)

### DIFF
--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/DrawTask.cpp
@@ -21,8 +21,10 @@ TaskStatus DrawTask::Impl(Player* player)
 
     for (int i = 0; i < m_amount; ++i)
     {
-        Playable* card = Generic::Draw(player, nullptr);
-        cards.emplace_back(card);
+        if (Playable* card = Generic::Draw(player, nullptr))
+        {
+            cards.emplace_back(card);
+        }
     }
 
     if (m_toStack)


### PR DESCRIPTION
This revision includes:
- Fix intermittent unit test failure of Puzzle Box of Yogg-Saron (ULD_216) (Resolves #820)
  - Correct code to consider the deck is empty