### PR TITLE
Fix compile error due to deprecated function

### DIFF
--- a/Extensions/RosettaConsole/main.cpp
+++ b/Extensions/RosettaConsole/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char* argv[])
 
     if (!result)
     {
-        std::cerr << "Error in command line: " << result.errorMessage() << '\n';
+        std::cerr << "Error in command line: " << result.message() << '\n';
         std::cerr << cli << '\n';
         return EXIT_FAILURE;
     }

--- a/Extensions/RosettaTool/main.cpp
+++ b/Extensions/RosettaTool/main.cpp
@@ -154,7 +154,7 @@ int main(int argc, char* argv[])
 
     if (!result)
     {
-        std::cerr << "Error in command line: " << result.errorMessage() << '\n';
+        std::cerr << "Error in command line: " << result.message() << '\n';
         exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
This revision includes:
- Fix compile error due to deprecated function
  - Change code to call func 'message()' instead of 'errorMessage()'
  - Reference: https://github.com/bfgroup/Lyra/blob/develop/docs/lyra.adoc#83-16