### PR TITLE
Update Hearthstone Patch 24.0.3

### DIFF
--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -150,7 +150,7 @@ constexpr int NUM_TIER3_MINIONS = 34;
 constexpr int NUM_TIER4_MINIONS = 32;
 
 //! The number of tier 5 minions in Battlegrounds.
-constexpr int NUM_TIER5_MINIONS = 28;
+constexpr int NUM_TIER5_MINIONS = 29;
 
 //! The number of tier 6 minions in Battlegrounds.
 constexpr int NUM_TIER6_MINIONS = 21;

--- a/Resources/cards.collectible.json
+++ b/Resources/cards.collectible.json
@@ -1176,7 +1176,7 @@
         "artist": "Dany Orizio",
         "cardClass": "WARRIOR",
         "collectible": true,
-        "cost": 3,
+        "cost": 2,
         "dbfId": 2729,
         "flavor": "You might think bashing doesn't take a lot of practice.  It doesn't.",
         "id": "AT_064",
@@ -1397,7 +1397,7 @@
         "name": "Warhorse Trainer",
         "rarity": "COMMON",
         "set": "TGT",
-        "text": "Your Silver Hand Recruits have +1 Attack.",
+        "text": "Your Silver Hand Recruits have +2 Attack and <b>Taunt</b>.",
         "type": "MINION"
     },
     {
@@ -2595,7 +2595,7 @@
         "rarity": "RARE",
         "set": "ALTERAC_VALLEY",
         "spellSchool": "FROST",
-        "text": "[x]Deal $4 damage to all\nminions. Costs (1) less\nfor each Armor you have.",
+        "text": "[x]Deal $5 damage to all\nminions. Costs (1) less\nfor each Armor you have.",
         "type": "SPELL"
     },
     {
@@ -2722,7 +2722,7 @@
         "cost": 2,
         "dbfId": 69577,
         "flavor": "\"Welcome to Dun Baldar Felwings! Do you want 'em mild, spicy, or BURNING Legion?\"",
-        "health": 1,
+        "health": 2,
         "id": "AV_118",
         "mechanics": [
             "TRIGGER_VISUAL"
@@ -3724,13 +3724,13 @@
     },
     {
         "artist": "Jakub Kasper",
-        "attack": 3,
+        "attack": 5,
         "cardClass": "SHAMAN",
         "collectible": true,
         "cost": 6,
         "dbfId": 67769,
         "flavor": "You’re finally awake! That fall looked really bad. Demon Hunters? Mercenaries? What are you talking about? Come on, I just unpacked a Golden Moorabi, let’s go build a Freeze Shaman deck.",
-        "health": 3,
+        "health": 5,
         "id": "AV_255",
         "mechanics": [
             "BATTLECRY"
@@ -3742,7 +3742,7 @@
             "FREEZE"
         ],
         "set": "ALTERAC_VALLEY",
-        "text": "<b>Battlecry:</b> <b>Freeze</b> all other minions. Gain +1/+1 for each <b>Frozen</b> minion.",
+        "text": "[x]<b>Battlecry:</b> <b>Freeze</b> all\nother minions.",
         "type": "MINION"
     },
     {
@@ -6216,7 +6216,7 @@
         "artist": "Alex Horley Orlandelli",
         "cardClass": "ROGUE",
         "collectible": true,
-        "cost": 2,
+        "cost": 1,
         "dbfId": 62889,
         "flavor": "Kazakus has taken to a more direct approach in recent times.",
         "id": "BAR_318",
@@ -6653,7 +6653,7 @@
         "rarity": "EPIC",
         "set": "THE_BARRENS",
         "spellSchool": "ARCANE",
-        "text": "Set each player to 0 Mana Crystals. Set the Cost of cards in all hands and decks to (1).",
+        "text": "Set your Mana Crystals to 0. Set the Cost of cards in your hand and deck to (1).",
         "type": "SPELL"
     },
     {
@@ -16926,7 +16926,7 @@
         "artist": "Dany Orizio",
         "cardClass": "WARRIOR",
         "collectible": true,
-        "cost": 3,
+        "cost": 2,
         "dbfId": 76304,
         "flavor": "You might think bashing doesn't take a lot of practice.  It doesn't.",
         "howToEarn": "Unlocked at level 7.",
@@ -16956,7 +16956,7 @@
         "name": "Warhorse Trainer",
         "rarity": "COMMON",
         "set": "CORE",
-        "text": "Your Silver Hand Recruits have +1 Attack.",
+        "text": "Your Silver Hand Recruits have +2 Attack and <b>Taunt</b>.",
         "type": "MINION"
     },
     {
@@ -17890,7 +17890,7 @@
         "artist": "James Zhang",
         "cardClass": "ROGUE",
         "collectible": true,
-        "cost": 6,
+        "cost": 5,
         "dbfId": 69526,
         "flavor": "Rogues are not good joggers.",
         "howToEarn": "Unlocked at level 1.",
@@ -20081,7 +20081,7 @@
         "artist": "E. M. Gist",
         "cardClass": "WARRIOR",
         "collectible": true,
-        "cost": 2,
+        "cost": 1,
         "dbfId": 69638,
         "flavor": "\"Dun da dun, dun da dun\": if you've heard an ogre sing this, it's too late.",
         "howToEarn": "Unlocked at level 1.",
@@ -20562,7 +20562,7 @@
         "cost": 2,
         "dbfId": 69644,
         "flavor": "\"I'm going to need you to come in on Sunday.\" - Cruel Taskmaster",
-        "health": 2,
+        "health": 3,
         "howToEarn": "Unlocked at level 1.",
         "howToEarnGolden": "Unlocked after winning 50 games as Warrior.",
         "id": "CORE_EX1_603",
@@ -22144,7 +22144,7 @@
         "artist": "Ralph Horsley",
         "cardClass": "PALADIN",
         "collectible": true,
-        "cost": 5,
+        "cost": 4,
         "dbfId": 69706,
         "flavor": "Or if you're too tired, you can just kind of lean against the darkness.",
         "howToEarn": "Unlocked at level 1.",
@@ -23382,7 +23382,7 @@
         "artist": "James Zhang",
         "cardClass": "ROGUE",
         "collectible": true,
-        "cost": 6,
+        "cost": 5,
         "dbfId": 630,
         "flavor": "Rogues are not good joggers.",
         "id": "CS2_077",
@@ -28244,14 +28244,14 @@
     },
     {
         "artist": "Zoltan Boros",
-        "attack": 4,
+        "attack": 3,
         "cardClass": "ROGUE",
         "collectible": true,
-        "cost": 4,
+        "cost": 3,
         "dbfId": 65645,
         "elite": true,
         "flavor": "He’s not going to tear down the walls of Stormwind sitting around in the Hall of Fame.",
-        "health": 4,
+        "health": 3,
         "id": "DED_510",
         "isMiniSet": true,
         "mechanics": [
@@ -37283,7 +37283,7 @@
         "artist": "E. M. Gist",
         "cardClass": "WARRIOR",
         "collectible": true,
-        "cost": 2,
+        "cost": 1,
         "dbfId": 1074,
         "flavor": "\"Dun da dun, dun da dun\": if you've heard an ogre sing this, it's too late.",
         "id": "EX1_391",
@@ -38476,7 +38476,7 @@
         "cost": 2,
         "dbfId": 285,
         "flavor": "\"I'm going to need you to come in on Sunday.\" - Cruel Taskmaster",
-        "health": 2,
+        "health": 3,
         "id": "EX1_603",
         "mechanics": [
             "BATTLECRY"
@@ -53782,7 +53782,7 @@
         "attack": 3,
         "cardClass": "ROGUE",
         "collectible": true,
-        "cost": 4,
+        "cost": 5,
         "dbfId": 45936,
         "faction": "ALLIANCE",
         "flavor": "He can make ANYTHING look like a candle.",
@@ -56647,7 +56647,7 @@
         "artist": "Ralph Horsley",
         "cardClass": "PALADIN",
         "collectible": true,
-        "cost": 5,
+        "cost": 4,
         "dbfId": 38843,
         "flavor": "Or if you're too tired, you can just kind of lean against the darkness.",
         "id": "OG_273",
@@ -59324,7 +59324,7 @@
         "name": "Vile Library",
         "rarity": "RARE",
         "set": "REVENDRETH",
-        "text": "Give a friendly minion +1/+1. Repeat for each Imp you control.",
+        "text": "Give a friendly minion +1/+1 for each Imp you control.",
         "type": "LOCATION"
     },
     {
@@ -59519,7 +59519,7 @@
     },
     {
         "artist": "Chris Hayes",
-        "attack": 2,
+        "attack": 3,
         "cardClass": "DEMONHUNTER",
         "collectible": true,
         "cost": 3,
@@ -59559,7 +59559,7 @@
     },
     {
         "artist": "Vladimir Kafanov",
-        "attack": 4,
+        "attack": 5,
         "cardClass": "DEMONHUNTER",
         "collectible": true,
         "cost": 2,
@@ -59819,7 +59819,8 @@
         "health": 4,
         "id": "REV_829",
         "mechanics": [
-            "DEATHRATTLE"
+            "DEATHRATTLE",
+            "STEALTH"
         ],
         "name": "Halkias",
         "race": "ELEMENTAL",
@@ -59828,14 +59829,14 @@
             "SECRET"
         ],
         "set": "REVENDRETH",
-        "text": "[x]<b>Deathrattle:</b> If you control a \n<b>Secret</b>, store Halkias' soul \n  inside of it. It resummons \n   Halkias when triggered.",
+        "text": "[x]<b>Stealth</b>. <b>Deathrattle:</b> Store\nHalkias's soul inside of a\nfriendly <b>Secret</b>. It resummons\nHalkias when triggered.",
         "type": "MINION"
     },
     {
         "artist": "Slawomir Maniak",
         "cardClass": "DEMONHUNTER",
         "collectible": true,
-        "cost": 2,
+        "cost": 1,
         "dbfId": 78469,
         "flavor": "Faster than an asteroid, and just as effective.",
         "id": "REV_834",
@@ -59970,7 +59971,7 @@
         "name": "Promotion",
         "rarity": "EPIC",
         "set": "REVENDRETH",
-        "text": "Give a Silver Hand Recruit +3/+3.",
+        "text": "[x]Give a Silver Hand\nRecruit +3/+3\nand <b>Taunt</b>.",
         "type": "SPELL"
     },
     {
@@ -60258,7 +60259,7 @@
         "name": "Imbued Axe",
         "rarity": "COMMON",
         "set": "REVENDRETH",
-        "text": "[x]After your hero attacks,\ngive your damaged minions\n+1/+1. <b>Infuse (3):</b>\n+2/+2 instead.",
+        "text": "[x]After your hero attacks,\ngive your damaged minions\n+1/+2. <b>Infuse (2):</b>\n+2/+2 instead.",
         "type": "WEAPON"
     },
     {
@@ -60405,7 +60406,7 @@
         "artist": "L. Lullabi & K. Turovec",
         "cardClass": "DEMONHUNTER",
         "collectible": true,
-        "cost": 3,
+        "cost": 2,
         "dbfId": 77615,
         "flavor": "Holds Sire Denathrius' most prized possession - his teddy bear, Jeremy Bearimy.",
         "health": 2,
@@ -60745,7 +60746,7 @@
         "name": "Sanguine Depths",
         "rarity": "RARE",
         "set": "REVENDRETH",
-        "text": "[x]Deal 1 damage to a \nminion and give it \n+1 Attack.",
+        "text": "[x]Deal 1 damage to a \nminion and give it \n+2 Attack.",
         "type": "LOCATION"
     },
     {
@@ -63886,7 +63887,7 @@
         "attack": 6,
         "cardClass": "DEMONHUNTER",
         "collectible": true,
-        "cost": 8,
+        "cost": 7,
         "dbfId": 64373,
         "flavor": "\"You don't understand… ogres are an untapped market for vengeance and hatred!\"",
         "health": 7,
@@ -66700,7 +66701,7 @@
         "rarity": "COMMON",
         "set": "THE_SUNKEN_CITY",
         "targetingArrowText": "Deal 5 damage.",
-        "text": "<b>Battlecry:</b> Deal 5 damage. Gain 5 Armor.",
+        "text": "<b>Battlecry:</b> Deal 5 damage. Gain 8 Armor.",
         "type": "MINION"
     },
     {
@@ -70393,7 +70394,7 @@
         "artist": "BOSi Studio",
         "cardClass": "DEMONHUNTER",
         "collectible": true,
-        "cost": 4,
+        "cost": 3,
         "dbfId": 71922,
         "flavor": "*Happy Wisp noises*",
         "id": "TSC_608",

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -2100,11 +2100,10 @@ void AlteracValleyCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - SHAMAN
-    // [AV_255] Snowfall Guardian - COST:6 [ATK:3/HP:3]
+    // [AV_255] Snowfall Guardian - COST:6 [ATK:5/HP:5]
     // - Race: Elemental, Set: ALTERAC_VALLEY, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> <b>Freeze</b> all other minions.
-    //       Gain +1/+1 for each <b>Frozen</b> minion.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
@@ -2581,12 +2580,12 @@ void AlteracValleyCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // - Set: ALTERAC_VALLEY, Rarity: Rare
     // - Spell School: Frost
     // --------------------------------------------------------
-    // Text: Deal 4 damage to all minions.
+    // Text: Deal 5 damage to all minions.
     //       Costs (1) less for each Armor you have.
     // --------------------------------------------------------
     cardDef.ClearData();
     cardDef.power.AddPowerTask(
-        std::make_shared<DamageTask>(EntityType::ALL_MINIONS, 4, true));
+        std::make_shared<DamageTask>(EntityType::ALL_MINIONS, 5, true));
     cardDef.power.AddAura(
         std::make_shared<AdaptiveCostEffect>([](const Playable* playable) {
             return playable->player->GetHero()->GetArmor();
@@ -2837,7 +2836,7 @@ void AlteracValleyCardsGen::AddDemonHunter(
     CardDef cardDef;
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [AV_118] Battleworn Vanguard - COST:2 [ATK:2/HP:1]
+    // [AV_118] Battleworn Vanguard - COST:2 [ATK:2/HP:2]
     // - Set: ALTERAC_VALLEY, Rarity: Common
     // --------------------------------------------------------
     // Text: After your hero attacks, summon two 1/1 Felwings.

--- a/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/CoreCardsGen.cpp
@@ -1042,7 +1042,7 @@ void CoreCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // [CORE_AT_075] Warhorse Trainer - COST:3 [ATK:3/HP:4]
     // - Set: CORE, Rarity: Common
     // --------------------------------------------------------
-    // Text: Your Silver Hand Recruits have +1 Attack.
+    // Text: Your Silver Hand Recruits have +2 Attack and <b>Taunt</b>.
     // --------------------------------------------------------
     // GameTag:
     // - AURA = 1
@@ -1300,7 +1300,7 @@ void CoreCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     cards.emplace("CORE_OG_229", cardDef);
 
     // ---------------------------------------- SPELL - PALADIN
-    // [CORE_OG_273] Stand Against Darkness - COST:5
+    // [CORE_OG_273] Stand Against Darkness - COST:4
     // - Set: CORE, Rarity: Common
     // --------------------------------------------------------
     // Text: Summon five 1/1 Silver Hand Recruits.
@@ -1928,7 +1928,7 @@ void CoreCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     cards.emplace("CORE_CS2_076", cardDef);
 
     // ------------------------------------------ SPELL - ROGUE
-    // [CORE_CS2_077] Sprint - COST:6
+    // [CORE_CS2_077] Sprint - COST:5
     // - Set: CORE, Rarity: Rare
     // --------------------------------------------------------
     // Text: Draw 4 cards.
@@ -2871,7 +2871,7 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     CardDef cardDef;
 
     // ---------------------------------------- SPELL - WARRIOR
-    // [CORE_AT_064] Bash - COST:3
+    // [CORE_AT_064] Bash - COST:2
     // - Set: CORE, Rarity: Common
     // --------------------------------------------------------
     // Text: Deal 3 damage.
@@ -2920,7 +2920,7 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     cards.emplace("CORE_CS2_108", cardDef);
 
     // ---------------------------------------- SPELL - WARRIOR
-    // [CORE_EX1_391] Slam - COST:2
+    // [CORE_EX1_391] Slam - COST:1
     // - Set: CORE, Rarity: Common
     // --------------------------------------------------------
     // Text: Deal 2 damage to a minion. If it survives, draw a card.
@@ -3049,7 +3049,7 @@ void CoreCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     cards.emplace("CORE_EX1_414", cardDef);
 
     // --------------------------------------- MINION - WARRIOR
-    // [CORE_EX1_603] Cruel Taskmaster - COST:2 [ATK:2/HP:2]
+    // [CORE_EX1_603] Cruel Taskmaster - COST:2 [ATK:2/HP:3]
     // - Set: CORE, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Deal 1 damage to a minion

--- a/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/Expert1CardsGen.cpp
@@ -3800,7 +3800,7 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     cards.emplace("CS2_104", cardDef);
 
     // ---------------------------------------- SPELL - WARRIOR
-    // [EX1_391] Slam - COST:2
+    // [EX1_391] Slam - COST:1
     // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
     // Text: Deal 2 damage to a minion.
@@ -4005,7 +4005,7 @@ void Expert1CardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     cards.emplace("EX1_414", cardDef);
 
     // --------------------------------------- MINION - WARRIOR
-    // [EX1_603] Cruel Taskmaster - COST:2 [ATK:2/HP:2]
+    // [EX1_603] Cruel Taskmaster - COST:2 [ATK:2/HP:3]
     // - Faction: Neutral, Set: Expert1, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Deal 1 damage to a minion

--- a/Sources/Rosetta/PlayMode/CardSets/LegacyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LegacyCardsGen.cpp
@@ -1735,7 +1735,7 @@ void LegacyCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     cards.emplace("CS2_076", cardDef);
 
     // ------------------------------------------ SPELL - ROGUE
-    // [CS2_077] Sprint - COST:6
+    // [CS2_077] Sprint - COST:5
     // - Faction: Neutral, Set: Legacy, Rarity: Free
     // --------------------------------------------------------
     // Text: Draw 4 cards.

--- a/Sources/Rosetta/PlayMode/CardSets/LootapaloozaCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LootapaloozaCardsGen.cpp
@@ -1065,7 +1065,7 @@ void LootapaloozaCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [LOOT_412] Kobold Illusionist - COST:4 [ATK:3/HP:3]
+    // [LOOT_412] Kobold Illusionist - COST:5 [ATK:3/HP:3]
     // - Faction: Alliance, Set: Lootapalooza, Rarity: Rare
     // --------------------------------------------------------
     // Text: <b>Deathrattle:</b> Summon a 1/1 copy of a minion

--- a/Sources/Rosetta/PlayMode/CardSets/OgCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/OgCardsGen.cpp
@@ -556,7 +556,7 @@ void OgCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     cards.emplace("OG_229", cardDef);
 
     // ---------------------------------------- SPELL - PALADIN
-    // [OG_273] Stand Against Darkness - COST:5
+    // [OG_273] Stand Against Darkness - COST:4
     // - Set: Og, Rarity: Common
     // --------------------------------------------------------
     // Text: Summon five 1/1 Silver Hand Recruits.

--- a/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
@@ -489,7 +489,7 @@ void RevendrethCardsGen::AddHunterNonCollect(
     // - Race: Beast, Set: REVENDRETH
     // --------------------------------------------------------
     // Text: <b>Dormant</b> for 3 turns.
-    //       When this awakens, equip a 4/2 Greatbow.
+    //       When this awakens, equip a 3/2 Greatbow.
     // --------------------------------------------------------
 
     // ----------------------------------- ENCHANTMENT - HUNTER
@@ -703,7 +703,7 @@ void RevendrethCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // [REV_842] Promotion - COST:1
     // - Set: REVENDRETH, Rarity: Epic
     // --------------------------------------------------------
-    // Text: Give a Silver Hand Recruit +3/+3.
+    // Text: Give a Silver Hand Recruit +3/+3 and <b>Taunt</b>.
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
@@ -849,7 +849,7 @@ void RevendrethCardsGen::AddPaladinNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - PALADIN
-    // [REV_951t] Legendary Invitation - COST:3
+    // [REV_951t] Legendary Invitation - COST:2
     // - Set: REVENDRETH
     // --------------------------------------------------------
     // Text: <b>Discover</b> a <b>Legendary</b> minion
@@ -1162,8 +1162,9 @@ void RevendrethCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // [REV_829] Halkias - COST:4 [ATK:5/HP:4]
     // - Race: Elemental, Set: REVENDRETH, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Deathrattle:</b> If you control a <b>Secret</b>,
-    //       store Halkias' soul inside of it.
+    // Text: <b>Stealth</b>.
+    //       <b>Deathrattle:</b> Store Halkias's soul
+    //       inside of a friendly <b>Secret</b>.
     //       It resummons Halkias when triggered.
     // --------------------------------------------------------
     // GameTag:
@@ -1531,8 +1532,7 @@ void RevendrethCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // [REV_371] Vile Library - COST:2
     // - Set: REVENDRETH, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Give a friendly minion +1/+1.
-    //       Repeat for each Imp you control.
+    // Text: Give a minion +1/+1 for each Imp you control.
     // --------------------------------------------------------
 
     // ---------------------------------------- SPELL - WARLOCK
@@ -1755,8 +1755,8 @@ void RevendrethCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // - Set: REVENDRETH, Rarity: Common
     // --------------------------------------------------------
     // Text: After your hero attacks,
-    //       give your damaged minions +1/+1.
-    //       <b>Infuse (3):</b> +2/+2 instead.
+    //       give your damaged minions +1/+2.
+    //       <b>Infuse (2):</b> +2/+2 instead.
     // --------------------------------------------------------
     // GameTag:
     // - INFUSE = 1
@@ -1779,7 +1779,7 @@ void RevendrethCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // [REV_990] Sanguine Depths - COST:1
     // - Set: REVENDRETH, Rarity: Rare
     // --------------------------------------------------------
-    // Text: Deal 1 damage to a minion and give it +1 Attack.
+    // Text: Deal 1 damage to a minion and give it +2 Attack.
     // --------------------------------------------------------
 }
 
@@ -1956,7 +1956,7 @@ void RevendrethCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [REV_511] Bibliomite - COST:2 [ATK:4/HP:4]
+    // [REV_511] Bibliomite - COST:2 [ATK:5/HP:4]
     // - Set: REVENDRETH, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry</b>: Choose a card in your hand
@@ -1967,7 +1967,7 @@ void RevendrethCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ------------------------------------ SPELL - DEMONHUNTER
-    // [REV_834] Relic of Extinction - COST:2
+    // [REV_834] Relic of Extinction - COST:1
     // - Set: REVENDRETH, Rarity: Common
     // --------------------------------------------------------
     // Text: Deal 1 damage to a random enemy minion, twice.
@@ -1991,7 +1991,7 @@ void RevendrethCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------- LOCATION - DEMONHUNTER
-    // [REV_942] Relic Vault - COST:3
+    // [REV_942] Relic Vault - COST:2
     // - Set: REVENDRETH, Rarity: Rare
     // --------------------------------------------------------
     // Text: The next Relic you play this turn casts twice.

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -1855,7 +1855,7 @@ void StormwindCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [DED_510] Edwin, Defias Kingpin - COST:4 [ATK:4/HP:4]
+    // [DED_510] Edwin, Defias Kingpin - COST:3 [ATK:3/HP:3]
     // - Race: Pirate, Set: STORMWIND, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Draw a card.
@@ -2832,7 +2832,7 @@ void StormwindCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     CardDef cardDef;
 
     // ----------------------------------- MINION - DEMONHUNTER
-    // [SW_037] Irebound Brute - COST:8 [ATK:6/HP:7]
+    // [SW_037] Irebound Brute - COST:7 [ATK:6/HP:7]
     // - Race: Demon, Set: STORMWIND, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Taunt</b>

--- a/Sources/Rosetta/PlayMode/CardSets/TgtCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TgtCardsGen.cpp
@@ -675,7 +675,7 @@ void TgtCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // [AT_075] Warhorse Trainer - COST:3 [ATK:2/HP:4]
     // - Set: Tgt, Rarity: Common
     // --------------------------------------------------------
-    // Text: Your Silver Hand Recruits have +1 Attack.
+    // Text: Your Silver Hand Recruits have +2 Attack and <b>Taunt</b>.
     // --------------------------------------------------------
     // GameTag:
     // - AURA = 1
@@ -772,7 +772,7 @@ void TgtCardsGen::AddPaladinNonCollect(std::map<std::string, CardDef>& cards)
     // [AT_075e] Might of the Hostler (*) - COST:0
     // - Set: Tgt
     // --------------------------------------------------------
-    // Text: Warhorse Trainer is granting this minion +1 Attack.
+    // Text: Warhorse Trainer is granting +2 Attack and <b>Taunt</b>.
     // --------------------------------------------------------
     cardDef.ClearData();
     cardDef.power.AddEnchant(Enchants::GetEnchantFromText("AT_075e"));
@@ -1380,7 +1380,7 @@ void TgtCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     CardDef cardDef;
 
     // ---------------------------------------- SPELL - WARRIOR
-    // [AT_064] Bash - COST:3
+    // [AT_064] Bash - COST:2
     // - Set: Tgt, Rarity: Common
     // --------------------------------------------------------
     // Text: Deal 3 damage.

--- a/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheBarrensCardsGen.cpp
@@ -137,8 +137,8 @@ void TheBarrensCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // - Set: THE_BARRENS, Rarity: Epic
     // - Spell School: Arcane
     // --------------------------------------------------------
-    // Text: Set each player to 0 Mana Crystals.
-    //       Set the Cost of cards in all hands and decks to (1).
+    // Text: Set your Mana Crystals to 0.
+    //       Set the cost of all cards in your hand and deck to (1).
     // --------------------------------------------------------
     cardDef.ClearData();
     cardDef.power.AddPowerTask(std::make_shared<SetManaCrystalTask>(0));
@@ -146,10 +146,6 @@ void TheBarrensCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
         std::make_shared<AddEnchantmentTask>("BAR_539e", EntityType::HAND));
     cardDef.power.AddPowerTask(
         std::make_shared<AddEnchantmentTask>("BAR_539e", EntityType::DECK));
-    cardDef.power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
-        "BAR_539e", EntityType::ENEMY_HAND));
-    cardDef.power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
-        "BAR_539e", EntityType::ENEMY_DECK));
     cards.emplace("BAR_539", cardDef);
 
     // ----------------------------------------- MINION - DRUID
@@ -1909,7 +1905,7 @@ void TheBarrensCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     cards.emplace("BAR_317", cardDef);
 
     // ------------------------------------------ SPELL - ROGUE
-    // [BAR_318] Silverleaf Poison - COST:2
+    // [BAR_318] Silverleaf Poison - COST:1
     // - Set: THE_BARRENS, Rarity: Common
     // - Spell School: Nature
     // --------------------------------------------------------

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -2468,7 +2468,7 @@ void TheSunkenCityCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // [TID_716] Tidal Revenant - COST:8 [ATK:5/HP:8]
     // - Race: Elemental, Set: THE_SUNKEN_CITY, Rarity: Common
     // --------------------------------------------------------
-    // Text: <b>Battlecry:</b> Deal 5 damage. Gain 5 Armor.
+    // Text: <b>Battlecry:</b> Deal 5 damage. Gain 8 Armor.
     // --------------------------------------------------------
     // GameTag:
     // - BATTLECRY = 1
@@ -2680,7 +2680,7 @@ void TheSunkenCityCardsGen::AddDemonHunter(
     // --------------------------------------------------------
 
     // ------------------------------------ SPELL - DEMONHUNTER
-    // [TSC_608] Abyssal Depths - COST:4
+    // [TSC_608] Abyssal Depths - COST:3
     // - Set: THE_SUNKEN_CITY, Rarity: Common
     // - Spell School: Shadow
     // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/AlteracValleyCardsGenTests.cpp
@@ -1807,7 +1807,7 @@ TEST_CASE("[Warlock : Minion] - AV_308 : Grave Defiler")
 // - Set: ALTERAC_VALLEY, Rarity: Rare
 // - Spell School: Frost
 // --------------------------------------------------------
-// Text: Deal 4 damage to all minions.
+// Text: Deal 5 damage to all minions.
 //       Costs (1) less for each Armor you have.
 // --------------------------------------------------------
 TEST_CASE("[Warrior : Spell] - AV_108 : Shield Shatter")
@@ -1864,8 +1864,8 @@ TEST_CASE("[Warrior : Spell] - AV_108 : Shield Shatter")
     CHECK_EQ(card1->GetCost(), 5);
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
-    CHECK_EQ(curField[0]->GetHealth(), 2);
-    CHECK_EQ(opField[0]->GetHealth(), 8);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(opField[0]->GetHealth(), 7);
 }
 
 // ---------------------------------------- SPELL - WARRIOR

--- a/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/CoreCardsGenTests.cpp
@@ -3084,7 +3084,7 @@ TEST_CASE("[Mage : Minion] - CORE_UNG_020 : Arcanologist")
 // [CORE_AT_075] Warhorse Trainer - COST:3 [ATK:3/HP:4]
 // - Set: CORE, Rarity: Common
 // --------------------------------------------------------
-// Text: Your Silver Hand Recruits have +1 Attack.
+// Text: Your Silver Hand Recruits have +2 Attack and <b>Taunt</b>.
 // --------------------------------------------------------
 // GameTag:
 // - AURA = 1
@@ -3128,7 +3128,8 @@ TEST_CASE("[Paladin : Minion] - CORE_AT_075 : Warhorse Trainer")
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     CHECK_EQ(curField.GetCount(), 3);
     CHECK_EQ(curField[0]->GetAttack(), 3);
-    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->HasTaunt(), true);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);
@@ -3137,6 +3138,7 @@ TEST_CASE("[Paladin : Minion] - CORE_AT_075 : Warhorse Trainer")
     CHECK_EQ(curField.GetCount(), 2);
     CHECK_EQ(curField[0]->GetAttack(), 3);
     CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->HasTaunt(), false);
 }
 
 // ---------------------------------------- SPELL - PALADIN
