### PR TITLE
Implement 4 REVENDRETH cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -1057,11 +1057,11 @@ REVENDRETH | REV_334 | Burden of Pride |
 REVENDRETH | REV_336 | Plot of Sin | O
 REVENDRETH | REV_337 | Riot! |  
 REVENDRETH | REV_338 | Dredger Staff |  
-REVENDRETH | REV_350 | Frenzied Fangs |  
+REVENDRETH | REV_350 | Frenzied Fangs | O
 REVENDRETH | REV_351 | Roosting Gargoyle |  
-REVENDRETH | REV_352 | Stonebound Gargon |  
-REVENDRETH | REV_353 | Huntsman Altimor |  
-REVENDRETH | REV_356 | Batty Guest |  
+REVENDRETH | REV_352 | Stonebound Gargon | O
+REVENDRETH | REV_353 | Huntsman Altimor | O
+REVENDRETH | REV_356 | Batty Guest | O
 REVENDRETH | REV_360 | Spirit Poacher |  
 REVENDRETH | REV_361 | Wild Spirits |  
 REVENDRETH | REV_362 | Castle Kennels |  
@@ -1147,4 +1147,4 @@ REVENDRETH | REV_961 | Elitist Snob |
 REVENDRETH | REV_983 | Great Hall |  
 REVENDRETH | REV_990 | Sanguine Depths |  
 
-- Progress: 4% (7 of 170 Cards)
+- Progress: 6% (11 of 170 Cards)

--- a/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
+++ b/Includes/Rosetta/PlayMode/Tasks/ComplexTask.hpp
@@ -400,6 +400,32 @@ class ComplexTask
                                                       isSpellDamage)
         };
     }
+
+    //! Returns a list of task for taking damages the minions
+    //! next to whomever this attacks.
+    static TaskList DamageMinionsNextToAttack()
+    {
+        return TaskList{
+            std::make_shared<SimpleTasks::FuncNumberTask>(
+                [](Playable* playable) {
+                    const auto target = dynamic_cast<Minion*>(
+                        playable->game->currentEventData->eventTarget);
+                    if (!target)
+                    {
+                        return 0;
+                    }
+
+                    auto& taskStack = playable->game->taskStack;
+                    for (auto& minion : target->GetAdjacentMinions())
+                    {
+                        taskStack.playables.emplace_back(minion);
+                    }
+
+                    return dynamic_cast<Minion*>(playable)->GetAttack();
+                }),
+            std::make_shared<SimpleTasks::DamageNumberTask>(EntityType::STACK)
+        };
+    }
 };
 }  // namespace RosettaStone::PlayMode
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
   * 12% Voyage to the Sunken City (22 of 170 cards)
-  * 4% Murder at Castle Nathria (7 of 170 cards)
+  * 6% Murder at Castle Nathria (11 of 170 cards)
 
 ### Wild Format
 

