### PR TITLE
Implement 5 KARA cards

### DIFF
--- a/Documents/CardList - Wild.md
+++ b/Documents/CardList - Wild.md
@@ -1039,10 +1039,10 @@ KARA | KAR_035 | Priest of the Feast | O
 KARA | KAR_036 | Arcane Anomaly | O
 KARA | KAR_037 | Avian Watcher | O
 KARA | KAR_041 | Moat Lurker | O
-KARA | KAR_044 | Moroes |  
+KARA | KAR_044 | Moroes | O
 KARA | KAR_057 | Ivory Knight | O
-KARA | KAR_061 | The Curator |  
-KARA | KAR_062 | Netherspite Historian |  
+KARA | KAR_061 | The Curator | O
+KARA | KAR_062 | Netherspite Historian | O
 KARA | KAR_063 | Spirit Claws | O
 KARA | KAR_065 | Menagerie Warden | O
 KARA | KAR_069 | Swashburglar | O
@@ -1055,8 +1055,8 @@ KARA | KAR_089 | Malchezaar's Imp | O
 KARA | KAR_091 | Ironforge Portal | O
 KARA | KAR_092 | Medivh's Valet | O
 KARA | KAR_094 | Deadly Fork | O
-KARA | KAR_095 | Zoobot |  
-KARA | KAR_096 | Prince Malchezaar |  
+KARA | KAR_095 | Zoobot | O
+KARA | KAR_096 | Prince Malchezaar | O
 KARA | KAR_097 | Medivh, the Guardian |  
 KARA | KAR_114 | Barnes |  
 KARA | KAR_204 | Onyx Bishop | O
@@ -1067,7 +1067,7 @@ KARA | KAR_710 | Arcanosmith |
 KARA | KAR_711 | Arcane Giant |  
 KARA | KAR_712 | Violet Illusionist |  
 
-- Progress: 75% (34 of 45 Cards)
+- Progress: 86% (39 of 45 Cards)
 
 ## Mean Streets of Gadgetzan
 

--- a/Includes/Rosetta/Common/Enums/TriggerEnums.hpp
+++ b/Includes/Rosetta/Common/Enums/TriggerEnums.hpp
@@ -13,6 +13,7 @@ namespace RosettaStone
 enum class TriggerType
 {
     NONE,        //!< The effect has nothing.
+    GAME_START,  //!< The effect will be triggered when a game begins.
     TURN_START,  //!< The effect will be triggered at the start of turn.
     TURN_END,    //!< The effect will be triggered at the end of turn.
     ADD_CARD,    //!< The effect will be triggered when a card is added in hand.

--- a/Includes/Rosetta/PlayMode/Managers/TriggerManager.hpp
+++ b/Includes/Rosetta/PlayMode/Managers/TriggerManager.hpp
@@ -21,6 +21,9 @@ class Entity;
 class TriggerManager
 {
  public:
+    //! Callback for trigger when a game begins.
+    void OnStartGameTrigger();
+
     //! Callback for trigger when player's turn is started.
     //! \param sender An entity that is the source of trigger.
     void OnStartTurnTrigger(Entity* sender);
@@ -133,6 +136,7 @@ class TriggerManager
     //! \param sender An entity that is the source of trigger.
     void OnManaCrystalTrigger(Entity* sender);
 
+    TriggerEvent startGameTrigger;
     TriggerEvent startTurnTrigger;
     TriggerEvent endTurnTrigger;
     TriggerEvent addCardTrigger;

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
@@ -272,6 +272,21 @@ class ComplexTask
         };
     }
 
+    //! Returns a list of task for giving buff to a random minion in field.
+    //! \param list A list of self conditions to filter card(s).
+    //! \param enchantmentCardID The ID of enchantment card to give buff.
+    static TaskList GiveBuffToRandomMinionInField(
+        std::string_view enchantmentCardID, const SelfCondList& list)
+    {
+        return TaskList{
+            std::make_shared<SimpleTasks::IncludeTask>(EntityType::MINIONS),
+            std::make_shared<SimpleTasks::FilterStackTask>(list),
+            std::make_shared<SimpleTasks::RandomTask>(EntityType::STACK, 1),
+            std::make_shared<SimpleTasks::AddEnchantmentTask>(enchantmentCardID,
+                                                              EntityType::STACK)
+        };
+    }
+
     //! Returns a list of task for giving buff to another random minion
     //! in field.
     //! \param enchantmentCardID The ID of enchantment card to give buff.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 8% The Grand Tournament (11 of 132 Cards)
   * **100% The League of Explorers (45 of 45 Cards)**
   * 5% Whispers of the Old Gods (8 of 134 Cards)
