### PR TITLE
Update Hearthstone Patch 24.4

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -976,6 +976,41 @@ THE_SUNKEN_CITY | TSC_963 | Filletfighter | O
 
 Set | ID | Name | Implemented
 :---: | :---: | :---: | :---:
+REVENDRETH | MAW_000 | Imp-oster |  
+REVENDRETH | MAW_001 | Arson Accusation |  
+REVENDRETH | MAW_002 | Habeas Corpses |  
+REVENDRETH | MAW_003 | Totemic Evidence |  
+REVENDRETH | MAW_004 | Soul Seeker |  
+REVENDRETH | MAW_005 | Framester |  
+REVENDRETH | MAW_006 | Objection! |  
+REVENDRETH | MAW_008 | Sightless Magistrate |  
+REVENDRETH | MAW_009 | Shadehound |  
+REVENDRETH | MAW_010 | Motion Denied |  
+REVENDRETH | MAW_011 | Defense Attorney Nathanos |  
+REVENDRETH | MAW_012 | All Fel Breaks Loose |  
+REVENDRETH | MAW_013 | Life Sentence |  
+REVENDRETH | MAW_014 | Prosecutor Mel'tranix |  
+REVENDRETH | MAW_015 | Jury Duty |  
+REVENDRETH | MAW_016 | Order in the Court |  
+REVENDRETH | MAW_017 | Class Action Lawyer |  
+REVENDRETH | MAW_018 | Perjury |  
+REVENDRETH | MAW_019 | Murder Accusation |  
+REVENDRETH | MAW_020 | Scribbling Stenographer |  
+REVENDRETH | MAW_021 | Clear Conscience |  
+REVENDRETH | MAW_022 | Incriminating Psychic |  
+REVENDRETH | MAW_023 | Theft Accusation |  
+REVENDRETH | MAW_024 | Dew Process |  
+REVENDRETH | MAW_025 | Attorney-at-Maw |  
+REVENDRETH | MAW_026 | Incarceration |  
+REVENDRETH | MAW_027 | Call to the Stand |  
+REVENDRETH | MAW_028 | Mawsworn Bailiff |  
+REVENDRETH | MAW_029 | Weapons Expert |  
+REVENDRETH | MAW_030 | Torghast Custodian |  
+REVENDRETH | MAW_031 | Afterlife Attendant |  
+REVENDRETH | MAW_032 | Tight-Lipped Witness |  
+REVENDRETH | MAW_033 | Sylvanas, the Accused |  
+REVENDRETH | MAW_034 | The Jailer |  
+REVENDRETH | MAW_101 | Contract Conjurer |  
 REVENDRETH | REV_000 | Suspicious Alchemist |  
 REVENDRETH | REV_002 | Suspicious Usher |  
 REVENDRETH | REV_006 | Suspicious Pirate |  
@@ -1112,4 +1147,4 @@ REVENDRETH | REV_961 | Elitist Snob |
 REVENDRETH | REV_983 | Great Hall |  
 REVENDRETH | REV_990 | Sanguine Depths |  
 
-- Progress: 1% (2 of 135 Cards)
+- Progress: 1% (2 of 170 Cards)

--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -73,7 +73,7 @@ constexpr std::array<CardSet, 1> CLASSIC_CARD_SETS = {
 };
 
 //! The number of Play mode cards.
-constexpr int NUM_PLAY_MODE_CARDS = 15561;
+constexpr int NUM_PLAY_MODE_CARDS = 15667;
 
 //! The number of Battlegrounds cards.
 constexpr int NUM_BATTLEGROUNDS_CARDS = 17402;

--- a/Includes/Rosetta/Common/Constants.hpp
+++ b/Includes/Rosetta/Common/Constants.hpp
@@ -76,7 +76,7 @@ constexpr std::array<CardSet, 1> CLASSIC_CARD_SETS = {
 constexpr int NUM_PLAY_MODE_CARDS = 15561;
 
 //! The number of Battlegrounds cards.
-constexpr int NUM_BATTLEGROUNDS_CARDS = 17259;
+constexpr int NUM_BATTLEGROUNDS_CARDS = 17402;
 
 //! The number of player class.
 //! \note Druid, Hunter, Mage, Paladin, Priest, Rogue, Shaman, Warlock, Warrior,
@@ -114,7 +114,7 @@ constexpr int MAX_SECERT_SIZE = 5;
 constexpr int NUM_BATTLEGROUNDS_PLAYERS = 8;
 
 //! The number of heroes in Battlegrounds.
-constexpr int NUM_BATTLEGROUNDS_HEROES = 87;
+constexpr int NUM_BATTLEGROUNDS_HEROES = 88;
 
 //! The number of heroes on the selection list in Battlegrounds.
 constexpr int NUM_HEROES_ON_SELECTION_LIST = 4;

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
   * 12% Voyage to the Sunken City (22 of 170 cards)
-  * 1% Murder at Castle Nathria (2 of 135 cards)
+  * 1% Murder at Castle Nathria (2 of 170 cards)
 
 ### Wild Format
 

--- a/Resources/cards.collectible.json
+++ b/Resources/cards.collectible.json
@@ -1396,6 +1396,9 @@
         ],
         "name": "Warhorse Trainer",
         "rarity": "COMMON",
+        "referencedTags": [
+            "TAUNT"
+        ],
         "set": "TGT",
         "text": "Your Silver Hand Recruits have +2 Attack and <b>Taunt</b>.",
         "type": "MINION"
@@ -7170,7 +7173,7 @@
         "name": "Warsong Envoy",
         "rarity": "RARE",
         "set": "THE_BARRENS",
-        "text": "[x]<b>Frenzy:</b> Gain +1  Attack\nfor each damaged\n character.",
+        "text": "[x]<b>Frenzy:</b> Gain +1  Attack\nfor each damaged\ncharacter.",
         "type": "MINION"
     },
     {
@@ -16939,6 +16942,9 @@
         ],
         "name": "Warhorse Trainer",
         "rarity": "COMMON",
+        "referencedTags": [
+            "TAUNT"
+        ],
         "set": "CORE",
         "text": "Your Silver Hand Recruits have +2 Attack and <b>Taunt</b>.",
         "type": "MINION"
@@ -29752,7 +29758,7 @@
         "name": "Open the Cages",
         "rarity": "COMMON",
         "set": "DARKMOON_FAIRE",
-        "text": "[x]<b>Secret:</b> When your\nturn starts, if you control\n two minions, summon an\nAnimal Companion.",
+        "text": "[x]<b>Secret:</b> When your\nturn starts, if you control\ntwo minions, summon an\nAnimal Companion.",
         "type": "SPELL"
     },
     {
@@ -38421,7 +38427,7 @@
         "name": "Imp Master",
         "rarity": "RARE",
         "set": "EXPERT1",
-        "text": "[x]At the end of your turn, deal\n1 damage to this minion\n and summon a 1/1 Imp.",
+        "text": "[x]At the end of your turn, deal\n1 damage to this minion\nand summon a 1/1 Imp.",
         "type": "MINION"
     },
     {
@@ -39271,7 +39277,6 @@
     {
         "artist": "Mike Nicholson",
         "attack": 1,
-        "battlegroundsPremiumDbfId": 61077,
         "cardClass": "NEUTRAL",
         "collectible": true,
         "cost": 2,
@@ -39288,7 +39293,6 @@
         "name": "Unstable Ghoul",
         "rarity": "COMMON",
         "set": "NAXX",
-        "techLevel": 2,
         "text": "<b>Taunt</b>. <b>Deathrattle:</b> Deal 1 damage to all minions.",
         "type": "MINION"
     },
@@ -44743,6 +44747,18 @@
         "type": "HERO"
     },
     {
+        "artist": "Konstantin Porubov",
+        "cardClass": "WARRIOR",
+        "collectible": true,
+        "dbfId": 93985,
+        "health": 30,
+        "id": "HERO_01y",
+        "name": "Goulash Garrosh",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
         "artist": "Glenn Rane",
         "cardClass": "SHAMAN",
         "collectible": true,
@@ -45286,6 +45302,18 @@
         "artist": "BOSi Studio",
         "cardClass": "ROGUE",
         "collectible": true,
+        "dbfId": 93987,
+        "health": 30,
+        "id": "HERO_03v",
+        "name": "Marshmallow Maiev",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
+        "artist": "BOSi Studio",
+        "cardClass": "ROGUE",
+        "collectible": true,
         "dbfId": 89941,
         "health": 30,
         "id": "HERO_03x",
@@ -45315,6 +45343,29 @@
         "id": "HERO_04a",
         "name": "Lady Liadrin",
         "rarity": "EPIC",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
+        "artist": "Konstantin Porubov",
+        "cardClass": "PALADIN",
+        "collectible": true,
+        "dbfId": 93984,
+        "health": 30,
+        "id": "HERO_04aa",
+        "name": "Burger Uther",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
+        "cardClass": "PALADIN",
+        "collectible": true,
+        "dbfId": 94026,
+        "health": 30,
+        "id": "HERO_04ab",
+        "name": "Fishy Finley",
+        "rarity": "FREE",
         "set": "HERO_SKINS",
         "type": "HERO"
     },