@@ -3887,7 +3889,7 @@ TEST_CASE("[Paladin : Minion] - CORE_OG_229 : Ragnaros, Lightlord")
 }
 
 // ---------------------------------------- SPELL - PALADIN
-// [CORE_OG_273] Stand Against Darkness - COST:5
+// [CORE_OG_273] Stand Against Darkness - COST:4
 // - Set: CORE, Rarity: Common
 // --------------------------------------------------------
 // Text: Summon five 1/1 Silver Hand Recruits.
@@ -5383,7 +5385,7 @@ TEST_CASE("[Rogue : Spell] - CORE_CS2_076 : Assassinate")
 }
 
 // ------------------------------------------ SPELL - ROGUE
-// [CORE_CS2_077] Sprint - COST:6
+// [CORE_CS2_077] Sprint - COST:5
 // - Set: CORE, Rarity: Rare
 // --------------------------------------------------------
 // Text: Draw 4 cards.
@@ -7705,7 +7707,7 @@ TEST_CASE("[Warlock : Minion] - CS3_003 : Felsoul Jailer")
 }
 
 // ---------------------------------------- SPELL - WARRIOR
-// [CORE_AT_064] Bash - COST:3
+// [CORE_AT_064] Bash - COST:2
 // - Set: CORE, Rarity: Common
 // --------------------------------------------------------
 // Text: Deal 3 damage.
