### PR TITLE
Implement 6 KARA cards

### DIFF
--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -1017,6 +1017,8 @@ OG | OG_340 | Soggoth the Slitherer |
 
 - Progress: 5% (8 of 134 Cards)
 
+## One Night in Karazhan
+
 Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
 KARA | KAR_004 | Cat Trick | O
@@ -1027,9 +1029,9 @@ KARA | KAR_010 | Nightbane Templar | O
 KARA | KAR_011 | Pompous Thespian |  
 KARA | KAR_013 | Purify | O
 KARA | KAR_021 | Wicked Witchdoctor | O
-KARA | KAR_025 | Kara Kazham! |  
-KARA | KAR_026 | Protect the King! |  
-KARA | KAR_028 | Fool's Bane |  
+KARA | KAR_025 | Kara Kazham! | O
+KARA | KAR_026 | Protect the King! | O
+KARA | KAR_028 | Fool's Bane | O
 KARA | KAR_029 | Runic Egg |  
 KARA | KAR_030a | Pantry Spider |  
 KARA | KAR_033 | Book Wyrm |  
@@ -1049,8 +1051,8 @@ KARA | KAR_073 | Maelstrom Portal | O
 KARA | KAR_075 | Moonglade Portal | O
 KARA | KAR_076 | Firelands Portal | O
 KARA | KAR_077 | Silvermoon Portal | O
-KARA | KAR_089 | Malchezaar's Imp |  
-KARA | KAR_091 | Ironforge Portal |  
+KARA | KAR_089 | Malchezaar's Imp | O
+KARA | KAR_091 | Ironforge Portal | O
 KARA | KAR_092 | Medivh's Valet | O
 KARA | KAR_094 | Deadly Fork | O
 KARA | KAR_095 | Zoobot |  
@@ -1058,14 +1060,14 @@ KARA | KAR_096 | Prince Malchezaar |
 KARA | KAR_097 | Medivh, the Guardian |  
 KARA | KAR_114 | Barnes |  
 KARA | KAR_204 | Onyx Bishop | O
-KARA | KAR_205 | Silverware Golem |  
+KARA | KAR_205 | Silverware Golem | O
 KARA | KAR_300 | Enchanted Raven | O
 KARA | KAR_702 | Menagerie Magician |  
 KARA | KAR_710 | Arcanosmith |  
 KARA | KAR_711 | Arcane Giant |  
 KARA | KAR_712 | Violet Illusionist |  
 
-- Progress: 48% (22 of 45 Cards)
+- Progress: 62% (28 of 45 Cards)
 
 ## Mean Streets of Gadgetzan
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 8% The Grand Tournament (11 of 132 Cards)
   * **100% The League of Explorers (45 of 45 Cards)**
   * 5% Whispers of the Old Gods (8 of 134 Cards)
-  * 48% One Night in Karazhan (22 of 45 Cards)
+  * 62% One Night in Karazhan (28 of 45 Cards)
   * 2% Mean Streets of Gadgetzan (3 of 132 Cards)
   * 7% Journey to Un'Goro (10 of 135 Cards)
   * 4% Knights of the Frozen Throne (6 of 135 Cards)

--- a/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
@@ -626,6 +626,15 @@ void KaraCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<CountTask>(EntityType::ENEMY_MINIONS));
+    cardDef.power.AddPowerTask(std::make_shared<EnqueueNumberTask>(TaskList{
+        std::make_shared<SummonTask>("KAR_026t", SummonSide::SPELL) }));
+    cardDef.property.playReqs =
+        PlayReqs{ { PlayReq::REQ_MINIMUM_ENEMY_MINIONS, 0 },
+                  { PlayReq::REQ_NUM_MINION_SLOTS, 0 } };
+    cards.emplace("KAR_026", cardDef);
 
     // --------------------------------------- WEAPON - WARRIOR
     // [KAR_028] Fool's Bane - COST:5 [ATK:3/HP:0]
