### PR TITLE
Implement 5 LOE cards

### DIFF
--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -830,22 +830,22 @@ Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
 LOE | LOE_002 | Forgotten Torch | O
 LOE | LOE_003 | Ethereal Conjurer | O
-LOE | LOE_006 | Museum Curator |  
+LOE | LOE_006 | Museum Curator | O
 LOE | LOE_007 | Curse of Rafaam |  
 LOE | LOE_009 | Obsidian Destroyer |  
 LOE | LOE_010 | Pit Snake |  
 LOE | LOE_011 | Reno Jackson | O
 LOE | LOE_012 | Tomb Pillager | O
 LOE | LOE_016 | Rumbling Elemental |  
-LOE | LOE_017 | Keeper of Uldaman |  
+LOE | LOE_017 | Keeper of Uldaman | O
 LOE | LOE_018 | Tunnel Trogg |  
 LOE | LOE_019 | Unearthed Raptor |  
 LOE | LOE_020 | Desert Camel | O
 LOE | LOE_021 | Dart Trap | O
 LOE | LOE_022 | Fierce Monkey |  
 LOE | LOE_023 | Dark Peddler |  
-LOE | LOE_026 | Anyfin Can Happen |  
-LOE | LOE_027 | Sacred Trial |  
+LOE | LOE_026 | Anyfin Can Happen | O
+LOE | LOE_027 | Sacred Trial | O
 LOE | LOE_029 | Jeweled Scarab |  
 LOE | LOE_038 | Naga Sea Witch |  
 LOE | LOE_039 | Gorillabot A-3 | O
@@ -862,7 +862,7 @@ LOE | LOE_079 | Elise Starseeker | O
 LOE | LOE_086 | Summoning Stone |  
 LOE | LOE_089 | Wobbling Runts |  
 LOE | LOE_092 | Arch-Thief Rafaam |  
-LOE | LOE_104 | Entomb |  
+LOE | LOE_104 | Entomb | O
 LOE | LOE_105 | Explorer's Hat | O
 LOE | LOE_107 | Eerie Statue |  
 LOE | LOE_110 | Ancient Shade |  
@@ -874,7 +874,7 @@ LOE | LOE_118 | Cursed Blade |
 LOE | LOE_119 | Animated Armor |  
 LOE | LOEA10_3 | Murloc Tinyfin | O
 
-- Progress: 33% (15 of 45 Cards)
+- Progress: 44% (20 of 45 Cards)
 
 ## Whispers of the Old Gods
 

--- a/Includes/Rosetta/Common/Enums/TriggerEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/TriggerEnums.hpp
@@ -96,6 +96,7 @@ enum class SequenceType
     NONE,
     PLAY_CARD,
     PLAY_MINION,
+    AFTER_PLAY_MINION,
     PLAY_SPELL,
     AFTER_PLAY_SPELL,
     TARGET

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 6% Goblins vs Gnomes (8 of 123 Cards)
   * **100% Blackrock Mountain (31 of 31 Cards)**
   * 8% The Grand Tournament (11 of 132 Cards)
-  * 33% The League of Explorers (15 of 45 Cards)
+  * 44% The League of Explorers (20 of 45 Cards)
   * 5% Whispers of the Old Gods (8 of 134 Cards)
   * 15% One Night in Karazhan (7 of 45 Cards)
   * 2% Mean Streets of Gadgetzan (3 of 132 Cards)