@@ -7817,7 +7819,7 @@ TEST_CASE("[Warrior : Spell] - CORE_CS2_108 : Execute")
 }
 
 // ---------------------------------------- SPELL - WARRIOR
-// [CORE_EX1_391] Slam - COST:2
+// [CORE_EX1_391] Slam - COST:1
 // - Set: CORE, Rarity: Common
 // --------------------------------------------------------
 // Text: Deal 2 damage to a minion. If it survives, draw a card.
@@ -8240,7 +8242,7 @@ TEST_CASE("[Warrior : Minion] - CORE_EX1_414 : Grommash Hellscream")
 }
 
 // --------------------------------------- MINION - WARRIOR
-// [CORE_EX1_603] Cruel Taskmaster - COST:2 [ATK:2/HP:2]
+// [CORE_EX1_603] Cruel Taskmaster - COST:2 [ATK:2/HP:3]
 // - Set: CORE, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Deal 1 damage to a minion
@@ -8284,13 +8286,13 @@ TEST_CASE("[Warrior : Minion] - CORE_EX1_603 : Cruel Taskmaster")
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     CHECK_EQ(curField[0]->GetAttack(), 2);
-    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
 
     game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card1));
     CHECK_EQ(curField[0]->GetAttack(), 4);
-    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
     CHECK_EQ(curField[1]->GetAttack(), 2);