@@ -45849,6 +45900,18 @@
         "type": "HERO"
     },
     {
+        "artist": "Décio Júnior",
+        "cardClass": "HUNTER",
+        "collectible": true,
+        "dbfId": 93981,
+        "health": 30,
+        "id": "HERO_05x",
+        "name": "Bakin' Brann",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
         "artist": "Alex Horley Orlandelli",
         "cardClass": "DRUID",
         "collectible": true,
@@ -45869,6 +45932,18 @@
         "id": "HERO_06a",
         "name": "Lunara",
         "rarity": "EPIC",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
+        "artist": "Tanamaes Leejierasaes",
+        "cardClass": "DRUID",
+        "collectible": true,
+        "dbfId": 93979,
+        "health": 30,
+        "id": "HERO_06aa",
+        "name": "Epicurean Elise",
+        "rarity": "FREE",
         "set": "HERO_SKINS",
         "type": "HERO"
     },
@@ -46413,6 +46488,18 @@
         "type": "HERO"
     },
     {
+        "artist": "Grace Liu",
+        "cardClass": "WARLOCK",
+        "collectible": true,
+        "dbfId": 93986,
+        "health": 30,
+        "id": "HERO_07x",
+        "name": "Noodle Nemsy",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
         "artist": "Glenn Rane",
         "cardClass": "MAGE",
         "collectible": true,
@@ -46480,6 +46567,18 @@
         "health": 30,
         "id": "HERO_08ad",
         "name": "Wicked Prince Kael'thas",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
+        "artist": "Grafit",
+        "cardClass": "MAGE",
+        "collectible": true,
+        "dbfId": 93976,
+        "health": 30,
+        "id": "HERO_08ae",
+        "name": "Cookin' Reno",
         "rarity": "FREE",
         "set": "HERO_SKINS",
         "type": "HERO"
@@ -47029,6 +47128,18 @@
         "type": "HERO"
     },
     {
+        "artist": "Mooncolony",
+        "cardClass": "PRIEST",
+        "collectible": true,
+        "dbfId": 93983,
+        "health": 30,
+        "id": "HERO_09w",
+        "name": "Appetizer Anduin",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
         "artist": "Alex Horley Orlandelli",
         "cardClass": "DEMONHUNTER",
         "collectible": true,
@@ -47264,6 +47375,18 @@
         "health": 30,
         "id": "HERO_10u",
         "name": "Songstress Aranna",
+        "rarity": "FREE",
+        "set": "HERO_SKINS",
+        "type": "HERO"
+    },
+    {
+        "artist": "Sora Kim",
+        "cardClass": "DEMONHUNTER",
+        "collectible": true,
+        "dbfId": 93980,
+        "health": 30,
+        "id": "HERO_10v",
+        "name": "Apple Aranna",
         "rarity": "FREE",
         "set": "HERO_SKINS",
         "type": "HERO"
@@ -54360,6 +54483,697 @@
         "type": "WEAPON"
     },
     {
+        "artist": "Jason Kang",
+        "attack": 1,
+        "cardClass": "WARLOCK",
+        "collectible": true,
+        "cost": 2,
+        "dbfId": 79537,
+        "flavor": "There is an imposter among us.",
+        "health": 1,
+        "id": "MAW_000",
+        "isMiniSet": true,
+        "mechanics": [
+            "BATTLECRY"
+        ],
+        "name": "Imp-oster",
+        "race": "DEMON",
+        "rarity": "COMMON",
+        "set": "REVENDRETH",
+        "targetingArrowText": "Choose a friendly Imp. Transform into a copy of it.",
+        "text": "<b>Battlecry:</b> Choose a friendly Imp. Transform into a copy of it.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Juan Calle",
+        "cardClass": "WARLOCK",
+        "collectible": true,
+        "cost": 2,
+        "dbfId": 79538,
+        "flavor": "We didn't start the fire!",
+        "id": "MAW_001",
+        "isMiniSet": true,
+        "name": "Arson Accusation",
+        "rarity": "COMMON",
+        "set": "REVENDRETH",
+        "spellSchool": "FIRE",
+        "text": "Choose a minion. Destroy it after your hero takes damage.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Konstantin Turovec",
+        "cardClass": "WARLOCK",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 79540,
+        "flavor": "Whoops, typo!",
+        "id": "MAW_002",
+        "isMiniSet": true,
+        "mechanics": [
+            "DISCOVER"
+        ],
+        "name": "Habeas Corpses",
+        "rarity": "RARE",
+        "referencedTags": [
+            "RUSH"
+        ],
+        "set": "REVENDRETH",
+        "spellSchool": "SHADOW",
+        "text": "<b>Discover</b> a friendly minion to resurrect and give it <b>Rush</b>.\nIt dies at the end of turn.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Sergey Tsvelykh",
+        "cardClass": "SHAMAN",
+        "collectible": true,
+        "cost": 1,
+        "dbfId": 79542,
+        "flavor": "Every totem is evidence of a tree's murder.",
+        "id": "MAW_003",
+        "isMiniSet": true,
+        "mechanics": [
+            "INFUSE"
+        ],
+        "name": "Totemic Evidence",
+        "rarity": "COMMON",
+        "set": "REVENDRETH",
+        "text": "Choose a basic Totem and summon it.\n<b>Infuse (3 Totems):</b>\nSummon all 4 instead.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Jaemin Kim",
+        "attack": 3,
+        "cardClass": "NEUTRAL",
+        "collectible": true,
+        "cost": 5,
+        "dbfId": 79546,
+        "flavor": "The Soul Seeker's job is to look for a snitch.",
+        "health": 3,
+        "id": "MAW_004",
+        "isMiniSet": true,
+        "mechanics": [
+            "BATTLECRY"
+        ],
+        "name": "Soul Seeker",
+        "rarity": "COMMON",
+        "set": "REVENDRETH",
+        "text": "<b>Battlecry:</b> Swap this with a random minion from your opponent's deck.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Jakub Kasper",
+        "attack": 3,
+        "cardClass": "SHAMAN",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 77033,
+        "flavor": "\"Who put these beans in my pocket?!\" -Man With Beans in Pocket",
+        "health": 3,
+        "id": "MAW_005",
+        "isMiniSet": true,
+        "mechanics": [
+            "BATTLECRY"
+        ],
+        "name": "Framester",
+        "rarity": "RARE",
+        "referencedTags": [
+            "OVERLOAD"
+        ],
+        "set": "REVENDRETH",
+        "text": "[x]<b>Battlecry:</b> Shuffle 3 'Framed'\ncards into the opponent's\ndeck. When drawn, they\n<b>Overload</b> for (2).",
+        "type": "MINION"
+    },
+    {
+        "artist": "Vlad Botos",
+        "cardClass": "MAGE",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 79548,
+        "flavor": "\"Sire, this is a Sindy's.\"",
+        "id": "MAW_006",
+        "isMiniSet": true,
+        "mechanics": [
+            "SECRET"
+        ],
+        "name": "Objection!",
+        "rarity": "RARE",
+        "referencedTags": [
+            "COUNTER"
+        ],
+        "set": "REVENDRETH",
+        "text": "<b>Secret:</b> When your opponent plays a\n minion, <b>Counter</b> it.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Ivan Fomin",
+        "attack": 5,
+        "cardClass": "DEMONHUNTER",
+        "collectible": true,
+        "cost": 4,
+        "dbfId": 79549,
+        "flavor": "Does \"Justice is Blind\" still apply with Spectral Sight?",
+        "health": 4,
+        "id": "MAW_008",
+        "isMiniSet": true,
+        "mechanics": [
+            "BATTLECRY"
+        ],
+        "name": "Sightless Magistrate",
+        "rarity": "COMMON",
+        "set": "REVENDRETH",
+        "text": "<b>Battlecry:</b> Both players draw\nuntil they have 5 cards.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Patrick Bjorkstrom",
+        "attack": 6,
+        "cardClass": "HUNTER",
+        "collectible": true,
+        "cost": 5,
+        "dbfId": 79552,
+        "flavor": "This Shadehound wasn't just a good boy. He was the best.",
+        "health": 5,
+        "id": "MAW_009",
+        "isMiniSet": true,
+        "mechanics": [
+            "INFUSE",
+            "TRIGGER_VISUAL"
+        ],
+        "name": "Shadehound",
+        "race": "BEAST",
+        "rarity": "RARE",
+        "referencedTags": [
+            "RUSH"
+        ],
+        "set": "REVENDRETH",
+        "text": "[x]Whenever this attacks, give\nyour other Beasts +2/+2.\n<b>Infuse (3 Beasts):</b>\nGain <b>Rush</b>.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Anton Zemskov",
+        "cardClass": "HUNTER",
+        "collectible": true,
+        "cost": 2,
+        "dbfId": 79555,
+        "flavor": "DO NOT PASS GO. DO NOT COLLECT 200 GOLD.",
+        "id": "MAW_010",
+        "isMiniSet": true,
+        "mechanics": [
+            "SECRET"
+        ],
+        "name": "Motion Denied",
+        "rarity": "COMMON",
+        "set": "REVENDRETH",
+        "text": "[x]<b>Secret:</b> After your\nopponent plays three cards\nin a turn, deal $6 damage\nto the enemy hero.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Arthur Bozonnet",
+        "attack": 5,
+        "cardClass": "HUNTER",
+        "collectible": true,
+        "cost": 6,
+        "dbfId": 79556,
+        "elite": true,
+        "flavor": "\"Your Honor, my client was simply trying a new tree trimming technique!\"",
+        "health": 4,
+        "id": "MAW_011",
+        "isMiniSet": true,
+        "mechanics": [
+            "BATTLECRY",
+            "DISCOVER"
+        ],
+        "name": "Defense Attorney Nathanos",
+        "rarity": "LEGENDARY",
+        "referencedTags": [
+            "DEATHRATTLE"
+        ],
+        "set": "REVENDRETH",
+        "text": "[x]<b>Battlecry:</b> <b>Discover</b> a friendly\n<b>Deathrattle</b> minion that died\nthis game. Trigger and gain\nits <b>Deathrattle</b>.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Mauricio Herrera",
+        "cardClass": "DEMONHUNTER",
+        "collectible": true,
+        "cost": 5,
+        "dbfId": 79593,
+        "flavor": "Maybe we should have made the bars closer together…",
+        "id": "MAW_012",
+        "isMiniSet": true,
+        "name": "All Fel Breaks Loose",
+        "rarity": "COMMON",
+        "referencedTags": [
+            "INFUSE"
+        ],
+        "set": "REVENDRETH",
+        "spellSchool": "FEL",
+        "text": "[x]Summon a friendly Demon\nthat died this game.\n<b>Infuse (3 Demons):</b>\nSummon three instead.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Konstantin Turovec",
+        "cardClass": "MAGE",
+        "collectible": true,
+        "cost": 4,
+        "dbfId": 79596,
+        "flavor": "Also sentenced to laugh and love.",
+        "id": "MAW_013",
+        "isMiniSet": true,
+        "name": "Life Sentence",
+        "rarity": "RARE",
+        "set": "REVENDRETH",
+        "text": "Remove a minion\nfrom the game.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Rafael Zanchetin",
+        "attack": 2,
+        "cardClass": "DEMONHUNTER",
+        "collectible": true,
+        "cost": 4,
+        "dbfId": 79598,
+        "elite": true,
+        "flavor": "\"Your Honor. The Defense isn't a clown, he's the whole circus.\"",
+        "health": 6,
+        "id": "MAW_014",
+        "isMiniSet": true,
+        "mechanics": [
+            "BATTLECRY"
+        ],
+        "name": "Prosecutor Mel'tranix",
+        "race": "DEMON",
+        "rarity": "LEGENDARY",
+        "set": "REVENDRETH",
+        "text": "[x]<b>Battlecry:</b> Your opponent\ncan only play their left- \nand right-most cards on \ntheir next turn.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Konstantin Turovec",
+        "cardClass": "PALADIN",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 78145,
+        "flavor": "The most criminal thing about paladins is that they actually <i>like</i> jury duty.",
+        "id": "MAW_015",
+        "isMiniSet": true,
+        "name": "Jury Duty",
+        "rarity": "COMMON",
+        "set": "REVENDRETH",
+        "text": "[x]Summon two\nSilver Hand Recruits.\nGive your Silver Hand\nRecruits +1/+1.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "James Ryman",
+        "cardClass": "PALADIN",
+        "collectible": true,
+        "cost": 2,
+        "dbfId": 78144,
+        "flavor": "\"I have nothing BUT contempt for this court!\"",
+        "id": "MAW_016",
+        "isMiniSet": true,
+        "name": "Order in the Court",
+        "rarity": "RARE",
+        "set": "REVENDRETH",
+        "text": "[x]Reorder your deck from\nhighest Cost to lowest\nCost. Draw a card.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "James Ryman",
+        "attack": 2,
+        "cardClass": "PALADIN",
+        "collectible": true,
+        "cost": 2,
+        "dbfId": 79602,
+        "flavor": "\"Have you or a loved one ever been injured in a Consecration?\"",
+        "health": 3,
+        "id": "MAW_017",
+        "isMiniSet": true,
+        "mechanics": [
+            "BATTLECRY"
+        ],
+        "name": "Class Action Lawyer",
+        "rarity": "RARE",
+        "set": "REVENDRETH",
+        "targetingArrowText": "Set stats to 1/1.",
+        "text": "[x]<b>Battlecry:</b> If your deck\nhas no Neutral cards, set\n a minion's stats to 1/1.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Ludo Lullabi",
+        "cardClass": "ROGUE",
+        "collectible": true,
+        "cost": 2,
+        "dbfId": 79607,
+        "flavor": "By Liar be Perjured!",
+        "id": "MAW_018",
+        "isMiniSet": true,
+        "mechanics": [
+            "DISCOVER",
+            "SECRET"
+        ],
+        "name": "Perjury",
+        "rarity": "COMMON",
+        "set": "REVENDRETH",
+        "text": "[x]<b>Secret:</b> When your\nturn starts, <b>Discover</b>\nand cast a <b>Secret</b> from\nanother class.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Konstantin Turovec",
+        "cardClass": "ROGUE",
+        "collectible": true,
+        "cost": 2,
+        "dbfId": 79608,
+        "flavor": "Quote From Man Murdered: \"What are you gonna do, murder me?\"",
+        "id": "MAW_019",
+        "isMiniSet": true,
+        "name": "Murder Accusation",
+        "rarity": "COMMON",
+        "set": "REVENDRETH",
+        "text": "Choose a minion. Destroy it after another enemy minion dies.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Matt Dixon",
+        "attack": 4,
+        "cardClass": "ROGUE",
+        "collectible": true,
+        "cost": 6,
+        "dbfId": 79612,
+        "flavor": "A truly staggering 180 scribbles per minute!",
+        "health": 4,
+        "id": "MAW_020",
+        "isMiniSet": true,
+        "mechanics": [
+            "RUSH"
+        ],
+        "name": "Scribbling Stenographer",
+        "rarity": "RARE",
+        "set": "REVENDRETH",
+        "text": "<b>Rush</b>. Costs (1) less for each card you've played this turn.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Arthur Bozonnet",
+        "cardClass": "PRIEST",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 79739,
+        "flavor": "Do you swear to give the buff, the whole buff, and nothing but the buff, so help you Kyrestia?",
+        "id": "MAW_021",
+        "isMiniSet": true,
+        "name": "Clear Conscience",
+        "rarity": "COMMON",
+        "set": "REVENDRETH",
+        "spellSchool": "HOLY",
+        "text": "[x]Give a friendly minion\n+2/+3 and \"Only you can\ntarget this with spells\nand Hero Powers.\"",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Zoltan Boros",
+        "attack": 2,
+        "cardClass": "PRIEST",
+        "collectible": true,
+        "cost": 4,
+        "dbfId": 79742,
+        "flavor": "Good news: He knows Kazakus's secret identity! Bad news: Now he's here.",
+        "health": 6,
+        "id": "MAW_022",
+        "isMiniSet": true,
+        "mechanics": [
+            "DEATHRATTLE",
+            "TAUNT"
+        ],
+        "name": "Incriminating Psychic",
+        "race": "DRAGON",
+        "rarity": "COMMON",
+        "set": "REVENDRETH",
+        "text": "<b>Taunt</b>\n <b>Deathrattle:</b> Copy a\n random card from your opponent's hand.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Anzka Nguyen",
+        "cardClass": "PRIEST",
+        "collectible": true,
+        "cost": 1,
+        "dbfId": 79745,
+        "flavor": "Honey, where are my paaaaaaants?",
+        "id": "MAW_023",
+        "isMiniSet": true,
+        "name": "Theft Accusation",
+        "rarity": "RARE",
+        "set": "REVENDRETH",
+        "spellSchool": "SHADOW",
+        "text": "[x]Choose a minion.\nDestroy it after you play\na card copied from\nthe opponent.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Konstantin Turovec",
+        "cardClass": "DRUID",
+        "collectible": true,
+        "cost": 2,
+        "dbfId": 79748,
+        "flavor": "All part of dewing your dew diligence.",
+        "id": "MAW_024",
+        "isMiniSet": true,
+        "name": "Dew Process",
+        "rarity": "RARE",
+        "set": "REVENDRETH",
+        "spellSchool": "NATURE",
+        "text": "[x]For the rest of the game,\nplayers draw an extra card\nat the start of their turn.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Alex Stone",
+        "attack": 1,
+        "cardClass": "DRUID",
+        "collectible": true,
+        "cost": 2,
+        "dbfId": 79757,
+        "flavor": "When the going gets tough, you don't want a criminal lawyer... you want a <i>criminal</i> lawyer...",
+        "health": 3,
+        "id": "MAW_025",
+        "isMiniSet": true,
+        "mechanics": [
+            "CHOOSE_ONE"
+        ],
+        "name": "Attorney-at-Maw",
+        "rarity": "COMMON",
+        "referencedTags": [
+            "IMMUNE",
+            "SILENCE"
+        ],
+        "set": "REVENDRETH",
+        "text": "<b>Choose One -</b> <b>Silence</b>\na minion; or Give a minion <b>Immune</b> this turn.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Jakub Kasper",
+        "cardClass": "DRUID",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 77488,
+        "flavor": "To Blizzard jail with you!",
+        "id": "MAW_026",
+        "isMiniSet": true,
+        "name": "Incarceration",
+        "rarity": "RARE",
+        "set": "REVENDRETH",
+        "text": "[x]Choose a minion.\nIt goes <b>Dormant</b>\nfor 3 turns.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Luca Zontini",
+        "cardClass": "WARRIOR",
+        "collectible": true,
+        "cost": 1,
+        "dbfId": 79770,
+        "flavor": "Don't worry, there is a chair for you to sit in. It's very misleading.",
+        "id": "MAW_027",
+        "isMiniSet": true,
+        "name": "Call to the Stand",
+        "rarity": "COMMON",
+        "set": "REVENDRETH",
+        "text": "Your opponent summons a random minion from their hand.",
+        "type": "SPELL"
+    },
+    {
+        "artist": "Vladimir Kafanov",
+        "attack": 4,
+        "cardClass": "WARRIOR",
+        "collectible": true,
+        "cost": 5,
+        "dbfId": 79771,
+        "flavor": "Bailiff, bring in the dancing lobsters!",
+        "health": 4,
+        "id": "MAW_028",
+        "isMiniSet": true,
+        "mechanics": [
+            "BATTLECRY",
+            "TAUNT"
+        ],
+        "name": "Mawsworn Bailiff",
+        "rarity": "COMMON",
+        "set": "REVENDRETH",
+        "text": "<b><b>Taunt</b>.</b> <b>Battlecry:</b> If you have 4 or more Armor, gain +4/+4.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Anton Zemskov",
+        "attack": 3,
+        "cardClass": "WARRIOR",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 79772,
+        "flavor": "\"Yes, Your Honor, this appears to be some sort of blade.\"",
+        "health": 2,
+        "id": "MAW_029",
+        "isMiniSet": true,
+        "mechanics": [
+            "BATTLECRY"
+        ],
+        "name": "Weapons Expert",
+        "rarity": "RARE",
+        "set": "REVENDRETH",
+        "text": "<b>Battlecry:</b> If you have a weapon equipped, give it +1/+1. Otherwise, draw a weapon.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Sergey Tsvelykh",
+        "attack": 6,
+        "cardClass": "SHAMAN",
+        "collectible": true,
+        "cost": 8,
+        "dbfId": 79774,
+        "flavor": "Why is it a common? Well we couldn't make it a LEGendary minion!",
+        "health": 10,
+        "id": "MAW_030",
+        "isMiniSet": true,
+        "mechanics": [
+            "BATTLECRY"
+        ],
+        "name": "Torghast Custodian",
+        "rarity": "RARE",
+        "referencedTags": [
+            "DIVINE_SHIELD",
+            "RUSH",
+            "WINDFURY"
+        ],
+        "set": "REVENDRETH",
+        "text": "[x]<b>Battlecry:</b> For each\nenemy minion, randomly\ngain <b>Rush</b>, <b>Divine Shield</b>,\nor <b>Windfury</b>.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Mike Sass",
+        "attack": 3,
+        "cardClass": "NEUTRAL",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 79778,
+        "flavor": "AH! Wrist cramp!",
+        "health": 4,
+        "id": "MAW_031",
+        "isMiniSet": true,
+        "mechanics": [
+            "INFUSE"
+        ],
+        "name": "Afterlife Attendant",
+        "rarity": "RARE",
+        "set": "REVENDRETH",
+        "text": "Your <b>Infuse</b> cards also <b>Infuse</b> while in your deck.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Arthur Gimaldinov",
+        "attack": 2,
+        "cardClass": "NEUTRAL",
+        "collectible": true,
+        "cost": 3,
+        "dbfId": 79779,
+        "flavor": "People keep asking for her award-winning vegetarian chili recipe, but she just can't spill the beans.",
+        "health": 5,
+        "id": "MAW_032",
+        "isMiniSet": true,
+        "mechanics": [
+            "AURA"
+        ],
+        "name": "Tight-Lipped Witness",
+        "rarity": "EPIC",
+        "referencedTags": [
+            "SECRET"
+        ],
+        "set": "REVENDRETH",
+        "text": "<b>Secrets</b> can't be revealed.",
+        "type": "MINION"
+    },
+    {
+        "artist": "James Ryman",
+        "attack": 5,
+        "cardClass": "NEUTRAL",
+        "collectible": true,
+        "cost": 6,
+        "dbfId": 79780,
+        "elite": true,
+        "flavor": "Turns into 'Sylvanas, the Infused'.",
+        "health": 5,
+        "id": "MAW_033",
+        "isMiniSet": true,
+        "mechanics": [
+            "BATTLECRY",
+            "INFUSE"
+        ],
+        "name": "Sylvanas, the Accused",
+        "rarity": "LEGENDARY",
+        "set": "REVENDRETH",
+        "targetingArrowText": "Destroy an enemy minion.",
+        "text": "[x]<b>Battlecry:</b> Destroy\nan enemy minion.\n<b>Infuse (7):</b> Take control\nof it instead.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Alex Horley Orlandelli",
+        "attack": 10,
+        "cardClass": "NEUTRAL",
+        "collectible": true,
+        "cost": 10,
+        "dbfId": 79782,
+        "elite": true,
+        "flavor": "At one point, The Jailer served as Arbiter over the souls of the Shadowlands. He was the epitome of an unbiased, righteous judge of character. WAS.",
+        "health": 10,
+        "id": "MAW_034",
+        "isMiniSet": true,
+        "mechanics": [
+            "BATTLECRY"
+        ],
+        "name": "The Jailer",
+        "rarity": "LEGENDARY",
+        "referencedTags": [
+            "IMMUNE"
+        ],
+        "set": "REVENDRETH",
+        "text": "<b>Battlecry:</b> Destroy your  deck. For the rest of the game, your minions are <b>Immune</b>.",
+        "type": "MINION"
+    },
+    {
+        "artist": "Matt Dixon",
+        "attack": 6,
+        "cardClass": "MAGE",
+        "collectible": true,
+        "cost": 6,
+        "dbfId": 84351,
+        "flavor": "This document looks illegally binding.",
+        "health": 6,
+        "id": "MAW_101",
+        "isMiniSet": true,
+        "name": "Contract Conjurer",
+        "rarity": "COMMON",
+        "referencedTags": [
+            "SECRET"
+        ],
+        "set": "REVENDRETH",
+        "text": "Costs (3) less for each <b>Secret</b> you control.",
+        "type": "MINION"
+    },
+    {
         "artist": "Jim Nelson",
         "cardClass": "WARLOCK",
         "collectible": true,
@@ -58501,7 +59315,7 @@
         "name": "Demolition Renovator",
         "rarity": "EPIC",
         "set": "REVENDRETH",
-        "targetingArrowText": "Destroy a <b>location</b>.",
+        "targetingArrowText": "Destroy an enemy <b>location</b>.",
         "text": "<b>Battlecry:</b> Destroy \nan enemy location.",
         "type": "MINION"
     },