--- a/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/PlayCard.cpp
@@ -368,6 +368,10 @@ void PlayMinion(Player* player, Minion* minion, Character* target, int fieldPos,
 
     player->game->ProcessDestroyAndUpdateAura();
 
+    // Validate after play minion trigger
+    Trigger::ValidateTriggers(player->game, minion,
+                              SequenceType::AFTER_PLAY_MINION);
+
     // Process after play minion trigger
     player->game->taskQueue.StartEvent();
     player->game->triggerManager.OnAfterPlayMinionTrigger(minion);

--- a/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
@@ -363,6 +363,13 @@ void LoECardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // - REQ_MINION_TARGET = 0
     // - REQ_ENEMY_TARGET = 0
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<MoveToDeckTask>(EntityType::TARGET));
+    cardDef.property.playReqs = PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 },
+                                          { PlayReq::REQ_MINION_TARGET, 0 },
+                                          { PlayReq::REQ_ENEMY_TARGET, 0 } };
+    cards.emplace("LOE_104", cardDef);
 
     // ----------------------------------------- SPELL - PRIEST
     // [LOE_111] Excavated Evil - COST:5

--- a/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
@@ -305,9 +305,10 @@ void LoECardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     cardDef.ClearData();
     cardDef.power.AddTrigger(
         std::make_shared<Trigger>(TriggerType::AFTER_PLAY_MINION));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::ENEMY;
     cardDef.power.GetTrigger()->conditions =
         SelfCondList{ std::make_shared<SelfCondition>(
-            SelfCondition::IsOpFieldCount(4, RelaSign::GEQ)) };
+            SelfCondition::IsFieldCount(4, RelaSign::GEQ)) };
     cardDef.power.GetTrigger()->tasks = ComplexTask::ActivateSecret(
         TaskList{ std::make_shared<DestroyTask>(EntityType::TARGET) });
     cards.emplace("LOE_027", cardDef);

--- a/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
@@ -279,6 +279,18 @@ void LoECardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Summon 7 Murlocs that died this game.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<IncludeTask>(EntityType::GRAVEYARD));
+    cardDef.power.AddPowerTask(std::make_shared<FilterStackTask>(SelfCondList{
+        std::make_shared<SelfCondition>(SelfCondition::IsMinion()),
+        std::make_shared<SelfCondition>(
+            SelfCondition::IsRace(Race::MURLOC)) }));
+    cardDef.power.AddPowerTask(
+        std::make_shared<RandomTask>(EntityType::STACK, 7));
+    cardDef.power.AddPowerTask(
+        std::make_shared<SummonCopyTask>(EntityType::STACK));
+    cards.emplace("LOE_026", cardDef);
 
     // ---------------------------------------- SPELL - PALADIN
     // [LOE_027] Sacred Trial - COST:1

--- a/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
@@ -302,6 +302,15 @@ void LoECardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - SECRET = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::AFTER_PLAY_MINION));
+    cardDef.power.GetTrigger()->conditions =
+        SelfCondList{ std::make_shared<SelfCondition>(
+            SelfCondition::IsOpFieldCount(4, RelaSign::GEQ)) };
+    cardDef.power.GetTrigger()->tasks = ComplexTask::ActivateSecret(
+        TaskList{ std::make_shared<DestroyTask>(EntityType::TARGET) });
+    cards.emplace("LOE_027", cardDef);
 }
 
 void LoECardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
@@ -331,6 +331,8 @@ void LoECardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 
 void LoECardsGen::AddPriest(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ---------------------------------------- MINION - PRIEST
     // [LOE_006] Museum Curator - COST:2 [ATK:1/HP:2]
     // - Set: LoE, Rarity: Common
@@ -345,6 +347,10 @@ void LoECardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DiscoverTask>(DiscoverType::DEATHRATTLE_MINION));
+    cards.emplace("LOE_006", cardDef);
 
     // ----------------------------------------- SPELL - PRIEST
     // [LOE_104] Entomb - COST:6

--- a/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LoECardsGen.cpp
@@ -250,6 +250,8 @@ void LoECardsGen::AddMageNonCollect(std::map<std::string, CardDef>& cards)
 
 void LoECardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // --------------------------------------- MINION - PALADIN
     // [LOE_017] Keeper of Uldaman - COST:4 [ATK:3/HP:4]
     // - Set: LoE, Rarity: Common
