### PR TITLE
Implement 6 REVENDRETH cards

### DIFF
--- a/Documents/CardList - Standard.md
+++ b/Documents/CardList - Standard.md
@@ -1015,14 +1015,14 @@ REVENDRETH | REV_000 | Suspicious Alchemist |
 REVENDRETH | REV_002 | Suspicious Usher |  
 REVENDRETH | REV_006 | Suspicious Pirate |  
 REVENDRETH | REV_011 | The Harvester of Envy |  
-REVENDRETH | REV_012 | Bog Beast |  
-REVENDRETH | REV_013 | Stoneborn Accuser |  
+REVENDRETH | REV_012 | Bog Beast | O
+REVENDRETH | REV_013 | Stoneborn Accuser | O
 REVENDRETH | REV_014 | Red Herring |  
 REVENDRETH | REV_015 | Masked Reveler |  
 REVENDRETH | REV_016 | Crooked Cook |  
 REVENDRETH | REV_017 | Insatiable Devourer |  
 REVENDRETH | REV_018 | Prince Renathal |  
-REVENDRETH | REV_019 | Famished Fool |  
+REVENDRETH | REV_019 | Famished Fool | O
 REVENDRETH | REV_020 | Dinner Performer |  
 REVENDRETH | REV_021 | Kael'thas Sinstrider |  
 REVENDRETH | REV_022 | Murloc Holmes |  
@@ -1038,12 +1038,12 @@ REVENDRETH | REV_247 | Partner in Crime |
 REVENDRETH | REV_248 | Boon of the Ascended |  
 REVENDRETH | REV_249 | The Light! It Burns! |  
 REVENDRETH | REV_250 | Pelagos |  
-REVENDRETH | REV_251 | Sinrunner |  
+REVENDRETH | REV_251 | Sinrunner | O
 REVENDRETH | REV_252 | Clean the Scene |  
 REVENDRETH | REV_253 | Identity Theft |  
 REVENDRETH | REV_290 | Cathedral of Atonement |  
 REVENDRETH | REV_307 | Natural Causes | O
-REVENDRETH | REV_308 | Maze Guide |  
+REVENDRETH | REV_308 | Maze Guide | O
 REVENDRETH | REV_310 | Death Blossom Whomper |  
 REVENDRETH | REV_311 | Nightshade Bud |  
 REVENDRETH | REV_313 | Planted Evidence | O
@@ -1056,7 +1056,7 @@ REVENDRETH | REV_333 | Hedge Maze |
 REVENDRETH | REV_334 | Burden of Pride |  
 REVENDRETH | REV_336 | Plot of Sin | O
 REVENDRETH | REV_337 | Riot! |  
-REVENDRETH | REV_338 | Dredger Staff |  
+REVENDRETH | REV_338 | Dredger Staff | O
 REVENDRETH | REV_350 | Frenzied Fangs | O
 REVENDRETH | REV_351 | Roosting Gargoyle |  
 REVENDRETH | REV_352 | Stonebound Gargon | O
@@ -1147,4 +1147,4 @@ REVENDRETH | REV_961 | Elitist Snob |
 REVENDRETH | REV_983 | Great Hall |  
 REVENDRETH | REV_990 | Sanguine Depths |  
 
-- Progress: 6% (11 of 170 Cards)
+- Progress: 10% (17 of 170 Cards)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ RosettaStone is Hearthstone simulator using C++ with some reinforcement learning
   * 35% United in Stormwind (60 of 170 cards)
   * 35% Fractured in Alterac Valley (61 of 170 cards)
   * 12% Voyage to the Sunken City (22 of 170 cards)
-  * 6% Murder at Castle Nathria (11 of 170 cards)
+  * 10% Murder at Castle Nathria (17 of 170 cards)
 
 ### Wild Format
 