@@ -58927,7 +59741,7 @@
             "BATTLECRY"
         ],
         "set": "REVENDRETH",
-        "text": "[x]<b>Battlecry:</b> Draw a Nature\nspell. Gain an empty\n Mana Crystal.",
+        "text": "[x]<b>Battlecry:</b> Draw a Nature\nspell. Gain an empty\nMana Crystal.",
         "type": "MINION"
     },
     {
@@ -59955,6 +60769,9 @@
         "id": "REV_842",
         "name": "Promotion",
         "rarity": "EPIC",
+        "referencedTags": [
+            "TAUNT"
+        ],
         "set": "REVENDRETH",
         "text": "[x]Give a Silver Hand\nRecruit +3/+3\nand <b>Taunt</b>.",
         "type": "SPELL"
@@ -61032,8 +61849,6 @@
     {
         "artist": "Matt Dixon",
         "attack": 1,
-        "battlegroundsDarkmoonPrizeTurn": 4,
-        "battlegroundsPremiumDbfId": 67493,
         "cardClass": "PALADIN",
         "collectible": true,
         "cost": 2,
@@ -61047,7 +61862,6 @@
         "name": "Argent Braggart",
         "rarity": "EPIC",
         "set": "SCHOLOMANCE",
-        "techLevel": 6,
         "text": "<b>Battlecry:</b> Gain Attack and Health to match the highest in the battlefield.",
         "type": "MINION"
     },
@@ -67679,7 +68493,7 @@
         "race": "BEAST",
         "rarity": "LEGENDARY",
         "set": "TROLL",
-        "text": "[x]<b>Divine Shield</b>, <b>Rush</b>, <b>Lifesteal</b>\n Costs (1) less for each Mana\nyou've spent on spells.",
+        "text": "[x]<b>Divine Shield</b>, <b>Rush</b>, <b>Lifesteal</b>\nCosts (1) less for each Mana\nyou've spent on spells.",
         "type": "MINION"
     },
     {
@@ -69630,6 +70444,7 @@
         "elite": true,
         "flavor": "Yet ANOTHER sword fighter that spams counters.",
         "health": 6,
+        "howToEarn": "Earnable after opening a <i>Voyage to the Sunken City</i> card pack.",
         "howToEarnGolden": "Earnable after purchasing the <i>Voyage to the Sunken City</i> Tavern Pass.",
         "id": "TSC_032",
         "mechanics": [
@@ -83313,7 +84128,7 @@
         "name": "Imp Master",
         "rarity": "RARE",
         "set": "VANILLA",
-        "text": "[x]At the end of your turn, deal\n1 damage to this minion\n and summon a 1/1 Imp.",
+        "text": "[x]At the end of your turn, deal\n1 damage to this minion\nand summon a 1/1 Imp.",
         "type": "MINION"
     },
     {

--- a/Resources/mercenaries.json
+++ b/Resources/mercenaries.json
@@ -4433,6 +4433,196 @@
     },
     {
         "collectible": true,
+        "craftingCost": 500,
+        "defaultSkinDbfId": 64567,
+        "equipment": [
+            {
+                "id": 464,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94979,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94978,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94977,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 94606,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 465,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94982,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94981,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94980,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 94608,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 466,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94985,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94984,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94983,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 94610,
+                        "tier": 4
+                    }
+                ]
+            }
+        ],
+        "id": 35,
+        "name": "Medivh",
+        "skinDbfIds": [
+            64565,
+            64566,
+            64567
+        ],
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 962,
+                        "name": "Arcane Rift",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94957,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94956,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94955,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94954,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94553,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 963,
+                        "name": "Mage Guard",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94961,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94960,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94959,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94958,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94557,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 964,
+                        "name": "Summon Raven Familiar",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94965,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94964,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94963,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94962,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94588,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 63,
+                "name": "Arcane"
+            }
+        ]
+    },
+    {
+        "collectible": true,
         "craftingCost": 100,
         "defaultSkinDbfId": 64550,
         "equipment": [
@@ -18802,6 +18992,197 @@
     {
         "collectible": true,
         "craftingCost": 500,
+        "defaultSkinDbfId": 84777,
+        "equipment": [
+            {
+                "id": 311,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 85178,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 85183,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 85184,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 85185,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 312,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 85194,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 85195,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 85196,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 85197,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 313,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 85198,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 86520,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 86521,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 86522,
+                        "tier": 4
+                    }
+                ]
+            }
+        ],
+        "id": 296,
+        "name": "Korrak the Bloodrager",
+        "shortName": "Korrak",
+        "skinDbfIds": [
+            84779,
+            84778,
+            84777
+        ],
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 781,
+                        "name": "Mounting Anger",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 85159,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 85161,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 85162,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 85163,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 85164,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 782,
+                        "name": "Eat the Dead",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 85165,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 85167,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 85168,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 85169,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 85170,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 783,
+                        "name": "Blood Rage",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 85171,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 85172,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 85173,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 85174,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 85175,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 355,
+                "name": "Combo"
+            }
+        ]
+    },
+    {
+        "collectible": true,
+        "craftingCost": 500,
         "defaultSkinDbfId": 84774,
         "equipment": [
             {
@@ -21052,6 +21433,181 @@
         ]
     },
     {
+        "collectible": true,
+        "craftingCost": 500,
+        "defaultSkinDbfId": 86982,
+        "equipment": [
+            {
+                "id": 430,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94461,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94460,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94459,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 93192,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 431,
+                "tiers": [
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 93196,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 432,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94492,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94491,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94490,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 93200,
+                        "tier": 4
+                    }
+                ]
+            }
+        ],
+        "id": 329,
+        "name": "Ysera",
+        "skinDbfIds": [
+            86982,
+            86980,
+            86979
+        ],
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 833,
+                        "name": "Verdant Breath",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94465,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94464,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 100,
+                                "dbf_id": 94463,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94462,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 86983,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 834,
+                        "name": "Emerald Dream",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94542,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94541,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94540,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94539,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 86984,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 835,
+                        "name": "Emerald Oracle",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94552,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94549,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94546,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94543,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 93188,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 385,
+                "name": "Uncategorized"
+            }
+        ]
+    },
+    {
         "collectible": false,
         "craftingCost": 50,
         "defaultSkinDbfId": 86901,
@@ -21587,12 +22143,12 @@
                                 "tier": 1
                             },
                             {
-                                "crafting_cost": 50,
+                                "crafting_cost": 100,
                                 "dbf_id": 94233,
                                 "tier": 2
                             },
                             {
-                                "crafting_cost": 100,
+                                "crafting_cost": 125,
                                 "dbf_id": 94232,
                                 "tier": 3
                             },