@@ -647,6 +656,8 @@ void KaraCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 
 void KaraCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // --------------------------------------- MINION - WARRIOR
     // [KAR_026t] Pawn (*) - COST:1 [ATK:1/HP:1]
     // - Set: Kara
@@ -656,6 +667,9 @@ void KaraCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("KAR_026t", cardDef);
 }
 
 void KaraCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
@@ -570,6 +570,13 @@ void KaraCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - InvisibleDeathrattle = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(std::make_shared<Trigger>(TriggerType::DISCARD));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    cardDef.power.GetTrigger()->triggerActivation = TriggerActivation::HAND;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<SummonTask>(
+        "KAR_205") };
+    cards.emplace("KAR_205", cardDef);
 }
 
 void KaraCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
@@ -528,6 +528,8 @@ void KaraCardsGen::AddShamanNonCollect(std::map<std::string, CardDef>& cards)
 
 void KaraCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ---------------------------------------- SPELL - WARLOCK
     // [KAR_025] Kara Kazham! - COST:5
     // - Set: Kara, Rarity: Common
@@ -537,6 +539,16 @@ void KaraCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // PlayReq:
     // - REQ_NUM_MINION_SLOTS = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<SummonTask>("KAR_025a", SummonSide::SPELL));
+    cardDef.power.AddPowerTask(
+        std::make_shared<SummonTask>("KAR_025b", SummonSide::SPELL));
+    cardDef.power.AddPowerTask(
+        std::make_shared<SummonTask>("KAR_025c", SummonSide::SPELL));
+    cardDef.property.playReqs =
+        PlayReqs{ { PlayReq::REQ_NUM_MINION_SLOTS, 1 } };
+    cards.emplace("KAR_025", cardDef);
 
     // --------------------------------------- MINION - WARLOCK
     // [KAR_089] Malchezaar's Imp - COST:1 [ATK:1/HP:3]
@@ -558,24 +570,37 @@ void KaraCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
 
 void KaraCardsGen::AddWarlockNonCollect(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // --------------------------------------- MINION - WARLOCK
     // [KAR_025a] Candle (*) - COST:1 [ATK:1/HP:1]
     // - Set: Kara
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("KAR_025a", cardDef);
 
     // --------------------------------------- MINION - WARLOCK
     // [KAR_025b] Broom (*) - COST:2 [ATK:2/HP:2]
     // - Set: Kara
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("KAR_025b", cardDef);
 
     // --------------------------------------- MINION - WARLOCK
     // [KAR_025c] Teapot (*) - COST:3 [ATK:3/HP:3]
     // - Set: Kara
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("KAR_025c", cardDef);
 }
 
 void KaraCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ---------------------------------------- SPELL - WARRIOR
     // [KAR_026] Protect the King! - COST:3
     // - Set: Kara, Rarity: Rare

--- a/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
@@ -556,6 +556,10 @@ void KaraCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Whenever you discard a card, draw a card.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(std::make_shared<Trigger>(TriggerType::DISCARD));
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<DrawTask>(1) };
+    cards.emplace("KAR_089", cardDef);
 
     // --------------------------------------- MINION - WARLOCK
     // [KAR_205] Silverware Golem - COST:3 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
@@ -645,6 +645,17 @@ void KaraCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DURABILITY = 4
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(std::make_shared<Aura>(
+        AuraType::HERO,
+        EffectList{ std::make_shared<Effect>(GameTag::CANNOT_ATTACK_HEROES,
+                                             EffectOperator::SET, 1) }));
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::HERO;
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<SetGameTagTask>(
+        EntityType::HERO, GameTag::EXHAUSTED, 0) };
+    cards.emplace("KAR_028", cardDef);
 
     // ---------------------------------------- SPELL - WARRIOR
     // [KAR_091] Ironforge Portal - COST:5

