### PR TITLE
Update Hearthstone Patch 24.2.2

### DIFF
--- a/Resources/cards.collectible.json
+++ b/Resources/cards.collectible.json
@@ -3359,7 +3359,7 @@
         "name": "Wildheart Guff",
         "rarity": "LEGENDARY",
         "set": "ALTERAC_VALLEY",
-        "text": "[x]<b>Battlecry:</b> Set your\nmaximum Mana to 20.\nGain a Mana Crystal.\nDraw a card.",
+        "text": "[x]<b>Battlecry:</b> Set your\nmaximum Mana to 20.\nGain an empty Mana\nCrystal. Draw a card.",
         "type": "HERO"
     },
     {
@@ -28221,14 +28221,14 @@
     },
     {
         "artist": "Zoltan Boros",
-        "attack": 3,
+        "attack": 4,
         "cardClass": "ROGUE",
         "collectible": true,
-        "cost": 3,
+        "cost": 4,
         "dbfId": 65645,
         "elite": true,
         "flavor": "He’s not going to tear down the walls of Stormwind sitting around in the Hall of Fame.",
-        "health": 3,
+        "health": 4,
         "id": "DED_510",
         "isMiniSet": true,
         "mechanics": [
@@ -58446,7 +58446,7 @@
         "attack": 4,
         "cardClass": "NEUTRAL",
         "collectible": true,
-        "cost": 6,
+        "cost": 8,
         "dbfId": 79934,
         "elite": true,
         "flavor": "You heard about Kael'thas? That's messed up, right?",
@@ -59686,7 +59686,7 @@
         "cost": 3,
         "dbfId": 84356,
         "flavor": "For VIPs only. (Very Infused Person)",
-        "health": 3,
+        "health": 2,
         "id": "REV_602",
         "name": "Nightcloak Sanctum",
         "rarity": "RARE",
@@ -65235,7 +65235,7 @@
         "cost": 3,
         "dbfId": 64368,
         "flavor": "Back in my day, we had to carry our inspiration uphill both ways to war.",
-        "health": 1,
+        "health": 2,
         "id": "SW_315",
         "mechanics": [
             "BATTLECRY"
@@ -65343,7 +65343,7 @@
         "name": "Defend the Dwarven District",
         "rarity": "LEGENDARY",
         "set": "STORMWIND",
-        "text": "<b>Questline:</b> Deal damage with 2 spells. <b>Reward:</b> Your Hero Power can target minions.",
+        "text": "<b>Questline:</b> Deal damage with 3 spells. <b>Reward:</b> Your Hero Power can target minions.",
         "type": "SPELL"
     },
     {
@@ -69692,7 +69692,7 @@
         "cost": 4,
         "dbfId": 72598,
         "flavor": "She also tutors 3 Piranha Swarmers on her off hours.",
-        "health": 3,
+        "health": 4,
         "howToEarnGolden": "Unlocked with \"Shale University\" Achievement.",
         "id": "TSC_052",
         "mechanics": [
@@ -71485,7 +71485,7 @@
         "attack": 2,
         "cardClass": "NEUTRAL",
         "collectible": true,
-        "cost": 3,
+        "cost": 4,
         "dbfId": 72333,
         "flavor": "Is a sucker for small talk.",
         "health": 4,

--- a/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/AlteracValleyCardsGen.cpp
@@ -85,7 +85,7 @@ void AlteracValleyCardsGen::AddHeroes(std::map<std::string, CardDef>& cards)
     // - Set: ALTERAC_VALLEY, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Set your maximum Mana to 20.
-    //       Gain a Mana Crystal. Draw a card.
+    //       Gain an empty Mana Crystal. Draw a card.
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
@@ -159,7 +159,7 @@ void AlteracValleyCardsGen::AddHeroPowers(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: <b>Hero Power</b>
     //       Deal 2 damage.
-    //       <b>Honorable Kill:</b> Gain +2 damage.
+    //       <b>Honorable Kill:</b> Gain +1 damage.
     // --------------------------------------------------------
     // GameTag:
     // - HONORABLEKILL = 1

--- a/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
@@ -2187,7 +2187,7 @@ void RevendrethCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [REV_021] Kael'thas Sinstrider - COST:6 [ATK:4/HP:7]
+    // [REV_021] Kael'thas Sinstrider - COST:8 [ATK:4/HP:7]
     // - Set: REVENDRETH, Rarity: Legendary
     // --------------------------------------------------------
     // Text: Every third minion you play each turn costs (0).

--- a/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/StormwindCardsGen.cpp
@@ -577,7 +577,7 @@ void StormwindCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // [SW_322] Defend the Dwarven District - COST:1
     // - Set: STORMWIND, Rarity: Legendary
     // --------------------------------------------------------
-    // Text: <b>Questline:</b> Deal damage with 2 spells.
+    // Text: <b>Questline:</b> Deal damage with 3 spells.
     //       <b>Reward:</b> Your Hero Power can target minions.
     // --------------------------------------------------------
     // GameTag:
@@ -1217,7 +1217,7 @@ void StormwindCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - PALADIN
-    // [SW_315] Alliance Bannerman - COST:3 [ATK:2/HP:1]
+    // [SW_315] Alliance Bannerman - COST:3 [ATK:2/HP:2]
     // - Set: STORMWIND, Rarity: Common
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Draw a minion.
@@ -1855,7 +1855,7 @@ void StormwindCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // ----------------------------------------- MINION - ROGUE
-    // [DED_510] Edwin, Defias Kingpin - COST:3 [ATK:3/HP:3]
+    // [DED_510] Edwin, Defias Kingpin - COST:4 [ATK:4/HP:4]
     // - Race: Pirate, Set: STORMWIND, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Draw a card.

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -3001,7 +3001,7 @@ void TheSunkenCityCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [TSC_052] School Teacher - COST:4 [ATK:4/HP:3]
+    // [TSC_052] School Teacher - COST:4 [ATK:4/HP:4]
     // - Race: Naga, Set: THE_SUNKEN_CITY, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Add a 1/1 Nagaling to your hand.
@@ -3274,7 +3274,7 @@ void TheSunkenCityCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [TSC_926] Smothering Starfish - COST:3 [ATK:2/HP:4]
+    // [TSC_926] Smothering Starfish - COST:4 [ATK:2/HP:4]
     // - Race: Beast, Set: THE_SUNKEN_CITY, Rarity: Epic
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> <b>Silence</b> ALL other minions.


### PR DESCRIPTION
This revision includes:
- Update Hearthstone Patch 24.2.2 (Resolves #836)
  - Card update
    - Wildheart Guff
      - Old: Battlecry and Hero Power granted full mana crystals
      - New: Battlecry and Hero Power grant empty mana crystals.
    - Edwin, Defias Kingpin
      - Old: [Costs 3] 3 Attack, 3 Health
      - New: [Costs 4] 4 Attack, 4 Health
    - Arcane Burst (Magister Dawngrasp’s Hero Power)
      - Old: Deal 2 damage. Honorable Kill: Gain +2 damage
      - New: Deal 2 damage. Honorable Kill: Gain +1 damage.
    - Nightcloak Sanctum
      - Old: 3 Durability
      - New: 2 Durability
    - Defend the Dwarven District (the first stage of the Hunter Questline)
      - Old: Deal damage with 2 spells
      - New: Deal damage with 3 spells.
    - Kael’thas Sinstrider
      - Old: [Costs 6]
      - New: [Costs 8]
    - Smothering Starfish
      - Old: [Costs 3]
      - New: [Costs 4]
    - School Teacher
      - Old: 4 Attack, 3 Health
      - New: 4 Attack, 4 Health
    - Alliance Bannerman
      - Old: 2 Attack, 1 Health
      - New: 2 Attack, 2 Health