@@ -25292,6 +25848,362 @@
         ]
     },
     {
+        "collectible": true,
+        "craftingCost": 100,
+        "defaultSkinDbfId": 92555,
+        "equipment": [
+            {
+                "id": 405,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94107,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94108,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94109,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 92588,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 406,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94110,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94111,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94112,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 92589,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 407,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 92590,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 92591,
+                        "tier": 4
+                    }
+                ]
+            }
+        ],
+        "id": 397,
+        "name": "Prince Malchezaar",
+        "shortName": "Malchezaar",
+        "skinDbfIds": [
+            92557,
+            92556,
+            92555
+        ],
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 915,
+                        "name": "Party Crasher",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 93202,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 93203,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 93204,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 93205,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 92558,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 916,
+                        "name": "Check Your Weapons",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 93206,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 93207,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 93208,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 93209,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 92560,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 917,
+                        "name": "All Realities",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 93213,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 93212,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 93211,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 93210,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 92562,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 455,
+                "name": ""
+            }
+        ]
+    },
+    {
+        "collectible": true,
+        "craftingCost": 300,
+        "defaultSkinDbfId": 92731,
+        "equipment": [
+            {
+                "id": 413,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94104,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94105,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94106,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 92936,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 411,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 92933,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 412,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94103,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94102,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94101,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 92934,
+                        "tier": 4
+                    }
+                ]
+            }
+        ],
+        "id": 398,
+        "name": "Archimonde",
+        "skinDbfIds": [
+            92733,
+            92732,
+            92731
+        ],
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 918,
+                        "name": "Finger of Death",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94089,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94090,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94091,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94092,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 92902,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 919,
+                        "name": "Rain of Chaos",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94096,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94095,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94094,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94093,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 92904,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 920,
+                        "name": "Doomfire",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94097,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94098,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94099,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94100,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 92908,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 456,
+                "name": ""
+            }
+        ]
+    },
+    {
         "collectible": false,
         "craftingCost": 500,
         "defaultSkinDbfId": 92981,
@@ -25310,6 +26222,1105 @@
         ]
     },
     {
+        "collectible": true,
+        "craftingCost": 100,
+        "defaultSkinDbfId": 92962,
+        "equipment": [
+            {
+                "id": 420,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94139,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94140,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94141,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 92995,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 421,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94142,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94143,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94144,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 92996,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 422,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 93022,
+                        "tier": 4
+                    }
+                ]
+            }
+        ],
+        "id": 402,
+        "name": "Neeru Fireblade",
+        "shortName": "Neeru",
+        "skinDbfIds": [
+            92964,
+            92963,
+            92962
+        ],
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 924,
+                        "name": "Command Demon",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94121,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94122,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94123,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94124,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 92967,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 925,
+                        "name": "Burning Blade Portal",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94130,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94131,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94132,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94133,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 92989,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 926,
+                        "name": "Imp-losion",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94134,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94135,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94136,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94137,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 92992,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 460,
+                "name": ""
+            }
+        ]
+    },
+    {
+        "collectible": true,
+        "craftingCost": 100,
+        "defaultSkinDbfId": 93090,
+        "equipment": [
+            {
+                "id": 424,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94274,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94275,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94276,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 93117,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 425,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 95398,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 95397,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 95396,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 93119,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 426,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94278,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94279,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94280,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 93121,
+                        "tier": 4
+                    }
+                ]
+            }
+        ],
+        "id": 403,
+        "name": "Nemsy Necrofizzle",
+        "shortName": "Nemsy",
+        "skinDbfIds": [
+            93091,
+            93089,
+            93090
+        ],
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 927,
+                        "name": "Boggy Blast",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94261,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94262,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94263,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94264,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 93092,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 928,
+                        "name": "Erupting Fungus",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94265,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94266,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94267,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94268,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 93097,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 929,
+                        "name": "Bogonomics",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94270,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94271,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94272,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94273,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 93108,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 461,
+                "name": ""
+            }
+        ]
+    },
+    {
+        "collectible": true,
+        "craftingCost": 100,
+        "defaultSkinDbfId": 93396,
+        "equipment": [
+            {
+                "id": 439,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 95895,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 95894,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 95893,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 93393,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 440,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 95852,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 95851,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 95850,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 93394,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 441,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 95892,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 95891,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 95890,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 93398,
+                        "tier": 4
+                    }
+                ]
+            }
+        ],
+        "id": 407,
+        "name": "Tess Greymane",
+        "shortName": "Tess",
+        "skinDbfIds": [
+            93397,
+            93339,
+            93396
+        ],
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 939,
+                        "name": "Yoink!",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 96639,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 96638,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 96637,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 96636,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 93341,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 940,
+                        "name": "Moonlight Resolve!",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 96643,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 96642,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 96641,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 96640,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 93348,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 941,
+                        "name": "Princess Power!",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 95881,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 95880,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 95879,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 95878,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 93388,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 465,
+                "name": "Uncategorized"
+            }
+        ]
+    },
+    {
+        "collectible": true,
+        "craftingCost": 300,
+        "defaultSkinDbfId": 93405,
+        "equipment": [
+            {
+                "id": 442,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94599,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 93447,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 443,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94602,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94601,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94600,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 85326,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 444,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94605,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94604,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94603,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 93452,
+                        "tier": 4
+                    }
+                ]
+            }
+        ],
+        "id": 408,
+        "name": "Bwonsamdi",
+        "skinDbfIds": [
+            93410,
+            93409,
+            93405
+        ],
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 942,
+                        "name": "Soul Subjugation",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 96680,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 96679,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 96678,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 96677,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 93416,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 943,
+                        "name": "Irrefusable Deal",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94594,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94593,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94592,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94591,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 93430,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 944,
+                        "name": "Binding Contract",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94598,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94597,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94596,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94595,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 85315,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 466,
+                "name": "Shadow"
+            }
+        ]
+    },
+    {
+        "collectible": true,
+        "craftingCost": 300,
+        "defaultSkinDbfId": 93402,
+        "equipment": [
+            {
+                "id": 445,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 95219,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 95218,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 95217,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 93411,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 446,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 93413,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 447,
+                "tiers": [
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94341,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94340,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 93415,
+                        "tier": 4
+                    }
+                ]
+            }
+        ],
+        "id": 409,
+        "name": "Khadgar",
+        "skinDbfIds": [
+            93404,
+            93403,
+            93402
+        ],
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 945,
+                        "name": "Arcane Surge",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94368,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94367,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94366,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94365,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 93454,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 946,
+                        "name": "Blizzard",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94360,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94359,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94358,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94357,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 93457,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 947,
+                        "name": "Hearthfire",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94376,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94375,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94374,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94373,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 93408,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 467,
+                "name": "Archmage"
+            }
+        ]
+    },
+    {
+        "collectible": true,
+        "craftingCost": 300,
+        "defaultSkinDbfId": 94125,
+        "equipment": [
+            {
+                "id": 451,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94579,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94578,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94577,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 94160,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 452,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94583,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94582,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94581,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 94161,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 453,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 94587,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 94585,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 94584,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 94165,
+                        "tier": 4
+                    }
+                ]
+            }
+        ],
+        "id": 411,
+        "name": "Genn Greymane",
+        "shortName": "Genn",
+        "skinDbfIds": [
+            94127,
+            94126,
+            94125
+        ],
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 952,
+                        "name": "Blistering Bullet",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94565,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94564,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94563,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94562,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94138,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 953,
+                        "name": "Space Maker",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 94569,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 94568,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 94567,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94566,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94145,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 954,
+                        "name": "Beastly Beauty",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 96887,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 96886,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 96885,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 96884,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94151,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 469,
+                "name": "Uncategorized"
+            }
+        ]
+    },
+    {
         "collectible": false,
         "craftingCost": 500,
         "defaultSkinDbfId": 94438,
@@ -25322,6 +27333,378 @@
         "specializations": []
     },
     {
+        "collectible": true,
+        "craftingCost": 100,
+        "defaultSkinDbfId": 70947,
+        "equipment": [
+            {
+                "id": 460,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 95849,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 94515,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 461,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 95132,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 95131,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 95130,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 94517,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 462,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 95135,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 95134,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 95133,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 94518,
+                        "tier": 4
+                    }
+                ]
+            }
+        ],
+        "id": 414,
+        "name": "Aranna Starseeker",
+        "shortName": "Aranna",
+        "skinDbfIds": [
+            70949,
+            70948,
+            70947
+        ],
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 959,
+                        "name": "Edge Cancel",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 95125,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 95124,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 95123,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 95122,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94493,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 960,
+                        "name": "Felodic Intonement",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 95129,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 95128,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 95127,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 95126,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94507,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 961,
+                        "name": "Aggrobatics",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 95877,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 95876,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 95875,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 95874,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94513,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 471,
+                "name": "Attack"
+            }
+        ]
+    },
+    {
+        "collectible": true,
+        "craftingCost": 100,
+        "defaultSkinDbfId": 70943,
+        "equipment": [
+            {
+                "id": 467,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 95913,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 95912,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 95910,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 94924,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 468,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 95909,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 95908,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 95907,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 94926,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 469,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 95905,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 95904,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 95903,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 94928,
+                        "tier": 4
+                    }
+                ]
+            }
+        ],
+        "id": 416,
+        "name": "Garona Halforcen",
+        "shortName": "Garona",
+        "skinDbfIds": [
+            70941,
+            70942,
+            70943
+        ],
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 965,
+                        "name": "Smoke and Knives",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 95928,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 95927,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 95926,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 95925,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94907,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 966,
+                        "name": "Shimmering Toxin",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 95932,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 95931,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 95930,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 95929,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94911,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 967,
+                        "name": "One And The Same",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 95924,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 95923,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 95922,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 95921,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 94922,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 472,
+                "name": "Orc"
+            }
+        ]
+    },
+    {
         "collectible": false,
         "craftingCost": 500,
         "defaultSkinDbfId": 95024,
@@ -25332,5 +27715,196 @@
             95024
         ],
         "specializations": []