@@ -263,6 +265,13 @@ void LoECardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // - REQ_TARGET_IF_AVAILABLE = 0
     // - REQ_MINION_TARGET = 0
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("LOE_017e", EntityType::TARGET));
+    cardDef.property.playReqs =
+        PlayReqs{ { PlayReq::REQ_TARGET_IF_AVAILABLE, 0 },
+                  { PlayReq::REQ_MINION_TARGET, 0 } };
+    cards.emplace("LOE_017", cardDef);
 
     // ---------------------------------------- SPELL - PALADIN
     // [LOE_026] Anyfin Can Happen - COST:10
@@ -285,12 +294,18 @@ void LoECardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
 
 void LoECardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ---------------------------------- ENCHANTMENT - PALADIN
     // [LOE_017e] Watched (*) - COST:0
     // - Set: LoE
     // --------------------------------------------------------
     // Text: Stats changed to 3/3.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddEnchant(
+        std::make_shared<Enchant>(Effects::SetAttackHealth(3)));
+    cards.emplace("LOE_017e", cardDef);
 }
 
 void LoECardsGen::AddPriest(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/MoveToDeckTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/MoveToDeckTask.cpp
@@ -22,7 +22,14 @@ TaskStatus MoveToDeckTask::Impl(Player* player)
 
     for (auto& playable : playables)
     {
-        playable->zone->Remove(playable);
+        Playable* removedMinion = playable->zone->Remove(playable);
+        removedMinion->Reset();
+
+        if (removedMinion->player != player)
+        {
+            removedMinion->player = player;
+            removedMinion->SetGameTag(GameTag::CONTROLLER, player->playerID);
+        }
 
         Generic::ShuffleIntoDeck(player, m_source, playable);
     }

--- a/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
+++ b/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
@@ -480,6 +480,13 @@ void Trigger::ValidateTriggers(const Game* game, Entity* source,
 {
     for (auto& trigger : game->triggers)
     {
+        // If the owner of the trigger is self, ignore it
+        if (trigger->m_owner == source &&
+            type == SequenceType::AFTER_PLAY_MINION)
+        {
+            continue;
+        }
+
         // If transformed or summoned minion tries to activate trigger,
         // ignore it
         if (const auto minion = dynamic_cast<Minion*>(trigger->m_owner);

--- a/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
+++ b/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
@@ -26,8 +26,10 @@ Trigger::Trigger(TriggerType type) : m_triggerType(type)
             m_sequenceType = SequenceType::PLAY_CARD;
             break;
         case TriggerType::PLAY_MINION:
-        case TriggerType::AFTER_PLAY_MINION:
             m_sequenceType = SequenceType::PLAY_MINION;
+            break;
+        case TriggerType::AFTER_PLAY_MINION:
+            m_sequenceType = SequenceType::AFTER_PLAY_MINION;
             break;
         case TriggerType::CAST_SPELL:
             m_sequenceType = SequenceType::PLAY_SPELL;

--- a/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
@@ -598,10 +598,10 @@ TEST_CASE("[Paladin : Spell] - LOE_027 : Sacred Trial")
     opPlayer->SetUsedMana(0);
 
     auto curSecret = curPlayer->GetSecretZone();
-    auto& opField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
 
     const auto card1 = Generic::DrawCard(
-        curPlayer, Cards::FindCardByName("AnyfinSacred Trial"));
+        curPlayer, Cards::FindCardByName("Sacred Trial"));
     const auto card2 =
         Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
     const auto card3 =

--- a/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
@@ -681,6 +681,61 @@ TEST_CASE("[Priest : Minion] - LOE_006 : Museum Curator")
     CHECK_EQ(curHand.GetCount(), 1);
 }
 
+// ----------------------------------------- SPELL - PRIEST
+// [LOE_104] Entomb - COST:6
+// - Set: LoE, Rarity: Common
+// --------------------------------------------------------
+// Text: Choose an enemy minion. Shuffle it into your deck.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_TO_PLAY = 0
+// - REQ_MINION_TARGET = 0
+// - REQ_ENEMY_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Priest : Spell] - LOE_104 : Entomb")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opDeck = *(opPlayer->GetDeckZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Entomb"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(opField.GetCount(), 1);
+    CHECK_EQ(opDeck.GetCount(), 0);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card1, card2));
+    CHECK_EQ(opField.GetCount(), 0);
+    CHECK_EQ(opDeck.GetCount(), 1);
+    CHECK_EQ(opDeck[0]->card->name, "Malygos");
+}
+
 // ----------------------------------------- MINION - ROGUE
 // [LOE_012] Tomb Pillager - COST:4 [ATK:5/HP:4]
 // - Set: LoE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