-    CHECK_EQ(curField[1]->GetHealth(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
 }
 
 // --------------------------------------- MINION - WARRIOR

--- a/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/Expert1CardsGenTests.cpp
@@ -8002,7 +8002,7 @@ TEST_CASE("[Warrior : Spell] - CS2_104 : Rampage")
 }
 
 // ---------------------------------------- SPELL - WARRIOR
-// [EX1_391] Slam - COST:2
+// [EX1_391] Slam - COST:1
 // - Faction: Neutral, Set: Expert1, Rarity: Common
 // --------------------------------------------------------
 // Text: Deal 2 damage to a minion.
@@ -8598,7 +8598,7 @@ TEST_CASE("[Warrior : Minion] - EX1_414 : Grommash Hellscream")
 }
 
 // --------------------------------------- MINION - WARRIOR
-// [EX1_603] Cruel Taskmaster - COST:2 [ATK:2/HP:2]
+// [EX1_603] Cruel Taskmaster - COST:2 [ATK:2/HP:3]
 // - Faction: Neutral, Set: Expert1, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Battlecry:</b> Deal 1 damage to a minion
@@ -8641,13 +8641,13 @@ TEST_CASE("[Warrior : Minion] - EX1_603 : Cruel Taskmaster")
 
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     CHECK_EQ(curField[0]->GetAttack(), 2);
-    CHECK_EQ(curField[0]->GetHealth(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
 
     game.Process(curPlayer, PlayCardTask::MinionTarget(card2, card1));
     CHECK_EQ(curField[0]->GetAttack(), 4);
-    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[0]->GetHealth(), 2);
     CHECK_EQ(curField[1]->GetAttack(), 2);
-    CHECK_EQ(curField[1]->GetHealth(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
 }
 
 // --------------------------------------- MINION - WARRIOR

--- a/Tests/UnitTests/PlayMode/CardSets/LegacyCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/LegacyCardsGenTests.cpp
@@ -3701,7 +3701,7 @@ TEST_CASE("[Rogue : Spell] - CS2_076 : Assassinate")
 }
 
 // ------------------------------------------ SPELL - ROGUE
-// [CS2_077] Sprint - COST:6
+// [CS2_077] Sprint - COST:5
 // - Faction: Neutral, Set: Legacy, Rarity: Free
 // --------------------------------------------------------
 // Text: Draw 4 cards.

--- a/Tests/UnitTests/PlayMode/CardSets/OgCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/OgCardsGenTests.cpp
@@ -187,7 +187,7 @@ TEST_CASE("[Paladin : Minion] - OG_229 : Ragnaros, Lightlord")
 }
 
 // ---------------------------------------- SPELL - PALADIN
