### PR TITLE
Restore code to use 'std::move' for performance

### DIFF
--- a/Sources/Rosetta/PlayMode/Enchants/Power.cpp
+++ b/Sources/Rosetta/PlayMode/Enchants/Power.cpp
@@ -94,17 +94,17 @@ void Power::ClearData()
 
 void Power::AddAura(std::shared_ptr<IAura> aura)
 {
-    m_aura = aura;
+    m_aura = std::move(aura);
 }
 
 void Power::AddEnchant(std::shared_ptr<Enchant> enchant)
 {
-    m_enchant = enchant;
+    m_enchant = std::move(enchant);
 }
 
 void Power::AddTrigger(std::shared_ptr<Trigger> trigger)
 {
-    m_trigger = trigger;
+    m_trigger = std::move(trigger);
 }
 
 void Power::AddPowerTask(const std::shared_ptr<ITask>& task)

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/ConditionTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/ConditionTask.cpp
@@ -14,7 +14,7 @@ namespace RosettaStone::PlayMode::SimpleTasks
 ConditionTask::ConditionTask(
     EntityType entityType,
     std::vector<std::shared_ptr<SelfCondition>> selfConditions)
-    : ITask(entityType), m_selfConditions(selfConditions)
+    : ITask(entityType), m_selfConditions(std::move(selfConditions))
 {
     // Do nothing
 }
@@ -22,7 +22,7 @@ ConditionTask::ConditionTask(
 ConditionTask::ConditionTask(
     EntityType entityType,
     std::vector<std::shared_ptr<RelaCondition>> relaConditions)
-    : ITask(entityType), m_relaConditions(relaConditions)
+    : ITask(entityType), m_relaConditions(std::move(relaConditions))
 {
     // Do nothing
 }
@@ -32,8 +32,8 @@ ConditionTask::ConditionTask(
     std::vector<std::shared_ptr<SelfCondition>> selfConditions,
     std::vector<std::shared_ptr<RelaCondition>> relaConditions)
     : ITask(entityType),
-      m_selfConditions(selfConditions),
-      m_relaConditions(relaConditions)
+      m_selfConditions(std::move(selfConditions)),
+      m_relaConditions(std::move(relaConditions))
 {
     // Do nothing
 }

--- a/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.cpp
+++ b/Sources/Rosetta/PlayMode/Tasks/SimpleTasks/FilterStackTask.cpp
@@ -13,14 +13,14 @@ namespace RosettaStone::PlayMode::SimpleTasks
 {
 FilterStackTask::FilterStackTask(
     std::vector<std::shared_ptr<SelfCondition>> selfConditions)
-    : m_selfConditions(selfConditions)
+    : m_selfConditions(std::move(selfConditions))
 {
     // Do nothing
 }
 
 FilterStackTask::FilterStackTask(
     EntityType type, std::vector<std::shared_ptr<RelaCondition>> relaConditions)
-    : ITask(type), m_relaConditions(relaConditions)
+    : ITask(type), m_relaConditions(std::move(relaConditions))
 {
     // Do nothing
 }


### PR DESCRIPTION
This revision includes:
- Restore code to use 'std::move' for performance
  - SonarCloud issues are false-positive. I checked 'Clang Static Analyzer (scan-build)' in my computer.
  - Reference: https://github.com/llvm/llvm-project/issues/60896