### PR TITLE
Fix SonarCloud issues

### DIFF
--- a/Includes/Rosetta/Common/PriorityQueue.hpp
+++ b/Includes/Rosetta/Common/PriorityQueue.hpp
@@ -57,7 +57,7 @@ class PriorityQueue
         }
     }
 
-    //! Deleted move constructor.
+    //! Move constructor.
     PriorityQueue(PriorityQueue&& rhs) noexcept : m_count(rhs.m_count)
     {
         const Node* rhsNode = rhs.m_head;
@@ -84,14 +84,24 @@ class PriorityQueue
     //! Copy assignment operator.
     PriorityQueue& operator=(const PriorityQueue& rhs)
     {
+        if (this == &rhs)
+        {
+            return *this;
+        }
+
         PriorityQueue<T> temp(rhs);
         std::swap(temp.m_head, m_head);
         return *this;
     }
 
-    //! Deleted move assignment operator.
+    //! Move assignment operator.
     PriorityQueue& operator=(PriorityQueue&& rhs) noexcept
     {
+        if (*this == rhs)
+        {
+            return *this;
+        }
+
         PriorityQueue<T> temp(rhs);
         std::swap(temp.m_head, m_head);
         return *this;

--- a/Sources/Rosetta/PlayMode/Enchants/Power.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/Power.cpp
@@ -94,17 +94,17 @@ void Power::ClearData()
 
 void Power::AddAura(std::shared_ptr<IAura> aura)
 {
-    m_aura = std::move(aura);
+    m_aura = aura;
 }
 
 void Power::AddEnchant(std::shared_ptr<Enchant> enchant)
 {
-    m_enchant = std::move(enchant);
+    m_enchant = enchant;
 }
 
 void Power::AddTrigger(std::shared_ptr<Trigger> trigger)
 {
-    m_trigger = std::move(trigger);
+    m_trigger = trigger;
 }
 
 void Power::AddPowerTask(const std::shared_ptr<ITask>& task)

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/ConditionTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/ConditionTask.cpp
@@ -14,7 +14,7 @@ namespace RosettaStone::PlayMode::SimpleTasks
 ConditionTask::ConditionTask(
     EntityType entityType,
     std::vector<std::shared_ptr<SelfCondition>> selfConditions)
-    : ITask(entityType), m_selfConditions(std::move(selfConditions))
+    : ITask(entityType), m_selfConditions(selfConditions)
 {
     // Do nothing
 }
@@ -22,7 +22,7 @@ ConditionTask::ConditionTask(
 ConditionTask::ConditionTask(
     EntityType entityType,
     std::vector<std::shared_ptr<RelaCondition>> relaConditions)
-    : ITask(entityType), m_relaConditions(std::move(relaConditions))
+    : ITask(entityType), m_relaConditions(relaConditions)
 {
     // Do nothing
 }
@@ -32,8 +32,8 @@ ConditionTask::ConditionTask(
     std::vector<std::shared_ptr<SelfCondition>> selfConditions,
     std::vector<std::shared_ptr<RelaCondition>> relaConditions)
     : ITask(entityType),
-      m_selfConditions(std::move(selfConditions)),
-      m_relaConditions(std::move(relaConditions))
+      m_selfConditions(selfConditions),
+      m_relaConditions(relaConditions)
 {
     // Do nothing
 }

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.cpp
@@ -13,14 +13,14 @@ namespace RosettaStone::PlayMode::SimpleTasks
 {
 FilterStackTask::FilterStackTask(
     std::vector<std::shared_ptr<SelfCondition>> selfConditions)
-    : m_selfConditions(std::move(selfConditions))
+    : m_selfConditions(selfConditions)
 {
     // Do nothing
 }
 
 FilterStackTask::FilterStackTask(
     EntityType type, std::vector<std::shared_ptr<RelaCondition>> relaConditions)
-    : ITask(type), m_relaConditions(std::move(relaConditions))
+    : ITask(type), m_relaConditions(relaConditions)
 {
     // Do nothing
 }

--- a/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
+++ b/Sources/Rosetta/PlayMode/Triggers/Trigger.cpp
@@ -284,12 +284,17 @@ std::shared_ptr<Trigger> Trigger::Activate(Playable* source,
 
 void Trigger::Remove()
 {
-    if (m_isRemoved)
+    if (m_isRemoved || !m_owner)
     {
         return;
     }
 
     Game* game = m_owner->game;
+
+    if (!game)
+    {
+        return;
+    }
 
     switch (m_triggerType)
     {


### PR DESCRIPTION
This revision includes:
- Fix SonarCloud issues
  - Check "rhs" for equality to "this" before proceeding with the assignment
  - Potential leak of memory pointed to by field '_M_pi'
  - Access to field 'game' results in a dereference of a null pointer (loaded from field 'm_owner')