-// [OG_273] Stand Against Darkness - COST:5
+// [OG_273] Stand Against Darkness - COST:4
 // - Set: Og, Rarity: Common
 // --------------------------------------------------------
 // Text: Summon five 1/1 Silver Hand Recruits.

--- a/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/StormwindCardsGenTests.cpp
@@ -2323,7 +2323,7 @@ TEST_CASE("[Warrior : Minion] - DED_519 : Defias Cannoneer")
 }
 
 // ----------------------------------- MINION - DEMONHUNTER
-// [SW_037] Irebound Brute - COST:8 [ATK:6/HP:7]
+// [SW_037] Irebound Brute - COST:7 [ATK:6/HP:7]
 // - Race: Demon, Set: STORMWIND, Rarity: Common
 // --------------------------------------------------------
 // Text: <b>Taunt</b>
@@ -2357,10 +2357,10 @@ TEST_CASE("[Demon Hunter : Minion] - SW_037 : Irebound Brute")
     const auto card2 =
         Generic::DrawCard(curPlayer, Cards::FindCardByName("Chaos Strike"));
 
-    CHECK_EQ(card1->GetCost(), 7);
+    CHECK_EQ(card1->GetCost(), 6);
 
     game.Process(curPlayer, PlayCardTask::Spell(card2));