--- a/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
@@ -2835,6 +2835,11 @@ void RevendrethCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // RefTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cardDef.property.numMinionsToInfuse = 5;
+    cardDef.property.infusedCardID = "REV_013t";
+    cards.emplace("REV_013", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [REV_014] Red Herring - COST:7 [ATK:3/HP:12]
@@ -3326,6 +3331,14 @@ void RevendrethCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    // PlayReq:
+    // - REQ_TARGET_TO_PLAY = 0
+    // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(
+        std::make_shared<DamageTask>(EntityType::TARGET, 5));
+    cardDef.property.playReqs = PlayReqs{ { PlayReq::REQ_TARGET_TO_PLAY, 0 } };
+    cards.emplace("REV_013t", cardDef);
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [REV_015t] Masked - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
@@ -2817,6 +2817,10 @@ void RevendrethCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - DEATHRATTLE = 1
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddDeathrattleTask(
+        std::make_shared<SummonTask>("REV_012t", SummonSide::DEATHRATTLE));
+    cards.emplace("REV_012", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [REV_013] Stoneborn Accuser - COST:5 [ATK:5/HP:5]
@@ -3308,6 +3312,9 @@ void RevendrethCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - TAUNT = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(nullptr);
+    cards.emplace("REV_012t", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [REV_013t] Stoneborn Accuser - COST:5 [ATK:5/HP:5]

--- a/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
@@ -2991,6 +2991,9 @@ void RevendrethCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - DEATHRATTLE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddDeathrattleTask(ComplexTask::DestroyRandomEnemyMinion(1));
+    cards.emplace("REV_251", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [REV_308] Maze Guide - COST:2 [ATK:1/HP:1]

--- a/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
@@ -2918,6 +2918,11 @@ void RevendrethCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // - BATTLECRY = 1
     // - INFUSE = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<DrawTask>(1));
+    cardDef.property.numMinionsToInfuse = 4;
+    cardDef.property.infusedCardID = "REV_019t";
+    cards.emplace("REV_019", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [REV_020] Dinner Performer - COST:3 [ATK:2/HP:3]
@@ -3383,6 +3388,9 @@ void RevendrethCardsGen::AddNeutralNonCollect(
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<DrawTask>(3));
+    cards.emplace("REV_019t", cardDef);
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [REV_021e] Sinstrider - COST:0

--- a/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
@@ -3004,6 +3004,11 @@ void RevendrethCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<RandomMinionTask>(
+        TagValues{ { GameTag::COST, 2, RelaSign::EQ } }));
+    cardDef.power.AddPowerTask(std::make_shared<SummonStackTask>());
+    cards.emplace("REV_308", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [REV_338] Dredger Staff - COST:1 [ATK:1/HP:2]

--- a/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
+++ b/Sources/Rosetta/PlayMode/CardSets/RevendrethCardsGen.cpp
@@ -3019,6 +3019,10 @@ void RevendrethCardsGen::AddNeutral(std::map<std::string, CardDef>& cards)
     // GameTag:
     // - BATTLECRY = 1
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddPowerTask(std::make_shared<AddEnchantmentTask>(
+        "REV_338e", EntityType::MINIONS_HAND));
+    cards.emplace("REV_338", cardDef);
 
     // --------------------------------------- MINION - NEUTRAL
     // [REV_351] Roosting Gargoyle - COST:2 [ATK:2/HP:3]
@@ -3413,6 +3417,9 @@ void RevendrethCardsGen::AddNeutralNonCollect(
     // --------------------------------------------------------
     // Text: +1 Health.
     // --------------------------------------------------------
+    cardDef.ClearData();
+    cardDef.power.AddEnchant(Enchants::GetEnchantFromText("REV_338e"));
+    cards.emplace("REV_338e", cardDef);
 
     // ---------------------------------- ENCHANTMENT - NEUTRAL
     // [REV_351e] Invigorated - COST:0

--- a/Tests/UnitTests/PlayMode/CardSets/RevendrethCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/RevendrethCardsGenTests.cpp
@@ -752,6 +752,80 @@ TEST_CASE("[Neutral : Minion] - REV_013 : Stoneborn Accuser")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [REV_019] Famished Fool - COST:5 [ATK:3/HP:5]
+// - Set: REVENDRETH, Rarity: Rare
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Draw a card.
+//       <b>Infuse (4):</b> Draw 3 instead.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// - INFUSE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - REV_019 : Famished Fool")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DEMONHUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Famished Fool"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Famished Fool"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card6 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Flamestrike"));
+
+    CHECK_EQ(curHand.GetCount(), 9);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    CHECK_EQ(curHand.GetCount(), 9);
+
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+    CHECK_EQ(curField.GetCount(), 4);
+    CHECK_EQ(card1->HasInfuse(), true);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Spell(card6));
+    CHECK_EQ(curField.GetCount(), 0);
+    CHECK_EQ(curHand[4]->IsInfused(), true);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    CHECK_EQ(curHand.GetCount(), 7);
+
+    game.Process(curPlayer, PlayCardTask::Minion(curHand[4]));
+    CHECK_EQ(curHand.GetCount(), 9);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [REV_956] Priest of the Deceased - COST:2 [ATK:2/HP:3]
 // - Set: REVENDRETH, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/RevendrethCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/RevendrethCardsGenTests.cpp
@@ -678,6 +678,80 @@ TEST_CASE("[Neutral : Minion] - REV_012 : Bog Beast")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [REV_013] Stoneborn Accuser - COST:5 [ATK:5/HP:5]
+// - Set: REVENDRETH, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Infuse (5):</b>
+//       Gain "<b>Battlecry:</b> Deal 5 damage."
+// --------------------------------------------------------
+// GameTag:
+// - INFUSE = 1
+// --------------------------------------------------------
+// RefTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - REV_013 : Stoneborn Accuser")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+    auto& curHand = *(curPlayer->GetHandZone());
+
+    const auto card1 = Generic::DrawCard(
+        curPlayer, Cards::FindCardByName("Stoneborn Accuser"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card3 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card4 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card5 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card6 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+    const auto card7 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Blizzard"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card2));
+    game.Process(curPlayer, PlayCardTask::Minion(card3));
+    game.Process(curPlayer, PlayCardTask::Minion(card4));
+    game.Process(curPlayer, PlayCardTask::Minion(card5));
+    game.Process(curPlayer, PlayCardTask::Minion(card6));
+    CHECK_EQ(curField.GetCount(), 5);
+    CHECK_EQ(card1->HasInfuse(), true);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Spell(card7));
+    CHECK_EQ(curField.GetCount(), 0);
+    CHECK_EQ(curHand[4]->IsInfused(), true);
+
+    game.Process(opPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(curPlayer,
+                 PlayCardTask::MinionTarget(curHand[4], opPlayer->GetHero()));
+    CHECK_EQ(opPlayer->GetHero()->GetHealth(), 25);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [REV_956] Priest of the Deceased - COST:2 [ATK:2/HP:3]
 // - Set: REVENDRETH, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/RevendrethCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/RevendrethCardsGenTests.cpp
@@ -623,6 +623,61 @@ TEST_CASE("[Hunter : Minion] - REV_356 : Batty Guest")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [REV_012] Bog Beast - COST:6 [ATK:3/HP:6]
+// - Set: REVENDRETH, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Taunt</b>
+//       <b>Deathrattle:</b> Summon a 2/4 Muckmare
+//       with <b>Taunt</b>.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// - TAUNT = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - REV_012 : Bog Beast")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Bog Beast"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField[0]->GetAttack(), 3);
+    CHECK_EQ(curField[0]->GetHealth(), 6);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(curField.GetCount(), 1);
+    CHECK_EQ(curField[0]->card->name, "Muckmare");
+    CHECK_EQ(curField[0]->GetAttack(), 2);
+    CHECK_EQ(curField[0]->GetHealth(), 4);
+    CHECK_EQ(curField[0]->HasTaunt(), true);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [REV_956] Priest of the Deceased - COST:2 [ATK:2/HP:3]
 // - Set: REVENDRETH, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/RevendrethCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/RevendrethCardsGenTests.cpp
@@ -879,6 +879,45 @@ TEST_CASE("[Neutral : Minion] - REV_251 : Sinrunner")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [REV_308] Maze Guide - COST:2 [ATK:1/HP:1]
+// - Set: REVENDRETH, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry</b>: Summon a random 2-Cost minion.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - REV_308 : Maze Guide")
+{
+    GameConfig config;
+    config.player1Class = CardClass::DRUID;
+    config.player2Class = CardClass::SHAMAN;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& curField = *(curPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Maze Guide"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(curField.GetCount(), 2);
+    CHECK_EQ(curField[1]->card->GetCost(), 2);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [REV_956] Priest of the Deceased - COST:2 [ATK:2/HP:3]
 // - Set: REVENDRETH, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/RevendrethCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/RevendrethCardsGenTests.cpp
@@ -826,6 +826,59 @@ TEST_CASE("[Neutral : Minion] - REV_019 : Famished Fool")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [REV_251] Sinrunner - COST:5 [ATK:6/HP:5]
+// - Race: Beast, Set: REVENDRETH, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Deathrattle:</b> Destroy a random enemy minion.
+// --------------------------------------------------------
+// GameTag:
+// - DEATHRATTLE = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - REV_251 : Sinrunner")
+{
+    GameConfig config;
+    config.player1Class = CardClass::HUNTER;
+    config.player2Class = CardClass::MAGE;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = true;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    auto& opField = *(opPlayer->GetFieldZone());
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Sinrunner"));
+    const auto card2 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Fireball"));
+    const auto card3 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Magma Rager"));
+    const auto card4 =
+        Generic::DrawCard(opPlayer, Cards::FindCardByName("Magma Rager"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+
+    game.Process(curPlayer, EndTurnTask());
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    game.Process(opPlayer, PlayCardTask::Minion(card3));
+    game.Process(opPlayer, PlayCardTask::Minion(card4));
+    CHECK_EQ(opField.GetCount(), 2);
+
+    game.Process(opPlayer, PlayCardTask::SpellTarget(card2, card1));
+    CHECK_EQ(opField.GetCount(), 1);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [REV_956] Priest of the Deceased - COST:2 [ATK:2/HP:3]
 // - Set: REVENDRETH, Rarity: Common
 // --------------------------------------------------------

--- a/Tests/UnitTests/PlayMode/CardSets/RevendrethCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/RevendrethCardsGenTests.cpp
@@ -918,6 +918,45 @@ TEST_CASE("[Neutral : Minion] - REV_308 : Maze Guide")
 }
 
 // --------------------------------------- MINION - NEUTRAL
+// [REV_338] Dredger Staff - COST:1 [ATK:1/HP:2]
+// - Set: REVENDRETH, Rarity: Common
+// --------------------------------------------------------
+// Text: <b>Battlecry:</b> Give minions in your hand +1 Health.
+// --------------------------------------------------------
+// GameTag:
+// - BATTLECRY = 1
+// --------------------------------------------------------
+TEST_CASE("[Neutral : Minion] - REV_338 : Dredger Staff")
+{
+    GameConfig config;
+    config.player1Class = CardClass::PALADIN;
+    config.player2Class = CardClass::WARRIOR;
+    config.startPlayer = PlayerType::PLAYER1;
+    config.doFillDecks = false;
+    config.autoRun = false;
+
+    Game game(config);
+    game.Start();
+    game.ProcessUntil(Step::MAIN_ACTION);
+
+    Player* curPlayer = game.GetCurrentPlayer();
+    Player* opPlayer = game.GetOpponentPlayer();
+    curPlayer->SetTotalMana(10);
+    curPlayer->SetUsedMana(0);
+    opPlayer->SetTotalMana(10);
+    opPlayer->SetUsedMana(0);
+
+    const auto card1 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Dredger Staff"));
+    const auto card2 =
+        Generic::DrawCard(curPlayer, Cards::FindCardByName("Wisp"));
+
+    game.Process(curPlayer, PlayCardTask::Minion(card1));
+    CHECK_EQ(dynamic_cast<Minion*>(card2)->GetAttack(), 1);
+    CHECK_EQ(dynamic_cast<Minion*>(card2)->GetHealth(), 2);
+}
+
+// --------------------------------------- MINION - NEUTRAL
 // [REV_956] Priest of the Deceased - COST:2 [ATK:2/HP:3]
 // - Set: REVENDRETH, Rarity: Common
 // --------------------------------------------------------


### PR DESCRIPTION
This revision includes:
- Implement 6 REVENDRETH cards
  - Bog Beast (REV_012)
  - Stoneborn Accuser (REV_013)
  - Famished Fool (REV_019)
  - Sinrunner (REV_251)
  - Maze Guide (REV_308)
  - Dredger Staff (REV_338)