+    },
+    {
+        "collectible": true,
+        "craftingCost": 500,
+        "defaultSkinDbfId": 95986,
+        "equipment": [
+            {
+                "id": 479,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 96238,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 96237,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 96236,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 96006,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 480,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 96242,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 96241,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 96239,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 96008,
+                        "tier": 4
+                    }
+                ]
+            },
+            {
+                "id": 481,
+                "tiers": [
+                    {
+                        "crafting_cost": 0,
+                        "dbf_id": 96245,
+                        "tier": 1
+                    },
+                    {
+                        "crafting_cost": 100,
+                        "dbf_id": 96244,
+                        "tier": 2
+                    },
+                    {
+                        "crafting_cost": 150,
+                        "dbf_id": 96243,
+                        "tier": 3
+                    },
+                    {
+                        "crafting_cost": 175,
+                        "dbf_id": 96009,
+                        "tier": 4
+                    }
+                ]
+            }
+        ],
+        "id": 421,
+        "name": "Murloc Holmes",
+        "shortName": "Holmes",
+        "skinDbfIds": [
+            95988,
+            95987,
+            95986
+        ],
+        "specializations": [
+            {
+                "abilities": [
+                    {
+                        "id": 977,
+                        "name": "On The Case",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 96213,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 96212,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 96211,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 96210,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 95989,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 979,
+                        "name": "Elementary!",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 96217,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 96216,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 96215,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 96214,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 96002,
+                                "tier": 5
+                            }
+                        ]
+                    },
+                    {
+                        "id": 978,
+                        "name": "And The Killer Is!",
+                        "tiers": [
+                            {
+                                "crafting_cost": 0,
+                                "dbf_id": 96222,
+                                "tier": 1
+                            },
+                            {
+                                "crafting_cost": 50,
+                                "dbf_id": 96221,
+                                "tier": 2
+                            },
+                            {
+                                "crafting_cost": 125,
+                                "dbf_id": 96220,
+                                "tier": 3
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 96219,
+                                "tier": 4
+                            },
+                            {
+                                "crafting_cost": 150,
+                                "dbf_id": 95992,
+                                "tier": 5
+                            }
+                        ]
+                    }
+                ],
+                "id": 476,
+                "name": "Uncategorized"
+            }
+        ]
     }
 ]