-    CHECK_EQ(card1->GetCost(), 6);
+    CHECK_EQ(card1->GetCost(), 5);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);
@@ -2368,7 +2368,7 @@ TEST_CASE("[Demon Hunter : Minion] - SW_037 : Irebound Brute")
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);
 
-    CHECK_EQ(card1->GetCost(), 7);
+    CHECK_EQ(card1->GetCost(), 6);
 }
 
 // ----------------------------------- MINION - DEMONHUNTER

--- a/Tests/UnitTests/PlayMode/CardSets/TgtCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TgtCardsGenTests.cpp
@@ -236,7 +236,7 @@ TEST_CASE("[Mage : Minion] - AT_008 : Coldarra Drake")
 // [AT_075] Warhorse Trainer - COST:3 [ATK:2/HP:4]
 // - Set: Tgt, Rarity: Common
 // --------------------------------------------------------
-// Text: Your Silver Hand Recruits have +1 Attack.
+// Text: Your Silver Hand Recruits have +2 Attack and <b>Taunt</b>.
 // --------------------------------------------------------
 // GameTag:
 // - AURA = 1
@@ -279,7 +279,8 @@ TEST_CASE("[Paladin : Minion] - AT_075 : Warhorse Trainer")
     game.Process(curPlayer, PlayCardTask::Minion(card1));
     CHECK_EQ(curField.GetCount(), 3);
     CHECK_EQ(curField[0]->GetAttack(), 3);
