### PR TITLE
Fix the problem that coverage reports are not uploaded to Codecov

### DIFF
--- a/.github/workflows/ubuntu-codecov.yml
+++ b/.github/workflows/ubuntu-codecov.yml
@@ -41,5 +41,7 @@ jobs:
       run: cd build && make
     - name: Run Unit Test
       run: /home/runner/work/RosettaStone/RosettaStone/build/bin/UnitTests
-    - name: Upload coverage to Codecov
-      run: bash <(curl -s https://codecov.io/bash)
+    - name: Upload Coverage Reports to Codecov
+      uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ubuntu-codecov.yml
+++ b/.github/workflows/ubuntu-codecov.yml
@@ -21,7 +21,7 @@ jobs:
     name: 🧪 Code Coverage - Codecov
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Install packages

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
-codecov:
-  require_ci_to_pass: yes
+codecov: 
+  token: ${{ secrets.CODECOV_TOKEN }}
 
 coverage:
   precision: 2


### PR DESCRIPTION
This revision includes:
- Fix the problem that coverage reports are not uploaded to Codecov
  - Add token for Codecov
  - Update step 'Upload coverage reports to Codecov'
  - Update checkout to 'v4'