--- a/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
@@ -137,6 +137,38 @@ void RevendrethCardsGen::AddDruid(std::map<std::string, CardDef>& cards)
     // Text: Cast 8 random Druid spells
     //       <i>(targets chosen randomly)</i>.
     // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [MAW_024] Dew Process - COST:2
+    // - Set: REVENDRETH, Rarity: Rare
+    // - Spell School: Nature
+    // --------------------------------------------------------
+    // Text: For the rest of the game,
+    //       players draw an extra card at the start of their turn.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - DRUID
+    // [MAW_025] Attorney-at-Maw - COST:2 [ATK:1/HP:3]
+    // - Set: REVENDRETH, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Choose One -</b> <b>Silence</b> a minion;
+    //       or Give a minion <b>Immune</b> this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CHOOSE_ONE = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - IMMUNE = 1
+    // - SILENCE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [MAW_026] Incarceration - COST:3
+    // - Set: REVENDRETH, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Choose a minion.
+    //       It goes <b>Dormant</b> for 3 turns.
+    // --------------------------------------------------------
 }
 
 void RevendrethCardsGen::AddDruidNonCollect(
@@ -238,6 +270,62 @@ void RevendrethCardsGen::AddDruidNonCollect(
     // --------------------------------------------------------
     // Text: <b>Infused</b>
     //       Summon two 5/5 Ancients.
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [MAW_024e2] Maw Rules - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: Player draws an extra card at the start of their turn.
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [MAW_024e3] Maw Rules - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: Draw an extra card at the start of your turn.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [MAW_025a] Guilty! - COST:2
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: <b>Silence</b> a minion.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - DRUID
+    // [MAW_025b] Innocent! - COST:2
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: Give a minion <b>Immune</b> this turn.
+    // --------------------------------------------------------
+    // RefTag:
+    // - IMMUNE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [MAW_025e] Proven Innocent - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: <b>Immune</b> this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [MAW_026e] Doing Time - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: <b>Dormant</b>. Awaken in 3 turns.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - DRUID
+    // [MAW_026e2] Doing Time - COST:0
+    // - Set: REVENDRETH
     // --------------------------------------------------------
 }
 
@@ -351,6 +439,50 @@ void RevendrethCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // GameTag:
     // - ImmuneToSpellpower = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [MAW_009] Shadehound - COST:5 [ATK:6/HP:5]
+    // - Race: Beast, Set: REVENDRETH, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Whenever this attacks,
+    //       give your other Beasts +2/+2.
+    //       <b>Infuse (3 Beasts):</b> Gain <b>Rush</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - INFUSE = 1
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [MAW_010] Motion Denied - COST:2
+    // - Set: REVENDRETH, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Secret:</b> After your opponent plays three cards
+    //       in a turn, deal 6 damage to the enemy hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [MAW_011] Defense Attorney Nathanos - COST:6 [ATK:5/HP:4]
+    // - Set: REVENDRETH, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> <b>Discover</b> a friendly
+    //       <b>Deathrattle</b> minion that died this game.
+    //       Trigger and gain its <b>Deathrattle</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DEATHRATTLE = 1
     // --------------------------------------------------------
 }
 