-    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->HasTaunt(), true);
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);
@@ -288,6 +289,7 @@ TEST_CASE("[Paladin : Minion] - AT_075 : Warhorse Trainer")
     CHECK_EQ(curField.GetCount(), 2);
     CHECK_EQ(curField[0]->GetAttack(), 3);
     CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->HasTaunt(), false);
 }
 
 // ----------------------------------------- SPELL - PRIEST
@@ -490,7 +492,7 @@ TEST_CASE("[Warlock : Minion] - AT_021 : Tiny Knight of Evil")
 }
 
 // ---------------------------------------- SPELL - WARRIOR
-// [AT_064] Bash - COST:3
+// [AT_064] Bash - COST:2
 // - Set: Tgt, Rarity: Common
 // --------------------------------------------------------
 // Text: Deal 3 damage.

--- a/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/TheBarrensCardsGenTests.cpp
@@ -364,8 +364,8 @@ TEST_CASE("[Druid : Minion] - BAR_538 : Druid of the Plains")
 // - Set: THE_BARRENS, Rarity: Epic
 // - Spell School: Arcane
 // --------------------------------------------------------
-// Text: Set each player to 0 Mana Crystals.
-//       Set the Cost of cards in all hands and decks to (1).
+// Text: Set your Mana Crystals to 0.
+//       Set the cost of all cards in your hand and deck to (1).
 // --------------------------------------------------------
 TEST_CASE("[Druid : Spell] - BAR_539 : Celestial Alignment")
 {
@@ -381,9 +381,6 @@ TEST_CASE("[Druid : Spell] - BAR_539 : Celestial Alignment")
         config.player1Deck[i] = Cards::FindCardByName("Fireball");
         config.player1Deck[i + 1] = Cards::FindCardByName("Wisp");
         config.player1Deck[i + 2] = Cards::FindCardByName("Doomhammer");
-        config.player2Deck[i] = Cards::FindCardByName("Fireball");
-        config.player2Deck[i + 1] = Cards::FindCardByName("Wisp");
-        config.player2Deck[i + 2] = Cards::FindCardByName("Doomhammer");
     }
 
     Game game(config);
@@ -406,11 +403,9 @@ TEST_CASE("[Druid : Spell] - BAR_539 : Celestial Alignment")
         curPlayer, Cards::FindCardByName("Celestial Alignment"));
 
     CHECK_EQ(curPlayer->GetTotalMana(), 10);
-    CHECK_EQ(opPlayer->GetTotalMana(), 10);
 
     game.Process(curPlayer, PlayCardTask::Spell(card1));
     CHECK_EQ(curPlayer->GetTotalMana(), 0);
-    CHECK_EQ(opPlayer->GetTotalMana(), 0);
     for (auto& card : curHand.GetAll())
     {
         CHECK_EQ(card->GetCost(), 1);
@@ -419,26 +414,16 @@ TEST_CASE("[Druid : Spell] - BAR_539 : Celestial Alignment")
     {
         CHECK_EQ(card->GetCost(), 1);
     }
-    for (auto& card : opHand.GetAll())
-    {
-        CHECK_EQ(card->GetCost(), 1);
-    }
-    for (auto& card : opDeck.GetAll())
-    {
-        CHECK_EQ(card->GetCost(), 1);
-    }
 
     game.Process(curPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);
 
     CHECK_EQ(curPlayer->GetTotalMana(), 0);
-    CHECK_EQ(opPlayer->GetTotalMana(), 1);
 
     game.Process(opPlayer, EndTurnTask());
     game.ProcessUntil(Step::MAIN_ACTION);
 
     CHECK_EQ(curPlayer->GetTotalMana(), 1);
-    CHECK_EQ(opPlayer->GetTotalMana(), 1);
 }
 
 // ----------------------------------------- MINION - DRUID
@@ -3338,7 +3323,7 @@ TEST_CASE("[Rogue : Minion] - BAR_317 : Field Contact")
 }
 
 // ------------------------------------------ SPELL - ROGUE