--- a/Sources/Rosetta/PlayMode/Actions/Generic.cpp
+++ b/Sources/Rosetta/PlayMode/Actions/Generic.cpp
@@ -198,6 +198,7 @@ void ChangeEntity(Player* player, Playable* playable, Card* newCard,
 
     if (playable->card->GetCardType() == newCard->GetCardType())
     {
+        playable->Reset();
         playable->card = newCard;
 
         for (const auto& gameTag : newCard->gameTags)

--- a/Sources/Rosetta/PlayMode/CardSets/LegacyCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/LegacyCardsGen.cpp
@@ -2345,23 +2345,7 @@ void LegacyCardsGen::AddWarlock(std::map<std::string, CardDef>& cards)
         std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
     cardDef.power.GetTrigger()->triggerSource = TriggerSource::SELF;
     cardDef.power.GetTrigger()->tasks = {
-        std::make_shared<FuncNumberTask>([](Playable* playable) {
-            const auto target = dynamic_cast<Minion*>(
-                playable->game->currentEventData->eventTarget);
-            if (!target)
-            {
-                return 0;
-            }
-
-            auto& taskStack = playable->game->taskStack;
-            for (auto& minion : target->GetAdjacentMinions())
-            {
-                taskStack.playables.emplace_back(minion);
-            }
-
-            return dynamic_cast<Minion*>(playable)->GetAttack();
-        }),
-        std::make_shared<DamageNumberTask>(EntityType::STACK)
+        ComplexTask::DamageMinionsNextToAttack()
     };
     cards.emplace("CS3_021", cardDef);
 

--- a/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
@@ -385,6 +385,8 @@ void RevendrethCardsGen::AddDruidNonCollect(
 
 void RevendrethCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ----------------------------------------- SPELL - HUNTER
     // [REV_350] Frenzied Fangs - COST:2
     // - Set: REVENDRETH, Rarity: Common
@@ -395,6 +397,12 @@ void RevendrethCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - INFUSE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<SummonTask>("REV_350t", 2, SummonSide::SPELL));
+    cardDef.property.numMinionsToInfuse = 3;
+    cardDef.property.infusedCardID = "REV_350t2";
+    cards.emplace("REV_350", cardDef);
 
     // ---------------------------------------- MINION - HUNTER
     // [REV_352] Stonebound Gargon - COST:4 [ATK:3/HP:5]
@@ -543,17 +551,25 @@ void RevendrethCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
 void RevendrethCardsGen::AddHunterNonCollect(
     std::map<std::string, CardDef>& cards)
 {
+    CardDef cardDef;
+
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [REV_350e] Bloodthirsty - COST:0
     // - Set: REVENDRETH
     // --------------------------------------------------------
     // Text: +1/+2.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddEnchant(Enchants::GetEnchantFromText("REV_350e"));
+    cards.emplace("REV_350e", cardDef);
 
     // ---------------------------------------- MINION - HUNTER
     // [REV_350t] Thirsty Bat - COST:1 [ATK:2/HP:1]
     // - Race: Beast, Set: REVENDRETH
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("REV_350t", cardDef);
 
     // ----------------------------------------- SPELL - HUNTER
     // [REV_350t2] Frenzied Fangs - COST:2
@@ -562,6 +578,12 @@ void RevendrethCardsGen::AddHunterNonCollect(
     // Text: <b>Infused</b>
     //       Summon two 2/1 Bats. Give them +1/+2.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<SummonTask>("REV_350t", 2, SummonSide::SPELL, true));
+    cardDef.power.AddPowerTask(
+        std::make_shared<AddEnchantmentTask>("REV_350e", EntityType::STACK));
+    cards.emplace("REV_350t2", cardDef);
 
     // ---------------------------------------- MINION - HUNTER
     // [REV_352t] Stonebound Gargon - COST:4 [ATK:3/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
@@ -427,14 +427,24 @@ void RevendrethCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // - Set: REVENDRETH, Rarity: Legendary
     // --------------------------------------------------------
     // Text: <b>Battlecry:</b> Summon a Gargon Companion.
-    //       <b>Infuse ({0}):</b> Summon another.
-    //       <b>Infuse ({1}):</b> And another!
+    //       <b>Infuse (4):</b> Summon another.
+    //       <b>Infuse (4):</b> And another!
+    // --------------------------------------------------------
+    // Entourage: REV_353t3, REV_353t4, REV_353t5
     // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
     // - BATTLECRY = 1
     // - INFUSE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<RandomEntourageTask>());
+    cardDef.power.AddPowerTask(std::make_shared<SummonTask>(SummonSide::RIGHT));
+    cardDef.property.entourages =
+        Entourages{ "REV_353t3", "REV_353t4", "REV_353t5" };
+    cardDef.property.numMinionsToInfuse = 4;
+    cardDef.property.infusedCardID = "REV_353t";
+    cards.emplace("REV_353", cardDef);
 
     // ---------------------------------------- MINION - HUNTER
     // [REV_356] Batty Guest - COST:1 [ATK:1/HP:1]
@@ -618,11 +628,22 @@ void RevendrethCardsGen::AddHunterNonCollect(
     //       <b>Battlecry:</b> Summon 2 Gargon Companions.
     //       <b>Infuse (4):</b> Summon all 3!   
     // --------------------------------------------------------
+    // Entourage: REV_353t3, REV_353t4, REV_353t5
+    // --------------------------------------------------------
     // GameTag:
     // - ELITE = 1
     // - BATTLECRY = 1
     // - INFUSE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<RandomEntourageTask>(2));
+    cardDef.power.AddPowerTask(std::make_shared<SummonTask>(
+        SummonSide::RIGHT, std::nullopt, true, false, 2));
+    cardDef.property.entourages =
+        Entourages{ "REV_353t3", "REV_353t4", "REV_353t5" };
+    cardDef.property.numMinionsToInfuse = 4;
+    cardDef.property.infusedCardID = "REV_353t2";
+    cards.emplace("REV_353t", cardDef);
 
     // ---------------------------------------- MINION - HUNTER
     // [REV_353t2] Huntsman Altimor - COST:7 [ATK:5/HP:4]
@@ -635,6 +656,14 @@ void RevendrethCardsGen::AddHunterNonCollect(
     // - ELITE = 1
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<SummonTask>("REV_353t5", SummonSide::RIGHT));
+    cardDef.power.AddPowerTask(
+        std::make_shared<SummonTask>("REV_353t4", SummonSide::RIGHT));
+    cardDef.power.AddPowerTask(
+        std::make_shared<SummonTask>("REV_353t3", SummonSide::RIGHT));
+    cards.emplace("REV_353t2", cardDef);
 
     // ---------------------------------------- MINION - HUNTER
     // [REV_353t3] Hecutis - COST:3 [ATK:4/HP:4]
@@ -645,6 +674,9 @@ void RevendrethCardsGen::AddHunterNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("REV_353t3", cardDef);
 
     // ---------------------------------------- MINION - HUNTER
     // [REV_353t4] Barghast - COST:3 [ATK:2/HP:4]
@@ -655,6 +687,10 @@ void RevendrethCardsGen::AddHunterNonCollect(
     // GameTag:
     // - AURA = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddAura(
+        std::make_shared<Aura>(AuraType::FIELD_EXCEPT_SOURCE, "REV_353t4e"));
+    cards.emplace("REV_353t4", cardDef);
 
     // ----------------------------------- ENCHANTMENT - HUNTER
     // [REV_353t4e] Bone from the Stone - COST:0
@@ -662,6 +698,9 @@ void RevendrethCardsGen::AddHunterNonCollect(
     // --------------------------------------------------------
     // Text: Barghast is granting this minion +1 Attack.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddEnchant(Enchants::GetEnchantFromText("REV_353t4e"));
+    cards.emplace("REV_353t4e", cardDef);
 
     // ---------------------------------------- MINION - HUNTER
     // [REV_353t5] Margore - COST:3 [ATK:4/HP:2]
@@ -672,6 +711,9 @@ void RevendrethCardsGen::AddHunterNonCollect(
     // GameTag:
     // - CHARGE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("REV_353t5", cardDef);
 
     // ---------------------------------------- MINION - HUNTER
     // [REV_360t] Fox Spirit Wildseed - COST:1 [ATK:3/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
@@ -455,6 +455,9 @@ void RevendrethCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddDeathrattleTask(std::make_shared<SummonTask>("REV_350t"));
+    cards.emplace("REV_356", cardDef);
 
     // ---------------------------------------- MINION - HUNTER
     // [REV_360] Spirit Poacher - COST:2 [ATK:2/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
@@ -416,6 +416,11 @@ void RevendrethCardsGen::AddHunter(std::map<std::string, CardDef>& cards)
     // - INFUSE = 1
     // - RUSH = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cardDef.property.numMinionsToInfuse = 3;
+    cardDef.property.infusedCardID = "REV_352t";
+    cards.emplace("REV_352", cardDef);
 
     // ---------------------------------------- MINION - HUNTER
     // [REV_353] Huntsman Altimor - COST:7 [ATK:5/HP:4]
@@ -596,6 +601,14 @@ void RevendrethCardsGen::AddHunterNonCollect(
     // GameTag:
     // - RUSH = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddTrigger(
+        std::make_shared<Trigger>(TriggerType::AFTER_ATTACK));
+    cardDef.power.GetTrigger()->triggerSource = TriggerSource::SELF;
+    cardDef.power.GetTrigger()->tasks = {
+        ComplexTask::DamageMinionsNextToAttack()
+    };
+    cards.emplace("REV_352t", cardDef);
 
     // ---------------------------------------- MINION - HUNTER
     // [REV_353t] Huntsman Altimor - COST:7 [ATK:5/HP:4]

--- a/Sources/Rosetta/PlayMode/Models/Entity.cpp
+++ b/Sources/Rosetta/PlayMode/Models/Entity.cpp
@@ -112,6 +112,9 @@ void Entity::Reset()
     m_gameTags.erase(GameTag::STEALTH);
     m_gameTags.erase(GameTag::SPELLBURST);
     m_gameTags.erase(GameTag::NUM_ATTACKS_THIS_TURN);
+    m_gameTags.erase(GameTag::INFUSE);
+    m_gameTags.erase(GameTag::INFUSED);
+    m_gameTags.erase(GameTag::INFUSE_COUNTER);
 }
 
 Playable* Entity::GetFromCard(Player* player, Card* card,

--- a/Tests/UnitTests/PlayMode/CardSets/RevendrethCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/RevendrethCardsGenTests.cpp
@@ -307,6 +307,79 @@ TEST_CASE("[Druid : Spell] - REV_336 : Plot of Sin")
     CHECK_EQ(curField[1]->GetHealth(), 5);
 }
 
+// ----------------------------------------- SPELL - HUNTER
+// [REV_350] Frenzied Fangs - COST:2
+// - Set: REVENDRETH, Rarity: Common
+// --------------------------------------------------------
+// Text: Summon two 2/1 Bats.
+//       <b>Infuse (3):</b> Give them +1/+2.
+// --------------------------------------------------------
+// GameTag:
+// - INFUSE = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Spell] - REV_350 : Frenzied Fangs")
+{
+    GameConfig config;
+    config.player1Class = CardClass::WARLOCK;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Frenzied Fangs"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Frenzied Fangs"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Blizzard"));
+
+    game.Process(curPlayer, PlayCardTask::Spell(card1));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(curField.GetCount(), 3);
+    CHECK_EQ(curField[0]->card->name, "Thirsty Bat");
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+    CHECK_EQ(curField[1]->card->name, "Thirsty Bat");
+    CHECK_EQ(curField[1]->GetAttack(), 2);
+    CHECK_EQ(curField[1]->GetHealth(), 1);
+    CHECK_EQ(card2->HasInfuse(), true);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Spell(card4));
+    CHECK_EQ(curField.GetCount(), 0);
+    CHECK_EQ(curHand[0]->IsInfused(), true);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer, PlayCardTask::Spell(curHand[0]));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[0]->card->name, "Thirsty Bat");
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 3);
+    CHECK_EQ(curField[1]->card->name, "Thirsty Bat");
+    CHECK_EQ(curField[1]->GetAttack(), 3);
+    CHECK_EQ(curField[1]->GetHealth(), 3);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [REV_956] Priest of the Deceased - COST:2 [ATK:2/HP:3]
 // - Set: REVENDRETH, Rarity: Common

--- a/Tests/UnitTests/PlayMode/CardSets/RevendrethCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/RevendrethCardsGenTests.cpp
@@ -576,6 +576,52 @@ TEST_CASE("[Hunter : Minion] - REV_353 : Huntsman Altimor")
     CHECK(isGargonCompanion(curField[3]));
 }
 
+// ---------------------------------------- MINION - HUNTER
+// [REV_356] Batty Guest - COST:1 [ATK:1/HP:1]
+// - Set: REVENDRETH, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Summon a 2/1 Bat.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Hunter : Minion] - REV_356 : Batty Guest")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Batty Guest"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, HeroPowerTask(card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Thirsty Bat");
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 1);
+}
+
 // --------------------------------------- MINION - NEUTRAL
 // [REV_956] Priest of the Deceased - COST:2 [ATK:2/HP:3]
 // - Set: REVENDRETH, Rarity: Common


### PR DESCRIPTION
This revision includes:
- Implement 4 REVENDRETH cards
  - Frenzied Fangs (REV_350)
  - Stonebound Gargon (REV_352)
  - Huntsman Altimor (REV_353)
  - Batty Guest (REV_356)
- Add complex task 'DamageMinionsNextToAttack()'
  - Returns a list of task for taking damages the minions next to whomever this attacks
  - Change code to use complex task 'DamageMinionsNextToAttack()'
- Add code to reset values related to keyword 'Infuse'
- Add code to reset the value of some game tags in function `ChangeEntity()`