### PR TITLE
Update Hearthstone Patch 24.6.2

### DIFF
--- a/Sources/Rosetta/Battlegrounds/Loaders/CardLoader.cpp
+++ b/Sources/Rosetta/Battlegrounds/Loaders/CardLoader.cpp
@@ -110,13 +110,6 @@ void CardLoader::Load(std::array<Card, NUM_BATTLEGROUNDS_CARDS>& cards)
             card.isCurHero = true;
         }
 
-        // NOTE: The value "isBattlegroundsPoolMinion" of Atramedes
-        //       (BG23_362) is missing.
-        if (id == "BG23_362")
-        {
-            card.isBattlegroundsPoolMinion = true;
-        }
-
         cards.at(idx) = card;
         ++idx;
     }


### PR DESCRIPTION
This revision includes:
- Update Hearthstone Patch 24.6 (Resolves #864)
  - Delete code to assign the value of 'battlegroundsPoolMinion' of card 'Atramedes' (BG23_362)
  - Quest Reward Updates
    - Volatile Venom (Quest Reward)
      - Old: Your minions have +8/+8. After they attack, they die. Horribly.
      - New: Your minions have +7/+7. After they attack, they die. Horribly.