-// [BAR_318] Silverleaf Poison - COST:2
+// [BAR_318] Silverleaf Poison - COST:1
 // - Set: THE_BARRENS, Rarity: Common
 // - Spell School: Nature
 // --------------------------------------------------------


### PR DESCRIPTION
This revision includes:
- Update Hearthstone Patch 24.0.3 (Resolves #825)
  - Card update
    - Celestial Alignment: Old: Set each player to 0 Mana Crystals. Set the cost of all cards in hands and decks to (1). → New:  Set your Mana Crystals to 0. Set the cost of all cards in your hand and deck to (1).
    - Stag Spirit Wildseed: Old: Dormant for 3 turns. When this awakens, equip a 4/2 Greatbow. → New: Dormant for 3 turns. When this awakens, equip a 3/2 Greatbow.
    - Snowfall Guardian: Old: 3 Attack, 3 Health. Battlecry: Freeze all other minions. Gain +1/+1 for each Frozen minion. → New: 5 Attack, 5 Health. Battlecry: Freeze all other minions.
    - Vile Library: Old: Give a friendly minion +1/+1. Repeat for each Imp you control. → New: Give a minion +1/+1 for each Imp you control.
    - Kobold Illusionist: Old: [Costs 4] → New: [Costs 5]
    - Relic Vault: Old: [Costs 3] → New: [Costs 2]
    - Relic of Extinction: Old: [Costs 2] → New: [Costs 1]
    - Bibliomite: Old: 4 Attack, 4 Health → New: 5 Attack, 4 Health
    - Magnifying Glaive: Old: 2 Attack, 2 Durability → New: 3 Attack, 2 Durability
    - Abyssal Depths: Old: [Costs 4] → New: [Costs 3]
    - Battleworn Vanguard: Old: 2 Attack, 1 Health → New: 2 Attack, 2 Health
    - Irebound Brute: Old: [Costs 8] →  New: [Costs 7]
    - Legendary Invitation (generated by The Countess): Old: [Costs 3] → New: [Costs 2]
    - Stand Against Darkness: Old: [Costs 5] → New: [Costs 4]
    - Warhorse Trainer: Old: Your Silver Hand Recruits Have +1 Attack. → New: Your Silver Hand Recruits have +2 Attack and Taunt.
    - Promotion: Old: Give a Silver Hand Recruit +3/+3. → New: Give a Silver Hand Recruit +3/+3 and Taunt.
    - Edwin, Defias Kingpin: Old: [Costs 4] 4 Attack, 4 Health → New: [Costs 3] 3 Attack, 3 Health
    - Sprint: Old: [Costs 6] →  New: [Costs 5]
    - Silverleaf Poison: Old: [Costs 2] → New: [Costs 1]
    - Halkias: Old: Deathrattle: If you control a Secret, store Halkias' soul inside of it. It resummons Halkias when triggered. → New: Stealth. Deathrattle: Store Halkias's soul inside of a friendly Secret. It resummons Halkias when triggered.
    - Sanguine Depths: Old: Deal 1 damage to a minion and give it +1 Attack. → New: Deal 1 damage to a minion and give it +2 Attack.
    - Imbued Axe: Old: After your hero attacks, give your damaged minions +1/+1. Infuse (3): +2/+2 instead. → New: After your hero attacks, give your damaged minions +1/+2. Infuse (2): +2/+2 instead.
    - Cruel Taskmaster: Old: 2 Attack, 2 Health →  New: 2 Attack, 3 Health
    - Tidal Revenant: Old: Battlecry: Deal 5 damage. Gain 5 Armor. → New: Battlecry: Deal 5 damage. Gain 8 Armor.
    - Shield Shatter: Old: Deal 4 damage to all minions. Costs (1) less for each Armor you have. → New: Deal 5 damage to all minions. Costs (1) less for each Armor you have.
    - Slam: Old: [Costs 2] → New: [Costs 1]
    - Bash: Old: [Costs 3] → New: [Costs 2]
  - Battlegrounds update
    - Lich Baz’hial has been moved to Armor Tier 1
    - Dancin’ Deryl, Deathwing, Elise Starseeker, Guff Runetotem, and Sneed have been moved to Armor Tier 2
    - Hero changes
      - Lich Baz’hial: Old: Take 2 damage and add a Gold coin to your hand. → New: Take 4 damage. Gain 2 Gold this turn only.
      - Guff Runetotem: Old: Give a friendly minion of each Tavern Tier +3/+2. → New: Give a friendly minion of each Tavern Tier +2/+2.
      - Deathwing: Old: Passive: Give ALL minions +2 Attack. → New: Passive: Give ALL minions +3 Attack.
      - Kael’thas Sunstrider: Old: Every third minion you buy gets +2/+2. → New: Every third minion you play gets +2/+2.
      - Elise Starseeker: Old: When you upgrade Bob’s Tavern get a ‘Recruitment Map’. → New: [Costs 1] Discover a minion from your Tavern Tier. Costs (1) more after each use.
      - Sneed: Old: Give a minion: “Deathrattle: Summon a random minion from a lower Tavern Tier.” → New: Give a minion: “Deathrattle: Summon a random minion from a Tavern Tier lower.”
    - Minion changes
      - Lieutenant Garr and Grease Bot have been returned to the minion pool.
      - Grease Bot: Old: Divine Shield. After a friendly minion loses Divine Shield, give it +3/+2 permanently. → New: After a friendly minion loses Divine Shield, give it +2/+2 permanently.
      - Lil’ Rag: Old: [Tavern Tier 6] → New: [Tavern Tier 5]
      - Gentle Djinni: Old: Taunt. Deathrattle: Summon another random Elemental and add a copy of it to your hand. → New: Taunt. Deathrattle: Add another random Elemental to your hand and summon a copy of it.
      - Evolving Chromawing: Old: 1 Attack, 1 Health. After you upgrade your Tavern Tier, gain +1/+1 for each friendly Dragon. →  New: 1 Attack, 4 Health. After you upgrade your Tavern Tier, gain +1 Attack for each friendly Dragon.