### PR TITLE
Update Hearthstone Patch 24.4.3

### DIFF
--- a/Resources/cards.collectible.json
+++ b/Resources/cards.collectible.json
@@ -59324,7 +59324,7 @@
         "attack": 3,
         "cardClass": "NEUTRAL",
         "collectible": true,
-        "cost": 4,
+        "cost": 5,
         "dbfId": 76984,
         "elite": true,
         "flavor": "\"I'm afraid you've gone mad! You're entirely bonkers. But I'll tell you a secret. All the best souls are.\"",
@@ -70797,7 +70797,7 @@
         "name": "Harpoon Gun",
         "rarity": "RARE",
         "set": "THE_SUNKEN_CITY",
-        "text": "After your hero attacks, <b>Dredge</b>. If it's a Beast, reduce its Cost by (3).",
+        "text": "After your hero attacks, <b>Dredge</b>. If it's a Beast, reduce its Cost by (2).",
         "type": "WEAPON"
     },
     {

--- a/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
@@ -650,7 +650,7 @@ void RevendrethCardsGen::AddHunterNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [REV_360t1] Bear Spirit Wildseed - COST:2 [ATK:2/HP:5]
+    // [REV_360t1] Bear Spirit Wildseed - COST:2 [ATK:2/HP:4]
     // - Race: Beast, Set: REVENDRETH
     // --------------------------------------------------------
     // Text: <b>Dormant</b> for 2 turns.
@@ -671,7 +671,7 @@ void RevendrethCardsGen::AddHunterNonCollect(
     // --------------------------------------------------------
 
     // ---------------------------------------- MINION - HUNTER
-    // [REV_360t2] Stag Spirit Wildseed - COST:3 [ATK:5/HP:4]
+    // [REV_360t2] Stag Spirit Wildseed - COST:3 [ATK:4/HP:3]
     // - Race: Beast, Set: REVENDRETH
     // --------------------------------------------------------
     // Text: <b>Dormant</b> for 3 turns.
@@ -2876,7 +2876,7 @@ void RevendrethCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // --------------------------------------------------------
 
     // --------------------------------------- MINION - NEUTRAL
-    // [REV_238] Theotar, the Mad Duke - COST:4 [ATK:3/HP:3]
+    // [REV_238] Theotar, the Mad Duke - COST:5 [ATK:3/HP:3]
     // - Set: REVENDRETH, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> <b>Discover</b> a card

--- a/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/TheSunkenCityCardsGen.cpp
@@ -364,7 +364,7 @@ void TheSunkenCityCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // - Set: THE_SUNKEN_CITY, Rarity: Rare
     // --------------------------------------------------------
     // Text: After your hero attacks, <b>Dredge</b>.
-    //       If it's a Beast, reduce its Cost by (3).
+    //       If it's a Beast, reduce its Cost by (2).
     // --------------------------------------------------------
     // GameTag:
     // - DREDGE = 1


### PR DESCRIPTION
This revision includes:
- Update Hearthstone Patch 24.4.3 (Resolves #852)
  - Update card data
    - Theotar, the Mad Duke
      - Old: Costs 4
      - New: Costs 5
    - Stag Spirit Wildseed
      - Old: 5 Attack, 4 Health
      - New: 4 Attack, 3 Health
    - Bear Spirit Wildseed
      - Old: 2 Attack, 5 Health
      - New: 2 Attack, 4 Health
    - Harpoon Gun
      - Old: After your hero attacks, Dredge. If it’s a Beast, reduce its cost by (3).
      - New: After your hero attacks, Dredge. It it’s a Beast, reduce its cost by (2).