@@ -533,6 +665,45 @@ void RevendrethCardsGen::AddHunterNonCollect(
     // GameTag:
     // - TAG_ONE_TURN_EFFECT = 1
     // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - HUNTER
+    // [MAW_009e] Maw Bound - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: +2/+2.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - HUNTER
+    // [MAW_009t] Shadehound - COST:5 [ATK:6/HP:5]
+    // - Race: Beast, Set: REVENDRETH, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Infused</b>
+    //       <b>Rush</b>. Whenever this attacks,
+    //       give your other Beasts +2/+2.
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // - TRIGGER_VISUAL = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - HUNTER
+    // [MAW_010t] Improved Motion Denied - COST:2
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: <b>Secret:</b> After your opponent plays three cards
+    //       in a turn, deal 9 damage to the enemy hero.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - HUNTER
+    // [MAW_011e] Defending Death - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: Copied <b>Deathrattle</b> from {0}.
+    // --------------------------------------------------------
 }
 
 void RevendrethCardsGen::AddMage(std::map<std::string, CardDef>& cards)
@@ -650,6 +821,37 @@ void RevendrethCardsGen::AddMage(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Deal 2 damage to all minions.
     //       Summon a 2/2 Volatile Skeleton for each killed.
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [MAW_006] Objection! - COST:3
+    // - Set: REVENDRETH, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Secret:</b> When your opponent plays a minion,
+    //       <b>Counter</b> it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - COUNTER = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------- SPELL - MAGE
+    // [MAW_013] Life Sentence - COST:4
+    // - Set: REVENDRETH, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Remove a minion from the game.
+    // --------------------------------------------------------
+
+    // ------------------------------------------ MINION - MAGE
+    // [MAW_101] Contract Conjurer - COST:6 [ATK:6/HP:6]
+    // - Set: REVENDRETH, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Costs (3) less for each <b>Secret</b> you control.
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
     // --------------------------------------------------------
 }
 