-  * 75% One Night in Karazhan (34 of 45 Cards)
+  * 86% One Night in Karazhan (39 of 45 Cards)
   * 2% Mean Streets of Gadgetzan (3 of 132 Cards)
   * 7% Journey to Un'Goro (10 of 135 Cards)
   * 4% Knights of the Frozen Throne (6 of 135 Cards)

--- a/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
@@ -884,6 +884,17 @@ void KaraCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - TAUNT = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(ComplexTask::DrawCardFromDeck(
+        1, SelfCondList{ std::make_shared<SelfCondition>(
+               SelfCondition::IsRace(Race::BEAST)) }));
+    cardDef.power.AddPowerTask(ComplexTask::DrawCardFromDeck(
+        1, SelfCondList{ std::make_shared<SelfCondition>(
+               SelfCondition::IsRace(Race::DRAGON)) }));
+    cardDef.power.AddPowerTask(ComplexTask::DrawCardFromDeck(
+        1, SelfCondList{ std::make_shared<SelfCondition>(
+               SelfCondition::IsRace(Race::MURLOC)) }));
+    cards.emplace("KAR_061", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [KAR_062] Netherspite Historian - COST:2 [ATK:1/HP:3]

--- a/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
@@ -928,6 +928,17 @@ void KaraCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(ComplexTask::GiveBuffToRandomMinionInField(
+        "KAR_095e", SelfCondList{ std::make_shared<SelfCondition>(
+                        SelfCondition::IsRace(Race::BEAST)) }));
+    cardDef.power.AddPowerTask(ComplexTask::GiveBuffToRandomMinionInField(
+        "KAR_095e", SelfCondList{ std::make_shared<SelfCondition>(
+                        SelfCondition::IsRace(Race::DRAGON)) }));
+    cardDef.power.AddPowerTask(ComplexTask::GiveBuffToRandomMinionInField(
+        "KAR_095e", SelfCondList{ std::make_shared<SelfCondition>(
+                        SelfCondition::IsRace(Race::MURLOC)) }));
+    cards.emplace("KAR_095", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [KAR_096] Prince Malchezaar - COST:5 [ATK:5/HP:6]
@@ -1072,6 +1083,9 @@ void KaraCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: +1/+1.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddEnchant(Enchants::GetEnchantFromText("KAR_095e"));
+    cards.emplace("KAR_095e", cardDef);
 
     // --------------------------------------- WEAPON - NEUTRAL
     // [KAR_097t] Atiesh (*) - COST:3 [ATK:1/HP:0]

--- a/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
@@ -950,6 +950,19 @@ void KaraCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - ELITE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::GAME_START));
+    cardDef.power.GetTrigger()->triggerActivation = TriggerActivation::DECK;
+    cardDef.power.GetTrigger()->removeAfterTriggered = true;
+    cardDef.power.GetTrigger()->tasks = TaskList{
+        std::make_shared<RandomMinionTask>(
+            TagValues{ { GameTag::RARITY, static_cast<int>(Rarity::LEGENDARY),
+                         RelaSign::EQ } },
+            5),
+        std::make_shared<AddStackToTask>(EntityType::DECK)
+    };
+    cards.emplace("KAR_096", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [KAR_097] Medivh, the Guardian - COST:8 [ATK:7/HP:7]

--- a/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
@@ -866,6 +866,11 @@ void KaraCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - ELITE = 1
     // - STEALTH = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(std::make_shared<Trigger>(TriggerType::TURN_END));
+    cardDef.power.GetTrigger()->tasks = { std::make_shared<SummonTask>(
+        "KAR_044a", SummonSide::RIGHT) };
+    cards.emplace("KAR_044", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [KAR_061] The Curator - COST:7 [ATK:4/HP:6]
@@ -1028,6 +1033,9 @@ void KaraCardsGen::AddNeutralNonCollect(std::map<std::string, CardDef>& cards)
     // [KAR_044a] Steward (*) - COST:1 [ATK:1/HP:1]
     // - Faction: neutral, Set: Kara
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("KAR_044a", cardDef);
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [KAR_077e] Silver Might (*) - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/KaraCardsGen.cpp
@@ -909,6 +909,14 @@ void KaraCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - DISCOVER = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<ConditionTask>(
+        EntityType::SOURCE, SelfCondList{ std::make_shared<SelfCondition>(
+                                SelfCondition::IsHoldingRace(Race::DRAGON)) }));
+    cardDef.power.AddPowerTask(std::make_shared<FlagTask>(
+        true,
+        TaskList{ std::make_shared<DiscoverTask>(DiscoverType::DRAGON) }));
+    cards.emplace("KAR_062", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [KAR_095] Zoobot - COST:3 [ATK:3/HP:3]

--- a/Sources/Rosetta/PlayMode/Games/Game.cpp
+++ b/Sources/Rosetta/PlayMode/Games/Game.cpp
@@ -600,6 +600,9 @@ void Game::FinalGameOver()
 
 void Game::Start()
 {
+    // Trigger 'Start of Game' triggers (but does not process tasks here)
+    triggerManager.OnStartGameTrigger();
+
     // Set next step
     nextStep = Step::BEGIN_FIRST;
 

--- a/Sources/Rosetta/PlayMode/Managers/TriggerManager.cpp
+++ b/Sources/Rosetta/PlayMode/Managers/TriggerManager.cpp
@@ -8,6 +8,11 @@
 
 namespace RosettaStone::PlayMode
 {
+void TriggerManager::OnStartGameTrigger()
+{
+    startGameTrigger(nullptr);
+}
+
 void TriggerManager::OnStartTurnTrigger(Entity* sender)
 {
     startTurnTrigger(sender);

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/AddStackToTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/AddStackToTask.cpp
@@ -36,6 +36,14 @@ TaskStatus AddStackToTask::Impl(Player* player)
             }
             break;
         }
+        case EntityType::DECK:
+        {
+            for (const auto& entity : player->game->taskStack.playables)
+            {
+                Generic::ShuffleIntoDeck(entity->player, m_source, entity);
+            }
+            break;
+        }
         default:
             throw std::invalid_argument(
                 "AddStackToTask::Impl() - Invalid entity type");

--- a/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
+++ b/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
@@ -105,6 +105,9 @@ std::shared_ptr<Trigger> Trigger::Activate(Playable* source,
 
     switch (m_triggerType)
     {
+        case TriggerType::GAME_START:
+            game->triggerManager.startGameTrigger += instance->handler;
+            break;
         case TriggerType::TURN_START:
             game->triggerManager.startTurnTrigger += instance->handler;
             break;
@@ -290,6 +293,9 @@ void Trigger::Remove()
 
     switch (m_triggerType)
     {
+        case TriggerType::GAME_START:
+            game->triggerManager.startGameTrigger -= handler;
+            break;
         case TriggerType::TURN_START:
             game->triggerManager.startTurnTrigger -= handler;
             break;

--- a/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
@@ -1788,3 +1788,74 @@ TEST_CASE("[Neutral : Minion] - KAR_062 : Netherspite Historian")
     CHECK(curPlayer->choice);
     CHECK_EQ(curPlayer->choice->choices.size(), 3u);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [KAR_095] Zoobot - COST:3 [ATK:3/HP:3]
+// - Race: Mechanical, Set: Kara, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give a random friendly Beast,
+//       Dragon, and Murloc +1/+1.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - KAR_095 : Zoobot")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARLOCK;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Zoobot"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bloodfen Raptor"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Murloc Tinyfin"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Faerie Dragon"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Voidwalker"));
+    const auto card6 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bloodsail Raider"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+    game.Process(curPlayer, PlayCardTask::Minion(card6));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 4);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 2);
+    CHECK_EQ(curField[2]->GetAttack(), 4);
+    CHECK_EQ(curField[2]->GetHealth(), 3);
+    CHECK_EQ(curField[3]->GetAttack(), 1);
+    CHECK_EQ(curField[3]->GetHealth(), 3);
+    CHECK_EQ(curField[4]->GetAttack(), 2);
+    CHECK_EQ(curField[4]->GetHealth(), 3);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
@@ -1623,3 +1623,51 @@ TEST_CASE("[Netural : Minion] - KAR_041 : Moat Lurker")
     CHECK_EQ(opField.GetCount(), 1);
     CHECK_EQ(opField[0]->card->name, "Malygos");
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [KAR_044] Moroes - COST:3 [ATK:1/HP:1]
+// - Set: Kara, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Stealth</b>
+//       At the end of your turn, summon a 1/1 Steward.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - STEALTH = 1
+// --------------------------------------------------------
+TEST_CASE("[Netural : Minion] - KAR_044 : Moroes")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Moroes"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[1]->card->name, "Steward");
+    CHECK_EQ(curField[1]->GetAttack(), 1);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
@@ -1671,3 +1671,59 @@ TEST_CASE("[Netural : Minion] - KAR_044 : Moroes")
     CHECK_EQ(curField[1]->GetAttack(), 1);
     CHECK_EQ(curField[1]->GetHealth(), 1);
 }
+
+// --------------------------------------- MINION - NEUTRAL
+// [KAR_061] The Curator - COST:7 [ATK:4/HP:6]
+// - Race: Mechanical, Set: Kara, Rarity: Legendary
+// --------------------------------------------------------
+// Text: <b>Taunt</b> <b>Battlecry:</b> Draw a Beast,
+//       Dragon, and Murloc from your deck.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// - TAUNT = 1
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - CS3_015 : The Curator")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    for (int i = 0; i < 30; i += 5)
+    {
+        config.player1Deck[i] = Cards::FindCardByName("Bloodfen Raptor");
+        config.player1Deck[i + 1] = Cards::FindCardByName("Murloc Tinyfin");
+        config.player1Deck[i + 2] = Cards::FindCardByName("Faerie Dragon");
+        config.player1Deck[i + 3] = Cards::FindCardByName("Voidwalker");
+        config.player1Deck[i + 4] = Cards::FindCardByName("Bloodsail Raider");
+    }
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curDeck = *(curPlayer->GetDeckZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("The Curator"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curDeck.GetCount(), 23);
+    CHECK_EQ(curHand.GetCount(), 7);
+    CHECK_EQ(curHand[4]->card->GetRace(), Race::BEAST);
+    CHECK_EQ(curHand[5]->card->GetRace(), Race::DRAGON);
+    CHECK_EQ(curHand[6]->card->GetRace(), Race::MURLOC);
+}

--- a/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
@@ -1684,7 +1684,7 @@ TEST_CASE("[Netural : Minion] - KAR_044 : Moroes")
 // - TAUNT = 1
 // - BATTLECRY = 1
 // --------------------------------------------------------
-TEST_CASE("[Neutral : Minion] - CS3_015 : The Curator")
+TEST_CASE("[Neutral : Minion] - KAR_061 : The Curator")
 {
     GameConfig config;
     config.formatType = FormatType::STANDARD;
@@ -1858,4 +1858,56 @@ TEST_CASE("[Neutral : Minion] - KAR_095 : Zoobot")
     CHECK_EQ(curField[3]->GetHealth(), 3);
     CHECK_EQ(curField[4]->GetAttack(), 2);
     CHECK_EQ(curField[4]->GetHealth(), 3);
+}
+
+// --------------------------------------- MINION - NEUTRAL
+// [KAR_096] Prince Malchezaar - COST:5 [ATK:5/HP:6]
+// - Race: Demon, Set: Kara, Rarity: Legendary
+// --------------------------------------------------------
+// Text: When the game starts,
+//       add 5 extra <b>Legendary</b> minions to your deck.
+// --------------------------------------------------------
+// GameTag:
+// - ELITE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - KAR_096 : Prince Malchezaar")
+{
+    GameConfig config;
+    config.formatType = FormatType::STANDARD;
+    config.player1Class = CardClass::SHAMAN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    config.player1Deck[0] = Cards::FindCardByName("Prince Malchezaar");
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curDeck = *(curPlayer->GetDeckZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    CHECK_EQ(curDeck.GetCount(), 4);
+    CHECK_EQ(curHand.GetCount(), 2);
+
+    for (auto& deckCard : curDeck.GetAll())
+    {
+        CHECK_EQ(deckCard->card->GetCardType(), CardType::MINION);
+        CHECK_EQ(deckCard->card->GetRarity(), Rarity::LEGENDARY);
+    }
+
+    for (auto& handCard : curHand.GetAll())
+    {
+        CHECK_EQ(handCard->card->GetCardType(), CardType::MINION);
+        CHECK_EQ(handCard->card->GetRarity(), Rarity::LEGENDARY);
+    }
 }


### PR DESCRIPTION
This revision includes:
- Implement 5 KARA cards
  - Moroes (KAR_044)
  - The Curator (KAR_061)
  - Netherspite Historian (KAR_062)
  - Zoobot (KAR_095)
  - Prince Malchezaar (KAR_096)
- Add complex task 'GiveBuffToRandomMinionInField()'
  - Returns a list of task for giving buff to a random minion in field
- Add enum value 'TriggerType::GAME_START'
  - The effect will be triggered when a game begins
- Add variable 'startGameTrigger' and related method
  - OnStartGameTrigger(): Callback for trigger when a game begins
- Add code to process 'TriggerType::GAME_START'
- Add code to trigger 'Start of Game' triggers
- Add code to process 'EntityType::DECK' in class 'AddStackToTask'