--- a/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
@@ -663,6 +663,12 @@ void KaraCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Gain 4 Armor. Summon a random 4-Cost minion.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<ArmorTask>(4));
+    cardDef.power.AddPowerTask(std::make_shared<RandomMinionTask>(
+        TagValues{ { GameTag::COST, 4, RelaSign::EQ } }));
+    cardDef.power.AddPowerTask(std::make_shared<SummonTask>());
+    cards.emplace("KAR_091", cardDef);
 }
 
 void KaraCardsGen::AddWarriorNonCollect(std::map<std::string, CardDef>& cards)

--- a/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
@@ -170,11 +170,21 @@ void AuraEffects::SetAttack(int value) const
 
 int AuraEffects::GetCannotAttackHeroes() const
 {
+    if (m_type != CardType::HERO)
+    {
+        return 0;
+    }
+
     return m_data[2];
 }
 
 void AuraEffects::SetCannotAttackHeroes(int value) const
 {
+    if (m_type != CardType::HERO)
+    {
+        throw std::logic_error("Not Implemented!");
+    }
+
     m_data[2] = value;
 }
 

--- a/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
@@ -190,11 +190,21 @@ void AuraEffects::SetHeroPowerDamage(int value) const
 
 int AuraEffects::GetHealth() const
 {
+    if (m_type != CardType::MINION)
+    {
+        return 0;
+    }
+
     return m_data[2];
 }
 
 void AuraEffects::SetHealth(int value) const
 {
+    if (m_type != CardType::MINION)
+    {
+        throw std::logic_error("Not Implemented!");
+    }
+
     m_data[2] = value;
 }
 

--- a/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/AuraEffects.cpp
@@ -270,11 +270,21 @@ void AuraEffects::SetLifesteal(int value) const
 
 int AuraEffects::GetCantAttack() const
 {
+    if (m_type != CardType::MINION)
+    {
+        return 0;
+    }
+
     return m_data[8];
 }
 
 void AuraEffects::SetCantAttack(int value) const
 {
+    if (m_type != CardType::MINION)
+    {
+        throw std::logic_error("Not Implemented!");
+    }
+
     m_data[8] = value;
 }
 }  // namespace RosettaStone::PlayMode

--- a/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
@@ -991,6 +991,47 @@ TEST_CASE("[Shaman : Spell] - KAR_073 : Maelstrom Portal")
     CHECK_EQ(opField[0]->GetHealth(), 11);
 }
 
+// ---------------------------------------- SPELL - WARLOCK
+// [KAR_025] Kara Kazham! - COST:5
+// - Set: Kara, Rarity: Common
+// --------------------------------------------------------
+// Text: Summon a 1/1 Candle, 2/2 Broom, and 3/3 Teapot.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Spell] - KAR_025 : Kara Kazham!")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::HUNTER;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Kara Kazham!"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[0]->card->name, "Candle");
+    CHECK_EQ(curField[1]->card->name, "Broom");
+    CHECK_EQ(curField[2]->card->name, "Teapot");
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [KAR_036] Arcane Anomaly - COST:1 [ATK:2/HP:1]
 // - Race: Elemental, Faction: Neutral, Set: Kara, Rarity: common

--- a/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
@@ -1032,6 +1032,46 @@ TEST_CASE("[Warlock : Spell] - KAR_025 : Kara Kazham!")
     CHECK_EQ(curField[2]->card->name, "Teapot");
 }
 
+// --------------------------------------- MINION - WARLOCK
+// [KAR_089] Malchezaar's Imp - COST:1 [ATK:1/HP:3]
+// - Race: Demon, Set: Kara, Rarity: Common
+// --------------------------------------------------------
+// Text: Whenever you discard a card, draw a card.
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - KAR_089 : Malchezaar's Imp")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::PALADIN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Malchezaar's Imp"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Darkshire Librarian"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curHand.GetCount(), 5);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curHand.GetCount(), 4);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [KAR_036] Arcane Anomaly - COST:1 [ATK:2/HP:1]
 // - Race: Elemental, Faction: Neutral, Set: Kara, Rarity: common