@@ -627,6 +627,60 @@ TEST_CASE("[Paladin : Spell] - LOE_027 : Sacred Trial")
     CHECK_EQ(opField.GetCount(), 3);
 }
 
+// ---------------------------------------- MINION - PRIEST
+// [LOE_006] Museum Curator - COST:2 [ATK:1/HP:2]
+// - Set: LoE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry: Discover</b> a <b>Deathrattle</b> card.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - DISCOVER = 1
+// - USE_DISCOVER_VISUALS = 1
+// --------------------------------------------------------
+// RefTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Priest : Minion] - LOE_006 : Museum Curator")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PRIEST;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Museum Curator"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK(curPlayer->choice);
+    CHECK_EQ(curPlayer->choice->choices.size(), 3);
+
+    auto cards = TestUtils::GetChoiceCards(game);
+    for (auto& card : cards)
+    {
+        CHECK_EQ(card->GetCardType(), CardType::MINION);
+        CHECK_EQ(card->HasGameTag(GameTag::DEATHRATTLE), true);
+    }
+
+    TestUtils::ChooseNthChoice(game, 1);
+    CHECK_EQ(curHand.GetCount(), 1);
+}
+
 // ----------------------------------------- MINION - ROGUE
 // [LOE_012] Tomb Pillager - COST:4 [ATK:5/HP:4]
 // - Set: LoE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
@@ -447,6 +447,61 @@ TEST_CASE("[Mage : Minion] - LOE_003 : Ethereal Conjurer")
     CHECK_EQ(curHand.GetCount(), 1);
 }
 
+// --------------------------------------- MINION - PALADIN
+// [LOE_017] Keeper of Uldaman - COST:4 [ATK:3/HP:4]
+// - Set: LoE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Set a minion's Attack and Health to 3.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_TARGET_IF_AVAILABLE = 0
+// - REQ_MINION_TARGET = 0
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Minion] - LOE_017 : Keeper of Uldaman")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Keeper of Uldaman"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Malygos"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(opField[0]->GetAttack(), 4);
+    CHECK_EQ(opField[0]->GetHealth(), 12);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::MinionTarget(card1, card2));
+    CHECK_EQ(opField[0]->GetAttack(), 3);
+    CHECK_EQ(opField[0]->GetHealth(), 3);
+}
+
 // ----------------------------------------- MINION - ROGUE
 // [LOE_012] Tomb Pillager - COST:4 [ATK:5/HP:4]
 // - Set: LoE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
@@ -567,6 +567,66 @@ TEST_CASE("[Paladin : Spell] - LOE_026 : Anyfin Can Happen")
     CHECK(curField[1]->IsRace(Race::MURLOC));
 }
 
+// ---------------------------------------- SPELL - PALADIN
+// [LOE_027] Sacred Trial - COST:1
+// - Set: LoE, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Secret:</b> After your opponent has at least
+//       3 minions and plays another, destroy it.
+// --------------------------------------------------------
+// GameTag:
+// - SECRET = 1
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Spell] - LOE_027 : Sacred Trial")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto curSecret = curPlayer->GetSecretZone();
+    auto& opField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("AnyfinSacred Trial"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card2));
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(curSecret->GetCount(), 1);
+    CHECK_EQ(opField.GetCount(), 3);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(curSecret->GetCount(), 0);
+    CHECK_EQ(opField.GetCount(), 3);
+}
+
 // ----------------------------------------- MINION - ROGUE
 // [LOE_012] Tomb Pillager - COST:4 [ATK:5/HP:4]
 // - Set: LoE, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