@@ -815,6 +1017,33 @@ void RevendrethCardsGen::AddPaladin(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Set a minion's Attack and Health to 3.
     // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [MAW_015] Jury Duty - COST:3
+    // - Set: REVENDRETH, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Summon two Silver Hand Recruits.
+    //       Give your Silver Hand Recruits +1/+1.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - PALADIN
+    // [MAW_016] Order in the Court - COST:2
+    // - Set: REVENDRETH, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Reorder your deck from highest Cost to lowest Cost.
+    //       Draw a card.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - PALADIN
+    // [MAW_017] Class Action Lawyer - COST:2 [ATK:2/HP:3]
+    // - Set: REVENDRETH, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If your deck has no Neutral cards,
+    //       set a minion's stats to 1/1.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
 }
 
 void RevendrethCardsGen::AddPaladinNonCollect(
@@ -903,6 +1132,20 @@ void RevendrethCardsGen::AddPaladinNonCollect(
     // - Set: REVENDRETH
     // --------------------------------------------------------
     // Text: Stats changed to 3/3.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [MAW_015e] Jury Summons - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: +1/+1.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - PALADIN
+    // [MAW_017e] Class Action - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: 1/1.
     // --------------------------------------------------------
 }
 
@@ -1018,6 +1261,38 @@ void RevendrethCardsGen::AddPriest(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
     // Text: Give a minion +2/+1 and draw a card.
     // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [MAW_021] Clear Conscience - COST:3
+    // - Set: REVENDRETH, Rarity: Common
+    // - Spell School: Holy
+    // --------------------------------------------------------
+    // Text: Give a friendly minion +2/+3 and
+    //       "Only you can target this with spells and Hero Powers."
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - PRIEST
+    // [MAW_022] Incriminating Psychic - COST:4 [ATK:2/HP:6]
+    // - Race: Dragon, Set: REVENDRETH, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Taunt</b>
+    //       <b>Deathrattle:</b> Copy a random card
+    //       from your opponent's hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DEATHRATTLE = 1
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - PRIEST
+    // [MAW_023] Theft Accusation - COST:1
+    // - Set: REVENDRETH, Rarity: Rare
+    // - Spell School: Shadow
+    // --------------------------------------------------------
+    // Text: Choose a minion.
+    //       Destroy it after you play a card
+    //       copied from the opponent.
+    // --------------------------------------------------------
 }
 
 void RevendrethCardsGen::AddPriestNonCollect(
@@ -1090,6 +1365,40 @@ void RevendrethCardsGen::AddPriestNonCollect(
     // - Set: REVENDRETH
     // --------------------------------------------------------
     // Text: +2/+1.
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - PRIEST
+    // [MAW_021e] Cleared Conscience - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: +2/+3 and "Can't be targeted by spells or Hero Powers".
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - PRIEST
+    // [MAW_021e2] In the Clear - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: Can't be targeted by spells or Hero Powers.
+    // --------------------------------------------------------
+    // GameTag:
+    // - CANT_BE_TARGETED_BY_SPELLS = 1
+    // - CANT_BE_TARGETED_BY_HERO_POWERS = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - PRIEST
+    // [MAW_023e] Theft Trial - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: When you play a card copied from your opponent,
+    //       destroy the accused.
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - PRIEST
+    // [MAW_023e2] Accused of Theft - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: When the accuser plays a card copied from their enemy,
+    //       this minion dies.
     // --------------------------------------------------------
 }
 
@@ -1223,6 +1532,38 @@ void RevendrethCardsGen::AddRogue(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - SECRET = 1
     // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [MAW_018] Perjury - COST:2
+    // - Set: REVENDRETH, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Secret:</b> When your turn starts,
+    //       <b>Discover</b> and cast a <b>Secret</b>
+    //       from another class.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DISCOVER = 1
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------------ SPELL - ROGUE
+    // [MAW_019] Murder Accusation - COST:2
+    // - Set: REVENDRETH, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Choose a minion.
+    //       Destroy it after another enemy minion dies.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- MINION - ROGUE
+    // [MAW_020] Scribbling Stenographer - COST:6 [ATK:4/HP:4]
+    // - Set: REVENDRETH, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>. Costs (1) less for each card
+    //       you've played this turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
 }
 
 void RevendrethCardsGen::AddRogueNonCollect(
@@ -1314,6 +1655,21 @@ void RevendrethCardsGen::AddRogueNonCollect(
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - ROGUE
+    // [MAW_019e] Murder Trial - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: When another enemy minion dies, destroy the accused.
+    // --------------------------------------------------------
+
+    // ------------------------------------ ENCHANTMENT - ROGUE
+    // [MAW_019e2] Accused of Murder - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: When an enemy minion of the accuser dies,
+    //       this minion dies.
     // --------------------------------------------------------
 }
 
@@ -1426,6 +1782,49 @@ void RevendrethCardsGen::AddShaman(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [MAW_003] Totemic Evidence - COST:1
+    // - Set: REVENDRETH, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Choose a basic Totem and summon it.
+    //       <b>Infuse (3 Totems):</b> Summon all 4 instead.
+    // --------------------------------------------------------
+    // GameTag:
+    // - INFUSE = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [MAW_005] Framester - COST:3 [ATK:3/HP:3]
+    // - Set: REVENDRETH, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Shuffle 3 'Framed' cards
+    //       into the opponent's deck.
+    //       When drawn, they <b>Overload</b> for (2).
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - OVERLOAD = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- MINION - SHAMAN
+    // [MAW_030] Torghast Custodian - COST:8 [ATK:6/HP:10]
+    // - Set: REVENDRETH, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> For each enemy minion,
+    //       randomly gain <b>Rush</b>, <b>Divine Shield</b>,
+    //       or <b>Windfury</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - DIVINE_SHIELD = 1
+    // - RUSH = 1
+    // - WINDFURY = 1
+    // --------------------------------------------------------
 }
 
 void RevendrethCardsGen::AddShamanNonCollect(
@@ -1476,6 +1875,47 @@ void RevendrethCardsGen::AddShamanNonCollect(
     // --------------------------------------------------------
     // GameTag:
     // - TAG_ONE_TURN_EFFECT = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [MAW_003t] Totemic Evidence - COST:1
+    // - Set: REVENDRETH, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Infused</b>
+    //       Summon all 4 basic Totems.
+    // --------------------------------------------------------
+
+    // ----------------------------------------- SPELL - SHAMAN
+    // [MAW_005t] Framed - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: <b>Casts When Drawn</b>
+    //       <b>Overload:</b> (2)
+    // --------------------------------------------------------
+    // GameTag:
+    // - OVERLOAD = 1
+    // - TOPDECK = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - SHAMAN
+    // [MAW_030e2] Crawling - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: <b>Rush</b>.
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - SHAMAN
+    // [MAW_030e3] Sweeping - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: <b>Divine Shield</b>.
+    // --------------------------------------------------------
+
+    // ----------------------------------- ENCHANTMENT - SHAMAN
+    // [MAW_030e4] Formidable - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: <b>Windfury</b>.
     // --------------------------------------------------------
 }
 
@@ -1586,6 +2026,42 @@ void RevendrethCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - INFUSE = 1
     // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARLOCK
+    // [MAW_000] Imp-oster - COST:2 [ATK:1/HP:1]
+    // - Race: Demon, Set: REVENDRETH, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Choose a friendly Imp.
+    //       Transform into a copy of it.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [MAW_001] Arson Accusation - COST:2
+    // - Set: REVENDRETH, Rarity: Common
+    // - Spell School: Fire
+    // --------------------------------------------------------
+    // Text: Choose a minion.
+    //       Destroy it after your hero takes damage.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARLOCK
+    // [MAW_002] Habeas Corpses - COST:3
+    // - Set: REVENDRETH, Rarity: Rare
+    // - Spell School: Shadow
+    // --------------------------------------------------------
+    // Text: <b>Discover</b> a friendly minion to resurrect
+    //       and give it <b>Rush</b>.
+    //       It dies at the end of turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - DISCOVER = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - RUSH = 1
+    // --------------------------------------------------------
 }
 
 void RevendrethCardsGen::AddWarlockNonCollect(
@@ -1669,6 +2145,31 @@ void RevendrethCardsGen::AddWarlockNonCollect(
     // GameTag:
     // - ELITE = 1
     // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARLOCK
+    // [MAW_001e] Arson Trial - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: When your hero takes damage, destroy the accused.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARLOCK
+    // [MAW_001e2] Accused of Arson - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: When the accuser takes damage, this minion dies.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARLOCK
+    // [MAW_002e] Habeas Corpse - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: Dies at the end of turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - TAG_ONE_TURN_EFFECT = 1
+    // - TRIGGER_VISUAL = 1
     // --------------------------------------------------------
 }
 
@@ -1780,6 +2281,37 @@ void RevendrethCardsGen::AddWarrior(std::map<std::string, CardDef>& cards)
     // - Set: REVENDRETH, Rarity: Rare
     // --------------------------------------------------------
     // Text: Deal 1 damage to a minion and give it +2 Attack.
+    // --------------------------------------------------------
+
+    // ---------------------------------------- SPELL - WARRIOR
+    // [MAW_027] Call to the Stand - COST:1
+    // - Set: REVENDRETH, Rarity: Common
+    // --------------------------------------------------------
+    // Text: Your opponent summons a random minion from their hand.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [MAW_028] Mawsworn Bailiff - COST:5 [ATK:4/HP:4]
+    // - Set: REVENDRETH, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b><b>Taunt</b>.</b>
+    //       <b>Battlecry:</b> If you have 4 or more Armor,
+    //       gain +4/+4.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // - TAUNT = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - WARRIOR
+    // [MAW_029] Weapons Expert - COST:3 [ATK:3/HP:2]
+    // - Set: REVENDRETH, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> If you have a weapon equipped,
+    //       give it +1/+1. Otherwise, draw a weapon.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
     // --------------------------------------------------------
 }
 
@@ -1902,6 +2434,20 @@ void RevendrethCardsGen::AddWarriorNonCollect(
     // --------------------------------------------------------
     // Text: +1 Attack.
     // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARRIOR
+    // [MAW_028e2] This Man Is Charged! - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: +4/+4.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - WARRIOR
+    // [MAW_029e2] Sharpened - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: +1/+1.
+    // --------------------------------------------------------
 }
 
 void RevendrethCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
@@ -2004,6 +2550,41 @@ void RevendrethCardsGen::AddDemonHunter(std::map<std::string, CardDef>& cards)
     // Text: Summon two 1/1 Spirits.
     //       Improve your future Relics.
     // --------------------------------------------------------
+
+    // ----------------------------------- MINION - DEMONHUNTER
+    // [MAW_008] Sightless Magistrate - COST:4 [ATK:5/HP:4]
+    // - Set: REVENDRETH, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Both players draw
+    //       until they have 5 cards.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ------------------------------------ SPELL - DEMONHUNTER
+    // [MAW_012] All Fel Breaks Loose - COST:5
+    // - Set: REVENDRETH, Rarity: Common
+    // - Spell School: Fel
+    // --------------------------------------------------------
+    // Text: Summon a friendly Demon that died this game.
+    //       <b>Infuse (3 Demons):</b> Summon three instead.
+    // --------------------------------------------------------
+    // RefTag:
+    // - INFUSE = 1
+    // --------------------------------------------------------
+
+    // ----------------------------------- MINION - DEMONHUNTER
+    // [MAW_014] Prosecutor Mel'tranix - COST:4 [ATK:2/HP:6]
+    // - Race: Demon, Set: REVENDRETH, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Your opponent can only play
+    //       their left- and right-most cards on their next turn.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
 }
 
 void RevendrethCardsGen::AddDemonHunterNonCollect(
@@ -2063,6 +2644,26 @@ void RevendrethCardsGen::AddDemonHunterNonCollect(
     // ----------------------------------- MINION - DEMONHUNTER
     // [REV_943t] Fleeting Spirit - COST:1 [ATK:1/HP:1]
     // - Set: REVENDRETH
+    // --------------------------------------------------------
+
+    // ------------------------------------ SPELL - DEMONHUNTER
+    // [MAW_012t] All Fel Breaks Loose - COST:5
+    // - Set: REVENDRETH, Rarity: Common
+    // - Spell School: Fel
+    // --------------------------------------------------------
+    // Text: <b>Infused</b>
+    //       Summon three friendly Demons that died this game.
+    // --------------------------------------------------------
+
+    // ------------------------------ ENCHANTMENT - DEMONHUNTER
+    // [MAW_014e2] Literally Unplayable - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: You can only play the left and right-most cards
+    //       in your hand.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AURA = 1
     // --------------------------------------------------------
 }
 
@@ -2494,6 +3095,69 @@ void RevendrethCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [MAW_004] Soul Seeker - COST:5 [ATK:3/HP:3]
+    // - Set: REVENDRETH, Rarity: Common
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Swap this with a random minion
+    //       from your opponent's deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [MAW_031] Afterlife Attendant - COST:3 [ATK:3/HP:4]
+    // - Set: REVENDRETH, Rarity: Rare
+    // --------------------------------------------------------
+    // Text: Your <b>Infuse</b> cards also <b>Infuse</b>
+    //       while in your deck.
+    // --------------------------------------------------------
+    // GameTag:
+    // - INFUSE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [MAW_032] Tight-Lipped Witness - COST:3 [ATK:2/HP:5]
+    // - Set: REVENDRETH, Rarity: Epic
+    // --------------------------------------------------------
+    // Text: <b>Secrets</b> can't be revealed.
+    // --------------------------------------------------------
+    // GameTag:
+    // - AURA = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - SECRET = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [MAW_033] Sylvanas, the Accused - COST:6 [ATK:5/HP:5]
+    // - Set: REVENDRETH, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Destroy an enemy minion.
+    //       <b>Infuse (7):</b> Take control of it instead.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // - INFUSE = 1
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [MAW_034] The Jailer - COST:10 [ATK:10/HP:10]
+    // - Set: REVENDRETH, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Battlecry:</b> Destroy your deck.
+    //       For the rest of the game, your minions are <b>Immune</b>.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+    // RefTag:
+    // - IMMUNE = 1
+    // --------------------------------------------------------
 }
 
 void RevendrethCardsGen::AddNeutralNonCollect(
@@ -2721,6 +3385,40 @@ void RevendrethCardsGen::AddNeutralNonCollect(
     // - Set: REVENDRETH
     // --------------------------------------------------------
     // Text: Gain 1 Mana Crystal this turn only.
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [MAW_031e] Afterlife - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: Your <b>Infuse</b> cards also <b>Infuse</b>
+    //       in your deck.
+    // --------------------------------------------------------
+
+    // --------------------------------------- MINION - NEUTRAL
+    // [MAW_033t] Sylvanas, the Accused - COST:6 [ATK:5/HP:5]
+    // - Set: REVENDRETH, Rarity: Legendary
+    // --------------------------------------------------------
+    // Text: <b>Infused</b>
+    //       <b>Battlecry:</b> Take control of an enemy minion.
+    // --------------------------------------------------------
+    // GameTag:
+    // - ELITE = 1
+    // - BATTLECRY = 1
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [MAW_034e] Mawsworn - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: Your minions are <b>Immune</b>
+    // --------------------------------------------------------
+
+    // ---------------------------------- ENCHANTMENT - NEUTRAL
+    // [MAW_034e2] Mawsworn - COST:0
+    // - Set: REVENDRETH
+    // --------------------------------------------------------
+    // Text: Can't die.
     // --------------------------------------------------------
 }
 


### PR DESCRIPTION
This revision includes:
- Update Hearthstone Patch 24.4 (Resolves #838 and #843)
  - Update card data
    - NUM_PLAY_MODE_CARDS: 15561 -> 15667
    - Add comments for 'REVENDRETH' mini-set cards
  - Update Battlegrounds data
    - NUM_BATTLEGROUNDS_CARDS: 17259 -> 17402
    - Returning Hero: Sylvanas Windrunner