--- a/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
@@ -1072,6 +1072,47 @@ TEST_CASE("[Warlock : Minion] - KAR_089 : Malchezaar's Imp")
     CHECK_EQ(curHand.GetCount(), 4);
 }
 
+// --------------------------------------- MINION - WARLOCK
+// [KAR_205] Silverware Golem - COST:3 [ATK:3/HP:3]
+// - Set: Kara, Rarity: Rare
+// --------------------------------------------------------
+// Text: If you discard this minion, summon it.
+// --------------------------------------------------------
+// GameTag:
+// - InvisibleDeathrattle = 1
+// --------------------------------------------------------
+TEST_CASE("[Warlock : Minion] - KAR_205 : Silverware Golem")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    [[maybe_unused]] const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Silverware Golem"));
+    const auto card2 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Darkshire Librarian"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[1]->card->name, "Silverware Golem");
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [KAR_036] Arcane Anomaly - COST:1 [ATK:2/HP:1]
 // - Race: Elemental, Faction: Neutral, Set: Kara, Rarity: common

--- a/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
@@ -1113,6 +1113,64 @@ TEST_CASE("[Warlock : Minion] - KAR_205 : Silverware Golem")
     CHECK_EQ(curField[1]->card->name, "Silverware Golem");
 }
 
+// ---------------------------------------- SPELL - WARRIOR
+// [KAR_026] Protect the King! - COST:3
+// - Set: Kara, Rarity: Rare
+// --------------------------------------------------------
+// Text: For each enemy minion,
+//       summon a 1/1 Pawn with <b>Taunt</b>.
+// --------------------------------------------------------
+// PlayReq:
+// - REQ_MINIMUM_ENEMY_MINIONS = 1
+// - REQ_NUM_MINION_SLOTS = 1
+// --------------------------------------------------------
+// RefTag:
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Spell] - KAR_026 : Protect the King!")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Protect the King!"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Kara Kazham!"));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Spell(card2));
+    CHECK_EQ(opField.GetCount(), 3);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[0]->card->name, "Pawn");
+    CHECK_EQ(curField[1]->card->name, "Pawn");
+    CHECK_EQ(curField[2]->card->name, "Pawn");
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [KAR_036] Arcane Anomaly - COST:1 [ATK:2/HP:1]
 // - Race: Elemental, Faction: Neutral, Set: Kara, Rarity: common

--- a/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
@@ -1241,6 +1241,43 @@ TEST_CASE("[Warrior : Weapon] - KAR_028 : Fool's Bane")
     CHECK_EQ(curPlayer->GetHero()->IsExhausted(), false);
 }
 
+// ---------------------------------------- SPELL - WARRIOR
+// [KAR_091] Ironforge Portal - COST:5
+// - Set: Kara, Rarity: Common
+// --------------------------------------------------------
+// Text: Gain 4 Armor. Summon a random 4-Cost minion.
+// --------------------------------------------------------
+TEST_CASE("[Warrior : Spell] - KAR_091 : Ironforge Portal")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARRIOR;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Ironforge Portal"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    CHECK_EQ(curPlayer->GetHero()->GetArmor(), 4);
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->GetCost(), 4);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [KAR_036] Arcane Anomaly - COST:1 [ATK:2/HP:1]
 // - Race: Elemental, Faction: Neutral, Set: Kara, Rarity: common


### PR DESCRIPTION
This revision includes:
- Implement 6 KARA cards
  - Kara Kazham! (KAR_025)
  - Protect the King! (KAR_026)
  - Fool's Bane (KAR_028)
  - Malchezaar's Imp (KAR_089)
  - Ironforge Portal (KAR_091)
  - Silverware Golem (KAR_205)
- Add code to check the type in getter/setter of some game tags
  - GameTag::HEALTH
  - GameTag::CANNOT_ATTACK_HEROES