@@ -712,7 +712,7 @@ TEST_CASE("[Priest : Spell] - LOE_104 : Entomb")
     opPlayer->SetTotalMana(10);
     opPlayer->SetUsedMana(0);
 
-    auto& opDeck = *(opPlayer->GetDeckZone());
+    auto& curDeck = *(curPlayer->GetDeckZone());
     auto& opField = *(opPlayer->GetFieldZone());
 
     const auto card1 =
@@ -725,15 +725,15 @@ TEST_CASE("[Priest : Spell] - LOE_104 : Entomb")
 
     game.Process(opPlayer, PlayCardTask::Minion(card2));
     CHECK_EQ(opField.GetCount(), 1);
-    CHECK_EQ(opDeck.GetCount(), 0);
+    CHECK_EQ(curDeck.GetCount(), 0);
 
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);
 
-    game.Process(opPlayer, PlayCardTask::SpellTarget(card1, card2));
+    game.Process(curPlayer, PlayCardTask::SpellTarget(card1, card2));
     CHECK_EQ(opField.GetCount(), 0);
-    CHECK_EQ(opDeck.GetCount(), 1);
-    CHECK_EQ(opDeck[0]->card->name, "Malygos");
+    CHECK_EQ(curDeck.GetCount(), 1);
+    CHECK_EQ(curDeck[0]->card->name, "Malygos");
 }
 
 // ----------------------------------------- MINION - ROGUE

--- a/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LoECardsGenTests.cpp
@@ -502,6 +502,71 @@ TEST_CASE("[Paladin : Minion] - LOE_017 : Keeper of Uldaman")
     CHECK_EQ(opField[0]->GetHealth(), 3);
 }
 
+// ---------------------------------------- SPELL - PALADIN
+// [LOE_026] Anyfin Can Happen - COST:10
+// - Set: LoE, Rarity: Rare
+// --------------------------------------------------------
+// Text: Summon 7 Murlocs that died this game.
+// --------------------------------------------------------
+TEST_CASE("[Paladin : Spell] - LOE_026 : Anyfin Can Happen")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Anyfin Can Happen"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Murloc Tinyfin"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Desk Imp"));
+    const auto card4 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Snowflipper Penguin"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Murloc Tinyfin"));
+    const auto card6 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Target Dummy"));
+    const auto card7 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Blizzard"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+    game.Process(curPlayer, PlayCardTask::Minion(card6));
+    CHECK_EQ(curField.GetCount(), 5);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Spell(card7));
+    CHECK_EQ(curField.GetCount(), 0);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK(curField[0]->IsRace(Race::MURLOC));
+    CHECK(curField[1]->IsRace(Race::MURLOC));
+}
+
 // ----------------------------------------- MINION - ROGUE
 // [LOE_012] Tomb Pillager - COST:4 [ATK:5/HP:4]
 // - Set: LoE, Rarity: Common


### PR DESCRIPTION
This revision includes:
- Implement 5 LOE cards
  - Museum Curator (LOE_006)
  - Keeper of Uldaman (LOE_017)
  - Anyfin Can Happen (LOE_026)
  - Sacred Trial (LOE_027)
  - Entomb (LOE_104)
- Add enum value 'SequenceType::AFTER_PLAY_MINION'
  - Change code to set sequence type of 'AFTER_PLAY_MINION'
- Correct some code logic
  - Add code to ignore trigger if the owner is self
  - Add code to validate after play minion trigger
  - Add code to reset the value of removed minion