### PR TITLE
Fix unit test code of card 'Silvermoon Portal' (KAR_077)

### DIFF
--- a/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
+++ b/Tests/UnitTests/PlayMode/CardSets/KaraCardsGenTests.cpp
@@ -565,7 +565,10 @@ TEST_CASE("[Paladin : Spell] - KAR_077 : Silvermoon Portal")
     game.Process(curPlayer, PlayCardTask::Minion(card2));
     game.Process(curPlayer, PlayCardTask::MinionTarget(card1, card2));
     CHECK_EQ(curField.GetCount(), 2);
-    CHECK_EQ(curField[0]->GetAttack(), 3);
+    // NOTE: Due to 'Flametongue Totem' (CORE_EX1_565),
+    //       adjacent minions have +2 Attack.
+    //       Therefore, use CHECK_GE instead of CHECK_EQ for Attack value.
+    CHECK_GE(curField[0]->GetAttack(), 3);
     CHECK_EQ(curField[0]->GetHealth(), 3);
     CHECK_EQ(curField[1]->card->GetCost(), 2);
 }


### PR DESCRIPTION
This revision includes:
- Fix unit test code of card 'Silvermoon Portal' (KAR_077) (Closes #936)
  - Due to 'Flametongue Totem' (CORE_EX1_565), adjacent minions have +2 Attack.
  - Therefore, use CHECK_GE instead of CHECK_EQ for Attack value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a card interaction test to better handle variable attack values when nearby effects can change a minion’s power.
  * Improved test coverage and reliability for a spell scenario where the exact attack value may differ depending on board state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->